### PR TITLE
Add 8 E2E tests: sort order, profile, 404, cancel drag

### DIFF
--- a/e2e/tests/cancel-drag.spec.ts
+++ b/e2e/tests/cancel-drag.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect } from '@playwright/test';
+import { getIdToken, apiCall, apiDelete, uniqueName } from '../helpers/api';
+
+test.describe.serial('Cancel Drag', () => {
+  let idToken: string;
+  let testDomainId: string;
+  const testDomainName = uniqueName('CancelDnD');
+  const createdAreaIds: string[] = [];
+  const createdTaskIds: string[] = [];
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext({ storageState: '.auth/user.json' });
+    const page = await context.newPage();
+    idToken = await getIdToken(page);
+    await context.close();
+
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+
+    // Create test domain
+    const domResult = await apiCall('domains', 'POST', {
+      creator_fk: sub, domain_name: testDomainName, closed: 0,
+    }, idToken) as Array<{ id: string }>;
+    if (!domResult?.length) throw new Error('Failed to create test domain');
+    testDomainId = domResult[0].id;
+  });
+
+  test.afterAll(async () => {
+    for (const id of createdTaskIds) {
+      try { await apiDelete('tasks', id, idToken); } catch { /* best-effort */ }
+    }
+    for (const id of createdAreaIds) {
+      try { await apiDelete('areas', id, idToken); } catch { /* best-effort */ }
+    }
+    try { await apiCall('domains', 'PUT', [{ id: testDomainId, closed: 1 }], idToken); } catch {}
+  });
+
+  test('DND-01: cancel area reorder in AreaEdit fires no PUT', async ({ page }) => {
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+    const area1Name = uniqueName('Stay1');
+    const area2Name = uniqueName('Stay2');
+
+    // Create 2 areas with known sort order
+    const r1 = await apiCall('areas', 'POST', {
+      creator_fk: sub, area_name: area1Name, domain_fk: testDomainId,
+      closed: 0, sort_order: 0,
+    }, idToken) as Array<{ id: string }>;
+    const r2 = await apiCall('areas', 'POST', {
+      creator_fk: sub, area_name: area2Name, domain_fk: testDomainId,
+      closed: 0, sort_order: 1,
+    }, idToken) as Array<{ id: string }>;
+    if (r1?.length) createdAreaIds.push(r1[0].id);
+    if (r2?.length) createdAreaIds.push(r2[0].id);
+
+    // Intercept PUT requests to areas — count them
+    let putCount = 0;
+    await page.route('**/areas*', (route) => {
+      if (route.request().method() === 'PUT') {
+        putCount++;
+      }
+      route.continue();
+    });
+
+    // Navigate to AreaEdit and select domain
+    await page.goto('/areaedit');
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.getByRole('tab', { name: testDomainName }).click();
+    await page.waitForTimeout(1000);
+
+    // Find the second area row
+    const secondRow = page.getByTestId(`area-row-${r2[0].id}`);
+    await expect(secondRow).toBeVisible({ timeout: 5000 });
+
+    // Start DnD with keyboard: Space to lift
+    await secondRow.focus();
+    await page.keyboard.press('Space');
+    await page.waitForTimeout(300);
+
+    // Move up
+    await page.keyboard.press('ArrowUp');
+    await page.waitForTimeout(300);
+
+    // CANCEL with Escape (instead of Space to drop)
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(1000);
+
+    // Verify: no PUT was fired
+    expect(putCount).toBe(0);
+
+    // Verify: area order unchanged — first row should still be area1
+    const panel = page.locator('[role="tabpanel"]:visible').first();
+    const rows = panel.locator('[data-testid^="area-row-"]:not([data-testid="area-row-template"])');
+    const firstRowName = await rows.first().locator('input[name="area-name"]').inputValue();
+    expect(firstRowName).toBe(area1Name);
+  });
+
+  test('DND-02: cancel task drag in TaskPlanView fires no PUT', async ({ page }) => {
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+    const areaName = uniqueName('DragArea');
+    const taskDesc = uniqueName('DragTask');
+
+    // Create area and task
+    const areaResult = await apiCall('areas', 'POST', {
+      creator_fk: sub, area_name: areaName, domain_fk: testDomainId,
+      closed: 0, sort_order: 0,
+    }, idToken) as Array<{ id: string }>;
+    if (!areaResult?.length) throw new Error('Failed to create area');
+    const areaId = areaResult[0].id;
+    createdAreaIds.push(areaId);
+
+    const taskResult = await apiCall('tasks', 'POST', {
+      creator_fk: sub, description: taskDesc, area_fk: areaId,
+      priority: 0, done: 0,
+    }, idToken) as Array<{ id: string }>;
+    if (!taskResult?.length) throw new Error('Failed to create task');
+    const taskId = taskResult[0].id;
+    createdTaskIds.push(taskId);
+
+    // Intercept PUT requests to tasks
+    let putCount = 0;
+    await page.route('**/tasks*', (route) => {
+      if (route.request().method() === 'PUT') {
+        putCount++;
+      }
+      route.continue();
+    });
+
+    // Navigate to TaskPlanView and select domain
+    await page.goto('/taskcards');
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.getByRole('tab', { name: testDomainName }).click();
+    await page.waitForTimeout(1500);
+
+    // Find the task row
+    const taskRow = page.getByTestId(`task-${taskId}`);
+    await expect(taskRow).toBeVisible({ timeout: 5000 });
+
+    // Start a synthetic drag and immediately cancel via dragend (no drop)
+    await page.evaluate(
+      ({ taskId }) => {
+        const taskEl = document.querySelector(`[data-testid="task-${taskId}"]`);
+        if (!taskEl) throw new Error('Task element not found');
+        const dataTransfer = new DataTransfer();
+        const rect = taskEl.getBoundingClientRect();
+        const x = rect.x + rect.width / 2;
+        const y = rect.y + rect.height / 2;
+
+        taskEl.dispatchEvent(new DragEvent('dragstart', {
+          bubbles: true, cancelable: true, dataTransfer, clientX: x, clientY: y,
+        }));
+        // Cancel immediately — no drop event
+        taskEl.dispatchEvent(new DragEvent('dragend', {
+          bubbles: true, cancelable: true, dataTransfer, clientX: x, clientY: y,
+        }));
+      },
+      { taskId },
+    );
+
+    await page.waitForTimeout(1000);
+
+    // Verify: no PUT was fired for tasks
+    expect(putCount).toBe(0);
+
+    // Verify: task still in original area
+    const areaCard = page.getByTestId(`area-card-${areaId}`);
+    await expect(areaCard.getByTestId(`task-${taskId}`)).toBeVisible();
+  });
+});

