### PR TITLE
[PAUSED] Separation method for Darwin Apps

### DIFF
--- a/src/HomePage/HomePage.jsx
+++ b/src/HomePage/HomePage.jsx
@@ -3,18 +3,39 @@ import '../index.css';
 import varDump from '../classifier/classifier';
 
 import AuthContext from '../Context/AuthContext';
+import { useAppModeStore } from '../stores/useAppModeStore';
 
 import React, { useContext } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate, Navigate } from 'react-router-dom';
 
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import AssignmentIcon from '@mui/icons-material/Assignment';
+import HiveIcon from '@mui/icons-material/Hive';
+
+const APP_PRIMARY_ROUTES = {
+    tasks: '/taskcards',
+    swarm: '/swarm',
+};
 
 const HomePage = () => {
 
     console.count('HomePage Render');
 
     const { idToken } = useContext(AuthContext);
+    const { appMode, setAppMode } = useAppModeStore();
+    const navigate = useNavigate();
+
+    const selectMode = (mode) => {
+        setAppMode(mode);
+        navigate(APP_PRIMARY_ROUTES[mode]);
+    };
+
+    if (idToken && appMode) {
+        return <Navigate to={APP_PRIMARY_ROUTES[appMode]} replace />;
+    }
 
     return (
         <>
@@ -24,9 +45,6 @@ const HomePage = () => {
             </Typography>
         </Box>
         <Box className="app-homepage">
-            <Typography variant="h6">
-                Accounts
-            </Typography>
             {!idToken ?
                 <Typography key="login"
                             variant="body1"
@@ -36,13 +54,40 @@ const HomePage = () => {
                     Login / Create Account
                 </Typography>
              :
+                <>
+                <Typography variant="h6" sx={{ mb: 2 }}>
+                    Select an App
+                </Typography>
+                <Stack direction="row" spacing={3}>
+                    <Button
+                        data-testid="app-mode-tasks"
+                        variant="contained"
+                        size="large"
+                        startIcon={<AssignmentIcon />}
+                        onClick={() => selectMode('tasks')}
+                        sx={{ px: 4, py: 2, fontSize: '1.1rem' }}
+                    >
+                        Tasks
+                    </Button>
+                    <Button
+                        data-testid="app-mode-swarm"
+                        variant="contained"
+                        size="large"
+                        startIcon={<HiveIcon />}
+                        onClick={() => selectMode('swarm')}
+                        sx={{ px: 4, py: 2, fontSize: '1.1rem' }}
+                    >
+                        Swarm
+                    </Button>
+                </Stack>
                 <Typography key="logout"
                             variant="body1"
                             component={Link}
                             to="/logout"
-                            sx={{marginBottom: 0 }} >
+                            sx={{ mt: 4 }} >
                     Logout
                 </Typography>
+                </>
             }
         </Box>
         </>

--- a/src/NavBar/NavBar.jsx
+++ b/src/NavBar/NavBar.jsx
@@ -1,16 +1,58 @@
 import '../index.css';
 import AuthContext from '../Context/AuthContext';
+import { useAppModeStore } from '../stores/useAppModeStore';
 
-import React, {useContext} from 'react';
-import { Link } from "react-router-dom"
+import React, {useContext, useEffect} from 'react';
+import { Link, useNavigate, useLocation } from "react-router-dom"
 
 import AppBar from '@mui/material/AppBar';
 import PedalBikeIcon from '@mui/icons-material/PedalBike';
+import HomeIcon from '@mui/icons-material/Home';
 import Stack from '@mui/material/Stack';
+
+const TASK_ROUTES = ['/taskcards', '/calview', '/domainedit', '/areaedit'];
+const SWARM_ROUTES = ['/swarm', '/devservers'];
+
+function inferModeFromPath(pathname) {
+    if (TASK_ROUTES.some(r => pathname.startsWith(r))) return 'tasks';
+    if (SWARM_ROUTES.some(r => pathname.startsWith(r))) return 'swarm';
+    return null;
+}
+
+const NAV_LINKS = {
+    tasks: [
+        { to: '/taskcards', label: 'Plan' },
+        { to: '/calview', label: 'Calendar' },
+        { to: '/domainedit', label: 'Domains' },
+        { to: '/areaedit', label: 'Areas' },
+    ],
+    swarm: [
+        { to: '/swarm', label: 'Swarm' },
+        { to: '/swarm/sessions', label: 'Sessions' },
+        { to: '/devservers', label: 'Dev Servers' },
+    ],
+};
 
 const NavBar = () => {
     console.count('Navbar render');
     const { idToken } = useContext(AuthContext);
+    const { appMode, setAppMode, clearAppMode } = useAppModeStore();
+    const navigate = useNavigate();
+    const location = useLocation();
+
+    const effectiveMode = appMode || inferModeFromPath(location.pathname);
+    useEffect(() => {
+        if (effectiveMode && !appMode) {
+            setAppMode(effectiveMode);
+        }
+    }, [effectiveMode, appMode, setAppMode]);
+
+    const handleHome = () => {
+        clearAppMode();
+        navigate('/');
+    };
+
+    const links = effectiveMode ? NAV_LINKS[effectiveMode] : [];
 
   return (
     <AppBar className="app-navbar" position="static" sx={{backgroundColor: 'black', padding: 2,  pb: {xs:2, md:3} }}>
@@ -28,15 +70,20 @@ const NavBar = () => {
           <Link className="nav-title" to="/">
             Darwin
           </Link>
-              <>
-                <Link className="nav-link" to="/taskcards"> Plan </Link>
-                <Link className="nav-link" to="/calview"> Calendar </Link>
-                <Link className="nav-link" to="/domainedit"> Domains </Link>
-                <Link className="nav-link" to="/areaedit"> Areas </Link>
-                <Link className="nav-link" to="/swarm"> Swarm </Link>
-                <Link className="nav-link" to="/swarm/sessions"> Sessions </Link>
-                <Link className="nav-link" to="/devservers"> Dev Servers </Link>
-              </>
+          {links.map(({ to, label }) => (
+            <Link key={to} className="nav-link" to={to}> {label} </Link>
+          ))}
+          {effectiveMode && (
+            <Link
+              className="nav-link"
+              to="/"
+              onClick={(e) => { e.preventDefault(); handleHome(); }}
+              style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+              data-testid="nav-home"
+            >
+              <HomeIcon fontSize="small" /> Home
+            </Link>
+          )}
         </Stack>
     </AppBar>
   );

--- a/src/stores/useAppModeStore.js
+++ b/src/stores/useAppModeStore.js
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export const useAppModeStore = create(
+    persist(
+        (set) => ({
+            appMode: null,
+
+            setAppMode: (mode) => set({ appMode: mode }),
+
+            clearAppMode: () => set({ appMode: null }),
+        }),
+        {
+            name: 'darwin_app_mode',
+        }
+    )
+);


### PR DESCRIPTION
## Context

**Source**: roadmap (taskId #228)
**Branch**: `feature/darwin-app-separation`

## Status: PAUSED

**Paused**: 2026-03-06

## What was done
- Created `useAppModeStore.js` — Zustand store with persist middleware for app mode (tasks/swarm/null)
- Updated `HomePage.jsx` — app selector with Tasks and Swarm buttons when authenticated, redirect when mode set
- Updated `NavBar.jsx` — conditional nav links per mode, Home icon to clear mode, URL-based mode inference for direct navigation
- All three files compile cleanly (vite build passes)

## What remains
- User review of look/feel via dev server
- E2E test updates (NAV-01 needs mode-aware nav, add NAV-02 for mode selection/switching)
- Test coverage analysis
- Final review and merge

## Resume instructions
1. `/swarm-resume darwin-app-separation` — recreates worktree from the remote branch, un-pauses the PR
2. Or manually: `git worktree add wt-darwin-app-separation/Darwin feature/darwin-app-separation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)