### PR TITLE
Fix: Priority sort doesn't trigger render

### DIFF
--- a/src/TaskPlanView/TaskCard.jsx
+++ b/src/TaskPlanView/TaskCard.jsx
@@ -59,6 +59,15 @@ const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlu
     const changeSortMode = (event, newMode) => {
         if (newMode === null) return; // MUI ToggleButtonGroup sends null when clicking already-selected
         setSortMode(newMode);
+
+        // Re-sort tasks immediately using newMode (not stale sortMode from closure)
+        if (tasksArray) {
+            const sortFn = newMode === 'hand' ? taskHandSort : taskPrioritySort;
+            const sorted = [...tasksArray];
+            sorted.sort((a, b) => sortFn(a, b));
+            setTasksArray(sorted);
+        }
+
         if (area.id !== '') {
             call_rest_api(`${darwinUri}/areas`, 'PUT', [{ id: area.id, sort_mode: newMode }], idToken)
                 .catch(error => showError(error, 'Unable to save sort preference'));
@@ -502,14 +511,6 @@ const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlu
         return sortMode === 'hand' ? taskHandSort(taskA, taskB) : taskPrioritySort(taskA, taskB);
     }
 
-    // Re-sort when sort mode changes
-    useEffect(() => {
-        if (!tasksArray) return;
-        const newTasksArray = [...tasksArray];
-        newTasksArray.sort((a, b) => activeSort(a, b));
-        setTasksArray(newTasksArray);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [sortMode]);
 
     return (
         <Card key={areaIndex} raised={true} ref={mergedRef}


### PR DESCRIPTION
## Summary
- Fixed hand-to-priority sort mode toggle not re-rendering tasks in TaskCard
- Moved task re-sort logic from `useEffect` (stale closure issue) into `changeSortMode` event handler, using `newMode` directly instead of relying on `sortMode` from closure
- Removed the now-unnecessary `useEffect` that watched `[sortMode]`
- Added TASK-14 E2E test: verifies hand→priority toggle re-sorts tasks (priority task jumps to first position)

## Files changed
- `src/TaskPlanView/TaskCard.jsx` — moved sort logic into `changeSortMode`, removed stale `useEffect`
- `tests/tests/sort-order.spec.ts` — added TASK-14 test for hand-to-priority toggle

## Testing
- Local E2E: TASK-14 passing (hand-tested by user + automated test)
- Existing TASK-12 (priority→hand) still passes

## Deploy notes
- Darwin only — no backend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)