### PR TITLE
Make PedalBike icon pink for Valentine's Day

### DIFF
--- a/src/NavBar/NavBar.jsx
+++ b/src/NavBar/NavBar.jsx
@@ -19,7 +19,7 @@ const NavBar = () => {
                spacing={1}
                alignItems={{xs: 'center', md: 'flex-start'}}
         >
-          <PedalBikeIcon />
+          <PedalBikeIcon sx={{ color: 'pink' }} />
           <Link className="nav-title" to="/">
             Darwin
           </Link>


### PR DESCRIPTION
## Summary
- Changes the NavBar PedalBike icon color to pink for Valentine's Day

## Files changed
- `src/NavBar/NavBar.jsx` — added `sx={{ color: 'pink' }}` to PedalBikeIcon

## Testing
- Local E2E: 27/27 passing

## Deploy notes
- Darwin frontend only — S3 + CloudFront invalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)