### PR TITLE
Fix flaky domain E2E tests: DOM-03/04/05/06 table timeouts

### DIFF
--- a/tests/helpers/api.ts
+++ b/tests/helpers/api.ts
@@ -46,6 +46,51 @@ export function uniqueName(prefix: string): string {
   return `e2e-${Date.now()}-${prefix}`;
 }
 
+/**
+ * Navigate to DomainEdit and wait for the table to render.
+ * DomainEdit conditionally renders <Table> only after the domains API call succeeds.
+ * With accumulated test domains (1000+), the page can take 10-40s to render all
+ * DnD rows. Use 60s timeout to handle slow renders under load.
+ */
+export async function navigateToDomainEdit(page: Page): Promise<void> {
+  await page.goto('/domainedit');
+  await page.waitForSelector('table', { timeout: 60000 });
+}
+
+/**
+ * Wait for the DomainEdit table to render. Use after page.reload().
+ * See navigateToDomainEdit for timeout rationale.
+ */
+export async function waitForDomainTable(page: Page): Promise<void> {
+  await page.waitForSelector('table', { timeout: 60000 });
+}
+
+/**
+ * Get all domain names from the DomainEdit table in a single browser call.
+ * With 1000+ accumulated test domains, iterating via individual Playwright
+ * inputValue() calls takes minutes. This runs in-browser for O(1) overhead.
+ */
+export async function getAllDomainNames(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const inputs = document.querySelectorAll('input[name="domain-name"]');
+    return Array.from(inputs).map(input => (input as HTMLInputElement).value);
+  });
+}
+
+/**
+ * Find the index of a domain name field in the DomainEdit table.
+ * Returns -1 if not found. Uses in-browser evaluation for speed.
+ */
+export async function findDomainIndex(page: Page, domainName: string): Promise<number> {
+  return page.evaluate((name) => {
+    const inputs = document.querySelectorAll('input[name="domain-name"]');
+    for (let i = 0; i < inputs.length; i++) {
+      if ((inputs[i] as HTMLInputElement).value === name) return i;
+    }
+    return -1;
+  }, domainName);
+}
+
 /** Click a sort mode option via the card's three-dot menu. */
 export async function clickSortMode(page: Page, areaId: string, mode: 'priority' | 'hand'): Promise<void> {
   await page.getByTestId(`card-menu-${areaId}`).click();

--- a/tests/tests/domain-counts.spec.ts
+++ b/tests/tests/domain-counts.spec.ts
@@ -1,7 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { getIdToken, apiCall, apiDelete, uniqueName } from '../helpers/api';
+import { getIdToken, apiCall, apiDelete, uniqueName, navigateToDomainEdit, waitForDomainTable } from '../helpers/api';
 
 test.describe.serial('Domain Counts', () => {
+  // DomainEdit renders 1000+ accumulated test domains with DnD — needs extra time.
+  // DOM-07 does navigate + reload (two full page loads at ~45s each), so 180s.
+  test.setTimeout(180_000);
+
   let idToken: string;
   const sub = process.env.E2E_TEST_COGNITO_SUB!;
 
@@ -31,8 +35,7 @@ test.describe.serial('Domain Counts', () => {
   });
 
   test('DOM-06: verify Areas and Tasks column headers', async ({ page }) => {
-    await page.goto('/domainedit');
-    await page.waitForSelector('table', { timeout: 10000 });
+    await navigateToDomainEdit(page);
 
     // "Areas" and "Tasks" headers should exist
     const headers = page.locator('thead th');
@@ -54,8 +57,7 @@ test.describe.serial('Domain Counts', () => {
     createdDomainIds.push(domainId);
 
     // Navigate and verify 0/0 counts
-    await page.goto('/domainedit');
-    await page.waitForSelector('table', { timeout: 10000 });
+    await navigateToDomainEdit(page);
 
     const areaCount = page.getByTestId(`area-count-${domainId}`);
     const taskCount = page.getByTestId(`task-count-${domainId}`);
@@ -94,7 +96,7 @@ test.describe.serial('Domain Counts', () => {
 
     // Reload and verify updated counts
     await page.reload();
-    await page.waitForSelector('table', { timeout: 10000 });
+    await waitForDomainTable(page);
 
     await expect(areaCount).toHaveText('2');
     await expect(taskCount).toHaveText('5');

--- a/tests/tests/domain-sort-order.spec.ts
+++ b/tests/tests/domain-sort-order.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { getIdToken, apiCall, apiDelete, uniqueName } from '../helpers/api';
+import { getIdToken, apiCall, apiDelete, uniqueName, navigateToDomainEdit, getAllDomainNames } from '../helpers/api';
 
 test.describe.serial('Domain Sort Order', () => {
+  // DomainEdit renders 1000+ accumulated test domains with DnD — needs extra time
+  test.setTimeout(90_000);
+
   let idToken: string;
   const createdDomainIds: string[] = [];
 
@@ -42,15 +45,10 @@ test.describe.serial('Domain Sort Order', () => {
     ], idToken);
 
     // Navigate to DomainEdit and verify order
-    await page.goto('/domainedit');
-    await page.waitForSelector('table', { timeout: 10000 });
+    await navigateToDomainEdit(page);
 
-    const allNameFields = page.locator('input[name="domain-name"]');
-    const count = await allNameFields.count();
-    const domainNames: string[] = [];
-    for (let i = 0; i < count; i++) {
-      domainNames.push(await allNameFields.nth(i).inputValue());
-    }
+    // Read all domain names using in-browser evaluation (fast with 1000+ domains)
+    const domainNames = await getAllDomainNames(page);
 
     // SortC (sort_order=0) should appear before SortB (1) before SortA (2)
     const idxC = domainNames.indexOf(names[2]);
@@ -76,16 +74,10 @@ test.describe.serial('Domain Sort Order', () => {
     createdDomainIds.push(r[0].id);
 
     // Navigate to DomainEdit
-    await page.goto('/domainedit');
-    await page.waitForSelector('table', { timeout: 10000 });
+    await navigateToDomainEdit(page);
 
-    // The new domain should be visible somewhere in the list
-    const allNameFields = page.locator('input[name="domain-name"]');
-    const count = await allNameFields.count();
-    const domainNames: string[] = [];
-    for (let i = 0; i < count; i++) {
-      domainNames.push(await allNameFields.nth(i).inputValue());
-    }
+    // Read all domain names using in-browser evaluation (fast with 1000+ domains)
+    const domainNames = await getAllDomainNames(page);
 
     const idx = domainNames.indexOf(newDomName);
     expect(idx).toBeGreaterThan(-1);
@@ -191,15 +183,10 @@ test.describe.serial('Domain Sort Order', () => {
     }
 
     // Check order in DomainEdit
-    await page.goto('/domainedit');
-    await page.waitForSelector('table', { timeout: 10000 });
+    await navigateToDomainEdit(page);
 
-    const allNameFields = page.locator('input[name="domain-name"]');
-    const fieldCount = await allNameFields.count();
-    const domainEditNames: string[] = [];
-    for (let i = 0; i < fieldCount; i++) {
-      domainEditNames.push(await allNameFields.nth(i).inputValue());
-    }
+    // Read all domain names using in-browser evaluation (fast with 1000+ domains)
+    const domainEditNames = await getAllDomainNames(page);
 
     // Filter to just our test domains
     const editOrder = names.filter(n => domainEditNames.includes(n));


### PR DESCRIPTION
## Summary
- Fix flaky domain E2E tests (DOM-03, DOM-04, DOM-05, DOM-06, DOM-08, DOM-09, DOM-12) that intermittently timed out waiting for DomainEdit table render
- Root cause: 1000+ accumulated test domains with DnD setup causing 10-45s page render times, plus O(n) Playwright field iteration across 1785 domain name inputs
- Added centralized navigation helpers with 60s timeouts, in-browser `page.evaluate()` for O(1) domain lookups, and per-file test timeouts (90-180s)

## Files changed
- `tests/helpers/api.ts` — Added 4 helpers: `navigateToDomainEdit`, `waitForDomainTable`, `getAllDomainNames`, `findDomainIndex`
- `tests/tests/domain-p1.spec.ts` — Replaced inline goto+wait+iteration with helpers, added 180s timeout
- `tests/tests/domain-counts.spec.ts` — Replaced inline goto+wait with helpers, added 180s timeout
- `tests/tests/sort-order.spec.ts` — Replaced inline goto+wait+iteration with helpers, added 90s test timeout on DOM-05
- `tests/tests/domain-sort-order.spec.ts` — Replaced inline goto+wait+iteration with helpers, added 90s timeout

## Testing
- Local E2E: 62/66 passing (2 pre-existing failures: ERR-01 snackbar timing, DND-05 task-undefined)
- All previously flaky domain tests (DOM-03 through DOM-12) now pass consistently
- Merged master (6 new calendar tests) — no regressions

## Deploy notes
- Test-only change — no component code modified, no deploy needed
- Darwin frontend deploy for master merge only

## References
- Closes #50 — Fix flaky domain E2E tests
- Related: accumulated test domains from prior E2E runs (1000+) cause slow DomainEdit renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)