### PR TITLE
MUI alternates for sort selector and triple dots

### DIFF
--- a/src/Components/AreaDeleteDialog/AreaDeleteDialog.jsx
+++ b/src/Components/AreaDeleteDialog/AreaDeleteDialog.jsx
@@ -1,0 +1,59 @@
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Button from '@mui/material/Button';
+
+
+const AreaDeleteDialog = ({ deleteDialogOpen, setDeleteDialogOpen, areaDeleteInfo, setAreaDeleteInfo, setDeleteConfirmed }) => {
+
+    const { areaName, taskCount } = areaDeleteInfo;
+
+    const truncatedName = areaName && areaName.length > 20
+        ? areaName.substring(0, 20) + '...'
+        : areaName;
+
+    const dialogCleanUp = () => {
+        setDeleteDialogOpen(false);
+        setAreaDeleteInfo({});
+    };
+
+    const confirmDelete = () => {
+        setDeleteConfirmed(true);
+        setDeleteDialogOpen(false);
+    };
+
+    const actionText = taskCount === 0
+        ? `Delete "${truncatedName}"? This area has no tasks.`
+        : `Delete "${truncatedName}" and its ${taskCount} task${taskCount === 1 ? '' : 's'}?`;
+
+    return (
+        <Dialog open={deleteDialogOpen}
+                onClose={dialogCleanUp}
+                data-testid="area-delete-dialog" >
+
+            <DialogTitle>
+                {"Delete Area"}
+            </DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    {actionText}
+                </DialogContentText>
+                <DialogContentText sx={{ mt: 2 }}>
+                    This cannot be undone.
+                </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={confirmDelete} variant="outlined" color="error">
+                    Delete
+                </Button>
+                <Button onClick={dialogCleanUp} variant="outlined" autoFocus>
+                    Cancel
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+export default AreaDeleteDialog

--- a/src/TaskPlanView/AreaTabPanel.jsx
+++ b/src/TaskPlanView/AreaTabPanel.jsx
@@ -11,6 +11,7 @@ import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { useDragTabStore } from '../stores/useDragTabStore';
 
 import CardCloseDialog from '../Components/CardClose/CardCloseDialog';
+import AreaDeleteDialog from '../Components/AreaDeleteDialog/AreaDeleteDialog';
 
 import { useDrop } from 'react-dnd';
 import AuthContext from '../Context/AuthContext'
@@ -48,6 +49,24 @@ const AreaTabPanel = ( { domain, domainIndex, activeTab } ) => {
                     }
                 }).catch(error => {
                     showError(error, `Unable to close ${areaName}`)
+                });
+        }
+    });
+
+    const areaDelete = useConfirmDialog({
+        onConfirm: ({ areaId, areaName }) => {
+            let uri = `${darwinUri}/areas`;
+            call_rest_api(uri, 'DELETE', { 'id': areaId }, idToken)
+                .then(result => {
+                    if (result.httpStatus.httpStatus === 200) {
+                        let newAreasArray = [...areasArray];
+                        newAreasArray = newAreasArray.filter(area => area.id !== areaId);
+                        setAreasArray(newAreasArray);
+                    } else {
+                        showError(result, `Unable to delete ${areaName}`);
+                    }
+                }).catch(error => {
+                    showError(error, `Unable to delete ${areaName}`);
                 });
         }
     });
@@ -153,6 +172,12 @@ const AreaTabPanel = ( { domain, domainIndex, activeTab } ) => {
     const clickCardClosed = (event, areaName, areaId) => {
         if (areaId !== '') {
             areaClose.openDialog({ areaName, areaId });
+        }
+    }
+
+    const clickCardDelete = (event, areaName, areaId, taskCount) => {
+        if (areaId !== '') {
+            areaDelete.openDialog({ areaName, areaId, taskCount });
         }
     }
 
@@ -423,6 +448,7 @@ const AreaTabPanel = ( { domain, domainIndex, activeTab } ) => {
                                            areaKeyDown,
                                            areaOnBlur,
                                            clickCardClosed,
+                                           clickCardDelete,
                                            moveCard,
                                            persistAreaOrder,
                                            removeArea,
@@ -435,6 +461,12 @@ const AreaTabPanel = ( { domain, domainIndex, activeTab } ) => {
                                  areaCloseId={areaClose.infoObject}
                                  setAreaCloseId={areaClose.setInfoObject}
                                  setAreaCloseConfirmed={areaClose.setConfirmed}
+                />
+                <AreaDeleteDialog deleteDialogOpen={areaDelete.dialogOpen}
+                                  setDeleteDialogOpen={areaDelete.setDialogOpen}
+                                  areaDeleteInfo={areaDelete.infoObject}
+                                  setAreaDeleteInfo={areaDelete.setInfoObject}
+                                  setDeleteConfirmed={areaDelete.setConfirmed}
                 />
             </Box>
     )

--- a/src/TaskPlanView/TaskCard.jsx
+++ b/src/TaskPlanView/TaskCard.jsx
@@ -30,14 +30,14 @@ import CloseIcon from '@mui/icons-material/Close';
 import FlagIcon from '@mui/icons-material/Flag';
 import SwapVertIcon from '@mui/icons-material/SwapVert';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
-import ArchiveIcon from '@mui/icons-material/Archive';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import Tooltip from '@mui/material/Tooltip';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import { CircularProgress } from '@mui/material';
 
 
-const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlur, clickCardClosed, moveCard, persistAreaOrder, removeArea, isTemplate }) => {
+const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlur, clickCardClosed, clickCardDelete, moveCard, persistAreaOrder, removeArea, isTemplate }) => {
 
     const revertDragTabSwitch = useDragTabStore(s => s.revertDragTabSwitch);
 
@@ -590,24 +590,25 @@ const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlu
                                     onClick={(event) => { handleMenuClose(); clickCardClosed(event, area.area_name, area.id); }}
                                     data-testid={`menu-close-area-${area.id}`}
                                 >
-                                    <ListItemIcon><ArchiveIcon fontSize="small" /></ListItemIcon>
+                                    <ListItemIcon><CloseIcon fontSize="small" /></ListItemIcon>
                                     <ListItemText>Close Area</ListItemText>
                                 </MenuItem>
                                 <Divider />
                                 <MenuItem
-                                    onClick={(event) => { handleMenuClose(); clickCardClosed(event, area.area_name, area.id); }}
+                                    onClick={(event) => {
+                                        handleMenuClose();
+                                        const taskCount = tasksArray ? tasksArray.filter(t => t.id !== '').length : 0;
+                                        clickCardDelete(event, area.area_name, area.id, taskCount);
+                                    }}
                                     data-testid={`menu-delete-area-${area.id}`}
                                     sx={{ color: 'error.main' }}
                                 >
-                                    <ListItemIcon><CloseIcon fontSize="small" sx={{ color: 'error.main' }} /></ListItemIcon>
+                                    <ListItemIcon><DeleteForeverIcon fontSize="small" sx={{ color: 'error.main' }} /></ListItemIcon>
                                     <ListItemText>Delete Area</ListItemText>
                                 </MenuItem>
                             </Menu>
                         </>
                     )}
