### PR TITLE
Dev server testing @ darwin2 table

### DIFF
--- a/src/Context/AppContext.jsx
+++ b/src/Context/AppContext.jsx
@@ -7,7 +7,8 @@ export const AppContextProvider = ({ children }) => {
 
     console.count('AppContext initilialized');
 
-    const [darwinUri, setDarwinUri] = useState('https://k5j0ftr527.execute-api.us-west-1.amazonaws.com/eng/darwin');
+    const database = import.meta.env.VITE_DARWIN_DATABASE || 'darwin';
+    const [darwinUri, setDarwinUri] = useState(`https://k5j0ftr527.execute-api.us-west-1.amazonaws.com/eng/${database}`);
 
     return (
         <AppContext.Provider value={{

--- a/tests/helpers/api.ts
+++ b/tests/helpers/api.ts
@@ -1,6 +1,7 @@
 import { Page } from '@playwright/test';
 
-const DARWIN_API = 'https://k5j0ftr527.execute-api.us-west-1.amazonaws.com/eng/darwin';
+const TEST_DATABASE = process.env.TEST_DATABASE || 'darwin';
+const DARWIN_API = `https://k5j0ftr527.execute-api.us-west-1.amazonaws.com/eng/${TEST_DATABASE}`;
 
 /** Extract the idToken from the browser context cookies. */
 export async function getIdToken(page: Page): Promise<string> {


### PR DESCRIPTION
## Summary
- Add `VITE_DARWIN_DATABASE` env var to AppContext.jsx for database selection (defaults to `darwin`)
- Add `TEST_DATABASE` env var to E2E test helpers for configurable test targeting
- Dev server automatically uses `darwin_dev` via `.env.development.local`

## Files changed
- `src/Context/AppContext.jsx` — env-var-driven database name in URI
- `tests/helpers/api.ts` — TEST_DATABASE env var for E2E API calls

## Testing
- Local backend: 151/151 passing (Lambda-Rest 83, DarwinSQL 50, Lambda-Cognito 18)
- Production E2E: 62/66 passing (2 pre-existing failures in task-dnd and error.spec)

## Deploy notes
- Darwin frontend will be deployed (new AppContext.jsx)
- Production builds use default `darwin` — zero production impact

## References
- Roadmap item #1: Unified darwin_dev test database
- Related PRs: Lambda-Rest #14, DarwinSQL #9, Lambda-Cognito #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)