### PR TITLE
Fix focus shadow on calendar nav buttons

### DIFF
--- a/src/CalendarFC/CalendarFC.css
+++ b/src/CalendarFC/CalendarFC.css
@@ -25,6 +25,11 @@
     padding-bottom: 0.2em;
 }
 
+/* Remove focus shadow left behind after mouse click on nav buttons */
+.fc .fc-button:focus {
+    box-shadow: none !important;
+}
+
 /* Today button — mid-gray between inactive and active */
 .fc .fc-today-button {
     background-color: #9e9e9e !important;


### PR DESCRIPTION
## Summary
- Remove persistent `box-shadow` on FullCalendar prev/next buttons after mouse click
- Added `.fc .fc-button:focus { box-shadow: none }` rule in `CalendarFC.css`
- Fixes #84

## Test plan
- [x] Manually verified — no shadow after clicking nav buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)