### PR TITLE
Rescale size of task drag preview, larger blueline

### DIFF
--- a/src/Components/TaskEdit/TaskDragLayer.jsx
+++ b/src/Components/TaskEdit/TaskDragLayer.jsx
@@ -32,13 +32,14 @@ const TaskDragLayer = () => {
         return null;
     }
 
-    const transform = `translate(${currentOffset.x}px, ${currentOffset.y}px)`;
+    const transform = `translate(${currentOffset.x}px, ${currentOffset.y}px) scale(0.67)`;
 
     return (
         <div style={layerStyles}>
             <Box className="task" sx={{
                 transform,
                 WebkitTransform: transform,
+                transformOrigin: 'top left',
                 width: item?.sourceWidth || 300,
                 opacity: 0.75,
                 background: '#fff',

--- a/src/Components/TaskEdit/TaskEdit.jsx
+++ b/src/Components/TaskEdit/TaskEdit.jsx
@@ -130,8 +130,8 @@ const TaskEdit = ({ supportDrag, task, taskIndex, areaId, areaName }) => {
                     opacity: 0,
                 }),
                  ...(isDragging && sortMode !== 'hand' && { opacity: 0.2 }),
-                 ...(insertIndicator === 'above' && { borderTop: '2px solid', borderTopColor: 'primary.main' }),
-                 ...(insertIndicator === 'below' && { borderBottom: '2px solid', borderBottomColor: 'primary.main' }),
+                 ...(insertIndicator === 'above' && { borderTop: '4px solid', borderTopColor: 'primary.main' }),
+                 ...(insertIndicator === 'below' && { borderBottom: '4px solid', borderBottomColor: 'primary.main' }),
              }}
         >
             <Checkbox


### PR DESCRIPTION
## Summary
- Scale down drag preview to 67% size (`scale(0.67)`) — reduces visual clutter during hand-sort DnD
- Thicken blue insertion line from 2px to 4px — improves drop target visibility
- Both changes are visual-only, no logic or DOM structure changes

## Files changed
- `src/Components/TaskEdit/TaskDragLayer.jsx` — added `scale(0.67)` to transform + `transformOrigin: 'top left'`
- `src/Components/TaskEdit/TaskEdit.jsx` — changed `borderTop`/`borderBottom` from `2px solid` to `4px solid`

## Testing
- Local E2E: 39/50 passing (4 pre-existing domain table failures, 1 skipped AUTH-01, 1 flaky ERR-01)
- No new test failures — changes are visual-only

## Deploy notes
- Darwin only (no backend changes)

## References
- Roadmap item #2: Rescale drag preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)