### PR TITLE
Remove blockApostrophe — server-side queries handle special chars

### DIFF
--- a/src/AreaEdit/AreaEditTabPanel.jsx
+++ b/src/AreaEdit/AreaEditTabPanel.jsx
@@ -131,7 +131,7 @@ const AreaEditTabPanel = ( { domain, domainIndex, activeTab } ) => {
 
     const { fieldChange: changeAreaName, fieldKeyDown: keyDownAreaName, fieldOnBlur: blurAreaName } = useCrudCallbacks({
         items: areasArray, setItems: setAreasArray, fieldName: 'area_name',
-        saveFn: (_event, index, id) => restUpdateAreaName(index, id), blockApostrophe: false
+        saveFn: (_event, index, id) => restUpdateAreaName(index, id)
     });
 
     const restSaveNewArea = (areaIndex) => {

--- a/src/DomainEdit/DomainEdit.jsx
+++ b/src/DomainEdit/DomainEdit.jsx
@@ -129,7 +129,7 @@ const DomainEdit = ( { domain, domainIndex } ) => {
 
     const { fieldChange: changeDomainName, fieldKeyDown: keyDownDomainName, fieldOnBlur: blurDomainName } = useCrudCallbacks({
         items: domainsArray, setItems: setDomainsArray, fieldName: 'domain_name',
-        saveFn: (_event, index, id) => restUpdateDomainName(index, id), blockApostrophe: false
+        saveFn: (_event, index, id) => restUpdateDomainName(index, id)
     });
 
     const restSaveDomainName = (domainIndex) => {

--- a/src/hooks/useCrudCallbacks.jsx
+++ b/src/hooks/useCrudCallbacks.jsx
@@ -1,4 +1,4 @@
-export function useCrudCallbacks({ items, setItems, fieldName, saveFn, blockApostrophe = true }) {
+export function useCrudCallbacks({ items, setItems, fieldName, saveFn }) {
 
     const fieldChange = (event, index) => {
         let newItems = [...items];
@@ -9,9 +9,6 @@ export function useCrudCallbacks({ items, setItems, fieldName, saveFn, blockApos
     const fieldKeyDown = (event, index, id) => {
         if (event.key === 'Enter') {
             saveFn(event, index, id);
-            event.preventDefault();
-        }
-        if (blockApostrophe && event.key === "'") {
             event.preventDefault();
         }
     };


### PR DESCRIPTION
## Summary
- Remove `blockApostrophe` parameter from `useCrudCallbacks` hook — no longer needed since server-side parameterized queries handle special characters safely
- Remove `blockApostrophe: false` props from AreaEditTabPanel and DomainEdit call sites
- Users can now type apostrophes, quotes, and other special characters in task descriptions, area names, and domain names

## Files changed
- `src/hooks/useCrudCallbacks.jsx` — Removed `blockApostrophe` parameter and `event.key === "'"` blocking logic
- `src/AreaEdit/AreaEditTabPanel.jsx` — Removed `blockApostrophe: false` prop
- `src/DomainEdit/DomainEdit.jsx` — Removed `blockApostrophe: false` prop

## Testing
- Production E2E: 35/35 passing against darwin.one
- Special characters verified working end-to-end via Lambda unit tests

## Deploy notes
- Already deployed to S3/CloudFront (www.darwin.one)
- Related PRs: Lambda-Rest (parameterized queries), Lambda-Cognito (parameterized INSERTs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)