### PR TITLE
Enable AUTH-01: full Cognito hosted UI login test

### DIFF
--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -10,10 +10,13 @@ test.describe('Authentication', () => {
   });
 
   // AUTH-01 requires HTTPS: Cognito redirects to https://localhost:3000/loggedin/ (from
-  // REACT_APP_LOGIN_REDIRECT) but the CRA dev server serves HTTP. The redirect fails with
-  // chrome-error://chromewebdata/. To enable: run CRA with HTTPS=true, or test against
-  // production (darwin.one). The programmatic auth in auth.setup.ts validates token acquisition.
-  test.skip('AUTH-01: full login via Cognito hosted UI', async ({ page }) => {
+  // REACT_APP_LOGIN_REDIRECT) but the CRA dev server serves HTTP by default.
+  // Prerequisites to enable:
+  //   1. Run CRA with HTTPS=true (uses self-signed cert)
+  //   2. Add ignoreHTTPSErrors: true to Playwright config for this test
+  //   3. OR test against production (darwin.one) which serves HTTPS natively
+  // See: https://github.com/BillWilliams79/Darwin/pull/3
+  test('AUTH-01: full login via Cognito hosted UI', async ({ page }) => {
     await page.goto('/');
 
     // Click login link on home page ("Login / Create Account")


### PR DESCRIPTION
## Summary
- Un-skip AUTH-01 test (full Cognito hosted UI login flow)
- Document prerequisites for making the test pass

## Problem
Cognito redirects to `https://localhost:3000/loggedin/` after login (configured in `REACT_APP_LOGIN_REDIRECT`), but the CRA dev server runs on HTTP. The HTTPS connection fails, resulting in `chrome-error://chromewebdata/`.

Additionally, `LoggedIn.js` sets auth cookies with `secure: true`, which won't persist on HTTP origins.

## Options to resolve
1. **HTTPS dev server**: Run CRA with `HTTPS=true` + add `ignoreHTTPSErrors: true` to Playwright config
2. **HTTP callback**: Add `http://localhost:3000/loggedin/` to Cognito allowed callbacks + update `.env.development.local`
3. **Production testing**: Run AUTH-01 against `https://darwin.one` instead of localhost

## Test plan
- [ ] Choose approach and implement HTTPS support
- [ ] Verify AUTH-01 passes end-to-end
- [ ] Verify no regression in other 13 P0 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)