### PR TITLE
E2E: AUTH-01 fix full Cognito hosted UI login test

### DIFF
--- a/tests/tests/auth.spec.ts
+++ b/tests/tests/auth.spec.ts
@@ -12,13 +12,19 @@ test.describe('Authentication', () => {
   // AUTH-01: Full browser login flow through Cognito hosted UI.
   // Requires HTTPS (Cognito redirect needs SSL). Works on production and localhost with basicSsl.
   test('AUTH-01: full login via Cognito hosted UI', async ({ page }) => {
+    // Multi-redirect flow through external service needs generous timeout
+    test.setTimeout(60_000);
+
     await page.goto('/');
 
-    // Click login link on home page ("Login / Create Account")
-    await page.getByRole('link', { name: /login/i }).click();
+    // Wait for React app to render before clicking
+    const loginLink = page.getByRole('link', { name: /login/i });
+    await expect(loginLink).toBeVisible({ timeout: 15000 });
+    await loginLink.click();
 
     // Should redirect to Cognito hosted UI
-    await expect(page).toHaveURL(/amazoncognito\.com/, { timeout: 10000 });
+    await expect(page).toHaveURL(/amazoncognito\.com/, { timeout: 15000 });
+    await page.waitForLoadState('domcontentloaded');
 
     // Cognito hosted UI has duplicate form fields (desktop/mobile).
     // The visible ones are the last instances on larger viewports.
@@ -26,15 +32,9 @@ test.describe('Authentication', () => {
     await page.locator('input[name="password"]:visible').fill(process.env.E2E_TEST_PASSWORD!);
     await page.locator('input[name="signInSubmitButton"]:visible').click();
 
-    // Auth code flow: Cognito redirects to /loggedin?code=xxx&state=yyy (PKCE).
-    // LoggedIn component exchanges code for tokens, then redirects.
-    await page.waitForURL('**/loggedin**', { timeout: 15000 });
-
-    // Wait for the redirect away from /loggedin (token exchange + profile fetch)
-    await expect(page).not.toHaveURL(/\/loggedin/, { timeout: 15000 });
-
-    // Verify authenticated state — Logout link visible on homepage
-    await expect(page.getByRole('link', { name: /logout/i })).toBeVisible({ timeout: 10000 });
+    // Auth code flow: Cognito redirects to /loggedin?code=xxx → token exchange → redirect.
+    // Wait for final authenticated state — avoids race if /loggedin redirect is fast.
+    await expect(page.getByRole('link', { name: /logout/i })).toBeVisible({ timeout: 30000 });
 
     // Verify in-session navigation to protected route works (SPA navigation, no reload)
     await page.getByRole('link', { name: /plan/i }).click();


### PR DESCRIPTION
## Summary
- Fix AUTH-01 E2E test (full Cognito hosted UI login) to eliminate intermittent failures
- Add 60s test timeout for multi-redirect flow through external Cognito service
- Wait for login link visibility before clicking, preventing race on app render
- Wait for Cognito page `domcontentloaded` and increase redirect timeout (10s→15s)
- Replace fragile two-step `/loggedin` URL check with single logout link visibility assertion (30s timeout), eliminating the primary race condition where fast token exchange causes `waitForURL` to miss the `/loggedin` URL entirely

## Files changed
- `tests/tests/auth.spec.ts` — AUTH-01 test: timeout, render wait, Cognito DOM wait, race condition fix

## Testing
- Local E2E auth suite: 5/5 passing
- Production E2E auth suite: 5/5 passing
- AUTH-01 verified on both localhost:3000 dev server and production (darwin.one)

## Deploy notes
- Test-only change — no application code modified, no deploy needed

## References
- Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)