-                    <IconButton onClick={(event) => clickCardClosed(event, area.area_name, area.id)} data-testid={`close-area-${area.id}`} >
-                        <CloseIcon />
-                    </IconButton>
                 </Box>
                 { (tasksArray) ?
                     <TaskActionsContext.Provider value={{ priorityClick, doneClick, descriptionChange,

--- a/tests/tests/area.spec.ts
+++ b/tests/tests/area.spec.ts
@@ -82,7 +82,7 @@ test.describe.serial('Area Management', () => {
     if (created) createdAreaIds.push(created.id);
   });
 
-  test('AREA-02: close area card', async ({ page }) => {
+  test('AREA-02: close area via card menu', async ({ page }) => {
     const areaName = uniqueName('CloseArea');
 
     // Create area via API
@@ -102,8 +102,13 @@ test.describe.serial('Area Management', () => {
     const areaCard = panel.locator('[data-testid^="area-card-"]').filter({ hasText: areaName });
     await expect(areaCard).toBeVisible({ timeout: 5000 });
 
-    // Click the close (X) icon on the area card header
-    await areaCard.locator('[data-testid^="close-area-"]').click();
+    // Open the triple-dot card menu
+    await areaCard.locator(`[data-testid^="card-menu-"]`).click();
+
+    // Click "Close Area" menu item
+    const closeMenuItem = page.locator(`[data-testid^="menu-close-area-"]`);
+    await expect(closeMenuItem).toBeVisible();
+    await closeMenuItem.click();
 
     // Confirm in CardCloseDialog
     const closeDialog = page.getByTestId('card-close-dialog');


### PR DESCRIPTION
## Summary
- Remove standalone X close button from area card header — close is now handled via the triple-dot card menu
- Wire "Delete Area" menu item to actual hard delete (REST API `DELETE /areas`, MySQL cascade deletes child tasks)
- Add `AreaDeleteDialog` component with truncated area name, task count, and separate "This cannot be undone" warning
- Update menu icons: Close Area → CloseIcon (X), Delete Area → DeleteForeverIcon (trash with X)
- Add `areaDelete` useConfirmDialog handler in AreaTabPanel
- Update AREA-02 E2E test to use card menu flow (old X button removed)
- Add AREA-07 E2E test: delete area with tasks via card menu (verifies dialog content + cascade delete)
- Add AREA-08 E2E test: delete empty area via card menu (verifies "has no tasks" message variant)

## Files changed
- `src/TaskPlanView/TaskCard.jsx` — Remove X button, add `clickCardDelete` prop, wire delete menu item with task count, swap icons (ArchiveIcon→CloseIcon, CloseIcon→DeleteForeverIcon)
- `src/TaskPlanView/AreaTabPanel.jsx` — Add `areaDelete` useConfirmDialog with DELETE call, `clickCardDelete` callback, pass prop to TaskCard, render AreaDeleteDialog
- `src/Components/AreaDeleteDialog/AreaDeleteDialog.jsx` — New dialog: truncated name, task count, split "cannot be undone" to separate line, red Delete button
- `tests/tests/area.spec.ts` — Update AREA-02 to use card menu instead of removed X button
- `tests/tests/area-p1.spec.ts` — Add AREA-07 (delete with tasks) and AREA-08 (delete empty area)

## Testing
- Local E2E: 38/49 passing (4 pre-existing DomainEdit failures, 1 skipped DnD, 6 cascading skips)
- All new/modified tests pass: AREA-02, AREA-07, AREA-08

## Deploy notes
- Darwin only (frontend change, no Lambda changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)