### PR TITLE
E2E: ERR-01 fix API error snackbar test

### DIFF
--- a/tests/tests/error.spec.ts
+++ b/tests/tests/error.spec.ts
@@ -3,10 +3,26 @@ import { test, expect } from '@playwright/test';
 test.describe('Error Handling P1', () => {
 
   test('ERR-01: API error shows snackbar', async ({ page }) => {
-    // Intercept API calls to return a 500 error.
-    // The Darwin API base URL is used by call_rest_api via darwinUri.
-    // We intercept the tasks endpoint to trigger an error when TaskPlanView loads tasks.
-    await page.route('**/eng/darwin/tasks**', route => {
+    // Mock all API calls for fast, isolated test.
+    // Domains → 1 domain, Areas → 1 area, Tasks → 500 error.
+
+    await page.route('**/domains**', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ id: 99999, domain_name: 'Test Domain', sort_order: 0 }]),
+      });
+    });
+
+    await page.route('**/areas**', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ id: 99999, area_name: 'Test Area', domain_fk: 99999, sort_order: 0, sort_mode: 'priority', creator_fk: 'test' }]),
+      });
+    });
+
+    await page.route('**/tasks**', route => {
       route.fulfill({
         status: 500,
         contentType: 'application/json',
@@ -14,30 +30,17 @@ test.describe('Error Handling P1', () => {
       });
     });
 
-    // Navigate to a view that fetches tasks — TaskPlanView loads tasks per area
+    // Navigate to TaskPlanView — mocked API calls fire quickly
     await page.goto('/taskcards');
-    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
 
-    // Click on a domain tab to trigger task fetching
-    // The first tab should be pre-selected, but click it to ensure it loads
-    const firstTab = page.locator('[role="tab"]').first();
-    await firstTab.click();
-    await page.waitForTimeout(2000);
-
-    // The SnackBar should appear with an error message.
-    // Each TaskCard has its own SnackBar, so multiple may appear.
-    // MUI renders the message inside a .MuiSnackbarContent-message element.
-    // Use .first() since multiple snackbars fire (one per area card).
+    // Snackbar appears via Zustand store (single shared SnackBar at App root).
+    // Use auto-retrying assertion to catch the 2-second visibility window.
     const snackbarMessage = page.locator('.MuiSnackbarContent-message').first();
     await expect(snackbarMessage).toBeVisible({ timeout: 10000 });
+    await expect(snackbarMessage).toContainText('Unable to read tasks');
+    await expect(snackbarMessage).toContainText('500');
 
-    // Verify the message contains error text
-    // snackBarError formats: `${error_text} ${error.httpStatus.httpStatus}`
-    const messageText = await snackbarMessage.textContent();
-    expect(messageText).toContain('Unable to read tasks');
-    expect(messageText).toContain('500');
-
-    // Verify snackbar auto-hides after 2 seconds (autoHideDuration=2000)
+    // Verify snackbar auto-hides (autoHideDuration=2000)
     await expect(snackbarMessage).not.toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
## Summary
- Fix ERR-01 E2E test that was failing due to flaky real-API dependency and timing race
- Mock all three API calls (domains, areas, tasks) for fast, isolated test execution
- Tasks endpoint returns 500 to trigger the error snackbar
- Remove timing-sensitive `waitForSelector` + `waitForTimeout(2000)` that raced with the snackbar's 2-second autoHideDuration
- Use auto-retrying `toContainText()` instead of snapshot-based `textContent()` + `toContain()`
- Fix incorrect comments about per-TaskCard SnackBars (there's one shared SnackBar at App root via Zustand store)

## Files changed
- `tests/tests/error.spec.ts` — complete rewrite of ERR-01 test with mocked API responses

## Testing
- Local E2E: 2/2 passing (auth setup + ERR-01)
- Verified no regressions in full suite (58/81 pass, 10 pre-existing failures unrelated to this change)

## Deploy notes
- Darwin frontend only (test file change)

## References
- Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)