### PR TITLE
Add inline domain name editing in plan view tabs

### DIFF
--- a/src/TaskPlanView/TaskPlanView.jsx
+++ b/src/TaskPlanView/TaskPlanView.jsx
@@ -53,6 +53,21 @@ const TaskPlanView = () => {
         domainInsertIndexRef.current = index;
     }, []);
 
+    const renameDomain = useCallback((domainId, newName) => {
+        const uri = `${darwinUri}/domains`;
+        call_rest_api(uri, 'PUT', [{ id: domainId, domain_name: newName }], idToken)
+            .then(result => {
+                if (result.httpStatus.httpStatus === 200) {
+                    setDomainsArray(prev => prev.map(d =>
+                        d.id === domainId ? { ...d, domain_name: newName } : d
+                    ));
+                } else {
+                    showError(result, 'Unable to rename domain');
+                }
+            })
+            .catch(error => showError(error, 'Unable to rename domain'));
+    }, [darwinUri, idToken, showError]);
+
     const domainClose = useConfirmDialog({
         onConfirm: ({ domainName, domainId, domainIndex }) => {
             let uri = `${darwinUri}/domains`;
@@ -223,6 +238,7 @@ const TaskPlanView = () => {
                                      domainName={domain.domain_name}
                                      setDomainInsertIndex={setDomainInsertIndex}
                                      persistDomainOrder={persistDomainOrder}
+                                     renameDomain={renameDomain}
                                      icon={<CloseIcon onClick={(event) => domainCloseClick(event, domain.domain_name, domain.id, domainIndex)}/>}
                                      label={domain.domain_name}
                                      value={domainIndex.toString()}


### PR DESCRIPTION
## Summary
- Double-click (desktop) or long-press (mobile) on a domain tab enters inline edit mode
- InputBase replaces tab label with autoFocus, select-all, Enter/Escape/blur handling
- `renameDomain` callback in TaskPlanView PUTs new name and updates local state
- DnD disabled while editing (`canDrag: false`), context menu suppressed on mobile
- `textTransform: inherit` on input keeps text appearance consistent with tab styling

Closes #86

## Test plan
- [x] Manual: double-click rename, Enter save, Escape cancel, blur save
- [x] Manual: single click still switches tabs, DnD still works, close icon still works
- [x] Build compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)