### PR TITLE
Dev server port coordination

### DIFF
--- a/src/DevServers/DevServersView.jsx
+++ b/src/DevServers/DevServersView.jsx
@@ -1,0 +1,109 @@
+import '../index.css';
+import AuthContext from '../Context/AuthContext';
+import AppContext from '../Context/AppContext';
+import call_rest_api from '../RestApi/RestApi';
+import { useSnackBarStore } from '../stores/useSnackBarStore';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+
+import React, { useState, useEffect, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import { CircularProgress, Typography } from '@mui/material';
+
+const getDevServerColumns = (navigate) => [
+    { field: 'id',             headerName: 'ID',        width: 70 },
+    {
+        field: 'port',
+        headerName: 'Port',
+        width: 100,
+        renderCell: (params) => (
+            <Chip label={params.value} size="small" color="primary"
+                  data-testid="chip-dev-server-port" />
+        ),
+    },
+    { field: 'pid',            headerName: 'PID',       width: 90,  type: 'number' },
+    { field: 'workspace_path', headerName: 'Workspace',  width: 300, flex: 1 },
+    {
+        field: 'session_fk',
+        headerName: 'Session',
+        width: 100,
+        renderCell: (params) => params.value
+            ? <a href={`/swarm/session/${params.value}`}
+                 onClick={(e) => { e.stopPropagation(); e.preventDefault(); navigate(`/swarm/session/${params.value}`); }}
+                 data-testid="dev-server-session-link">
+                #{params.value}
+              </a>
+            : '—',
+    },
+    {
+        field: 'started_at',
+        headerName: 'Started',
+        width: 170,
+        valueFormatter: (value) => value ? new Date(value).toLocaleString() : '—',
+    },
+];
+
+const DevServersView = () => {
+
+    const { idToken, profile } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
+    const navigate = useNavigate();
+
+    const [devServersArray, setDevServersArray] = useState(null);
+    const showError = useSnackBarStore(s => s.showError);
+
+    useEffect(() => {
+        const devServersUri = `${darwinUri}/dev_servers?creator_fk=${profile.userName}`;
+
+        call_rest_api(devServersUri, 'GET', '', idToken)
+            .then(result => {
+                if (result.httpStatus.httpStatus === 200) {
+                    setDevServersArray(result.data);
+                } else {
+                    setDevServersArray([]);
+                }
+            }).catch(error => {
+                if (error.httpStatus && error.httpStatus.httpStatus === 404) {
+                    setDevServersArray([]);
+                } else {
+                    showError(error, 'Unable to read dev servers');
+                }
+            });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+        <Box sx={{ gridArea: 'content', p: 3 }}>
+            <Typography variant="h5" sx={{ mb: 1 }}>Dev Servers</Typography>
+
+            {devServersArray === null ? (
+                <CircularProgress />
+            ) : (
+                <Box sx={{ height: 600, width: '100%' }} data-testid="dev-servers-datagrid">
+                    <DataGrid
+                        rows={devServersArray}
+                        columns={getDevServerColumns(navigate)}
+                        slots={{ toolbar: GridToolbar }}
+                        slotProps={{
+                            toolbar: {
+                                showQuickFilter: true,
+                            },
+                        }}
+                        initialState={{
+                            pagination: { paginationModel: { pageSize: 25 } },
+                            sorting: { sortModel: [{ field: 'id', sort: 'desc' }] },
+                        }}
+                        pageSizeOptions={[10, 25, 50, 100]}
+                        disableRowSelectionOnClick
+                        sx={{ cursor: 'default' }}
+                        data-testid="dev-servers-grid"
+                    />
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+export default DevServersView;

--- a/src/NavBar/NavBar.jsx
+++ b/src/NavBar/NavBar.jsx
@@ -35,6 +35,7 @@ const NavBar = () => {
                 <Link className="nav-link" to="/areaedit"> Areas </Link>
                 <Link className="nav-link" to="/swarm"> Swarm </Link>
                 <Link className="nav-link" to="/swarm/sessions"> Sessions </Link>
+                <Link className="nav-link" to="/devservers"> Dev Servers </Link>
               </>
         </Stack>
     </AppBar>

--- a/src/SwarmView/SessionsView.jsx
+++ b/src/SwarmView/SessionsView.jsx
@@ -37,13 +37,23 @@ const getSessionColumns = (navigate) => [
                   data-testid="chip-swarm-status" />
         ),
     },
-    { field: 'task_name',    headerName: 'Task',        width: 200, flex: 1 },
     { field: 'title',        headerName: 'Title',       width: 250 },
+    { field: 'task_name',    headerName: 'Task',        width: 200, flex: 1 },
     {
         field: 'source_ref',
         headerName: 'Source',
         width: 140,
         renderCell: (params) => renderSourceRef(params.value, navigate),
+    },
+    {
+        field: 'dev_server_port',
+        headerName: 'Dev Server',
+        width: 100,
+        renderCell: (params) => params.value
+            ? <Chip label={params.value} size="small" color="primary"
+                    onClick={(e) => { e.stopPropagation(); navigate('/devservers'); }}
+                    data-testid="chip-dev-server-port" />
+            : '—',
     },
     { field: 'branch',       headerName: 'Branch',      width: 200 },
     {
@@ -78,13 +88,18 @@ const SessionsView = () => {
     const navigate = useNavigate();
 
     const [sessionsArray, setSessionsArray] = useState(null);
+    const [devServerMap, setDevServerMap] = useState({});
     const showError = useSnackBarStore(s => s.showError);
     const showClosedSessions = useShowClosedStore(s => s.showClosedSessions);
     const toggleShowClosedSessions = useShowClosedStore(s => s.toggleShowClosedSessions);
 
-    const filteredSessions = sessionsArray && !showClosedSessions
-        ? sessionsArray.filter(s => s.swarm_status !== 'completed')
-        : sessionsArray;
+    const enrichedSessions = sessionsArray
+        ? sessionsArray.map(s => ({ ...s, dev_server_port: devServerMap[s.id] || null }))
+        : null;
+
+    const filteredSessions = enrichedSessions && !showClosedSessions
+        ? enrichedSessions.filter(s => s.swarm_status !== 'completed')
+        : enrichedSessions;
 
     useEffect(() => {
         const sessionsUri = `${darwinUri}/swarm_sessions?creator_fk=${profile.userName}`;
@@ -103,6 +118,17 @@ const SessionsView = () => {
                     showError(error, 'Unable to read swarm sessions');
                 }
             });
+
+        const devServersUri = `${darwinUri}/dev_servers?creator_fk=${profile.userName}`;
+
+        call_rest_api(devServersUri, 'GET', '', idToken)
+            .then(result => {
+                if (result.httpStatus.httpStatus === 200) {
+                    const map = {};
+                    result.data.forEach(ds => { if (ds.session_fk) map[ds.session_fk] = ds.port; });
+                    setDevServerMap(map);
+                }
+            }).catch(() => {});
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/src/SwarmView/detail/SwarmSessionDetail.jsx
+++ b/src/SwarmView/detail/SwarmSessionDetail.jsx
@@ -31,6 +31,7 @@ const SwarmSessionDetail = () => {
 
     const [session, setSession] = useState(null);
     const [loading, setLoading] = useState(true);
+    const [devServers, setDevServers] = useState([]);
 
     const showError = useSnackBarStore(s => s.showError);
 
@@ -49,6 +50,17 @@ const SwarmSessionDetail = () => {
                 showError(error, 'Unable to load swarm session');
                 setLoading(false);
             });
+    }, [id, idToken, darwinUri]);
+
+    useEffect(() => {
+        const devServersUri = `${darwinUri}/dev_servers?session_fk=${id}`;
+
+        call_rest_api(devServersUri, 'GET', '', idToken)
+            .then(result => {
+                if (result.httpStatus.httpStatus === 200) {
+                    setDevServers(result.data);
+                }
+            }).catch(() => {});
     }, [id, idToken, darwinUri]);
 
     if (loading) return <CircularProgress />;
@@ -161,6 +173,24 @@ const SwarmSessionDetail = () => {
                     {session.update_ts || '—'}
                 </Typography>
             </Box>
+
+            {devServers.length > 0 &&
+                <Box sx={{ mb: 1, mt: 2 }}>
+                    <Typography variant="subtitle2" color="text.secondary">Dev Servers</Typography>
+                    <Box sx={{ display: 'flex', gap: 1, mt: 0.5 }} data-testid="session-dev-servers">
+                        {devServers.map(ds => (
+                            <Chip
+                                key={ds.id}
+                                label={`Port ${ds.port}`}
+                                size="small"
+                                color="primary"
+                                onClick={() => navigate('/devservers')}
+                                data-testid="chip-dev-server-port"
+                            />
+                        ))}
+                    </Box>
+                </Box>
+            }
         </Box>
     );
 };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -25,6 +25,7 @@ import SwarmView from './SwarmView/SwarmView';
 import PriorityDetail from './SwarmView/detail/PriorityDetail';
 import SessionsView from './SwarmView/SessionsView';
 import SwarmSessionDetail from './SwarmView/detail/SwarmSessionDetail';
+import DevServersView from './DevServers/DevServersView';
 
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
@@ -68,6 +69,9 @@ root.render(
                                                          </AuthenticatedRoute>} />
 <Route path="swarm/session/:id" element= {<AuthenticatedRoute>
                                                              <SwarmSessionDetail />
+                                                         </AuthenticatedRoute>} />
+                    <Route path="devservers" element= {<AuthenticatedRoute>
+                                                             <DevServersView />
                                                          </AuthenticatedRoute>} />
                 </Route >
                 <Route path="*"                element= {<Error404 />} />

--- a/tests/tests/dev-servers.spec.ts
+++ b/tests/tests/dev-servers.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Dev Servers View', () => {
+  test('DEV-01: /devservers renders DataGrid', async ({ page }) => {
+    await page.goto('/devservers');
+    await expect(page.getByTestId('dev-servers-datagrid')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('DEV-02: Dev Servers navbar link navigates correctly', async ({ page }) => {
+    await page.goto('/taskcards');
+    await page.getByRole('link', { name: /dev servers/i }).click();
+    await expect(page).toHaveURL(/\/devservers/);
+    await expect(page.getByTestId('dev-servers-datagrid')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('DEV-03: Dev Servers page shows heading', async ({ page }) => {
+    await page.goto('/devservers');
+    await expect(page.getByRole('heading', { name: 'Dev Servers' })).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/tests/tests/navigation.spec.ts
+++ b/tests/tests/navigation.spec.ts
@@ -19,8 +19,12 @@ test.describe('Navigation', () => {
     await expect(page).toHaveURL(/\/areaedit/);
 
     // Navigate to Swarm
-    await page.getByRole('link', { name: /swarm/i }).click();
-    await expect(page).toHaveURL(/\/swarm/);
+    await page.getByRole('link', { name: /^swarm$/i }).click();
+    await expect(page).toHaveURL(/\/swarm$/);
+
+    // Navigate to Dev Servers
+    await page.getByRole('link', { name: /dev servers/i }).click();
+    await expect(page).toHaveURL(/\/devservers/);
 
     // Navigate back to Plan
     await page.getByRole('link', { name: /plan/i }).click();


### PR DESCRIPTION
## Summary
- New **Dev Servers** page (`/devservers`) with MUI DataGrid showing active port claims (id, port, pid, workspace, session link, started_at)
- **Sessions table** now includes Dev Server column with clickable port chip, column order: ID, Status, Title, Task, Source, Dev Server, Branch, PR, Workers, Started, Completed
- **Session detail** shows linked dev server ports as clickable chips
- **Navbar** updated with Dev Servers link
- **API Gateway** route added for `/darwin/dev_servers` (Cognito auth, Lambda proxy, CORS)
- **devserver-start skill** fixed to pass workspace path explicitly (prevents worktree from serving main repo files)

## Files changed
- `src/DevServers/DevServersView.jsx` — new component: read-only DataGrid for dev server claims
- `src/SwarmView/SessionsView.jsx` — added Dev Server column, reordered columns, fetches dev_servers to join port→session
- `src/SwarmView/detail/SwarmSessionDetail.jsx` — added dev server cross-link section with port chips
- `src/index.jsx` — added `/devservers` route
- `src/NavBar/NavBar.jsx` — added Dev Servers navbar link
- `tests/tests/dev-servers.spec.ts` — 3 new E2E tests (DEV-01 through DEV-03)
- `tests/tests/navigation.spec.ts` — updated NAV-01 to include Dev Servers link

## Testing
- Local E2E: 87/88 passing (1 pre-existing flaky DnD test)
- 3 new dev-servers tests all passing
- All 17 swarm tests passing

## Deploy notes
- Darwin frontend deploy
- API Gateway route already deployed (resource `fbatro`)
- DB migration 010 (dev_servers table) already applied to production

## References
- Roadmap priority #5: Dev server port coordination
- Related PRs: BillWilliams79/AWS-Lambda-REST-API#15, BillWilliams79/DarwinSQL#14

🤖 Generated with [Claude Code](https://claude.com/claude-code)