### PR TITLE
Remove hoverhelp tooltips

### DIFF
--- a/src/Components/TaskEdit/TaskEdit.jsx
+++ b/src/Components/TaskEdit/TaskEdit.jsx
@@ -13,7 +13,6 @@ import TextField from '@mui/material/TextField';
 import Checkbox from '@mui/material/Checkbox';
 
 import IconButton from '@mui/material/IconButton';
-import Tooltip from '@mui/material/Tooltip';
 import DeleteIcon from '@mui/icons-material/Delete';
 import SavingsIcon from '@mui/icons-material/Savings';
 import ReportIcon from '@mui/icons-material/Report';
@@ -135,34 +134,30 @@ const TaskEdit = ({ supportDrag, task, taskIndex, areaId, areaName }) => {
                  ...(insertIndicator === 'below' && { borderBottom: '4px solid', borderBottomColor: 'primary.main' }),
              }}
         >
-            <Tooltip title={task.priority ? "Clear Priority" : "Set Priority"} arrow>
-                <Checkbox
-                    checked = {task.priority ? true : false}
-                    onClick = {() => priorityClick(taskIndex, task.id)}
-                    icon={<ReportGmailerrorredOutlinedIcon />}
-                    checkedIcon={<ReportIcon />}
-                    disabled = {areaId !== '' ? false : areaName === '' ? true : false}
-                    key={`priority-${task.id}`}
-                    sx = {{maxWidth: "25px",
-                           maxHeight: "25px",
-                           mr: "2px",
-                    }}
-                />
-            </Tooltip>
-            <Tooltip title={task.done ? "Mark Open" : "Mark Complete"} arrow>
-                <Checkbox
-                    checked = {task.done ? true : false}
-                    onClick = {() => doneClick(taskIndex, task.id)}
-                    icon={<CheckCircleOutlineIcon />}
-                    checkedIcon={<CheckCircleIcon />}
-                    disabled = {areaId !== '' ? false : areaName === '' ? true : false}
-                    key={`done-${task.id}`}
-                    sx = {{maxWidth: "25px",
-                           maxHeight: "25px",
-                           mr: "2px",
-                    }}
-                />
-            </Tooltip> 
+            <Checkbox
+                checked = {task.priority ? true : false}
+                onClick = {() => priorityClick(taskIndex, task.id)}
+                icon={<ReportGmailerrorredOutlinedIcon />}
+                checkedIcon={<ReportIcon />}
+                disabled = {areaId !== '' ? false : areaName === '' ? true : false}
+                key={`priority-${task.id}`}
+                sx = {{maxWidth: "25px",
+                       maxHeight: "25px",
+                       mr: "2px",
+                }}
+            />
+            <Checkbox
+                checked = {task.done ? true : false}
+                onClick = {() => doneClick(taskIndex, task.id)}
+                icon={<CheckCircleOutlineIcon />}
+                checkedIcon={<CheckCircleIcon />}
+                disabled = {areaId !== '' ? false : areaName === '' ? true : false}
+                key={`done-${task.id}`}
+                sx = {{maxWidth: "25px",
+                       maxHeight: "25px",
+                       mr: "2px",
+                }}
+            />
             <TextField variant="outlined"
                         value={task.description || ''}
                         name='description'
@@ -179,27 +174,23 @@ const TaskEdit = ({ supportDrag, task, taskIndex, areaId, areaName }) => {
                         key={`description-${task.id}`}
              />
             { task.id === '' ?
-                <Tooltip title="New task" arrow>
-                    <IconButton key={`savings-${task.id}`}
-                                disabled = {areaId !== '' ? false : areaName === '' ? true : false}
-                                sx = {{maxWidth: "25px",
-                                       maxHeight: "25px",
-                                }}
-                    >
-                        <SavingsIcon key={`savings1-${task.id}`}/>
-                    </IconButton>
-                </Tooltip>
+                <IconButton key={`savings-${task.id}`}
+                            disabled = {areaId !== '' ? false : areaName === '' ? true : false}
+                            sx = {{maxWidth: "25px",
+                                   maxHeight: "25px",
+                            }}
+                >
+                    <SavingsIcon key={`savings1-${task.id}`}/>
+                </IconButton>
                 :
-                <Tooltip title="Delete task" arrow>
-                    <IconButton  onClick={(event) => deleteClick(event, task.id)}
-                                 key={`delete-${task.id}`}
-                                 sx = {{maxWidth: "25px",
-                                        maxHeight: "25px",
-                                 }}
-                    >
-                        <DeleteIcon key={`delete1-${task.id}`} />
-                    </IconButton>
-                </Tooltip>
+                <IconButton  onClick={(event) => deleteClick(event, task.id)}
+                             key={`delete-${task.id}`}
+                             sx = {{maxWidth: "25px",
+                                    maxHeight: "25px",
+                             }}
+                >
+                    <DeleteIcon key={`delete1-${task.id}`} />
+                </IconButton>
             }
         </Box>
     )

