### PR TITLE
Replace profile drawer with dedicated profile page

### DIFF
--- a/src/NavBar/NavBar.jsx
+++ b/src/NavBar/NavBar.jsx
@@ -1,6 +1,5 @@
 import '../index.css';
 import AuthContext from '../Context/AuthContext';
-import ProfileDrawer from './ProfileDrawer';
 
 import React, {useContext} from 'react';
 import { Link } from "react-router-dom"
@@ -19,7 +18,13 @@ const NavBar = () => {
                spacing={1}
                alignItems={{xs: 'center', md: 'flex-start'}}
         >
-          <PedalBikeIcon sx={{ color: '#E91E63' }} />
+          {idToken ? (
+            <Link to="/profile" style={{ display: 'flex' }}>
+              <PedalBikeIcon sx={{ color: '#E91E63' }} />
+            </Link>
+          ) : (
+            <PedalBikeIcon sx={{ color: '#E91E63' }} />
+          )}
           <Link className="nav-title" to="/">
             Darwin
           </Link>
@@ -28,9 +33,6 @@ const NavBar = () => {
                 <Link className="nav-link" to="/calview"> Calendar </Link>
                 <Link className="nav-link" to="/domainedit"> Domains </Link>
                 <Link className="nav-link" to="/areaedit"> Areas </Link>
-                {idToken &&
-                    <ProfileDrawer/>
-                }
               </>
         </Stack>
     </AppBar>

--- a/src/NavBar/Profile.jsx
+++ b/src/NavBar/Profile.jsx
@@ -20,37 +20,42 @@ const Profile = () => {
                 Profile
             </Typography>
         </Box >
-        <Box className="app-content" sx={{ margin: 2}}>
+        <Box className="app-content" sx={{ margin: 2, display: 'flex', flexDirection: 'column', gap: 2, maxWidth: 400 }}>
             <TextField  label="Name"
                         value = { profile.name }
                         id= "Name"
                         key="Name"
                         variant= "outlined"
-                        size = 'small' />
+                        size = 'small'
+                        disabled />
             <TextField  label="E-mail"
                         value = { profile.email }
                         id= "email"
                         key="email"
                         variant= "outlined"
-                        size = 'small' />
+                        size = 'small'
+                        disabled />
             <TextField  label="Region"
                         value = { profile.region }
                         id= "region"
                         key="region"
                         variant= "outlined"
-                        size = 'small' />
+                        size = 'small'
+                        disabled />
             <TextField  label="User Pool ID"
                         value = { profile.userPoolId }
                         id= "userPoolId"
                         key="userPoolId"
                         variant= "outlined"
-                        size = 'small' />
+                        size = 'small'
+                        disabled />
             <TextField  label="Cognito Identifier"
                         value = { profile.userName }
                         id= "userName"
                         key="userName"
                         variant= "outlined"
-                        size = 'small' />
+                        size = 'small'
+                        disabled />
         </Box>
         </>
     )


### PR DESCRIPTION
## Summary
- Remove Profile drawer button from navbar
- Make bicycle (PedalBike) icon a clickable link to `/profile` when logged in
- Profile page fields now display vertically and are read-only (disabled)

Fixes #88

## Test plan
- [ ] Verify bike icon navigates to /profile when logged in
- [ ] Verify bike icon is static (not clickable) when logged out
- [ ] Verify profile fields are read-only and stacked vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)