### PR TITLE
Fix JSON double-encoding: remove double-parse workarounds

### DIFF
--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -24,18 +24,9 @@ export async function apiCall(
   });
 
   const text = await res.text();
-  // Lambda double-encodes JSON responses. The response format is typically:
-  //   POST: '["[{\"id\": 168, ...}]"]'  (array containing a JSON string)
-  //   GET:  '"[{\"id\": 168, ...}]"'     (string containing JSON)
-  // The frontend handles this via JSON.parse(array) which coerces array.toString().
-  // We replicate that approach: parse once, then if the result has a .length,
-  // parse it again (matching the front-end's call_rest_api behavior).
+  // Lambda responses are single-encoded JSON.
   try {
-    let data = JSON.parse(text);
-    if (data?.length > 0) {
-      try { data = JSON.parse(data); } catch { /* already final form */ }
-    }
-    return data;
+    return JSON.parse(text);
   } catch {
     return text;
   }

--- a/src/RestApi/RestApi.jsx
+++ b/src/RestApi/RestApi.jsx
@@ -41,8 +41,11 @@ const call_rest_api = async (url, method, body, idToken) => {
         // 204 is a No Content response and independent of what is returned from api lambda
         // gives an error retrieving the json data. So skip it!
         try {
-            const jsonData = await response.json();
-            var data = (jsonData.length > 0) ? JSON.parse(jsonData) : '';
+            var data = await response.json();
+            // Defensive: handle transition period (cached old frontend + new Lambda)
+            if (typeof data === 'string' && data.length > 0) {
+                try { data = JSON.parse(data); } catch (e) { /* plain string, keep as-is */ }
+            }
         } catch (error) {
             varDump(error, 'Error retrieving response.json')
         }


### PR DESCRIPTION
## Summary
- Remove second `JSON.parse()` workaround in `RestApi.jsx` — Lambda responses are now properly single-encoded
- Add defensive parsing for transition safety (handles cached old frontend talking to new Lambda)
- Remove double-parse workaround in E2E test helper `api.ts`

## Files changed
- `src/RestApi/RestApi.jsx` — remove double-parse, add defensive transition parsing
- `e2e/helpers/api.ts` — remove double-parse workaround in test API helper

## Testing
- Darwin E2E (production): 35/35 passing
- All test categories green: auth, domain CRUD, area CRUD, task CRUD, calendar, DnD, sort order, profile, error handling, navigation

## Deploy notes
- Deployed to S3 `www.darwin.one` + CloudFront invalidation
- Coordinated with Lambda-Rest PR (BillWilliams79/AWS-Lambda-REST-API) and Lambda-JWT deploy

## References
- Roadmap item #5: Fix JSON double-encoding across the stack
- Related: Lambda-Rest PR (server-side encoding fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)