### PR TITLE
E2E: CAL-07 remove outdated calendar title assertion

### DIFF
--- a/tests/tests/calendar.spec.ts
+++ b/tests/tests/calendar.spec.ts
@@ -266,7 +266,7 @@ test.describe('Calendar View P1', () => {
 
     // Calendar container and title should render
     await expect(page.locator('.fc')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('Completed Tasks Calendar')).toBeVisible();
+    await expect(page.getByText(/Completed Tasks$/)).toBeVisible();
 
     // Navigate 3 months into the future — guaranteed no done tasks
     await page.locator('.fc-next-button').click();
@@ -278,7 +278,7 @@ test.describe('Calendar View P1', () => {
 
     // Calendar still renders correctly with no events
     await expect(page.locator('.fc')).toBeVisible();
-    await expect(page.getByText('Completed Tasks Calendar')).toBeVisible();
+    await expect(page.getByText(/Completed Tasks$/)).toBeVisible();
     await expect(page.getByRole('button', { name: 'Month', exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Week', exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Day', exact: true })).toBeVisible();


### PR DESCRIPTION
## Summary
- Fix CAL-07 E2E test that always failed because it expected literal string `'Completed Tasks Calendar'`
- CalendarFC renders dynamic titles like `"Feb '26 Completed Tasks"` via `handleDatesSet` — the hardcoded string never appeared
- Replace both assertions (lines 269, 281) with regex `/Completed Tasks$/` that matches regardless of month/year

## Files changed
- `tests/tests/calendar.spec.ts` — Updated 2 assertions from hardcoded string to regex pattern

## Testing
- Local E2E: 74/81 passing (5 pre-existing failures confirmed on production, unrelated to this change)
- CAL-07 specifically: passes on both local dev server and after merge with master

## Deploy notes
- Test-only change — no application code modified, no deploy needed

## References
- Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)