### PR TITLE
Priorities UI overhaul

### DIFF
--- a/src/SwarmView/CategoryCard.jsx
+++ b/src/SwarmView/CategoryCard.jsx
@@ -98,7 +98,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
     // READ priorities for this category
     useEffect( () => {
 
-        let priorityUri = `${darwinUri}/priorities?creator_fk=${profile.userName}&closed=0&category_fk=${category.id}&fields=id,title,in_progress,closed,category_fk,sort_order,completed_at`
+        let priorityUri = `${darwinUri}/priorities?creator_fk=${profile.userName}&closed=0&category_fk=${category.id}&fields=id,title,in_progress,closed,scheduled,category_fk,sort_order,completed_at`
 
         call_rest_api(priorityUri, 'GET', '', idToken)
             .then(result => {
@@ -121,7 +121,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
                     }
 
                     sortedPrioritiesArray.sort((a, b) => activeSort(a, b));
-                    sortedPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'category_fk': parseInt(category.id), 'sort_order': null, 'creator_fk': profile.userName });
+                    sortedPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'scheduled': 0, 'category_fk': parseInt(category.id), 'sort_order': null, 'creator_fk': profile.userName });
                     setPrioritiesArray(sortedPrioritiesArray);
 
                     // Fetch session statuses for these priorities
@@ -152,7 +152,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
             }).catch(error => {
                 if (error.httpStatus.httpStatus === 404) {
                     let sortedPrioritiesArray = [];
-                    sortedPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'category_fk': parseInt(category.id), 'sort_order': null, 'creator_fk': profile.userName });
+                    sortedPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'scheduled': 0, 'category_fk': parseInt(category.id), 'sort_order': null, 'creator_fk': profile.userName });
                     setPrioritiesArray(sortedPrioritiesArray);
                 } else {
                     showError(error, 'Unable to read priorities')
@@ -377,6 +377,29 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
         }
     }
 
+    const scheduledClick = (priorityIndex, priorityId) => {
+
+        let newPrioritiesArray = [...prioritiesArray]
+        newPrioritiesArray[priorityIndex].scheduled = newPrioritiesArray[priorityIndex].scheduled ? 0 : 1;
+
+        if (priorityId !== '') {
+            let uri = `${darwinUri}/priorities`;
+            call_rest_api(uri, 'PUT', [{'id': priorityId, 'scheduled': newPrioritiesArray[priorityIndex].scheduled}], idToken)
+                .then(result => {
+                    if (result.httpStatus.httpStatus !== 200) {
+                        showError(result, "Unable to change priority's scheduled flag")
+                    }
+                }).catch(error => {
+                    showError(error, "Unable to change priority's scheduled flag")
+                }
+            );
+        } else if (savingRef.current) {
+            pendingMutationsRef.current.scheduled = newPrioritiesArray[priorityIndex].scheduled;
+        }
+
+        setPrioritiesArray(newPrioritiesArray);
+    }
+
     const updatePriority = (event, priorityIndex, priorityId) => {
 
         const noop = ()=>{};
@@ -433,7 +456,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
                     }
 
                     newPrioritiesArray.sort((a, b) => activeSort(a, b));
