### PR TITLE
Clean up accumulated test domains in darwin database

### DIFF
--- a/tests/tests/area-p1.spec.ts
+++ b/tests/tests/area-p1.spec.ts
@@ -24,12 +24,8 @@ test.describe.serial('Area Management P1', () => {
   });
 
   test.afterAll(async () => {
-    for (const id of createdAreaIds) {
-      try { await apiDelete('areas', id, idToken); } catch { /* best-effort */ }
-    }
-    try {
-      await apiCall('domains', 'PUT', [{ id: testDomainId, closed: 1 }], idToken);
-    } catch { /* best-effort */ }
+    // Hard-delete the domain (ON DELETE CASCADE handles child areas/tasks)
+    try { await apiDelete('domains', testDomainId, idToken); } catch { /* best-effort */ }
   });
 
   test('AREA-04: update area name', async ({ page }) => {
@@ -369,9 +365,8 @@ test.describe.serial('Area Management P1', () => {
       await page.waitForTimeout(1500);
       await expect(page.getByTestId(`area-card-${areaId}`)).toBeVisible({ timeout: 5000 });
     } finally {
-      // Cleanup: delete area2 and close domain2
-      if (area2Id) try { await apiDelete('areas', area2Id, idToken); } catch {}
-      try { await apiCall('domains', 'PUT', [{ id: domain2Id, closed: 1 }], idToken); } catch {}
+      // Cleanup: hard-delete domain2 (CASCADE handles area2)
+      try { await apiDelete('domains', domain2Id, idToken); } catch {}
     }
   });
 });

--- a/tests/tests/area.spec.ts
+++ b/tests/tests/area.spec.ts
@@ -27,12 +27,8 @@ test.describe.serial('Area Management', () => {
   });
 
   test.afterAll(async () => {
-    for (const id of createdAreaIds) {
-      try { await apiDelete('areas', id, idToken); } catch { /* best-effort */ }
-    }
-    try {
-      await apiCall('domains', 'PUT', [{ id: testDomainId, closed: 1 }], idToken);
-    } catch { /* best-effort */ }
+    // Hard-delete the domain (ON DELETE CASCADE handles child areas/tasks)
+    try { await apiDelete('domains', testDomainId, idToken); } catch { /* best-effort */ }
   });
 
   /** Navigate to TaskPlanView, select the test domain tab, return the visible panel. */

