### PR TITLE
Domain three dot menu

### DIFF
--- a/src/TaskPlanView/TaskCard.jsx
+++ b/src/TaskPlanView/TaskCard.jsx
@@ -19,8 +19,7 @@ import { useDrop, useDrag } from "react-dnd";
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import IconButton from '@mui/material/IconButton';
-import ToggleButton from '@mui/material/ToggleButton';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Check from '@mui/icons-material/Check';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -541,34 +540,6 @@ const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlu
                                 key={`area-${area.id}`}
                      />
                     {area.id !== '' && (
-                        <ToggleButtonGroup
-                            value={sortMode}
-                            exclusive
-                            onChange={changeSortMode}
-                            size="small"
-                            sx={{ height: 30 }}
-                        >
-                            <ToggleButton
-                                value="priority"
-                                data-testid={`sort-priority-${area.id}`}
-                                aria-label="Sort by priority"
-                            >
-                                <Tooltip title="Sort by priority" arrow>
-                                    <FlagIcon fontSize="small" />
-                                </Tooltip>
-                            </ToggleButton>
-                            <ToggleButton
-                                value="hand"
-                                data-testid={`sort-hand-${area.id}`}
-                                aria-label="Sort by hand"
-                            >
-                                <Tooltip title="Sort by hand" arrow>
-                                    <SwapVertIcon fontSize="small" />
-                                </Tooltip>
-                            </ToggleButton>
-                        </ToggleButtonGroup>
-                    )}
-                    {area.id !== '' && (
                         <>
                             <Tooltip title="Card options" arrow>
                                 <IconButton
@@ -587,6 +558,23 @@ const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlu
                                 anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                                 transformOrigin={{ vertical: 'top', horizontal: 'right' }}
                             >
+                                <MenuItem
+                                    onClick={(event) => { handleMenuClose(); changeSortMode(event, 'priority'); }}
+                                    data-testid={`sort-priority-${area.id}`}
+                                >
+                                    <ListItemIcon><FlagIcon fontSize="small" /></ListItemIcon>
+                                    <ListItemText>Sort by Priority</ListItemText>
+                                    {sortMode === 'priority' && <Check fontSize="small" sx={{ ml: 1 }} />}
+                                </MenuItem>
+                                <MenuItem
+                                    onClick={(event) => { handleMenuClose(); changeSortMode(event, 'hand'); }}
+                                    data-testid={`sort-hand-${area.id}`}
+                                >
+                                    <ListItemIcon><SwapVertIcon fontSize="small" /></ListItemIcon>
+                                    <ListItemText>Sort by Hand</ListItemText>
+                                    {sortMode === 'hand' && <Check fontSize="small" sx={{ ml: 1 }} />}
+                                </MenuItem>
+                                <Divider />
                                 <MenuItem
                                     onClick={(event) => { handleMenuClose(); clickCardClosed(event, area.area_name, area.id); }}
                                     data-testid={`menu-close-area-${area.id}`}

--- a/tests/helpers/api.ts
+++ b/tests/helpers/api.ts
@@ -45,3 +45,9 @@ export async function apiDelete(table: string, id: number | string, idToken: str
 export function uniqueName(prefix: string): string {
   return `e2e-${Date.now()}-${prefix}`;
 }
+
+/** Click a sort mode option via the card's three-dot menu. */
+export async function clickSortMode(page: Page, areaId: string, mode: 'priority' | 'hand'): Promise<void> {
+  await page.getByTestId(`card-menu-${areaId}`).click();
+  await page.getByTestId(`sort-${mode}-${areaId}`).click();
+}

--- a/tests/tests/sort-order.spec.ts
+++ b/tests/tests/sort-order.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { getIdToken, apiCall, apiDelete, uniqueName } from '../helpers/api';
+import { getIdToken, apiCall, apiDelete, uniqueName, clickSortMode } from '../helpers/api';
 
 test.describe.serial('Sort Order Verification', () => {
   let idToken: string;
@@ -289,8 +289,8 @@ test.describe.serial('Sort Order Verification', () => {
     const priorityDescs = await getDescs();
     expect(priorityDescs[0]).toBe(priTask);
 
-    // Switch to hand-sort mode
-    await page.getByTestId(`sort-hand-${areaId}`).click();
+    // Switch to hand-sort mode via card menu
+    await clickSortMode(page, areaId, 'hand');
     await page.waitForTimeout(500);
 
     // In hand-sort mode: sort_order=0 (noPriTask) should be first
@@ -432,8 +432,8 @@ test.describe.serial('Sort Order Verification', () => {
     const handDescs = await getDescs();
     expect(handDescs).toEqual([noPri1, noPri2, priTask]);
 
-    // Switch to priority mode
-    await page.getByTestId(`sort-priority-${areaId}`).click();
+    // Switch to priority mode via card menu
+    await clickSortMode(page, areaId, 'priority');
     await page.waitForTimeout(500);
 
     // In priority mode: priority task should jump to first position

--- a/tests/tests/task-dnd.spec.ts
+++ b/tests/tests/task-dnd.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { getIdToken, apiCall, apiDelete, uniqueName } from '../helpers/api';
+import { getIdToken, apiCall, apiDelete, uniqueName, clickSortMode } from '../helpers/api';
 import { dragAndDrop } from '../helpers/react-dnd-drag';
 
 test.describe.serial('Task DnD — Hand Sort & Cross Card', () => {
@@ -182,7 +182,7 @@ test.describe.serial('Task DnD — Hand Sort & Cross Card', () => {
     await resetSortOrder();
     await goToTestDomain(page);
 
-    await page.getByTestId(`sort-hand-${area1Id}`).click();
+    await clickSortMode(page, area1Id, 'hand');
     await page.waitForTimeout(500);
 
     let order = await getTaskDescriptions(page, area1Id);
@@ -210,7 +210,7 @@ test.describe.serial('Task DnD — Hand Sort & Cross Card', () => {
     await resetSortOrder();
     await goToTestDomain(page);
 
-    await page.getByTestId(`sort-hand-${area1Id}`).click();
+    await clickSortMode(page, area1Id, 'hand');
     await page.waitForTimeout(500);
 
     const source = page.getByTestId(`task-${task2Id}`);
@@ -239,8 +239,8 @@ test.describe.serial('Task DnD — Hand Sort & Cross Card', () => {
 
     await goToTestDomain(page);
 
-    await page.getByTestId(`sort-priority-${area1Id}`).click();
-    await page.getByTestId(`sort-priority-${area2Id}`).click();
+    await clickSortMode(page, area1Id, 'priority');
+    await clickSortMode(page, area2Id, 'priority');
     await page.waitForTimeout(500);
 
     const area1Before = await getTaskCount(page, area1Id);
@@ -278,8 +278,8 @@ test.describe.serial('Task DnD — Hand Sort & Cross Card', () => {
 
     await goToTestDomain(page);
 
-    await page.getByTestId(`sort-priority-${area1Id}`).click();
-    await page.getByTestId(`sort-hand-${area2Id}`).click();
+    await clickSortMode(page, area1Id, 'priority');
+    await clickSortMode(page, area2Id, 'hand');
     await page.waitForTimeout(500);
 
     const area2Before = await getTaskCount(page, area2Id);


### PR DESCRIPTION
## Summary
- Moved sort mode toggles (priority/hand) from standalone ToggleButtonGroup into the area card's three-dot menu
- Menu now has 4 items: Sort by Priority (with checkmark), Sort by Hand (with checkmark), Close Area, Delete Area
- Reduces visual clutter from 3 controls (two toggle buttons + menu icon) to 1 control (menu icon only)
- Active sort mode shown with a checkmark icon next to the selected option

## Files changed
- `src/TaskPlanView/TaskCard.jsx` — Removed ToggleButtonGroup, added sort menu items with Check icon, replaced ToggleButton/ToggleButtonGroup imports with Check import
- `tests/helpers/api.ts` — Added `clickSortMode()` helper to open card menu and select sort option
- `tests/tests/sort-order.spec.ts` — Updated TASK-12 and TASK-14 to use clickSortMode helper
- `tests/tests/task-dnd.spec.ts` — Updated DND-03 through DND-06 to use clickSortMode helper

## Testing
- Local E2E: 37/50 passing (5 pre-existing failures: AUTH-01 port redirect, 4 DOM-* DomainEdit timing)
- All sort-mode and DnD tests pass after test updates

## Deploy notes
- Darwin frontend only — no backend changes

## References
- Roadmap item #7: Domain three-dot menu
- Builds on PR#38 (card menu) and PR#40 (sort toggle fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)