### PR TITLE
E2E test gaps for Completed Tasks Calendar (CalendarFC)

### DIFF
--- a/tests/tests/calendar.spec.ts
+++ b/tests/tests/calendar.spec.ts
@@ -103,4 +103,221 @@ test.describe('Calendar View P1', () => {
     await dialog.getByRole('button', { name: 'Close Dialog' }).click();
     await expect(dialog).not.toBeVisible({ timeout: 3000 });
   });
+
+  test('CAL-03: delete task via calendar dialog', async ({ page }) => {
+    const taskDesc = uniqueName('CalDel');
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const doneTs = today.toISOString().slice(0, 19);
+
+    const result = await apiCall('tasks', 'POST', {
+      creator_fk: sub, description: taskDesc, area_fk: testAreaId, priority: 0, done: 1, done_ts: doneTs,
+    }, idToken) as Array<{ id: string }>;
+    if (!result?.length) throw new Error('Failed to create task');
+    const taskId = result[0].id;
+    createdTaskIds.push(taskId);
+
+    await page.goto('/calview');
+    await page.waitForTimeout(3000);
+
+    const event = page.locator('.fc-event').filter({ hasText: taskDesc });
+    await expect(event).toBeVisible({ timeout: 10000 });
+
+    // Click event to open TaskEditDialog
+    await event.click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Click delete icon (IconButton inside the task row within dialog)
+    const taskRow = dialog.getByTestId(`task-${taskId}`);
+    await taskRow.getByRole('button').click();
+
+    // TaskDeleteDialog appears
+    const deleteDialog = page.getByTestId('task-delete-dialog');
+    await expect(deleteDialog).toBeVisible({ timeout: 3000 });
+    await deleteDialog.getByRole('button', { name: 'Delete' }).click();
+
+    // Wait for deletion to process
+    await page.waitForTimeout(2000);
+
+    // Task should be gone from calendar
+    await expect(event).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('CAL-04: drag task reschedules to different day (API verification)', async ({ page }) => {
+    // FullCalendar DnD is unreliable in Playwright (issue #48).
+    // This test verifies the PUT done_ts → calendar update pipeline that eventDrop triggers.
+    const taskDesc = uniqueName('CalDrag');
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const doneTs = today.toISOString().slice(0, 19);
+    const todayStr = today.toISOString().slice(0, 10);
+
+    const result = await apiCall('tasks', 'POST', {
+      creator_fk: sub, description: taskDesc, area_fk: testAreaId, priority: 0, done: 1, done_ts: doneTs,
+    }, idToken) as Array<{ id: string }>;
+    if (!result?.length) throw new Error('Failed to create task');
+    const taskId = result[0].id;
+    createdTaskIds.push(taskId);
+
+    // Verify task appears on today's date
+    await page.goto('/calview');
+    await page.waitForTimeout(3000);
+    const event = page.locator('.fc-event').filter({ hasText: taskDesc });
+    await expect(event).toBeVisible({ timeout: 10000 });
+    await expect(page.locator(`td[data-date="${todayStr}"] .fc-event`).filter({ hasText: taskDesc })).toBeVisible();
+
+    // Simulate eventDrop: PUT done_ts to tomorrow (same API call eventDrop makes)
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(12, 0, 0, 0);
+    const newDoneTs = tomorrow.toISOString().slice(0, 19);
+    const tomorrowStr = tomorrow.toISOString().slice(0, 10);
+    await apiCall('tasks', 'PUT', [{ id: taskId, done_ts: newDoneTs }], idToken);
+
+    // Reload to refetch — task should appear on new date
+    await page.reload();
+    await page.waitForTimeout(3000);
+    await expect(page.locator(`td[data-date="${tomorrowStr}"] .fc-event`).filter({ hasText: taskDesc })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('CAL-05: month/week/day view switching', async ({ page }) => {
+    const taskDesc = uniqueName('CalView');
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const doneTs = today.toISOString().slice(0, 19);
+
+    const result = await apiCall('tasks', 'POST', {
+      creator_fk: sub, description: taskDesc, area_fk: testAreaId, priority: 0, done: 1, done_ts: doneTs,
+    }, idToken) as Array<{ id: string }>;
+    if (!result?.length) throw new Error('Failed to create task');
+    createdTaskIds.push(result[0].id);
+
+    await page.goto('/calview');
+    await page.waitForTimeout(3000);
+
+    // Month view (default) — task visible
+    const event = page.locator('.fc-event').filter({ hasText: taskDesc });
+    await expect(event).toBeVisible({ timeout: 10000 });
+
+    // Switch to week view
+    await page.getByRole('button', { name: 'Week', exact: true }).click();
+    await page.waitForTimeout(2000);
+    await expect(page.locator('.fc-event').filter({ hasText: taskDesc })).toBeVisible({ timeout: 10000 });
+
+    // Switch to day view
+    await page.getByRole('button', { name: 'Day', exact: true }).click();
+    await page.waitForTimeout(2000);
+    await expect(page.locator('.fc-event').filter({ hasText: taskDesc })).toBeVisible({ timeout: 10000 });
+
+    // Switch back to month view
+    await page.getByRole('button', { name: 'Month', exact: true }).click();
+    await page.waitForTimeout(2000);
+    await expect(page.locator('.fc-event').filter({ hasText: taskDesc })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('CAL-06: toggle done via dialog removes task from calendar', async ({ page }) => {
+    const taskDesc = uniqueName('CalDone');
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const doneTs = today.toISOString().slice(0, 19);
+
+    const result = await apiCall('tasks', 'POST', {
+      creator_fk: sub, description: taskDesc, area_fk: testAreaId, priority: 0, done: 1, done_ts: doneTs,
+    }, idToken) as Array<{ id: string }>;
+    if (!result?.length) throw new Error('Failed to create task');
+    createdTaskIds.push(result[0].id);
+
+    await page.goto('/calview');
+    await page.waitForTimeout(3000);
+
+    const event = page.locator('.fc-event').filter({ hasText: taskDesc });
+    await expect(event).toBeVisible({ timeout: 10000 });
+
+    // Click event to open dialog
+    await event.click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Click done checkbox (index 1) to toggle done=0
+    const checkboxes = dialog.getByRole('checkbox');
+    await checkboxes.nth(1).click();
+    await page.waitForTimeout(1000);
+
+    // Close dialog — triggers refetch via taskApiToggle
+    await dialog.getByRole('button', { name: 'Close Dialog' }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 3000 });
+
+    // Wait for refetch (done=0 tasks excluded from calendar query)
+    await page.waitForTimeout(3000);
+
+    // Task should no longer appear on calendar
+    await expect(event).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('CAL-07: empty calendar renders without errors', async ({ page }) => {
+    await page.goto('/calview');
+    await page.waitForTimeout(3000);
+
+    // Calendar container and title should render
+    await expect(page.locator('.fc')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Completed Tasks Calendar')).toBeVisible();
+
+    // Navigate 3 months into the future — guaranteed no done tasks
+    await page.locator('.fc-next-button').click();
+    await page.waitForTimeout(1000);
+    await page.locator('.fc-next-button').click();
+    await page.waitForTimeout(1000);
+    await page.locator('.fc-next-button').click();
+    await page.waitForTimeout(2000);
+
+    // Calendar still renders correctly with no events
+    await expect(page.locator('.fc')).toBeVisible();
+    await expect(page.getByText('Completed Tasks Calendar')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Month', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Week', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Day', exact: true })).toBeVisible();
+    await expect(page.locator('.fc-event')).toHaveCount(0);
+  });
+
+  test('CAL-08: prev/next navigation fetches new data', async ({ page }) => {
+    const taskDesc = uniqueName('CalNav');
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+
+    // Create a done task for the 15th of the previous month
+    const prevMonth = new Date();
+    prevMonth.setMonth(prevMonth.getMonth() - 1);
+    prevMonth.setDate(15);
+    prevMonth.setHours(12, 0, 0, 0);
+    const doneTs = prevMonth.toISOString().slice(0, 19);
+
+    const result = await apiCall('tasks', 'POST', {
+      creator_fk: sub, description: taskDesc, area_fk: testAreaId, priority: 0, done: 1, done_ts: doneTs,
+    }, idToken) as Array<{ id: string }>;
+    if (!result?.length) throw new Error('Failed to create task');
+    createdTaskIds.push(result[0].id);
+
+    // Navigate to calendar (current month)
+    await page.goto('/calview');
+    await page.waitForTimeout(3000);
+
+    // Task should NOT be visible in current month
+    const event = page.locator('.fc-event').filter({ hasText: taskDesc });
+    await expect(event).not.toBeVisible({ timeout: 3000 });
+
+    // Click prev to navigate to previous month
+    await page.locator('.fc-prev-button').click();
+    await page.waitForTimeout(3000);
+
+    // Task should now be visible
+    await expect(event).toBeVisible({ timeout: 10000 });
+  });
 });


### PR DESCRIPTION
## Summary
Closes #48. Adds 6 new E2E tests for CalendarFC features uncovered after PR#44 replaced CalendarView with FullCalendar.

## Files changed
- `tests/tests/calendar.spec.ts` — Added 6 new tests (CAL-03 through CAL-08) within existing describe block

## Tests Added (60 → 66 total)

| Test | Priority | Description |
|------|----------|-------------|
| CAL-03 | Medium | Delete task via calendar edit dialog |
| CAL-04 | Medium | Drag/reschedule task to different day (API verification) |
| CAL-05 | Low | Month/Week/Day view switching |
| CAL-06 | Low | Toggle done via dialog removes task from calendar |
| CAL-07 | Low | Empty calendar renders without errors |
| CAL-08 | Low | Prev/Next navigation fetches new data |

## Testing
- Calendar tests: 9/9 passing (2 existing + 6 new + 1 auth setup)
- Full suite: 66 tests — 44 pass, 6 pre-existing failures, 1 skipped, 15 did not run

## Key Design Decisions
- CAL-04 uses API verification (PUT done_ts + reload) instead of UI drag — FullCalendar DnD unreliable in Playwright
- FullCalendar button selectors require `exact: true` — "Day" matches "Today", "Month" matches "Previous/Next Month"
- CAL-07 navigates 3 months forward to guarantee empty calendar state

## Deploy notes
- Test-only changes — no code deployment needed
- Darwin frontend unchanged

## References
- Issue: #48 (CalendarFC E2E test gaps)
- Related: PR#44 (Calendar enhancements — FullCalendar replacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)