### PR TITLE
Fix E2E selectors for MUI v7 icons, un-skip AUTH-01

### DIFF
--- a/e2e/playwright.production.config.ts
+++ b/e2e/playwright.production.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  retries: 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'https://darwin.one',
+    ignoreHTTPSErrors: true,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: '.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+});

--- a/e2e/tests/area-p1.spec.ts
+++ b/e2e/tests/area-p1.spec.ts
@@ -100,8 +100,8 @@ test.describe.serial('Area Management P1', () => {
     const areaRow = panel.getByTestId(`area-row-${result[0].id}`);
     await expect(areaRow).toBeVisible({ timeout: 5000 });
 
-    // Click the delete icon in the row
-    await areaRow.locator('button:has(svg[data-testid="DeleteIcon"])').click();
+    // Click the delete button (last cell's button in the row)
+    await areaRow.locator('td:last-child button').click();
 
     // AreaDeleteDialog should appear
     const deleteDialog = page.getByRole('dialog');

--- a/e2e/tests/domain-p1.spec.ts
+++ b/e2e/tests/domain-p1.spec.ts
@@ -107,8 +107,8 @@ test.describe('Domain Management P1', () => {
     }
     expect(targetRow).not.toBeNull();
 
-    // Click the delete icon (DeleteIcon button) in the row
-    await targetRow!.locator('button:has(svg[data-testid="DeleteIcon"])').click();
+    // Click the delete button (last cell's button in the row)
+    await targetRow!.locator('td:last-child button').click();
 
     // DomainDeleteDialog should appear
     const deleteDialog = page.getByRole('dialog');

--- a/e2e/tests/domain.spec.ts
+++ b/e2e/tests/domain.spec.ts
@@ -29,9 +29,8 @@ test.describe('Domain Management', () => {
     // Wait for domains to load
     await page.waitForSelector('[role="tab"]', { timeout: 10000 });
 
-    // Click the "+" tab to open DomainAddDialog
-    // The "+" tab is the last tab with an AddIcon
-    await page.locator('[data-testid="MuiTab-root"]:last-child, [role="tab"]:has(svg[data-testid="AddIcon"])').first().click();
+    // Click the "+" tab to open DomainAddDialog (last tab, has no text — just the add icon)
+    await page.locator('[role="tab"]').last().click();
 
     // Wait for and interact with DomainAddDialog
     const dialog = page.getByTestId('domain-add-dialog');


### PR DESCRIPTION
## Summary
- Fix AREA-05, DOM-04 delete button selectors (`svg[data-testid="DeleteIcon"]` → `td:last-child button`) — MUI v7 dropped `data-testid` from icon SVGs
- Fix DOM-01 add-domain tab selector (`[data-testid="MuiTab-root"]` → `[role="tab"]').last()`)
- Un-skip AUTH-01 (full Cognito hosted UI login) — now works on both HTTPS localhost and production
- Add `playwright.production.config.ts` for running against darwin.one without local webServer

## Test plan
- [x] 27/27 E2E tests pass on production (darwin.one)
- [x] 27/27 E2E tests pass on dev server (localhost:3000 HTTPS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)