### PR TITLE
Update status line with dev server on/off/port

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
-# Redirect URLs are now derived dynamically from window.location.origin in src/config/auth.js
-# No VITE_*_REDIRECT env vars needed — auth works on any port registered in Cognito
+# Production redirect URLs (must match Cognito app client settings)
+VITE_LOGIN_REDIRECT=https://www.darwin.one/loggedin/
+VITE_LOGOUT_REDIRECT=https://www.darwin.one/

--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -8,6 +8,6 @@ export const AUTH_CONFIG = {
     clientId: '8s82usrcfe58mllbceiavfcd2', // Replace after creating public app client in Cognito Console
     domain: 'darwin2.auth.us-west-1.amazoncognito.com',
     scopes: ['email', 'openid'],
-    redirectSignIn: `${window.location.origin}/loggedin/`,
-    redirectSignOut: `${window.location.origin}/`,
+    redirectSignIn: import.meta.env.VITE_LOGIN_REDIRECT,
+    redirectSignOut: import.meta.env.VITE_LOGOUT_REDIRECT,
 };


### PR DESCRIPTION
## Summary
- **Dev server status line indicator**: Vite plugin writes `.devserver` marker file (`port:pid`) on startup, cleans up on shutdown. Status line script detects marker, validates PID + port, appends `DevServ:{port}`
- **Self-healing stale markers**: if dev server crashes (SIGKILL), next status line poll detects dead PID and auto-deletes marker
- **Cognito multi-port**: registered callback/sign-out URLs for localhost ports 3000-3005 (enables worktree dev servers on different ports)

## Files changed
- `vite.config.js` — added `devserverMarker()` plugin (~25 lines): writes marker on `httpServer.listening`, cleans up on SIGINT/SIGTERM/exit
- `.gitignore` — added `.devserver`
- `~/.claude/settings.json` — status line enhanced with marker detection (dual-path check)
- `CLAUDE.md` — Dev Server Protocol documented in Local Development section

## Reverted
- Dynamic `window.location.origin` auth redirects — caused production auth failures (token exchange stuck on /loggedin). Restored to env var approach. Follow-up needed for multi-port auth.

## Testing
- Production E2E: 64/66 passing (1 pre-existing flaky ERR-01, 1 skipped)
- Manual verification: marker creation, cleanup on SIGTERM, self-healing on SIGKILL

🤖 Generated with [Claude Code](https://claude.com/claude-code)