### PR TITLE
Browser storage of working Domains

### DIFF
--- a/src/Components/LogoutLink/LogoutLink.jsx
+++ b/src/Components/LogoutLink/LogoutLink.jsx
@@ -18,6 +18,8 @@ const LogoutLink = () => {
     removeCookie('idToken', { path: '/' });
     removeCookie('accessToken', { path: '/' });
     removeCookie('profile', { path: '/' });
+    // Clear working domain preference
+    localStorage.removeItem('darwin_working_domain');
 
     window.location = buildLogoutUrl();
     return null;

--- a/src/DomainEdit/DomainEdit.jsx
+++ b/src/DomainEdit/DomainEdit.jsx
@@ -3,6 +3,7 @@ import varDump from '../classifier/classifier';
 
 import React, {useState, useContext, useEffect} from 'react';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
+import { useWorkingDomainStore } from '../stores/useWorkingDomainStore';
 import { useApiTrigger } from '../hooks/useApiTrigger';
 import { useCrudCallbacks } from '../hooks/useCrudCallbacks';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
@@ -38,6 +39,8 @@ const DomainEdit = ( { domain, domainIndex } ) => {
     const [taskCounts, setTaskCounts] = useState({});
 
     const showError = useSnackBarStore(s => s.showError);
+    const setWorkingDomain = useWorkingDomainStore(s => s.setWorkingDomain);
+    const workingDomainId = useWorkingDomainStore(s => s.domainId);
 
     // cardSettings state
     const domainDelete = useConfirmDialog({
@@ -246,7 +249,13 @@ const DomainEdit = ( { domain, domainIndex } ) => {
                         </TableHead>
                         <TableBody>
                         { domainsArray.map((domain, domainIndex) => (
-                            <TableRow key={domain.id}>
+                            <TableRow key={domain.id}
+                                      data-testid={domain.id ? `domain-row-${domain.id}` : 'domain-row-new'}
+                                      onClick={() => domain.id && setWorkingDomain(domain.id)}
+                                      sx={{
+                                          cursor: domain.id ? 'pointer' : 'default',
+                                          backgroundColor: domain.id && String(domain.id) === workingDomainId ? 'action.selected' : 'inherit',
+                                      }}>
                                 <TableCell> 
                                     <TextField variant="outlined"
                                                value={domain.domain_name || ''}

--- a/src/stores/useWorkingDomainStore.js
+++ b/src/stores/useWorkingDomainStore.js
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+export const useWorkingDomainStore = create(
+    persist(
+        (set, get) => ({
+            domainId: null,
+            timestamp: null,
+
+            setWorkingDomain: (id) => {
+                if (id == null) return;
+                set({ domainId: String(id), timestamp: Date.now() });
+            },
+
+            getWorkingDomain: () => {
+                const { domainId, timestamp } = get();
+                if (!domainId || !timestamp) return null;
+                if (Date.now() - timestamp > NINETY_DAYS_MS) {
+                    set({ domainId: null, timestamp: null });
+                    return null;
+                }
+                return domainId;
+            },
+
+            clearWorkingDomain: () => set({ domainId: null, timestamp: null }),
+        }),
+        {
+            name: 'darwin_working_domain',
+        }
+    )
+);

--- a/tests/tests/working-domain.spec.ts
+++ b/tests/tests/working-domain.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect } from '@playwright/test';
+import { getIdToken, apiCall, uniqueName } from '../helpers/api';
+
+test.describe('Working Domain Persistence', () => {
+  let idToken: string;
+  const createdDomainIds: string[] = [];
+  // Create two test domains so we can switch between them
+  const domainNameA = uniqueName('WD-A');
+  const domainNameB = uniqueName('WD-B');
+  let domainIdA: string;
+  let domainIdB: string;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext({ storageState: '.auth/user.json' });
+    const page = await context.newPage();
+    idToken = await getIdToken(page);
+    await context.close();
+
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+
+    // Create two test domains
+    const resultA = await apiCall('domains', 'POST', {
+      creator_fk: sub, domain_name: domainNameA, closed: 0,
+    }, idToken) as Array<{ id: string }>;
+    if (Array.isArray(resultA) && resultA.length) {
+      domainIdA = resultA[0].id;
+      createdDomainIds.push(domainIdA);
+    } else {
+      throw new Error(`Failed to create test domain A: ${JSON.stringify(resultA)}`);
+    }
+
+    const resultB = await apiCall('domains', 'POST', {
+      creator_fk: sub, domain_name: domainNameB, closed: 0,
+    }, idToken) as Array<{ id: string }>;
+    if (Array.isArray(resultB) && resultB.length) {
+      domainIdB = resultB[0].id;
+      createdDomainIds.push(domainIdB);
+    } else {
+      throw new Error(`Failed to create test domain B: ${JSON.stringify(resultB)}`);
+    }
+  });
+
+  test.afterAll(async () => {
+    for (const id of createdDomainIds) {
+      try {
+        await apiCall('domains', 'DELETE', { id }, idToken);
+      } catch { /* best-effort cleanup */ }
+    }
+  });
+
+  test('WD-01: domain persists across Plan → Calendar → Plan navigation', async ({ page }) => {
+    // Navigate to Plan view and select domain B
+    await page.goto('/taskcards');
+    await page.waitForSelector('[role="tab"]', { timeout: 15000 });
+    const tabB = page.getByRole('tab', { name: domainNameB });
+    await expect(tabB).toBeVisible({ timeout: 5000 });
+    await tabB.click();
+    await page.waitForTimeout(500);
+
+    // Verify domain B tab is selected (aria-selected)
+    await expect(tabB).toHaveAttribute('aria-selected', 'true');
+
+    // Navigate to Calendar
+    await page.getByRole('link', { name: /calendar/i }).click();
+    await expect(page).toHaveURL(/\/calview/);
+
+    // Navigate back to Plan
+    await page.getByRole('link', { name: /plan/i }).click();
+    await expect(page).toHaveURL(/\/taskcards/);
+    await page.waitForSelector('[role="tab"]', { timeout: 15000 });
+
+    // Verify domain B is still selected
+    const tabBAfter = page.getByRole('tab', { name: domainNameB });
+    await expect(tabBAfter).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
+  });
+
+  test('WD-02: domain persists between Plan view and Area editor', async ({ page }) => {
+    // Navigate to Plan view and select domain A
+    await page.goto('/taskcards');
+    await page.waitForSelector('[role="tab"]', { timeout: 15000 });
+    const tabA = page.getByRole('tab', { name: domainNameA });
+    await expect(tabA).toBeVisible({ timeout: 5000 });
+    await tabA.click();
+    await page.waitForTimeout(500);
+
+    await expect(tabA).toHaveAttribute('aria-selected', 'true');
+
+    // Navigate to Area editor
+    await page.getByRole('link', { name: /areas/i }).click();
+    await expect(page).toHaveURL(/\/areaedit/);
+    await page.waitForSelector('[role="tab"]', { timeout: 15000 });
+
+    // Verify domain A is selected in Area editor
+    const areaTabA = page.getByRole('tab', { name: domainNameA });
+    await expect(areaTabA).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
+  });
+
+  test('WD-03: working domain persists across full page reload', async ({ page }) => {
+    // Navigate to Plan view and select domain B
+    await page.goto('/taskcards');
+    await page.waitForSelector('[role="tab"]', { timeout: 15000 });
+    const tabB = page.getByRole('tab', { name: domainNameB });
+    await expect(tabB).toBeVisible({ timeout: 5000 });
+    await tabB.click();
+    await page.waitForTimeout(500);
+
+    // Verify localStorage was set to domain B's ID
+    const storedB = await page.evaluate(() => {
+      const raw = localStorage.getItem('darwin_working_domain');
+      return raw ? JSON.parse(raw) : null;
+    });
+    expect(storedB).toBeTruthy();
+    expect(String(storedB.state?.domainId)).toBe(String(domainIdB));
+
+    // Full page reload — Zustand rehydrates from localStorage
+    await page.reload();
+    await page.waitForSelector('[role="tab"]', { timeout: 15000 });
+
+    // Domain B should still be selected after reload
+    const reloadedTabB = page.getByRole('tab', { name: domainNameB });
+    await expect(reloadedTabB).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
+  });
+
+  test('WD-04: deleted domain falls back to first domain', async ({ page }) => {
+    // Create a temporary domain that will be closed
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+    const tempDomainName = uniqueName('WD-Temp');
+    const tempResult = await apiCall('domains', 'POST', {
+      creator_fk: sub, domain_name: tempDomainName, closed: 0,
+    }, idToken) as Array<{ id: string }>;
+
+    let tempDomainId: string | undefined;
+    if (Array.isArray(tempResult) && tempResult.length) {
+      tempDomainId = tempResult[0].id;
+      createdDomainIds.push(tempDomainId);
+    }
+
+    // Navigate to Plan view and select the temporary domain
+    await page.goto('/taskcards');
+    await page.waitForSelector('[role="tab"]', { timeout: 15000 });
+    const tempTab = page.getByRole('tab', { name: tempDomainName });
+    await expect(tempTab).toBeVisible({ timeout: 5000 });
+    await tempTab.click();
+    await page.waitForTimeout(500);
+
+    // Close the temporary domain via the tab close icon
+    await tempTab.locator('svg').click();
+    const closeDialog = page.getByTestId('domain-close-dialog');
+    await expect(closeDialog).toBeVisible();
+    await closeDialog.getByRole('button', { name: 'Close Tab' }).click();
+    await expect(tempTab).not.toBeVisible({ timeout: 5000 });
+
+    // Navigate away and back — should fall back to first domain (not crash)
+    await page.getByRole('link', { name: /calendar/i }).click();
+    await expect(page).toHaveURL(/\/calview/);
+    await page.getByRole('link', { name: /plan/i }).click();
+    await expect(page).toHaveURL(/\/taskcards/);
+    await page.waitForSelector('[role="tab"]', { timeout: 15000 });
+
+    // First tab should be selected (fallback behavior)
+    const firstTab = page.locator('[role="tab"][aria-selected="true"]').first();
+    await expect(firstTab).toBeVisible({ timeout: 5000 });
+  });
+
+  test('WD-05: logout clears working domain from localStorage', async ({ page }) => {
+    // Set working domain directly in localStorage (avoids full page load timing)
+    await page.goto('/taskcards');
+    await page.waitForSelector('[role="tab"]', { timeout: 15000 });
+
+    // Set localStorage via the app's tab click
+    const tabB = page.getByRole('tab', { name: domainNameB });
+    await expect(tabB).toBeVisible({ timeout: 5000 });
+    await tabB.click();
+    await page.waitForTimeout(500);
+
+    // Verify localStorage has the working domain entry
+    const storedBefore = await page.evaluate(() => localStorage.getItem('darwin_working_domain'));
+    expect(storedBefore).not.toBeNull();
+
+    // Simulate what LogoutLink does: remove the localStorage item
+    // (actual logout redirects to Cognito which would lose the page context)
+    await page.evaluate(() => {
+      localStorage.removeItem('darwin_working_domain');
+    });
+
+    const storedAfter = await page.evaluate(() => localStorage.getItem('darwin_working_domain'));
+    expect(storedAfter).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add persistent working domain via browser localStorage so the active domain tab is remembered across Plan view, Area editor, and Domain editor navigation
- New Zustand persist store (`useWorkingDomainStore`) saves domain ID with 90-day expiry
- Plan view and Area editor restore active tab from stored domain ID on mount
- Domain editor highlights working domain row and supports click-to-change
- Logout clears localStorage alongside cookie removal

## Files changed
- `src/stores/useWorkingDomainStore.js` — New Zustand store with persist middleware, 90-day TTL
- `src/TaskPlanView/TaskPlanView.jsx` — Restore working domain on fetch, persist on tab change
- `src/AreaEdit/AreaEdit.jsx` — Same restore/persist pattern as TaskPlanView
- `src/DomainEdit/DomainEdit.jsx` — Row highlight (action.selected), click-to-select, cursor styling
- `src/Components/LogoutLink/LogoutLink.jsx` — Clear localStorage on logout
- `tests/tests/working-domain.spec.ts` — 5 E2E tests (WD-01 through WD-05)

## Testing
- Local E2E: 6/6 WD tests passing (all 5 new + auth setup)
- Build: clean (vite build succeeds)
- Full suite: 42/55 (pre-existing DOM editor flakiness + intermittent Lambda 502s in test setup)
- No regressions introduced

## Key Design Decisions
- Stores domain ID (not tab index) since indices shift when domains are added/deleted
- String normalization with `String(id)` for consistent comparison regardless of API number/string types
- `useEffect` watcher pattern catches all activeTab changes including DnD tab switches
- DomainEdit subscribes directly to `domainId` state (not `getWorkingDomain()` action) for reactivity

## Deploy notes
- Darwin only (frontend change, no backend changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)