### PR TITLE
Add task counts to domain editor

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const baseURL = process.env.BASE_URL || 'https://localhost:3000';
+
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
@@ -8,7 +10,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: [['html', { open: 'never' }]],
   use: {
-    baseURL: 'https://localhost:3000',
+    baseURL,
     ignoreHTTPSErrors: true,
     trace: 'on-first-retry',
   },

--- a/e2e/tests/domain-counts.spec.ts
+++ b/e2e/tests/domain-counts.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { getIdToken, apiCall, apiDelete, uniqueName } from '../helpers/api';
+
+test.describe.serial('Domain Counts', () => {
+  let idToken: string;
+  const sub = process.env.E2E_TEST_COGNITO_SUB!;
+
+  // Track IDs for cleanup (reverse dependency order)
+  const createdTaskIds: string[] = [];
+  const createdAreaIds: string[] = [];
+  const createdDomainIds: string[] = [];
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext({ storageState: '.auth/user.json' });
+    const page = await context.newPage();
+    idToken = await getIdToken(page);
+    await context.close();
+  });
+
+  test.afterAll(async () => {
+    // Cleanup in reverse dependency order: tasks → areas → domains
+    for (const id of createdTaskIds) {
+      try { await apiDelete('tasks', id, idToken); } catch { /* best-effort */ }
+    }
+    for (const id of createdAreaIds) {
+      try { await apiDelete('areas', id, idToken); } catch { /* best-effort */ }
+    }
+    for (const id of createdDomainIds) {
+      try { await apiDelete('domains', id, idToken); } catch { /* best-effort */ }
+    }
+  });
+
+  test('DOM-06: verify Areas and Tasks column headers', async ({ page }) => {
+    await page.goto('/domainedit');
+    await page.waitForSelector('table', { timeout: 10000 });
+
+    // "Areas" and "Tasks" headers should exist
+    const headers = page.locator('thead th');
+    await expect(headers.filter({ hasText: 'Areas' })).toBeVisible();
+    await expect(headers.filter({ hasText: 'Tasks' })).toBeVisible();
+
+    // "Area Count" should NOT exist
+    await expect(headers.filter({ hasText: 'Area Count' })).toHaveCount(0);
+  });
+
+  test('DOM-07: verify area and task counts are accurate', async ({ page }) => {
+    // Create a test domain via API
+    const domainName = uniqueName('Counts');
+    const domainResult = await apiCall('domains', 'POST', {
+      creator_fk: sub, domain_name: domainName, closed: 0,
+    }, idToken) as Array<{ id: string }>;
+
+    const domainId = domainResult[0].id;
+    createdDomainIds.push(domainId);
+
+    // Navigate and verify 0/0 counts
+    await page.goto('/domainedit');
+    await page.waitForSelector('table', { timeout: 10000 });
+
+    const areaCount = page.getByTestId(`area-count-${domainId}`);
+    const taskCount = page.getByTestId(`task-count-${domainId}`);
+
+    await expect(areaCount).toHaveText('0');
+    await expect(taskCount).toHaveText('0');
+
+    // Create 2 areas via API
+    const area1Result = await apiCall('areas', 'POST', {
+      creator_fk: sub, area_name: uniqueName('Area1'), domain_fk: domainId, closed: 0,
+    }, idToken) as Array<{ id: string }>;
+    const area1Id = area1Result[0].id;
+    createdAreaIds.push(area1Id);
+
+    const area2Result = await apiCall('areas', 'POST', {
+      creator_fk: sub, area_name: uniqueName('Area2'), domain_fk: domainId, closed: 0,
+    }, idToken) as Array<{ id: string }>;
+    const area2Id = area2Result[0].id;
+    createdAreaIds.push(area2Id);
+
+    // Create 3 tasks in area1, 2 tasks in area2 (5 total)
+    for (let i = 0; i < 3; i++) {
+      const result = await apiCall('tasks', 'POST', {
+        creator_fk: sub, description: uniqueName(`T1-${i}`), area_fk: area1Id,
+        done: 0, priority: 0,
+      }, idToken) as Array<{ id: string }>;
+      createdTaskIds.push(result[0].id);
+    }
+    for (let i = 0; i < 2; i++) {
+      const result = await apiCall('tasks', 'POST', {
+        creator_fk: sub, description: uniqueName(`T2-${i}`), area_fk: area2Id,
+        done: 0, priority: 0,
+      }, idToken) as Array<{ id: string }>;
+      createdTaskIds.push(result[0].id);
+    }
+
+    // Reload and verify updated counts
+    await page.reload();
+    await page.waitForSelector('table', { timeout: 10000 });
+
+    await expect(areaCount).toHaveText('2');
+    await expect(taskCount).toHaveText('5');
+  });
+});


### PR DESCRIPTION
## Summary
- Add "Tasks" column to the domain editor table showing total task count per domain
- Rename "Area Count" header to "Areas" and center-align both count columns
- Fix pre-existing bug: DomainDeleteDialog expects `tasksCount` but was receiving `areasCount` — task count in delete confirmation was always undefined
- Fetch area list and task counts in parallel via `Promise.all` for better performance
- Add `BASE_URL` env var support to Playwright config (enables testing on non-standard ports and production)
- Add 2 new E2E tests verifying column headers and count accuracy

## Files changed
- `src/DomainEdit/DomainEdit.jsx` — taskCounts state, parallel API fetch (areas + task counts), renamed/added columns, centered alignment, data-testid attrs, fixed delete dialog prop, updated POST handler
- `e2e/tests/domain-counts.spec.ts` — DOM-06 (verify headers), DOM-07 (create domain → 0/0 → create 2 areas + 5 tasks → reload → verify 2/5)
- `e2e/playwright.config.ts` — `BASE_URL` env var override (was hardcoded to localhost:3000)

## Testing
- Local E2E: 37 passing, 1 skipped (AREA-03)
- AUTH-01 excluded from local run (Cognito redirect configured for port 3000, worktree tested on 3001)

## Deploy notes
- Darwin only (frontend change, no Lambda changes)
- No database changes

## References
- Roadmap item #1: Add task counts to domain editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)