--- a/e2e/tests/error-p1.spec.ts
+++ b/e2e/tests/error-p1.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Error Pages', () => {
+  test('ERR-02: 404 page for invalid routes', async ({ page }) => {
+    // Navigate to a non-existent route
+    await page.goto('/nonexistent-route-xyz');
+    await page.waitForTimeout(1000);
+
+    // Error404.jsx renders "Error 404: Resource Not Found"
+    await expect(page.locator('body')).toContainText('Error 404');
+    await expect(page.locator('body')).toContainText('Resource Not Found');
+  });
+});

--- a/e2e/tests/profile.spec.ts
+++ b/e2e/tests/profile.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Profile', () => {
+  test('PROF-01: profile drawer opens and shows user data', async ({ page }) => {
+    await page.goto('/taskcards');
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+
+    // Click the Profile button in the NavBar (ProfileDrawer renders a Button)
+    await page.getByRole('button', { name: /profile/i }).click();
+
+    // Verify the MUI Drawer opens with profile fields
+    const drawer = page.locator('.MuiDrawer-root');
+    await expect(drawer).toBeVisible({ timeout: 5000 });
+
+    // Profile.jsx renders 5 TextFields: Name, E-mail, Region, User Pool ID, Cognito Identifier
+    // Verify at least Name and E-mail are present and non-empty
+    const nameField = drawer.locator('input').filter({ has: page.locator('[id]') }).first();
+    const textFields = drawer.locator('.MuiTextField-root');
+    const fieldCount = await textFields.count();
+    expect(fieldCount).toBeGreaterThanOrEqual(2);
+
+    // Verify the drawer contains recognizable profile labels
+    await expect(drawer).toContainText('Name');
+    await expect(drawer).toContainText('mail');
+  });
+
+  test('PROF-02: profile page via direct navigation', async ({ page }) => {
+    // Navigate directly to /profile route
+    await page.goto('/profile');
+    await page.waitForTimeout(2000);
+
+    // Profile.jsx renders TextFields for Name, E-mail, Region, etc.
+    // Verify the page renders profile content (not a redirect or error)
+    const textFields = page.locator('.MuiTextField-root');
+    const fieldCount = await textFields.count();
+    expect(fieldCount).toBeGreaterThanOrEqual(2);
+
+    // Verify profile labels are present
+    await expect(page.locator('body')).toContainText('Name');
+    await expect(page.locator('body')).toContainText('mail');
+  });
+});

