### PR TITLE
swarm-start issues must create link to same

### DIFF
--- a/src/SwarmView/SessionsView.jsx
+++ b/src/SwarmView/SessionsView.jsx
@@ -5,6 +5,7 @@ import call_rest_api from '../RestApi/RestApi';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
 import { DataGrid, GridToolbar } from '@mui/x-data-grid';
 
+import { renderSourceRef } from './repoGitHubMap.jsx';
 import React, { useState, useEffect, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -23,7 +24,7 @@ const swarmStatusColor = (status) => {
     }
 };
 
-const sessionColumns = [
+const getSessionColumns = (navigate) => [
     { field: 'id',           headerName: 'ID',          width: 70 },
     {
         field: 'swarm_status',
@@ -37,6 +38,12 @@ const sessionColumns = [
     },
     { field: 'task_name',    headerName: 'Task',        width: 200, flex: 1 },
     { field: 'title',        headerName: 'Title',       width: 250 },
+    {
+        field: 'source_ref',
+        headerName: 'Source',
+        width: 140,
+        renderCell: (params) => renderSourceRef(params.value, navigate),
+    },
     { field: 'branch',       headerName: 'Branch',      width: 200 },
     {
         field: 'pr_url',
@@ -102,7 +109,7 @@ const SessionsView = () => {
                 <Box sx={{ height: 600, width: '100%' }} data-testid="sessions-datagrid">
                     <DataGrid
                         rows={sessionsArray}
-                        columns={sessionColumns}
+                        columns={getSessionColumns(navigate)}
                         slots={{ toolbar: GridToolbar }}
                         slotProps={{
                             toolbar: {

--- a/src/SwarmView/detail/PriorityDetail.jsx
+++ b/src/SwarmView/detail/PriorityDetail.jsx
@@ -6,6 +6,7 @@ import AuthContext from '../../Context/AuthContext';
 import AppContext from '../../Context/AppContext';
 import { DataGrid } from '@mui/x-data-grid';
 
+import { renderSourceRef } from '../repoGitHubMap.jsx';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -25,13 +26,19 @@ const swarmStatusColor = (status) => {
     }
 };
 
-const sessionColumns = [
+const getSessionColumns = (navigate) => [
     { field: 'id',           headerName: 'ID',        width: 70 },
     { field: 'swarm_status', headerName: 'Status',    width: 110,
       renderCell: (params) => (
           <Chip label={params.value} size="small"
                 color={swarmStatusColor(params.value)} />
       )
+    },
+    {
+        field: 'source_ref',
+        headerName: 'Source',
+        width: 140,
+        renderCell: (params) => renderSourceRef(params.value, navigate),
     },
     { field: 'branch',       headerName: 'Branch',    width: 200, flex: 1 },
     { field: 'started_at',   headerName: 'Started',   width: 170,
@@ -253,7 +260,7 @@ const PriorityDetail = () => {
                 <Box sx={{ height: 300 }} data-testid="linked-sessions-grid">
                     <DataGrid
                         rows={sessions}
-                        columns={sessionColumns}
+                        columns={getSessionColumns(navigate)}
                         density="compact"
                         disableRowSelectionOnClick
                         onRowClick={(params) => navigate(`/swarm/session/${params.id}`)}

--- a/src/SwarmView/detail/SwarmSessionDetail.jsx
+++ b/src/SwarmView/detail/SwarmSessionDetail.jsx
@@ -5,10 +5,10 @@ import { useSnackBarStore } from '../../stores/useSnackBarStore';
 import AuthContext from '../../Context/AuthContext';
 import AppContext from '../../Context/AppContext';
 
+import { renderSourceRef } from '../repoGitHubMap.jsx';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
-import Link from '@mui/material/Link';
 import { CircularProgress, Typography } from '@mui/material';
 
 const swarmStatusColor = (status) => {
@@ -20,14 +20,6 @@ const swarmStatusColor = (status) => {
         case 'completed':  return 'success';
         default:           return 'default';
     }
-};
-
-const repoGitHubMap = {
-    'darwin':  'BillWilliams79/Darwin',
-    'sql':     'BillWilliams79/DarwinSQL',
-    'rest':    'BillWilliams79/AWS-Lambda-REST-API',
-    'cognito': 'BillWilliams79/AWS-Lambda-Cognito-User-Confirmation',
-    'jwt':     'BillWilliams79/AWS-JWT-Verification',
 };
 
 const SwarmSessionDetail = () => {
@@ -104,28 +96,7 @@ const SwarmSessionDetail = () => {
                     <Typography variant="subtitle2" color="text.secondary">Source</Typography>
                     <Typography variant="body2" component="div" data-testid="session-source">
                         {session.source_type}
-                        {session.source_ref && (() => {
-                            const priorityMatch = session.source_ref.match(/^priority:(\d+)$/);
-                            if (priorityMatch) {
-                                return <> — <Link component="button" variant="body2"
-                                        onClick={() => navigate(`/swarm/priority/${priorityMatch[1]}`)}
-                                        data-testid="session-priority-link">
-                                        Priority #{priorityMatch[1]}
-                                    </Link></>;
-                            }
-                            const issueMatch = session.source_ref.match(/^(.+)#(\d+)$/);
-                            if (issueMatch) {
-                                const ghRepo = repoGitHubMap[issueMatch[1]];
-                                if (ghRepo) {
-                                    return <> — <Link href={`https://github.com/${ghRepo}/issues/${issueMatch[2]}`}
-                                            target="_blank" rel="noopener noreferrer"
-                                            data-testid="session-issue-link">
-                                            {session.source_ref}
-                                        </Link></>;
-                                }
-                            }
-                            return ` — ${session.source_ref}`;
-                        })()}
+                        {session.source_ref && <> — {renderSourceRef(session.source_ref, navigate)}</>}
                     </Typography>
                 </Box>
             }

--- a/src/SwarmView/repoGitHubMap.jsx
+++ b/src/SwarmView/repoGitHubMap.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import Link from '@mui/material/Link';
+
+const repoGitHubMap = {
+    'darwin':  'BillWilliams79/Darwin',
+    'sql':     'BillWilliams79/DarwinSQL',
+    'rest':    'BillWilliams79/AWS-Lambda-REST-API',
+    'cognito': 'BillWilliams79/AWS-Lambda-Cognito-User-Confirmation',
+    'jwt':     'BillWilliams79/AWS-JWT-Verification',
+};
+
+/**
+ * Render a source_ref value as a clickable link (issue or priority) or plain text.
+ * @param {string} sourceRef - e.g. "darwin#79" or "priority:42"
+ * @param {function} [navigate] - react-router navigate function (for priority links)
+ * @returns {React.ReactNode}
+ */
+const renderSourceRef = (sourceRef, navigate) => {
+    if (!sourceRef) return '—';
+
+    const priorityMatch = sourceRef.match(/^priority:(\d+)$/);
+    if (priorityMatch) {
+        if (navigate) {
+            return (
+                <Link component="button" variant="body2"
+                      onClick={(e) => { e.stopPropagation(); navigate(`/swarm/priority/${priorityMatch[1]}`); }}
+                      data-testid="source-priority-link">
+                    Priority #{priorityMatch[1]}
+                </Link>
+            );
+        }
+        return `Priority #${priorityMatch[1]}`;
+    }
+
+    const issueMatch = sourceRef.match(/^(.+)#(\d+)$/);
+    if (issueMatch) {
+        const ghRepo = repoGitHubMap[issueMatch[1]];
+        if (ghRepo) {
+            return (
+                <Link href={`https://github.com/${ghRepo}/issues/${issueMatch[2]}`}
+                      target="_blank" rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      data-testid="source-issue-link">
+                    {sourceRef}
+                </Link>
+            );
+        }
+    }
+
+    return sourceRef;
+};
+
+export { repoGitHubMap, renderSourceRef };

--- a/tests/tests/swarm.spec.ts
+++ b/tests/tests/swarm.spec.ts
@@ -145,15 +145,15 @@ test.describe('Swarm View', () => {
 
   test('SWM-18: Session detail shows priority link — click navigates', async ({ page }) => {
     await page.goto(`/swarm/session/${testSessionId}`);
-    await expect(page.getByTestId('session-priority-link')).toBeVisible({ timeout: 10000 });
-    await page.getByTestId('session-priority-link').click();
+    await expect(page.getByTestId('source-priority-link')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('source-priority-link').click();
     await expect(page).toHaveURL(new RegExp(`/swarm/priority/${testPriorityId}`));
   });
 
   test('SWM-19: Session detail shows GitHub issue link for issue source_ref', async ({ page }) => {
     await page.goto(`/swarm/session/${testIssueSessionId}`);
-    await expect(page.getByTestId('session-issue-link')).toBeVisible({ timeout: 10000 });
-    const href = await page.getByTestId('session-issue-link').getAttribute('href');
+    await expect(page.getByTestId('source-issue-link')).toBeVisible({ timeout: 10000 });
+    const href = await page.getByTestId('source-issue-link').getAttribute('href');
     expect(href).toContain('github.com/BillWilliams79/Darwin/issues/8');
   });
 
@@ -162,6 +162,16 @@ test.describe('Swarm View', () => {
     await expect(page.getByTestId('sessions-datagrid')).toBeVisible({ timeout: 10000 });
     // The DataGrid should contain our test session's task_name (.first() for prior-run orphans)
     await expect(page.getByText('e2e-test-task').first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('SWM-22: SessionsView Source column shows issue link', async ({ page }) => {
+    await page.goto('/swarm/sessions');
+    await expect(page.getByTestId('sessions-datagrid')).toBeVisible({ timeout: 10000 });
+    // The Source column should render a clickable issue link for the issue-sourced session
+    const issueLink = page.getByTestId('sessions-datagrid').getByTestId('source-issue-link').first();
+    await expect(issueLink).toBeVisible({ timeout: 10000 });
+    const href = await issueLink.getAttribute('href');
+    expect(href).toContain('github.com/BillWilliams79/Darwin/issues/8');
   });
 
   test('SWM-21: Back to Swarm navigation works', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Extract `repoGitHubMap` and `renderSourceRef` to shared utility (`repoGitHubMap.jsx`)
- Add **Source column** to SessionsView DataGrid — issue refs render as clickable GitHub links, priority refs as internal navigation links
- Add **Source column** to PriorityDetail linked-sessions grid
- Refactor SwarmSessionDetail to use shared `renderSourceRef` instead of inline logic
- Add SWM-22 E2E test verifying Source column issue link rendering
- Update SWM-18/SWM-19 test IDs to match shared helper's `data-testid` values

## Files changed
- `src/SwarmView/repoGitHubMap.jsx` — **New** shared utility with repo→GitHub URL map and `renderSourceRef` helper
- `src/SwarmView/SessionsView.jsx` — Add Source column, convert `sessionColumns` to `getSessionColumns(navigate)`
- `src/SwarmView/detail/PriorityDetail.jsx` — Add Source column to linked-sessions grid
- `src/SwarmView/detail/SwarmSessionDetail.jsx` — Use shared `renderSourceRef`, remove inline map and link logic
- `tests/tests/swarm.spec.ts` — Add SWM-22 test, update test IDs for SWM-18/SWM-19

## Testing
- Local E2E: 14/14 passing (swarm suite)
- New test SWM-22 validates Source column renders issue link in SessionsView

## Deploy notes
- Darwin frontend only — no backend or schema changes

## References
- Related: DarwinSQL PR #11 (no changes needed)
- Roadmap priority #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)