--- a/tests/tests/calendar.spec.ts
+++ b/tests/tests/calendar.spec.ts
@@ -33,11 +33,8 @@ test.describe('Calendar View P1', () => {
   });
 
   test.afterAll(async () => {
-    for (const id of createdTaskIds) {
-      try { await apiDelete('tasks', id, idToken); } catch { /* best-effort */ }
-    }
-    try { await apiDelete('areas', testAreaId, idToken); } catch {}
-    try { await apiCall('domains', 'PUT', [{ id: testDomainId, closed: 1 }], idToken); } catch {}
+    // Hard-delete the domain (ON DELETE CASCADE handles child areas/tasks)
+    try { await apiDelete('domains', testDomainId, idToken); } catch {}
   });
 
   test('CAL-01: done tasks appear in CalendarView', async ({ page }) => {

--- a/tests/tests/cancel-drag.spec.ts
+++ b/tests/tests/cancel-drag.spec.ts
@@ -25,13 +25,8 @@ test.describe.serial('Cancel Drag', () => {
   });
 
   test.afterAll(async () => {
-    for (const id of createdTaskIds) {
-      try { await apiDelete('tasks', id, idToken); } catch { /* best-effort */ }
-    }
-    for (const id of createdAreaIds) {
-      try { await apiDelete('areas', id, idToken); } catch { /* best-effort */ }
-    }
-    try { await apiCall('domains', 'PUT', [{ id: testDomainId, closed: 1 }], idToken); } catch {}
+    // Hard-delete the domain (ON DELETE CASCADE handles child areas/tasks)
+    try { await apiDelete('domains', testDomainId, idToken); } catch {}
   });
 
   test('DND-01: cancel area reorder in AreaEdit fires no PUT', async ({ page }) => {

--- a/tests/tests/domain-sort-order.spec.ts
+++ b/tests/tests/domain-sort-order.spec.ts
@@ -16,8 +16,9 @@ test.describe.serial('Domain Sort Order', () => {
   });
 
   test.afterAll(async () => {
+    // Hard-delete test domains (ON DELETE CASCADE handles child areas/tasks)
     for (const id of createdDomainIds) {
-      try { await apiCall('domains', 'PUT', [{ id, closed: 1 }], idToken); } catch { /* best-effort */ }
+      try { await apiDelete('domains', id, idToken); } catch { /* best-effort */ }
     }
   });
 

--- a/tests/tests/domain.spec.ts
+++ b/tests/tests/domain.spec.ts
@@ -14,10 +14,10 @@ test.describe('Domain Management', () => {
   });
 
   test.afterAll(async () => {
-    // Close all test domains created during tests
+    // Hard-delete test domains (ON DELETE CASCADE handles child areas/tasks)
     for (const id of createdDomainIds) {
       try {
-        await apiCall('domains', 'PUT', [{ id, closed: 1 }], idToken);
+        await apiDelete('domains', id, idToken);
       } catch { /* best-effort cleanup */ }
     }
   });

--- a/tests/tests/sort-order.spec.ts
+++ b/tests/tests/sort-order.spec.ts
@@ -15,14 +15,9 @@ test.describe.serial('Sort Order Verification', () => {
   });
 
   test.afterAll(async () => {
-    for (const id of createdTaskIds) {
-      try { await apiDelete('tasks', id, idToken); } catch { /* best-effort */ }
-    }
-    for (const id of createdAreaIds) {
-      try { await apiDelete('areas', id, idToken); } catch { /* best-effort */ }
-    }
+    // Hard-delete test domains (ON DELETE CASCADE handles child areas/tasks)
     for (const id of createdDomainIds) {
-      try { await apiCall('domains', 'PUT', [{ id, closed: 1 }], idToken); } catch { /* best-effort */ }
+      try { await apiDelete('domains', id, idToken); } catch { /* best-effort */ }
     }
   });
 

--- a/tests/tests/task-dnd.spec.ts
+++ b/tests/tests/task-dnd.spec.ts
@@ -84,13 +84,8 @@ test.describe.serial('Task DnD — Hand Sort & Cross Card', () => {
   });
 
   test.afterAll(async () => {
-    for (const id of [task0Id, task1Id, task2Id, a2TaskId, ...extraTaskIds]) {
-      try { await apiDelete('tasks', id, idToken); } catch { /* best-effort */ }
-    }
-    for (const id of [area1Id, area2Id]) {
-      try { await apiDelete('areas', id, idToken); } catch { /* best-effort */ }
-    }
-    try { await apiCall('domains', 'PUT', [{ id: testDomainId, closed: 1 }], idToken); } catch {}
+    // Hard-delete the domain (ON DELETE CASCADE handles child areas/tasks)
+    try { await apiDelete('domains', testDomainId, idToken); } catch {}
   });
 
   async function goToTestDomain(page: any) {

--- a/tests/tests/task-p1.spec.ts
+++ b/tests/tests/task-p1.spec.ts
@@ -33,11 +33,8 @@ test.describe.serial('Task Management P1', () => {
   });
 
   test.afterAll(async () => {
-    for (const id of createdTaskIds) {
-      try { await apiDelete('tasks', id, idToken); } catch { /* best-effort */ }
-    }
-    try { await apiDelete('areas', testAreaId, idToken); } catch {}
-    try { await apiCall('domains', 'PUT', [{ id: testDomainId, closed: 1 }], idToken); } catch {}
+    // Hard-delete the domain (ON DELETE CASCADE handles child areas/tasks)
+    try { await apiDelete('domains', testDomainId, idToken); } catch {}
   });
 
   /** Navigate to TaskPlanView and select the test domain tab. */

--- a/tests/tests/task.spec.ts
+++ b/tests/tests/task.spec.ts
@@ -42,13 +42,8 @@ test.describe('Task Management', () => {
   });
 
   test.afterAll(async () => {
-    // Clean up: delete tasks → areas → close domain
-    for (const id of createdTaskIds) {
-      try { await apiDelete('tasks', id, idToken); } catch { /* best-effort */ }
-    }
-    try { await apiDelete('areas', testAreaId, idToken); } catch {}
-    try { await apiDelete('areas', testArea2Id, idToken); } catch {}
-    try { await apiCall('domains', 'PUT', [{ id: testDomainId, closed: 1 }], idToken); } catch {}
+    // Hard-delete the domain (ON DELETE CASCADE handles child areas/tasks)
+    try { await apiDelete('domains', testDomainId, idToken); } catch {}
   });
 
   /** Navigate to TaskPlanView and select the test domain tab. */


### PR DESCRIPTION
## Summary

- Updated 10 E2E test files: afterAll blocks changed from soft-close (`PUT closed:1`) to hard-delete (`apiDelete domains`) using ON DELETE CASCADE for automatic child area/task cleanup
- Created one-time cleanup script (`DarwinSQL/scripts/cleanup_production_e2e.py`) with 5 safety guardrails — deleted 2,377 accumulated e2e-* domains from production
- Fixed inline cleanup in area-p1.spec.ts AREA-06 (domain2 soft-close → hard-delete)
- Net -34 lines: simplified multi-step cleanup (delete tasks → delete areas → close domain) to single domain delete

## Files changed

- `tests/tests/domain.spec.ts` — afterAll: soft-close → hard-delete
- `tests/tests/domain-sort-order.spec.ts` — afterAll: soft-close → hard-delete
- `tests/tests/area.spec.ts` — afterAll: simplified to domain delete only
- `tests/tests/area-p1.spec.ts` — afterAll: simplified + AREA-06 inline cleanup fixed
- `tests/tests/task.spec.ts` — afterAll: simplified to domain delete only
- `tests/tests/task-p1.spec.ts` — afterAll: simplified to domain delete only
- `tests/tests/task-dnd.spec.ts` — afterAll: simplified to domain delete only
- `tests/tests/cancel-drag.spec.ts` — afterAll: simplified to domain delete only
- `tests/tests/calendar.spec.ts` — afterAll: simplified to domain delete only
- `tests/tests/sort-order.spec.ts` — afterAll: simplified to domain delete only

## Testing

- Local E2E: 63/66 passing (1 failed DND-05 pre-existing #62, 1 skipped AREA-03, 1 cascading DND-06)
- Post-merge retest: 63/66 passing (same result after merging master)
- Cleanup script verified: dry-run showed 2,377 domains, execute deleted all, Personal domain preserved

## Deploy notes

- Darwin frontend only — no Lambda or backend changes
- The cleanup script in DarwinSQL is for one-time use, not deployed

## References

- Closes #59 — Clean up accumulated E2E test domains
- Related: #62 — DND-05 flaky test (pre-existing, filed during this session)
- Related: PR #54 — DomainEdit timeout workarounds (no longer needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)