--- a/e2e/tests/sort-order.spec.ts
+++ b/e2e/tests/sort-order.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect } from '@playwright/test';
+import { getIdToken, apiCall, apiDelete, uniqueName } from '../helpers/api';
+
+test.describe.serial('Sort Order Verification', () => {
+  let idToken: string;
+  const createdDomainIds: string[] = [];
+  const createdAreaIds: string[] = [];
+  const createdTaskIds: string[] = [];
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext({ storageState: '.auth/user.json' });
+    const page = await context.newPage();
+    idToken = await getIdToken(page);
+    await context.close();
+  });
+
+  test.afterAll(async () => {
+    for (const id of createdTaskIds) {
+      try { await apiDelete('tasks', id, idToken); } catch { /* best-effort */ }
+    }
+    for (const id of createdAreaIds) {
+      try { await apiDelete('areas', id, idToken); } catch { /* best-effort */ }
+    }
+    for (const id of createdDomainIds) {
+      try { await apiCall('domains', 'PUT', [{ id, closed: 1 }], idToken); } catch { /* best-effort */ }
+    }
+  });
+
+  test('DOM-05: closed domains sort after open domains in DomainEdit', async ({ page }) => {
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+    const openDom1 = uniqueName('OpenA');
+    const openDom2 = uniqueName('OpenB');
+    const closedDom = uniqueName('Closed');
+
+    // Create 2 open domains and 1 closed domain
+    const r1 = await apiCall('domains', 'POST', {
+      creator_fk: sub, domain_name: openDom1, closed: 0,
+    }, idToken) as Array<{ id: string }>;
+    if (!r1?.length) throw new Error('Failed to create open domain 1');
+    createdDomainIds.push(r1[0].id);
+
+    const r2 = await apiCall('domains', 'POST', {
+      creator_fk: sub, domain_name: openDom2, closed: 0,
+    }, idToken) as Array<{ id: string }>;
+    if (!r2?.length) throw new Error('Failed to create open domain 2');
+    createdDomainIds.push(r2[0].id);
+
+    const r3 = await apiCall('domains', 'POST', {
+      creator_fk: sub, domain_name: closedDom, closed: 1,
+    }, idToken) as Array<{ id: string }>;
+    if (!r3?.length) throw new Error('Failed to create closed domain');
+    createdDomainIds.push(r3[0].id);
+
+    // Navigate to DomainEdit
+    await page.goto('/domainedit');
+    await page.waitForSelector('table', { timeout: 10000 });
+
+    // Read all domain names in order from the table
+    const allNameFields = page.locator('input[name="domain-name"]');
+    const count = await allNameFields.count();
+    const domainNames: string[] = [];
+    for (let i = 0; i < count; i++) {
+      domainNames.push(await allNameFields.nth(i).inputValue());
+    }
+
+    // Find the positions of our test domains
+    const closedIdx = domainNames.indexOf(closedDom);
+    const open1Idx = domainNames.indexOf(openDom1);
+    const open2Idx = domainNames.indexOf(openDom2);
+
+    // Closed domain should appear after both open domains
+    expect(closedIdx).toBeGreaterThan(-1);
+    expect(open1Idx).toBeGreaterThan(-1);
+    expect(open2Idx).toBeGreaterThan(-1);
+    expect(closedIdx).toBeGreaterThan(open1Idx);
+    expect(closedIdx).toBeGreaterThan(open2Idx);
+  });
+
+  test('AREA-07: areas render in sort_order sequence in TaskPlanView', async ({ page }) => {
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+    const domainName = uniqueName('SortDom');
+
+    // Create domain
+    const domResult = await apiCall('domains', 'POST', {
+      creator_fk: sub, domain_name: domainName, closed: 0,
+    }, idToken) as Array<{ id: string }>;
+    if (!domResult?.length) throw new Error('Failed to create domain');
+    const domainId = domResult[0].id;
+    createdDomainIds.push(domainId);
+
+    // Create 3 areas with non-sequential sort_order: 2, 0, 1
+    const areaNames = ['SortTwo', 'SortZero', 'SortOne'];
+    const sortOrders = [2, 0, 1];
+    for (let i = 0; i < 3; i++) {
+      const r = await apiCall('areas', 'POST', {
+        creator_fk: sub, area_name: areaNames[i], domain_fk: domainId,
+        closed: 0, sort_order: sortOrders[i],
+      }, idToken) as Array<{ id: string }>;
+      if (r?.length) createdAreaIds.push(r[0].id);
+    }
+
+    // Navigate to TaskPlanView and select the domain
+    await page.goto('/taskcards');
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.getByRole('tab', { name: domainName }).click();
+    await page.waitForTimeout(1500);
+
+    // Read area card names in order from the visible panel
+    const panel = page.locator('[role="tabpanel"]:visible').first();
+    const areaCards = panel.locator('[data-testid^="area-card-"]:not([data-testid="area-card-template"])');
+    const cardCount = await areaCards.count();
+
+    const renderedNames: string[] = [];
+    for (let i = 0; i < cardCount; i++) {
+      const nameField = areaCards.nth(i).locator('[name="area-name"]');
+      renderedNames.push(await nameField.inputValue());
+    }
+
+    // Expected order by sort_order ascending: SortZero(0), SortOne(1), SortTwo(2)
+    expect(renderedNames).toEqual(['SortZero', 'SortOne', 'SortTwo']);
+  });
+
+  test('TASK-09: priority tasks render first within area card', async ({ page }) => {
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+    const domainName = uniqueName('PriDom');
+    const areaName = uniqueName('PriArea');
+
+    // Create domain and area
+    const domResult = await apiCall('domains', 'POST', {
+      creator_fk: sub, domain_name: domainName, closed: 0,
+    }, idToken) as Array<{ id: string }>;
+    if (!domResult?.length) throw new Error('Failed to create domain');
+    const domainId = domResult[0].id;
+    createdDomainIds.push(domainId);
+
+    const areaResult = await apiCall('areas', 'POST', {
+      creator_fk: sub, area_name: areaName, domain_fk: domainId,
+      closed: 0, sort_order: 0,
+    }, idToken) as Array<{ id: string }>;
+    if (!areaResult?.length) throw new Error('Failed to create area');
+    const areaId = areaResult[0].id;
+    createdAreaIds.push(areaId);
+
+    // Create 3 tasks: non-priority, priority, non-priority
+    const taskDescs = [uniqueName('NoPri1'), uniqueName('HasPri'), uniqueName('NoPri2')];
+    const priorities = [0, 1, 0];
+    for (let i = 0; i < 3; i++) {
+      const r = await apiCall('tasks', 'POST', {
+        creator_fk: sub, description: taskDescs[i], area_fk: areaId,
+        priority: priorities[i], done: 0,
+      }, idToken) as Array<{ id: string }>;
+      if (r?.length) createdTaskIds.push(r[0].id);
+    }
+
+    // Navigate to TaskPlanView and select the domain
+    await page.goto('/taskcards');
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.getByRole('tab', { name: domainName }).click();
+    await page.waitForTimeout(1500);
+
+    // Find the area card
+    const panel = page.locator('[role="tabpanel"]:visible').first();
+    const areaCard = panel.getByTestId(`area-card-${areaId}`);
+    await expect(areaCard).toBeVisible({ timeout: 5000 });
+
+    // Read task descriptions in order (excluding the template row)
+    const taskRows = areaCard.locator('[data-testid^="task-"]:not([data-testid="task-template"])');
+    const taskCount = await taskRows.count();
+    const renderedDescs: string[] = [];
+    for (let i = 0; i < taskCount; i++) {
+      const desc = taskRows.nth(i).locator('textarea[name="description"], input[name="description"]').first();
+      renderedDescs.push(await desc.inputValue());
+    }
+
+    // The priority task (taskDescs[1]) should be first
+    expect(renderedDescs[0]).toBe(taskDescs[1]);
+  });
+});


### PR DESCRIPTION
## Summary
- Added 8 new Playwright E2E tests across 4 spec files (27 → 35 total)
- Sort order verification: DOM-05 (closed domains sort last), AREA-07 (areas render in sort_order), TASK-09 (priority tasks first)
- Profile coverage: PROF-01 (drawer opens with user data), PROF-02 (direct /profile route)
- Error pages: ERR-02 (404 page renders for invalid routes)
- Cancel drag: DND-01 (cancel area reorder, no PUT fired), DND-02 (cancel task drag, no PUT fired)

## Files changed
- `e2e/tests/sort-order.spec.ts` — 3 tests for domain, area, task sort order
- `e2e/tests/profile.spec.ts` — 2 tests for profile drawer and page route
- `e2e/tests/error-p1.spec.ts` — 1 test for 404 error page
- `e2e/tests/cancel-drag.spec.ts` — 2 tests for cancel DnD with API interception

## Testing
- Local E2E: 35/35 passing (2 pre-existing flaky AREA tests passed on retry)
- All 8 new tests pass consistently

## Deploy notes
- No deployment needed — test-only addition
- No production code was modified

## References
- Roadmap item #3: Evaluate test coverage
- Related: Lambda-Rest PR #3 (API tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)