--- a/src/TaskPlanView/TaskCard.jsx
+++ b/src/TaskPlanView/TaskCard.jsx
@@ -30,7 +30,6 @@ import FlagIcon from '@mui/icons-material/Flag';
 import SwapVertIcon from '@mui/icons-material/SwapVert';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
-import Tooltip from '@mui/material/Tooltip';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import { CircularProgress } from '@mui/material';
@@ -522,7 +521,6 @@ const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlu
               }}>
             <CardContent>
                 <Box className="card-header" sx={{marginBottom: 2}}>
-                    <Tooltip title={area.id === '' && !area.area_name ? 'Add new area' : ''} arrow>
                     <TextField  /*variant={area.id === '' ? "outlined" : "standard"}*/
                                 variant="standard"
                                 value={area.area_name || ''}
@@ -540,18 +538,15 @@ const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlu
                                 }}
                                 key={`area-${area.id}`}
                      />
-                    </Tooltip>
                     {area.id !== '' && (
                         <>
-                            <Tooltip title="Card options" arrow>
-                                <IconButton
-                                    onClick={handleMenuOpen}
-                                    data-testid={`card-menu-${area.id}`}
-                                    size="small"
-                                >
-                                    <MoreVertIcon />
-                                </IconButton>
-                            </Tooltip>
+                            <IconButton
+                                onClick={handleMenuOpen}
+                                data-testid={`card-menu-${area.id}`}
+                                size="small"
+                            >
+                                <MoreVertIcon />
+                            </IconButton>
                             <Menu
                                 anchorEl={menuAnchorEl}
                                 open={menuOpen}

--- a/src/TaskPlanView/TaskPlanView.jsx
+++ b/src/TaskPlanView/TaskPlanView.jsx
@@ -18,7 +18,6 @@ import React, { useState, useEffect, useContext, useRef, useCallback } from 'rea
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 
 import Box from '@mui/material/Box';
-import Tooltip from '@mui/material/Tooltip';
 import CloseIcon from '@mui/icons-material/Close';
 import AddIcon from '@mui/icons-material/Add';
 import Tab from '@mui/material/Tab';
@@ -224,13 +223,13 @@ const TaskPlanView = () => {
                                      domainName={domain.domain_name}
                                      setDomainInsertIndex={setDomainInsertIndex}
                                      persistDomainOrder={persistDomainOrder}
-                                     icon={<Tooltip title="Close domain" arrow><CloseIcon onClick={(event) => domainCloseClick(event, domain.domain_name, domain.id, domainIndex)}/></Tooltip>}
+                                     icon={<CloseIcon onClick={(event) => domainCloseClick(event, domain.domain_name, domain.id, domainIndex)}/>}
                                      label={domain.domain_name}
                                      value={domainIndex.toString()}
                                      iconPosition="end" />
                             )}
                             <Tab key={'add-domain'}
-                                 icon={<Tooltip title="Add domain" arrow><AddIcon onClick={addDomain}/></Tooltip>}
+                                 icon={<AddIcon onClick={addDomain}/>}
                                  iconPosition="start"
                                  value={9999} // this value is used in changeActiveTab()
                             />


### PR DESCRIPTION
## Summary
- Removed all 8 MUI Tooltip hover-help wrappers from task and domain icons
- Tooltips obscured nearby UI elements and slowed down interaction
- All icons, click handlers, styling, and layout remain unchanged

## Files changed
- `src/Components/TaskEdit/TaskEdit.jsx` — removed 4 Tooltip wrappers (priority, done, save, delete) + import
- `src/TaskPlanView/TaskCard.jsx` — removed 2 Tooltip wrappers (area name, card options menu) + import
- `src/TaskPlanView/TaskPlanView.jsx` — removed 2 Tooltip wrappers (close domain, add domain) + import

## Testing
- Local E2E: 63/66 passing (2 pre-existing failures: AUTH-01 port mismatch, ERR-01 snackbar timing)
- No E2E tests reference tooltip text or visibility
- Build compiles clean

## Deploy notes
- Darwin only — no backend changes

## References
- Roadmap item #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)