### PR TITLE
User settable timezone for all dates/times

### DIFF
--- a/src/CalendarFC/CalendarFC.jsx
+++ b/src/CalendarFC/CalendarFC.jsx
@@ -8,6 +8,7 @@ import AuthContext from '../Context/AuthContext';
 import AppContext from '../Context/AppContext';
 import call_rest_api from '../RestApi/RestApi';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
+import { toLocaleDateString } from '../utils/dateFormat';
 import { useCrudCallbacks } from '../hooks/useCrudCallbacks';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { TaskActionsContext } from '../hooks/useTaskActions';
@@ -75,12 +76,7 @@ const CalendarFC = () => {
     const events = useMemo(() =>
         localTasksArray.map(task => {
             const start = task.done_ts
-                ? (() => {
-                    const d = new Date(task.done_ts.replace(' ', 'T') + 'Z');
-                    return d.getFullYear() + '-' +
-                        String(d.getMonth() + 1).padStart(2, '0') + '-' +
-                        String(d.getDate()).padStart(2, '0');
-                })()
+                ? toLocaleDateString(task.done_ts, profile?.timezone)
                 : null;
             return {
                 id: String(task.id),

--- a/src/CalendarView/DayView.jsx
+++ b/src/CalendarView/DayView.jsx
@@ -5,6 +5,7 @@ import TaskEditDialog from '../Components/TaskEditDialog/TaskEditDialog';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
 import { useCrudCallbacks } from '../hooks/useCrudCallbacks';
 import { TaskActionsContext } from '../hooks/useTaskActions';
+import { formatDateWithOptions } from '../utils/dateFormat';
 
 
 import React, { useState, useEffect, useContext } from 'react'
@@ -85,9 +86,9 @@ const DayView = (date) => {
 
         // set the date and day for the card title
         const date_options = {month: 'short', day: 'numeric'};
-        setCardTitleDate(startDate.toLocaleDateString(undefined, date_options));
+        setCardTitleDate(formatDateWithOptions(startDate.toISOString(), profile?.timezone, date_options));
         const day_options = {weekday: 'long'};
-        setCardTitleDay(startDate.toLocaleDateString(undefined, day_options));
+        setCardTitleDay(formatDateWithOptions(startDate.toISOString(), profile?.timezone, day_options));
 
         // FETCH TASKS: filter for creator, done=1 and props.date
         // QSPs limit fields to minimum: id,description

--- a/src/Context/AuthContext.jsx
+++ b/src/Context/AuthContext.jsx
@@ -38,7 +38,10 @@ export const AuthContextProvider = ({ children }) => {
                 const tokens = await refreshTokensApi(refreshTokenRef.current);
                 setIdToken(tokens.idToken);
                 setAccessToken(tokens.accessToken);
-                setProfile(parseIdToken(tokens.idToken));
+                const jwtProfile = parseIdToken(tokens.idToken);
+                const cached = localStorage.getItem('darwin-profile');
+                const dbProfile = cached ? JSON.parse(cached) : {};
+                setProfile({ ...dbProfile, ...jwtProfile });
                 scheduleRefresh(tokens.expiresIn);
             } catch (e) {
                 console.log('Background token refresh failed:', e.message);
@@ -68,7 +71,11 @@ export const AuthContextProvider = ({ children }) => {
                     const tokens = await refreshTokensApi(refreshToken);
                     setIdToken(tokens.idToken);
                     setAccessToken(tokens.accessToken);
-                    setProfile(parseIdToken(tokens.idToken));
+                    // Merge JWT claims with cached DB profile (preserves timezone, etc.)
+                    const jwtProfile = parseIdToken(tokens.idToken);
+                    const cached = localStorage.getItem('darwin-profile');
+                    const dbProfile = cached ? JSON.parse(cached) : {};
+                    setProfile({ ...dbProfile, ...jwtProfile });
                     scheduleRefresh(tokens.expiresIn);
                     setAuthLoading(false);
                     return;

--- a/src/DevServers/DevServersView.jsx
+++ b/src/DevServers/DevServersView.jsx
@@ -1,6 +1,7 @@
 import '../index.css';
 import AuthContext from '../Context/AuthContext';
 import { useDevServers } from '../hooks/useDataQueries';
+import { formatDateTime, formatDate } from '../utils/dateFormat';
 import { DataGrid, GridToolbar } from '@mui/x-data-grid';
 
 import React, { useContext } from 'react';
@@ -14,7 +15,7 @@ import Stack from '@mui/material/Stack';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { CircularProgress, Typography } from '@mui/material';
 
-const getDevServerColumns = (navigate) => [
+const getDevServerColumns = (navigate, timezone) => [
     { field: 'id',             headerName: 'ID',        width: 70 },
     {
         field: 'port',
@@ -43,11 +44,11 @@ const getDevServerColumns = (navigate) => [
         field: 'started_at',
         headerName: 'Started',
         width: 170,
-        valueFormatter: (value) => value ? new Date(value).toLocaleString() : '—',
+        valueFormatter: (value) => value ? formatDateTime(value, timezone) : '—',
     },
 ];
 
-const DevServerCard = ({ server, navigate }) => {
+const DevServerCard = ({ server, navigate, timezone }) => {
     const workspaceName = server.workspace_path
         ? server.workspace_path.split('/').pop()
         : '—';
@@ -75,7 +76,7 @@ const DevServerCard = ({ server, navigate }) => {
                         PID {server.pid}
                     </Typography>
                     <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
-                        {server.started_at ? new Date(server.started_at).toLocaleDateString() : ''}
+                        {server.started_at ? formatDate(server.started_at, timezone) : ''}
                     </Typography>
                 </Stack>
             </CardContent>
@@ -107,7 +108,7 @@ const DevServersView = () => {
                         <Typography color="text.secondary" sx={{ p: 2 }}>No dev servers</Typography>
                     ) : (
                         sortedServers.map(server => (
-                            <DevServerCard key={server.id} server={server} navigate={navigate} />
+                            <DevServerCard key={server.id} server={server} navigate={navigate} timezone={profile?.timezone} />
                         ))
                     )}
                 </Box>
@@ -115,7 +116,7 @@ const DevServersView = () => {
                 <Box sx={{ height: 600, width: '100%' }} data-testid="dev-servers-datagrid">
                     <DataGrid
                         rows={devServersArray}
-                        columns={getDevServerColumns(navigate)}
+                        columns={getDevServerColumns(navigate, profile?.timezone)}
                         slots={{ toolbar: GridToolbar }}
                         slotProps={{
                             toolbar: {

--- a/src/LoggedIn/LoggedIn.jsx
+++ b/src/LoggedIn/LoggedIn.jsx
@@ -94,7 +94,9 @@ function LoggedIn() {
                         return call_rest_api(profileUri, 'GET', '', tokens.idToken)
                             .then(result => {
                                 if (result.httpStatus.httpStatus === 200) {
-                                    setProfile(result.data[0]);
+                                    const dbProfile = result.data[0];
+                                    setProfile(dbProfile);
+                                    localStorage.setItem('darwin-profile', JSON.stringify(dbProfile));
                                     // Schedule background token refresh (pass refresh token for the ref)
                                     scheduleRefresh(tokens.expiresIn, tokens.refreshToken);
                                 } else {
@@ -120,7 +122,7 @@ function LoggedIn() {
     return (
         <>
             {(idToken && profile && redirectPath) ?
-                <Navigate to={redirectPath} replace={true} />
+                <Navigate to={profile.timezone == null ? '/setup' : redirectPath} replace={true} />
             :
                 <>
                     {errorMsg ?

--- a/src/NavBar/Profile.jsx
+++ b/src/NavBar/Profile.jsx
@@ -1,9 +1,15 @@
 import '../index.css';
 import AuthContext from '../Context/AuthContext';
+import AppContext from '../Context/AppContext';
+import call_rest_api from '../RestApi/RestApi';
+import { useSnackBarStore } from '../stores/useSnackBarStore';
+import { getTimezoneList } from '../utils/dateFormat';
 
-import React, {useContext} from 'react';
+import React, { useContext, useState, useMemo } from 'react';
 
+import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
@@ -11,8 +17,36 @@ const Profile = () => {
 
     console.count('Profile Render');
 
-    const { profile } = useContext(AuthContext);
-    
+    const { idToken, profile, setProfile } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
+    const showError = useSnackBarStore(s => s.showError);
+
+    const [name, setName] = useState(profile?.name || '');
+    const [timezone, setTimezone] = useState(profile?.timezone || '');
+    const [saving, setSaving] = useState(false);
+
+    const timezoneOptions = useMemo(() => getTimezoneList(), []);
+    const selectedTimezone = timezoneOptions.find(tz => tz.value === timezone) || null;
+
+    const hasChanges = name !== (profile?.name || '') || timezone !== (profile?.timezone || '');
+
+    const handleSave = () => {
+        setSaving(true);
+        const uri = `${darwinUri}/profiles`;
+        call_rest_api(uri, 'PUT', [{ id: profile.id, name, timezone }], idToken)
+            .then(result => {
+                if (result.httpStatus.httpStatus === 200 || result.httpStatus.httpStatus === 204) {
+                    const updated = { ...profile, name, timezone };
+                    setProfile(updated);
+                    localStorage.setItem('darwin-profile', JSON.stringify(updated));
+                } else {
+                    showError(result, 'Unable to save profile');
+                }
+            })
+            .catch(error => showError(error, 'Unable to save profile'))
+            .finally(() => setSaving(false));
+    };
+
     return (
         <>
         <Box className="app-title" sx={{ ml: 2}}>
@@ -22,12 +56,24 @@ const Profile = () => {
         </Box >
         <Box className="app-content" sx={{ margin: 2, display: 'flex', flexDirection: 'column', gap: 2, maxWidth: 400 }}>
             <TextField  label="Name"
-                        value = { profile.name }
-                        id= "Name"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        id="Name"
                         key="Name"
-                        variant= "outlined"
-                        size = 'small'
-                        disabled />
+                        variant="outlined"
+                        size='small'
+                        data-testid="profile-name" />
+            <Autocomplete
+                        options={timezoneOptions}
+                        value={selectedTimezone}
+                        onChange={(e, newValue) => setTimezone(newValue?.value || '')}
+                        isOptionEqualToValue={(option, value) => option.value === value.value}
+                        renderInput={(params) => (
+                            <TextField {...params} label="Timezone" size="small" />
+                        )}
+                        data-testid="profile-timezone"
+                        disableClearable
+                        />
             <TextField  label="E-mail"
                         value = { profile.email }
                         id= "email"
@@ -56,6 +102,13 @@ const Profile = () => {
                         variant= "outlined"
                         size = 'small'
                         disabled />
+            <Button variant="contained"
+                    onClick={handleSave}
+                    disabled={!hasChanges || saving}
+                    data-testid="profile-save"
+                    sx={{ alignSelf: 'flex-start' }}>
+                {saving ? 'Saving...' : 'Save'}
+            </Button>
         </Box>
         </>
     )

--- a/src/SetupWizard/SetupWizard.jsx
+++ b/src/SetupWizard/SetupWizard.jsx
@@ -1,0 +1,97 @@
+import '../index.css';
+import AuthContext from '../Context/AuthContext';
+import AppContext from '../Context/AppContext';
+import call_rest_api from '../RestApi/RestApi';
+import { useSnackBarStore } from '../stores/useSnackBarStore';
+import { getTimezoneList } from '../utils/dateFormat';
+
+import React, { useContext, useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import Autocomplete from '@mui/material/Autocomplete';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+
+const SetupWizard = () => {
+
+    const { idToken, profile, setProfile } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
+    const showError = useSnackBarStore(s => s.showError);
+    const navigate = useNavigate();
+
+    const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    const [name, setName] = useState(profile?.name || '');
+    const [timezone, setTimezone] = useState(browserTimezone);
+    const [saving, setSaving] = useState(false);
+
+    const timezoneOptions = useMemo(() => getTimezoneList(), []);
+    const selectedTimezone = timezoneOptions.find(tz => tz.value === timezone) || null;
+
+    const handleSubmit = () => {
+        setSaving(true);
+        const uri = `${darwinUri}/profiles`;
+        call_rest_api(uri, 'PUT', [{ id: profile.id, name, timezone }], idToken)
+            .then(result => {
+                if (result.httpStatus.httpStatus === 200 || result.httpStatus.httpStatus === 204) {
+                    const updated = { ...profile, name, timezone };
+                    setProfile(updated);
+                    localStorage.setItem('darwin-profile', JSON.stringify(updated));
+                    navigate('/', { replace: true });
+                } else {
+                    showError(result, 'Unable to save profile');
+                }
+            })
+            .catch(error => showError(error, 'Unable to save profile'))
+            .finally(() => setSaving(false));
+    };
+
+    return (
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center',
+                   minHeight: '60vh', p: 2 }}>
+            <Paper elevation={3} sx={{ p: 4, maxWidth: 450, width: '100%' }}>
+                <Typography variant="h5" gutterBottom>
+                    Welcome to Darwin
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+                    Let's set up your profile. You can change these later in Settings.
+                </Typography>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    <TextField
+                        label="Display Name"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        size="small"
+                        autoFocus
+                        data-testid="setup-name"
+                    />
+                    <Autocomplete
+                        options={timezoneOptions}
+                        value={selectedTimezone}
+                        onChange={(e, newValue) => setTimezone(newValue?.value || browserTimezone)}
+                        isOptionEqualToValue={(option, value) => option.value === value.value}
+                        renderInput={(params) => (
+                            <TextField {...params} label="Timezone" size="small" />
+                        )}
+                        data-testid="setup-timezone"
+                        disableClearable
+                    />
+                    <Button
+                        variant="contained"
+                        onClick={handleSubmit}
+                        disabled={!name.trim() || !timezone || saving}
+                        data-testid="setup-save"
+                        sx={{ mt: 1 }}
+                    >
+                        {saving ? 'Saving...' : 'Get Started'}
+                    </Button>
+                </Box>
+            </Paper>
+        </Box>
+    );
+};
+
+export default SetupWizard;

--- a/src/SwarmView/SessionsView.jsx
+++ b/src/SwarmView/SessionsView.jsx
@@ -2,6 +2,7 @@ import '../index.css';
 import AuthContext from '../Context/AuthContext';
 import { useSessions, useDevServers } from '../hooks/useDataQueries';
 import { useShowClosedStore } from '../stores/useShowClosedStore';
+import { formatDateTime, formatDate } from '../utils/dateFormat';
 import { DataGrid, GridToolbar } from '@mui/x-data-grid';
 
 import { renderSourceRef } from './repoGitHubMap.jsx';
@@ -28,7 +29,7 @@ const swarmStatusColor = (status) => {
     }
 };
 
-const getSessionColumns = (navigate) => [
+const getSessionColumns = (navigate, timezone) => [
     { field: 'id',           headerName: 'ID',          width: 70 },
     {
         field: 'swarm_status',
@@ -74,17 +75,17 @@ const getSessionColumns = (navigate) => [
         field: 'started_at',
         headerName: 'Started',
         width: 170,
-        valueFormatter: (value) => value ? new Date(value).toLocaleString() : '—',
+        valueFormatter: (value) => value ? formatDateTime(value, timezone) : '—',
     },
     {
         field: 'completed_at',
         headerName: 'Completed',
         width: 170,
-        valueFormatter: (value) => value ? new Date(value).toLocaleString() : '—',
+        valueFormatter: (value) => value ? formatDateTime(value, timezone) : '—',
     },
 ];
 
-const SessionCard = ({ session, navigate }) => (
+const SessionCard = ({ session, navigate, timezone }) => (
     <Card variant="outlined" sx={{ mb: 1 }}>
         <CardActionArea onClick={() => navigate(`/swarm/session/${session.id}`)}>
             <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
@@ -121,7 +122,7 @@ const SessionCard = ({ session, navigate }) => (
                               data-testid="session-pr-url" />
                     )}
                     <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
-                        {session.started_at ? new Date(session.started_at).toLocaleDateString() : ''}
+                        {session.started_at ? formatDate(session.started_at, timezone) : ''}
                     </Typography>
                 </Stack>
             </CardContent>
@@ -179,7 +180,7 @@ const SessionsView = () => {
                         <Typography color="text.secondary" sx={{ p: 2 }}>No sessions</Typography>
                     ) : (
                         sortedSessions.map(session => (
-                            <SessionCard key={session.id} session={session} navigate={navigate} />
+                            <SessionCard key={session.id} session={session} navigate={navigate} timezone={profile?.timezone} />
                         ))
                     )}
                 </Box>
@@ -187,7 +188,7 @@ const SessionsView = () => {
                 <Box sx={{ height: 600, width: '100%' }} data-testid="sessions-datagrid">
                     <DataGrid
                         rows={filteredSessions}
-                        columns={getSessionColumns(navigate)}
+                        columns={getSessionColumns(navigate, profile?.timezone)}
                         slots={{ toolbar: GridToolbar }}
                         slotProps={{
                             toolbar: {

--- a/src/SwarmView/detail/PriorityDetail.jsx
+++ b/src/SwarmView/detail/PriorityDetail.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import call_rest_api from '../../RestApi/RestApi';
 import { useSnackBarStore } from '../../stores/useSnackBarStore';
+import { formatDateTime, formatDate } from '../../utils/dateFormat';
 import AuthContext from '../../Context/AuthContext';
 import AppContext from '../../Context/AppContext';
 import { DataGrid } from '@mui/x-data-grid';
@@ -26,7 +27,7 @@ const swarmStatusColor = (status) => {
     }
 };
 
-const getSessionColumns = (navigate) => [
+const getSessionColumns = (navigate, timezone) => [
     { field: 'id',           headerName: 'ID',        width: 70 },
     { field: 'swarm_status', headerName: 'Status',    width: 110,
       renderCell: (params) => (
@@ -42,16 +43,17 @@ const getSessionColumns = (navigate) => [
     },
     { field: 'branch',       headerName: 'Branch',    width: 200, flex: 1 },
     { field: 'started_at',   headerName: 'Started',   width: 170,
-      valueFormatter: (value) => value ? new Date(value).toLocaleDateString() : '—' },
+      valueFormatter: (value) => value ? formatDate(value, timezone) : '—' },
     { field: 'completed_at', headerName: 'Completed', width: 120,
-      valueFormatter: (value) => value ? new Date(value).toLocaleDateString() : '—' },
+      valueFormatter: (value) => value ? formatDate(value, timezone) : '—' },
 ];
 
 const PriorityDetail = () => {
 
     const { id } = useParams();
     const navigate = useNavigate();
-    const { idToken } = useContext(AuthContext);
+    const { idToken, profile } = useContext(AuthContext);
+    const timezone = profile?.timezone;
     const { darwinUri } = useContext(AppContext);
 
     const [priority, setPriority] = useState(null);
@@ -226,28 +228,28 @@ const PriorityDetail = () => {
             <Box sx={{ mb: 1 }}>
                 <Typography variant="subtitle2" color="text.secondary">Started</Typography>
                 <Typography variant="body2" data-testid="priority-started-at">
-                    {priority.started_at ? new Date(priority.started_at).toLocaleString() : '—'}
+                    {priority.started_at ? formatDateTime(priority.started_at, timezone) : '—'}
                 </Typography>
             </Box>
 
             <Box sx={{ mb: 1 }}>
                 <Typography variant="subtitle2" color="text.secondary">Completed</Typography>
                 <Typography variant="body2" data-testid="priority-completed-at">
-                    {priority.completed_at ? new Date(priority.completed_at).toLocaleString() : '—'}
+                    {priority.completed_at ? formatDateTime(priority.completed_at, timezone) : '—'}
                 </Typography>
             </Box>
 
             <Box sx={{ mb: 1 }}>
                 <Typography variant="subtitle2" color="text.secondary">Created</Typography>
                 <Typography variant="body2" data-testid="priority-create-ts">
-                    {priority.create_ts ? new Date(priority.create_ts).toLocaleString() : '—'}
+                    {priority.create_ts ? formatDateTime(priority.create_ts, timezone) : '—'}
                 </Typography>
             </Box>
 
             <Box sx={{ mb: 3 }}>
                 <Typography variant="subtitle2" color="text.secondary">Updated</Typography>
                 <Typography variant="body2" data-testid="priority-update-ts">
-                    {priority.update_ts ? new Date(priority.update_ts).toLocaleString() : '—'}
+                    {priority.update_ts ? formatDateTime(priority.update_ts, timezone) : '—'}
                 </Typography>
             </Box>
 
@@ -260,7 +262,7 @@ const PriorityDetail = () => {
                 <Box sx={{ height: 300 }} data-testid="linked-sessions-grid">
                     <DataGrid
                         rows={sessions}
-                        columns={getSessionColumns(navigate)}
+                        columns={getSessionColumns(navigate, timezone)}
                         density="compact"
                         disableRowSelectionOnClick
                         onRowClick={(params) => navigate(`/swarm/session/${params.id}`)}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -27,6 +27,7 @@ import PriorityDetail from './SwarmView/detail/PriorityDetail';
 import SessionsView from './SwarmView/SessionsView';
 import SwarmSessionDetail from './SwarmView/detail/SwarmSessionDetail';
 import DevServersView from './DevServers/DevServersView';
+import SetupWizard from './SetupWizard/SetupWizard';
 
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
@@ -71,6 +72,9 @@ root.render(
                                                          </AuthenticatedRoute>} />
 <Route path="swarm/session/:id" element= {<AuthenticatedRoute>
                                                              <SwarmSessionDetail />
+                                                         </AuthenticatedRoute>} />
+                    <Route path="setup"      element= {<AuthenticatedRoute>
+                                                             <SetupWizard />
                                                          </AuthenticatedRoute>} />
                     <Route path="devservers" element= {<AuthenticatedRoute>
                                                              <DevServersView />

--- a/src/utils/dateFormat.js
+++ b/src/utils/dateFormat.js
@@ -1,0 +1,104 @@
+// Timezone-aware date formatting utilities.
+// All functions accept an IANA timezone string (e.g. 'America/Los_Angeles').
+// If timezone is null/undefined, falls back to browser default.
+
+function toDate(dateStr) {
+    if (!dateStr) return null;
+    // MySQL format: "YYYY-MM-DD HH:MM:SS" — stored as UTC, append Z
+    if (typeof dateStr === 'string' && dateStr.includes(' ') && !dateStr.includes('T')) {
+        return new Date(dateStr.replace(' ', 'T') + 'Z');
+    }
+    return new Date(dateStr);
+}
+
+export function formatDateTime(dateStr, timezone) {
+    const d = toDate(dateStr);
+    if (!d || isNaN(d)) return '—';
+    const options = {
+        year: 'numeric', month: 'short', day: 'numeric',
+        hour: 'numeric', minute: '2-digit',
+        ...(timezone && { timeZone: timezone }),
+    };
+    return d.toLocaleString(undefined, options);
+}
+
+export function formatDate(dateStr, timezone) {
+    const d = toDate(dateStr);
+    if (!d || isNaN(d)) return '—';
+    const options = {
+        year: 'numeric', month: 'short', day: 'numeric',
+        ...(timezone && { timeZone: timezone }),
+    };
+    return d.toLocaleDateString(undefined, options);
+}
+
+export function formatDateWithOptions(dateStr, timezone, extraOptions) {
+    const d = toDate(dateStr);
+    if (!d || isNaN(d)) return '—';
+    const options = {
+        ...extraOptions,
+        ...(timezone && { timeZone: timezone }),
+    };
+    return d.toLocaleDateString(undefined, options);
+}
+
+// Extract a YYYY-MM-DD date string in the given timezone (for calendar day placement)
+export function toLocaleDateString(dateStr, timezone) {
+    const d = toDate(dateStr);
+    if (!d || isNaN(d)) return null;
+    const options = {
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        ...(timezone && { timeZone: timezone }),
+    };
+    // Intl gives locale-formatted; use formatToParts for reliable YYYY-MM-DD
+    const parts = new Intl.DateTimeFormat('en-CA', options).formatToParts(d);
+    const get = (type) => parts.find(p => p.type === type)?.value;
+    return `${get('year')}-${get('month')}-${get('day')}`;
+}
+
+// One representative per major timezone, Americas first, then east across the globe.
+const TIMEZONE_ENTRIES = [
+    // Americas
+    { value: 'Pacific/Honolulu',              label: 'Hawaii (HST)' },
+    { value: 'America/Anchorage',             label: 'Alaska (AKST/AKDT)' },
+    { value: 'America/Los_Angeles',           label: 'Pacific (PST/PDT)' },
+    { value: 'America/Phoenix',               label: 'Arizona (MST, no DST)' },
+    { value: 'America/Denver',                label: 'Mountain (MST/MDT)' },
+    { value: 'America/Chicago',               label: 'Central (CST/CDT)' },
+    { value: 'America/New_York',              label: 'Eastern (EST/EDT)' },
+    { value: 'America/Halifax',               label: 'Atlantic (AST/ADT)' },
+    { value: 'America/St_Johns',              label: 'Newfoundland (NST/NDT)' },
+    { value: 'America/Sao_Paulo',             label: 'Brasilia (BRT)' },
+    { value: 'America/Argentina/Buenos_Aires', label: 'Argentina (ART)' },
+    // Atlantic / Europe / Africa
+    { value: 'Atlantic/Cape_Verde',           label: 'Cape Verde (CVT)' },
+    { value: 'UTC',                           label: 'UTC' },
+    { value: 'Europe/London',                 label: 'London (GMT/BST)' },
+    { value: 'Europe/Paris',                  label: 'Central Europe (CET/CEST)' },
+    { value: 'Europe/Athens',                 label: 'Eastern Europe (EET/EEST)' },
+    { value: 'Africa/Nairobi',               label: 'East Africa (EAT)' },
+    // Middle East / Asia
+    { value: 'Europe/Moscow',                 label: 'Moscow (MSK)' },
+    { value: 'Asia/Dubai',                    label: 'Gulf (GST)' },
+    { value: 'Asia/Kolkata',                  label: 'India (IST)' },
+    { value: 'Asia/Dhaka',                    label: 'Bangladesh (BST)' },
+    { value: 'Asia/Bangkok',                  label: 'Indochina (ICT)' },
+    { value: 'Asia/Shanghai',                 label: 'China (CST)' },
+    { value: 'Asia/Tokyo',                    label: 'Japan (JST)' },
+    { value: 'Asia/Seoul',                    label: 'Korea (KST)' },
+    // Oceania
+    { value: 'Australia/Adelaide',            label: 'Adelaide (ACST/ACDT)' },
+    { value: 'Australia/Sydney',              label: 'Sydney (AEST/AEDT)' },
+    { value: 'Pacific/Auckland',              label: 'New Zealand (NZST/NZDT)' },
+];
+
+export function getTimezoneList() {
+    const now = new Date();
+    return TIMEZONE_ENTRIES.map(({ value, label }) => {
+        const offset = new Intl.DateTimeFormat('en-US', {
+            timeZone: value,
+            timeZoneName: 'shortOffset',
+        }).formatToParts(now).find(p => p.type === 'timeZoneName')?.value || '';
+        return { value, label: `(${offset}) ${label}` };
+    });
+}


### PR DESCRIPTION
## Summary
- Add user-settable timezone preference stored in profiles DB table
- Create first-login setup wizard that triggers when timezone is null (new users)
- Build centralized date formatting utility using Intl.DateTimeFormat with timeZone option
- Convert Profile page from read-only to editable (name + timezone Autocomplete + Save)
- Replace all 13 raw toLocaleString/toLocaleDateString calls with timezone-aware formatting
- Cache full DB profile in localStorage for silent refresh persistence
- Curated timezone list (~28 entries) sorted Americas-first with UTC offset labels

## Files changed
- `src/utils/dateFormat.js` — new: formatDateTime, formatDate, formatDateWithOptions, toLocaleDateString, getTimezoneList
- `src/SetupWizard/SetupWizard.jsx` — new: first-login wizard component
- `src/NavBar/Profile.jsx` — editable name + timezone picker + save button
- `src/Context/AuthContext.jsx` — merge cached DB profile with JWT on refresh
- `src/LoggedIn/LoggedIn.jsx` — store profile in localStorage, redirect to /setup when timezone null
- `src/index.jsx` — add /setup route
- `src/SwarmView/SessionsView.jsx` — timezone-aware date columns + mobile cards
- `src/SwarmView/detail/PriorityDetail.jsx` — timezone-aware date displays + DataGrid columns
- `src/DevServers/DevServersView.jsx` — timezone-aware DataGrid + mobile cards
- `src/CalendarView/DayView.jsx` — timezone-aware card title formatting
- `src/CalendarFC/CalendarFC.jsx` — timezone-aware calendar day placement

## Testing
- DarwinSQL: 50/50 passing
- Lambda-Rest: 83/83 passing
- Lambda-Cognito: 18/18 passing
- Darwin build: clean
- E2E: 39/39 passing (11 skipped = AUTH-01 port-3000 only)

## Deploy notes
- Deploy Darwin to S3 + CloudFront
- DB migration 011 must be applied to production before deploy (adds timezone column)

## References
- Related PR: BillWilliams79/DarwinSQL#15 (DB migration)
- Roadmap priority #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)