### PR TITLE
Priorities don't show drag handle off card tho drop does work

### DIFF
--- a/src/SwarmView/PriorityDragLayer.jsx
+++ b/src/SwarmView/PriorityDragLayer.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { useDragLayer } from 'react-dnd';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import IconButton from '@mui/material/IconButton';
+import DeleteIcon from '@mui/icons-material/Delete';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
+import RocketIcon from '@mui/icons-material/Rocket';
+
+const layerStyles = {
+    position: 'fixed',
+    pointerEvents: 'none',
+    zIndex: 1500,
+    left: 0,
+    top: 0,
+    width: '100%',
+    height: '100%',
+};
+
+const PriorityDragLayer = () => {
+    const { itemType, isDragging, item, currentOffset } = useDragLayer((monitor) => ({
+        item: monitor.getItem(),
+        itemType: monitor.getItemType(),
+        currentOffset: monitor.getSourceClientOffset(),
+        isDragging: monitor.isDragging(),
+    }));
+
+    if (!isDragging || !currentOffset || itemType !== 'priorityRow') {
+        return null;
+    }
+
+    const transform = `translate(${currentOffset.x}px, ${currentOffset.y}px) scale(0.67)`;
+
+    return (
+        <div style={layerStyles}>
+            <Box className="task priority-row" sx={{
+                transform,
+                WebkitTransform: transform,
+                transformOrigin: 'top left',
+                width: item?.sourceWidth || 300,
+                opacity: 0.75,
+                background: '#fff',
+                boxShadow: 3,
+                borderRadius: 1,
+            }}>
+                <ToggleButtonGroup
+                    value="idle"
+                    exclusive
+                    size="small"
+                    sx={{ height: 28, '& .MuiToggleButton-root': { px: 0.5, py: 0, minWidth: 28 } }}
+                >
+                    <ToggleButton value="idle" disabled><RocketIcon sx={{ fontSize: 18 }} /></ToggleButton>
+                </ToggleButtonGroup>
+                <TextField
+                    variant="outlined"
+                    value={item?.title || ''}
+                    size="small"
+                    slotProps={{ input: { readOnly: true } }}
+                    sx={{...(item?.closed === 1 && { textDecoration: 'line-through' })}}
+                />
+                <Box sx={{ display: 'flex', justifyContent: 'flex-start', width: 56 }}>
+                    <IconButton sx={{ maxWidth: "25px", maxHeight: "25px" }}>
+                        <OpenInNewIcon />
+                    </IconButton>
+                    <IconButton sx={{ maxWidth: "25px", maxHeight: "25px" }}>
+                        <DeleteIcon />
+                    </IconButton>
+                </Box>
+            </Box>
+        </div>
+    );
+};
+
+export default PriorityDragLayer;

--- a/src/SwarmView/SwarmView.jsx
+++ b/src/SwarmView/SwarmView.jsx
@@ -10,6 +10,7 @@ import { useApiTrigger } from '../hooks/useApiTrigger';
 import ProjectCloseDialog from './ProjectCloseDialog';
 import ProjectAddDialog from './ProjectAddDialog';
 import CategoryTabPanel from './CategoryTabPanel';
+import PriorityDragLayer from './PriorityDragLayer';
 
 import React, { useState, useEffect, useContext } from 'react';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
@@ -192,6 +193,7 @@ const SwarmView = () => {
             :
             <CircularProgress/>
         }
+        <PriorityDragLayer />
         </>
     );
 


### PR DESCRIPTION
## Summary
- Add `PriorityDragLayer` component to render a custom drag preview when dragging priority rows in SwarmView
- PriorityRow was calling `preview(getEmptyImage())` to hide the browser default drag image, but had no companion `useDragLayer` component to render a custom ghost — so nothing appeared during drag
- Follows the same pattern as the existing `TaskDragLayer` used in TaskPlanView

## Files changed
- `src/SwarmView/PriorityDragLayer.jsx` — New component using `useDragLayer` hook to render a scaled preview for `priorityRow` drag type
- `src/SwarmView/SwarmView.jsx` — Import and render `PriorityDragLayer`

## Testing
- Local E2E: 74/81 passing (6 failures are pre-existing, verified against production)
- Vite build: clean, no warnings

## Deploy notes
- Darwin frontend only (S3 + CloudFront)

## References
- Roadmap item #41: Priorities don't show drag handle off card tho drop does work

🤖 Generated with [Claude Code](https://claude.com/claude-code)