### PR TITLE
Beautify calendar toolbar

### DIFF
--- a/src/CalendarFC/CalendarFC.css
+++ b/src/CalendarFC/CalendarFC.css
@@ -12,3 +12,56 @@
 .fc-event-main {
     overflow: visible !important;
 }
+
+/* Match navbar Roboto font across calendar controls */
+.fc .fc-button,
+.fc .fc-col-header-cell-cushion {
+    font-family: 'Roboto', sans-serif;
+}
+
+/* Tighter button profile */
+.fc .fc-button {
+    padding-top: 0.2em;
+    padding-bottom: 0.2em;
+}
+
+/* Today button — mid-gray between inactive and active */
+.fc .fc-today-button {
+    background-color: #9e9e9e !important;
+    border-color: #8e8e8e !important;
+    color: white !important;
+}
+
+.fc .fc-today-button:disabled {
+    background-color: #bdbdbd !important;
+    border-color: #aaa !important;
+    color: white !important;
+    opacity: 0.8 !important;
+}
+
+
+/* Segmented toggle — active view button (pressed in) */
+.fc .fc-dayGridMonth-button.fc-button-active,
+.fc .fc-dayGridWeek-button.fc-button-active,
+.fc .fc-dayGridDay-button.fc-button-active {
+    background-color: #616161 !important;
+    border-color: #515151 !important;
+    color: white !important;
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.25) !important;
+}
+
+/* Segmented toggle — inactive view buttons (raised) */
+.fc .fc-dayGridMonth-button:not(.fc-button-active),
+.fc .fc-dayGridWeek-button:not(.fc-button-active),
+.fc .fc-dayGridDay-button:not(.fc-button-active) {
+    background-color: #f5f5f5 !important;
+    border-color: #ccc !important;
+    color: #555 !important;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1) !important;
+}
+
+.fc .fc-dayGridMonth-button:not(.fc-button-active):hover,
+.fc .fc-dayGridWeek-button:not(.fc-button-active):hover,
+.fc .fc-dayGridDay-button:not(.fc-button-active):hover {
+    background-color: #e0e0e0 !important;
+}

--- a/src/CalendarFC/CalendarFC.jsx
+++ b/src/CalendarFC/CalendarFC.jsx
@@ -22,6 +22,8 @@ const CalendarFC = () => {
     const calendarRef = useRef(null);
     const dateRangeRef = useRef(null);
 
+    const [calendarTitle, setCalendarTitle] = useState('');
+
     // Task data — full objects, same shape as original calendar
     const [tasksArray, setTasksArray] = useState([]);
     const [taskApiToggle, setTaskApiToggle] = useState(false);
@@ -99,6 +101,9 @@ const CalendarFC = () => {
     const handleDatesSet = useCallback((dateInfo) => {
         dateRangeRef.current = { start: dateInfo.start, end: dateInfo.end };
         fetchTasks(dateInfo.start, dateInfo.end);
+        const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        const d = dateInfo.view.currentStart;
+        setCalendarTitle(`${months[d.getMonth()]} '${String(d.getFullYear()).slice(-2)} Completed Tasks`);
     }, [fetchTasks]);
 
     // Refetch when dialog closes (taskApiToggle changes)
@@ -207,20 +212,29 @@ const CalendarFC = () => {
 
     return (
         <>
-            <Box className="app-title">
-                <Typography variant="h4" sx={{ ml: 2 }}>
-                    Completed Tasks Calendar
+            <Box sx={{ px: 2, pb: 2, pt: '18pt', position: 'relative' }}>
+                <Typography sx={{
+                    position: 'absolute',
+                    left: 0,
+                    right: 0,
+                    top: '18pt',
+                    textAlign: 'center',
+                    lineHeight: '28px',
+                    fontFamily: "'Roboto', sans-serif",
+                    fontSize: '1.3em',
+                    fontWeight: 500,
+                    pointerEvents: 'none',
+                }}>
+                    {calendarTitle}
                 </Typography>
-            </Box>
-            <Box sx={{ p: 2 }}>
                 <FullCalendar
                     ref={calendarRef}
                     plugins={[dayGridPlugin, interactionPlugin]}
                     initialView="dayGridMonth"
                     headerToolbar={{
-                        left: 'prev,next today',
-                        center: 'title',
-                        right: 'dayGridMonth,dayGridWeek,dayGridDay',
+                        left: 'prev,next today dayGridMonth,dayGridWeek,dayGridDay',
+                        center: '',
+                        right: '',
                     }}
                     buttonText={{
                         today: 'Today',


### PR DESCRIPTION
## Summary
- Remove page title and whitespace; replace with compact "Feb '26 Completed Tasks" title rendered via React state (no FullCalendar DOM manipulation)
- Move Month/Week/Day buttons next to Today; style as segmented toggle with pressed/raised states
- Tighter button profile, mid-gray Today button, Roboto font across all calendar controls, 18pt top spacing

Closes #82

## Test plan
- [ ] Navigate to Calendar page — verify title shows "Feb '26 Completed Tasks" centered
- [ ] Click prev/next — title updates with correct month/year
- [ ] Month/Week/Day toggle — active button appears pressed, inactive raised
- [ ] Today button is lighter gray than active toggle but darker than inactive
- [ ] Font matches navbar Roboto across buttons, title, day-of-week headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)