-                    newPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'category_fk': category.id, 'sort_order': null, 'creator_fk': profile.userName });
+                    newPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'scheduled': 0, 'category_fk': category.id, 'sort_order': null, 'creator_fk': profile.userName });
                     setPrioritiesArray(newPrioritiesArray);
                 } else if (result.httpStatus.httpStatus === 201) {
                     triggerPriorityRefresh();
@@ -558,7 +581,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
                     )}
                 </Box>
                 { (prioritiesArray) ?
-                    <PriorityActionsContext.Provider value={{ inProgressClick, closedClick, titleChange,
+                    <PriorityActionsContext.Provider value={{ inProgressClick, closedClick, scheduledClick, titleChange,
                         titleKeyDown, titleOnBlur, deleteClick, prioritiesArray, setPrioritiesArray,
                         sortMode, setCrossCardInsertIndex, sessionStatusMap }}>
                         {prioritiesArray.map((priority, priorityIndex) => (

--- a/src/SwarmView/PriorityRow.jsx
+++ b/src/SwarmView/PriorityRow.jsx
@@ -9,24 +9,22 @@ import { usePriorityActions } from '../hooks/usePriorityActions';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import IconButton from '@mui/material/IconButton';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import ToggleButton from '@mui/material/ToggleButton';
 import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import DeleteIcon from '@mui/icons-material/Delete';
 import SavingsIcon from '@mui/icons-material/Savings';
-import RocketIcon from '@mui/icons-material/Rocket';
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
-import FlightTakeoffIcon from '@mui/icons-material/FlightTakeoff';
-import FlightLandIcon from '@mui/icons-material/FlightLand';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import HotelIcon from '@mui/icons-material/Hotel';
-import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
+import PlayCircleIcon from '@mui/icons-material/PlayCircle';
+import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
 
 const PriorityRow = ({ supportDrag, priority, priorityIndex, categoryId, categoryName }) => {
 
     const navigate = useNavigate();
-    const { inProgressClick, closedClick, titleChange, titleKeyDown,
+    const { inProgressClick, closedClick, scheduledClick, titleChange, titleKeyDown,
         titleOnBlur, deleteClick, prioritiesArray, setPrioritiesArray,
         sortMode, setCrossCardInsertIndex, sessionStatusMap } = usePriorityActions();
     const [insertIndicator, setInsertIndicator] = useState(null);
@@ -109,6 +107,23 @@ const PriorityRow = ({ supportDrag, priority, priorityIndex, categoryId, categor
         priorityDrop(node);
     }, [drag, priorityDrop]);
 
+    // Determine status for indicator
+    const sessionStatus = sessionStatusMap && sessionStatusMap[priority.id];
+    const isRunning = !!(priority.in_progress || sessionStatus);
+    const getStatusIcon = () => {
+        if (priority.id === '') return null;
+        if (priority.closed) {
+            return <Tooltip title="Completed"><CheckCircleIcon sx={{ fontSize: 18, color: 'success.main' }} /></Tooltip>;
+        }
+        if (sessionStatus) {
+            return <Tooltip title={sessionStatus}><RocketLaunchIcon sx={{ fontSize: 18, color: 'primary.main' }} /></Tooltip>;
+        }
+        if (priority.in_progress) {
+            return <Tooltip title="In Progress"><RocketLaunchIcon sx={{ fontSize: 18, color: 'primary.main' }} /></Tooltip>;
+        }
+        return <Tooltip title="Not Started"><HotelIcon sx={{ fontSize: 18, color: 'text.disabled' }} /></Tooltip>;
+    };
+
     return (
         <Box className="task priority-row"
              data-testid={priority.id === '' ? 'priority-template' : `priority-${priority.id}`}
@@ -129,26 +144,54 @@ const PriorityRow = ({ supportDrag, priority, priorityIndex, categoryId, categor
                  ...(insertIndicator === 'below' && { borderBottom: '4px solid', borderBottomColor: 'primary.main' }),
              }}
         >
-            <ToggleButtonGroup
-                value={
-                    sessionStatusMap && sessionStatusMap[priority.id]
-                        ? sessionStatusMap[priority.id]
-                        : priority.closed ? 'completed'
-                        : priority.in_progress ? 'active'
-                        : 'idle'
-                }
-                exclusive
-                size="small"
-                key={`status-${priority.id}`}
-                sx={{ height: 28, '& .MuiToggleButton-root': { px: 0.5, py: 0, minWidth: 28 } }}
+            {/* Col 1: Row number */}
+            <Typography
+                variant="body2"
+                sx={{ color: 'text.secondary', textAlign: 'center', minWidth: 24, userSelect: 'none' }}
             >
-                <ToggleButton value="idle" disabled><Tooltip title="Idle"><RocketIcon sx={{ fontSize: 18 }} /></Tooltip></ToggleButton>
-                <ToggleButton value="starting" disabled><Tooltip title="Starting"><FlightTakeoffIcon sx={{ fontSize: 18 }} /></Tooltip></ToggleButton>
-                <ToggleButton value="active" disabled><Tooltip title="Active"><RocketLaunchIcon sx={{ fontSize: 18 }} /></Tooltip></ToggleButton>
-                <ToggleButton value="paused" disabled><Tooltip title="Paused"><HotelIcon sx={{ fontSize: 18 }} /></Tooltip></ToggleButton>
-                <ToggleButton value="completing" disabled><Tooltip title="Completing"><FlightLandIcon sx={{ fontSize: 18 }} /></Tooltip></ToggleButton>
-                <ToggleButton value="completed" disabled><Tooltip title="Completed"><AttachMoneyIcon sx={{ fontSize: 18 }} /></Tooltip></ToggleButton>
-            </ToggleButtonGroup>
+                {priority.id !== '' ? priorityIndex + 1 : ''}
+            </Typography>
+
+            {/* Col 2: Scheduled toggle — hidden when running, spacer preserves layout */}
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minWidth: 28 }}>
+                {priority.id !== '' && !isRunning ? (
+                    <Tooltip title={priority.scheduled ? "Marked for Swarm-Start" : "Mark for Swarm-Start"}>
+                        <IconButton
+                            onClick={() => scheduledClick(priorityIndex, priority.id)}
+                            data-testid={`scheduled-toggle-${priority.id}`}
+                            sx={{ maxWidth: 28, maxHeight: 28 }}
+                        >
+                            {priority.scheduled ?
+                                <PlayCircleIcon sx={{ fontSize: 20, color: 'primary.main' }} /> :
+                                <PlayCircleOutlineIcon sx={{ fontSize: 20, color: 'text.disabled' }} />
+                            }
+                        </IconButton>
+                    </Tooltip>
+                ) : null}
+            </Box>
+
+            {/* Col 3: Details link */}
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                {priority.id !== '' ? (
+                    <Tooltip title="Details">
+                        <IconButton onClick={() => navigate(`/swarm/priority/${priority.id}`)}
+                                    key={`navigate-${priority.id}`}
+                                    sx={{ maxWidth: 25, maxHeight: 25 }}
+                        >
+                            <OpenInNewIcon sx={{ fontSize: 18 }} />
+                        </IconButton>
+                    </Tooltip>
+                ) : (
+                    <Box sx={{ width: 25 }} />
+                )}
+            </Box>
+
+            {/* Col 4: Status indicator */}
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minWidth: 28 }}>
+                {getStatusIcon()}
+            </Box>
+
+            {/* Col 5: Title */}
             <TextField variant="outlined"
                         value={priority.title || ''}
                         name='title'
@@ -163,7 +206,9 @@ const PriorityRow = ({ supportDrag, priority, priorityIndex, categoryId, categor
                         slotProps={{ htmlInput: { maxLength: 256 } }}
                         key={`title-${priority.id}`}
              />
-            <Box sx={{ display: 'flex', justifyContent: 'flex-start', width: 56 }}>
+
+            {/* Col 6: Delete / Savings */}
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             { priority.id === '' ?
                     <IconButton key={`savings-${priority.id}`}
                                 disabled = {categoryId !== '' ? false : categoryName === '' ? true : false}
@@ -174,24 +219,16 @@ const PriorityRow = ({ supportDrag, priority, priorityIndex, categoryId, categor
                         <SavingsIcon key={`savings1-${priority.id}`}/>
                     </IconButton>
                 :
-                <>
-                    <IconButton onClick={() => navigate(`/swarm/priority/${priority.id}`)}
-                                key={`navigate-${priority.id}`}
-                                sx = {{maxWidth: "25px",
-                                       maxHeight: "25px",
-                                }}
-                    >
-                        <OpenInNewIcon key={`navigate1-${priority.id}`} />
-                    </IconButton>
-                    <IconButton onClick={(event) => deleteClick(event, priority.id)}
-                                key={`delete-${priority.id}`}
-                                sx = {{maxWidth: "25px",
-                                       maxHeight: "25px",
-                                }}
-                    >
-                        <DeleteIcon key={`delete1-${priority.id}`} />
-                    </IconButton>
-                </>
+                    <Tooltip title="Delete priority">
+                        <IconButton onClick={(event) => deleteClick(event, priority.id)}
+                                    key={`delete-${priority.id}`}
+                                    sx = {{maxWidth: "25px",
+                                           maxHeight: "25px",
+                                    }}
+                        >
+                            <DeleteIcon key={`delete1-${priority.id}`} />
+                        </IconButton>
+                    </Tooltip>
             }
             </Box>
         </Box>

--- a/src/index.css
+++ b/src/index.css
@@ -69,7 +69,7 @@
 }
 
 .task.priority-row {
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: 24px auto auto auto 1fr auto;
 }
 
 .app-navbar{

--- a/tests/tests/swarm.spec.ts
+++ b/tests/tests/swarm.spec.ts
@@ -6,12 +6,14 @@ test.describe('Swarm View', () => {
   let testProjectId: string;
   let testCategoryId: string;
   let testPriorityId: string;
+  let testIdlePriorityId: string;
   let testSessionId: string;
   let testIssueSessionId: string;
 
   const testProjectName = uniqueName('SwarmProj');
   const testCategoryName = uniqueName('SwarmCat');
   const testPriorityTitle = uniqueName('SwarmPri');
+  const testIdlePriorityTitle = uniqueName('SwarmIdle');
 
   test.beforeAll(async ({ browser }) => {
     const context = await browser.newContext({ storageState: '.auth/user.json' });
@@ -43,6 +45,14 @@ test.describe('Swarm View', () => {
     }, idToken) as Array<{ id: string }>;
     if (!priResult?.length) throw new Error('Failed to create test priority');
     testPriorityId = priResult[0].id;
+
+    // Create idle priority (not in_progress) for scheduled toggle test
+    const idlePriResult = await apiCall('priorities', 'POST', {
+      creator_fk: sub, title: testIdlePriorityTitle, category_fk: testCategoryId,
+      in_progress: 0, closed: 0, sort_order: 1,
+    }, idToken) as Array<{ id: string }>;
+    if (!idlePriResult?.length) throw new Error('Failed to create idle test priority');
+    testIdlePriorityId = idlePriResult[0].id;
 
     // Create swarm session linked to priority via source_ref
     const sessResult = await apiCall('swarm_sessions', 'POST', {
@@ -85,6 +95,7 @@ test.describe('Swarm View', () => {
     try { await apiDelete('swarm_sessions', testSessionId, idToken); } catch {}
     try { await apiDelete('swarm_sessions', testIssueSessionId, idToken); } catch {}
     try { await apiDelete('priorities', testPriorityId, idToken); } catch {}
+    try { await apiDelete('priorities', testIdlePriorityId, idToken); } catch {}
     // CASCADE handles categories when project is deleted
     try { await apiDelete('projects', testProjectId, idToken); } catch {}
   });
@@ -107,6 +118,46 @@ test.describe('Swarm View', () => {
     await page.waitForSelector('[role="tab"]', { timeout: 10000 });
     await page.getByRole('tab', { name: testProjectName }).click();
     await expect(page.getByTestId(`priority-${testPriorityId}`)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('SWM-12a: Priority row shows row number', async ({ page }) => {
+    await page.goto('/swarm');
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.getByRole('tab', { name: testProjectName }).click();
+    await expect(page.getByTestId(`priority-${testPriorityId}`)).toBeVisible({ timeout: 10000 });
+    // Row number "1" should be visible in the priority row
+    const row = page.getByTestId(`priority-${testPriorityId}`);
+    await expect(row.locator('p').first()).toContainText('1');
+  });
+
+  test('SWM-12b: Scheduled toggle works on idle priority row', async ({ page }) => {
+    await page.goto('/swarm');
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.getByRole('tab', { name: testProjectName }).click();
+    await expect(page.getByTestId(`priority-${testIdlePriorityId}`)).toBeVisible({ timeout: 10000 });
+
+    const toggleBtn = page.getByTestId(`scheduled-toggle-${testIdlePriorityId}`);
+    await expect(toggleBtn).toBeVisible({ timeout: 5000 });
+
+    // Click to schedule
+    await toggleBtn.click();
+    // Verify the toggle persists by reloading
+    await page.reload();
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.getByRole('tab', { name: testProjectName }).click();
+    await expect(page.getByTestId(`scheduled-toggle-${testIdlePriorityId}`)).toBeVisible({ timeout: 10000 });
+
+    // Click again to unschedule (cleanup)
+    await page.getByTestId(`scheduled-toggle-${testIdlePriorityId}`).click();
+  });
+
+  test('SWM-12c: Scheduled toggle hidden on in-progress priority', async ({ page }) => {
+    await page.goto('/swarm');
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.getByRole('tab', { name: testProjectName }).click();
+    await expect(page.getByTestId(`priority-${testPriorityId}`)).toBeVisible({ timeout: 10000 });
+    // The in-progress priority should NOT have a scheduled toggle
+    await expect(page.getByTestId(`scheduled-toggle-${testPriorityId}`)).not.toBeVisible();
   });
 
   test('SWM-13: /swarm/priority/:id renders PriorityDetail with correct title', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Replace the 6-button disabled ToggleButtonGroup status bar with a compact row layout
- Add row numbers (#1, #2...) for easy reference when using swarm-start commands
- Add status indicator icons: hotel/sleeping (idle), rocket (in-progress), check (completed)
- Add scheduled toggle button (play icon) to mark priorities for batch `/swarm-start roadmap`
- Toggle automatically hidden when priority is already running (in_progress or has active session)
- Add tooltips to all action buttons (Details, Delete, Mark for Swarm-Start)
- Add `scheduled` field to CategoryCard data fetch and template objects
- Update CSS grid to new 6-column layout: number | scheduled | details | status | title | delete

## Files changed
- `src/SwarmView/PriorityRow.jsx` — Major rewrite: remove ToggleButtonGroup, add row number, status icons, scheduled toggle, tooltips
- `src/SwarmView/CategoryCard.jsx` — Add `scheduled` to fields query, template objects, scheduledClick handler, context provider
- `src/index.css` — Update `.task.priority-row` grid-template-columns to 6-column layout
- `tests/tests/swarm.spec.ts` — Add SWM-12a (row numbers), SWM-12b (scheduled toggle on idle), SWM-12c (toggle hidden on running)

## Related PR
- DarwinSQL#12 — Add `scheduled` column to priorities table

## Testing
- Local E2E: 17/17 passing (includes 3 new tests)
- DarwinSQL: 49/50 passing (1 pre-existing table_count test failure)

## Deploy notes
- Darwin frontend only (DarwinSQL migration already applied to both darwin_dev and darwin production)
- MCP server changes (darwin-mcp/db.py, server.py) are in the main repo, not this PR

## References
- Roadmap item #1: Priorities UI overhaul

🤖 Generated with [Claude Code](https://claude.com/claude-code)