### PR TITLE
Enforce creator_id on all REST API requests

### DIFF
--- a/src/AreaEdit/AreaEdit.jsx
+++ b/src/AreaEdit/AreaEdit.jsx
@@ -90,7 +90,7 @@ const AreaEdit = () => {
     const domainAdd = useConfirmDialog({
         onConfirm: (newDomainName) => {
             let uri = `${darwinUri}/domains`;
-            call_rest_api(uri, 'POST', {'creator_fk': profile.userName, 'domain_name': newDomainName, 'closed': 0, 'sort_order': domainsArray.length}, idToken)
+            call_rest_api(uri, 'POST', {'domain_name': newDomainName, 'closed': 0, 'sort_order': domainsArray.length}, idToken)
                 .then(result => {
                     if (result.httpStatus.httpStatus === 200) {
                         let newDomainsArray = [...domainsArray];

--- a/src/AreaEdit/AreaEditTabPanel.jsx
+++ b/src/AreaEdit/AreaEditTabPanel.jsx
@@ -47,10 +47,10 @@ const AreaEditTabPanel = ( { domain, domainIndex, activeTab } ) => {
         if (serverAreas) {
             const sorted = [...serverAreas];
             sorted.sort((areaA, areaB) => areaSortByClosedThenSortOrder(areaA, areaB));
-            sorted.push({'id':'', 'area_name':'', 'closed': 0, 'domain_fk': parseInt(domain.id), 'creator_fk': profile.userName, 'sort_order': null });
+            sorted.push({'id':'', 'area_name':'', 'closed': 0, 'domain_fk': parseInt(domain.id), 'sort_order': null });
             setAreasArray(sorted);
         } else if (serverAreas && serverAreas.length === 0) {
-            setAreasArray([{'id':'', 'area_name':'', 'closed': 0, 'domain_fk': parseInt(domain.id), 'creator_fk': profile.userName }]);
+            setAreasArray([{'id':'', 'area_name':'', 'closed': 0, 'domain_fk': parseInt(domain.id) }]);
         }
     }, [serverAreas]);
 
@@ -134,7 +134,7 @@ const AreaEditTabPanel = ( { domain, domainIndex, activeTab } ) => {
                     // show snackbar, place new data in table and created another blank element
                     newAreasArray[areaIndex] = {...result.data[0]};
                     newAreasArray.sort((areaA, areaB) => areaSortByClosedThenSortOrder(areaA, areaB));
-                    newAreasArray.push({'id':'', 'area_name':'', 'closed': 0, 'domain_fk': domain.id, 'creator_fk': profile.userName, 'sort_order': null });
+                    newAreasArray.push({'id':'', 'area_name':'', 'closed': 0, 'domain_fk': domain.id, 'sort_order': null });
                     setAreasArray(newAreasArray);
 
                     // update the taskCounts data

--- a/src/CalendarView/DayView.jsx
+++ b/src/CalendarView/DayView.jsx
@@ -92,7 +92,7 @@ const DayView = (date) => {
 
         // FETCH TASKS: filter for creator, done=1 and props.date
         // QSPs limit fields to minimum: id,description
-        let taskUri = `${darwinUri}/tasks?creator_fk=${profile.userName}&done=1&filter_ts=(done_ts,${startDateString},${endDateString})&fields=id,priority,done,description`
+        let taskUri = `${darwinUri}/tasks?done=1&filter_ts=(done_ts,${startDateString},${endDateString})&fields=id,priority,done,description`
 
          call_rest_api(taskUri, 'GET', '', idToken)
             .then(result => {

--- a/src/DomainEdit/DomainEdit.jsx
+++ b/src/DomainEdit/DomainEdit.jsx
@@ -54,7 +54,7 @@ const DomainEdit = ( { domain, domainIndex } ) => {
         if (serverDomains) {
             const sorted = [...serverDomains];
             sorted.sort((domainA, domainB) => domainSortByClosedThenSortOrder(domainA, domainB));
-            sorted.push({'id':'', 'domain_name':'', 'closed': 0, 'sort_order': null, 'creator_fk': profile.userName });
+            sorted.push({'id':'', 'domain_name':'', 'closed': 0, 'sort_order': null });
             setDomainsArray(sorted);
         }
     }, [serverDomains]);
@@ -154,7 +154,7 @@ const DomainEdit = ( { domain, domainIndex } ) => {
                     let freshDomainsArray = [...domainsArray];
                     freshDomainsArray[domainIndex] = {...result.data[0]};
                     freshDomainsArray.sort((domainA, domainB) => domainSortByClosedThenSortOrder(domainA, domainB));
-                    freshDomainsArray.push({'id':'', 'domain_name':'', 'closed': 0, 'sort_order': null, 'creator_fk': profile.userName });
+                    freshDomainsArray.push({'id':'', 'domain_name':'', 'closed': 0, 'sort_order': null });
                     setDomainsArray(freshDomainsArray);
 
                     // update the areaCounts and taskCounts data

--- a/src/SwarmView/CategoryCard.jsx
+++ b/src/SwarmView/CategoryCard.jsx
@@ -128,11 +128,11 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
             }
 
             sortedPrioritiesArray.sort((a, b) => activeSort(a, b));
-            sortedPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'scheduled': 0, 'category_fk': parseInt(category.id), 'sort_order': null, 'creator_fk': profile.userName });
+            sortedPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'scheduled': 0, 'category_fk': parseInt(category.id), 'sort_order': null });
             setPrioritiesArray(sortedPrioritiesArray);
         } else if (serverPriorities && serverPriorities.length === 0) {
             let sortedPrioritiesArray = [];
-            sortedPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'scheduled': 0, 'category_fk': parseInt(category.id), 'sort_order': null, 'creator_fk': profile.userName });
+            sortedPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'scheduled': 0, 'category_fk': parseInt(category.id), 'sort_order': null });
             setPrioritiesArray(sortedPrioritiesArray);
         }
     }, [serverPriorities]);
@@ -455,7 +455,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
                     }
 
                     newPrioritiesArray.sort((a, b) => activeSort(a, b));
-                    newPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'scheduled': 0, 'category_fk': category.id, 'sort_order': null, 'creator_fk': profile.userName });
+                    newPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'scheduled': 0, 'category_fk': category.id, 'sort_order': null });
                     setPrioritiesArray(newPrioritiesArray);
                     queryClient.invalidateQueries({ queryKey: priorityKeys.all(profile.userName) });
                 } else if (result.httpStatus.httpStatus === 201) {

--- a/src/SwarmView/CategoryTabPanel.jsx
+++ b/src/SwarmView/CategoryTabPanel.jsx
@@ -41,10 +41,10 @@ const CategoryTabPanel = ( { project, projectIndex, activeTab, showClosed } ) =>
             const sorted = [...serverCategories];
             sorted.sort((a, b) => categorySortBySortOrder(a, b));
             let maxSortOrder = sorted.at(-1).sort_order + 1;
-            sorted.push({'id':'', 'category_name':'', 'project_fk': project.id, 'closed': 0, 'sort_order': maxSortOrder, 'sort_mode': 'priority', 'creator_fk': profile.userName, });
+            sorted.push({'id':'', 'category_name':'', 'project_fk': project.id, 'closed': 0, 'sort_order': maxSortOrder, 'sort_mode': 'priority', });
             setCategoriesArray(sorted);
         } else if (serverCategories && serverCategories.length === 0) {
-            setCategoriesArray([{'id':'', 'category_name':'', 'project_fk': project.id, 'sort_order': 1, 'sort_mode': 'priority', 'creator_fk': profile.userName, }]);
+            setCategoriesArray([{'id':'', 'category_name':'', 'project_fk': project.id, 'sort_order': 1, 'sort_mode': 'priority', }]);
         }
     }, [serverCategories]);
 
@@ -130,7 +130,7 @@ const CategoryTabPanel = ( { project, projectIndex, activeTab, showClosed } ) =>
                 if (result.httpStatus.httpStatus === 200) {
                     newCategoriesArray[categoryIndex] = {...result.data[0]};
                     let newSortOrder = result.data[0].sort_order + 1;
-                    newCategoriesArray.push({'id':'', 'category_name':'', 'closed': 0, 'project_fk': project.id, 'creator_fk': profile.userName, 'sort_order': newSortOrder });
+                    newCategoriesArray.push({'id':'', 'category_name':'', 'closed': 0, 'project_fk': project.id, 'sort_order': newSortOrder });
                     setCategoriesArray(newCategoriesArray);
                     queryClient.invalidateQueries({ queryKey: categoryKeys.all(profile.userName) });
                 } else if (result.httpStatus.httpStatus === 201) {

--- a/src/SwarmView/SwarmView.jsx
+++ b/src/SwarmView/SwarmView.jsx
@@ -100,7 +100,7 @@ const SwarmView = () => {
     const projectAdd = useConfirmDialog({
         onConfirm: (newProjectName) => {
             let uri = `${darwinUri}/projects`;
-            call_rest_api(uri, 'POST', {'creator_fk': profile.userName, 'project_name': newProjectName, 'closed': 0, 'sort_order': projectsArray.length}, idToken)
+            call_rest_api(uri, 'POST', {'project_name': newProjectName, 'closed': 0, 'sort_order': projectsArray.length}, idToken)
                 .then(result => {
                     if (result.httpStatus.httpStatus === 200) {
                         let newProjectsArray = [...projectsArray];

--- a/src/TaskPlanView/AreaTabPanel.jsx
+++ b/src/TaskPlanView/AreaTabPanel.jsx
@@ -46,10 +46,10 @@ const AreaTabPanel = ( { domain, domainIndex, activeTab } ) => {
             const sorted = [...serverAreas];
             sorted.sort((areaA, areaB) => areaSortBySortOrder(areaA, areaB));
             let maxSortOrder = sorted.at(-1).sort_order + 1;
-            sorted.push({'id':'', 'area_name':'', 'domain_fk': domain.id, 'closed': 0, 'sort_order': maxSortOrder, 'sort_mode': 'priority', 'creator_fk': profile.userName, });
+            sorted.push({'id':'', 'area_name':'', 'domain_fk': domain.id, 'closed': 0, 'sort_order': maxSortOrder, 'sort_mode': 'priority', });
             setAreasArray(sorted);
         } else if (serverAreas && serverAreas.length === 0) {
-            setAreasArray([{'id':'', 'area_name':'', 'domain_fk': domain.id, 'sort_order': 1, 'sort_mode': 'priority', 'creator_fk': profile.userName, }]);
+            setAreasArray([{'id':'', 'area_name':'', 'domain_fk': domain.id, 'sort_order': 1, 'sort_mode': 'priority', }]);
         }
     }, [serverAreas]);
 
@@ -138,7 +138,7 @@ const AreaTabPanel = ( { domain, domainIndex, activeTab } ) => {
                     // place new data in table and created another template area
                     newAreasArray[areaIndex] = {...result.data[0]};
                     let newSortOrder = result.data[0].sort_order + 1;
-                    newAreasArray.push({'id':'', 'area_name':'', 'closed': 0, 'domain_fk': domain.id, 'creator_fk': profile.userName, 'sort_order': newSortOrder });
+                    newAreasArray.push({'id':'', 'area_name':'', 'closed': 0, 'domain_fk': domain.id, 'sort_order': newSortOrder });
                     setAreasArray(newAreasArray);
                     setNewlyCreatedAreaId(result.data[0].id);
                     queryClient.invalidateQueries({ queryKey: areaKeys.all(profile.userName) });

--- a/src/TaskPlanView/TaskCard.jsx
+++ b/src/TaskPlanView/TaskCard.jsx
@@ -89,11 +89,11 @@ const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlu
             }
 
             sortedTasksArray.sort((taskA, taskB) => activeSort(taskA, taskB));
-            sortedTasksArray.push({'id':'', 'description':'', 'priority': 0, 'done': 0, 'area_fk': parseInt(area.id), 'sort_order': null, 'creator_fk': profile.userName });
+            sortedTasksArray.push({'id':'', 'description':'', 'priority': 0, 'done': 0, 'area_fk': parseInt(area.id), 'sort_order': null });
             setTasksArray(sortedTasksArray);
         } else if (serverTasks && serverTasks.length === 0) {
             let sortedTasksArray = [];
-            sortedTasksArray.push({'id':'', 'description':'', 'priority': 0, 'done': 0, 'area_fk': parseInt(area.id), 'sort_order': null, 'creator_fk': profile.userName });
+            sortedTasksArray.push({'id':'', 'description':'', 'priority': 0, 'done': 0, 'area_fk': parseInt(area.id), 'sort_order': null });
             setTasksArray(sortedTasksArray);
         }
     }, [serverTasks]);
@@ -462,7 +462,7 @@ const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlu
                     }
 
                     newTasksArray.sort((taskA, taskB) => activeSort(taskA, taskB));
-                    newTasksArray.push({'id':'', 'description':'', 'priority': 0, 'done': 0, 'area_fk': area.id, 'sort_order': null, 'creator_fk': profile.userName });
+                    newTasksArray.push({'id':'', 'description':'', 'priority': 0, 'done': 0, 'area_fk': area.id, 'sort_order': null });
                     setTasksArray(newTasksArray);
                     queryClient.invalidateQueries({ queryKey: taskKeys.all(profile.userName) });
                 } else if (result.httpStatus.httpStatus === 201) {

--- a/src/TaskPlanView/TaskPlanView.jsx
+++ b/src/TaskPlanView/TaskPlanView.jsx
@@ -117,7 +117,7 @@ const TaskPlanView = () => {
     const domainAdd = useConfirmDialog({
         onConfirm: (newDomainName) => {
             let uri = `${darwinUri}/domains`;
-            call_rest_api(uri, 'POST', {'creator_fk': profile.userName, 'domain_name': newDomainName, 'closed': 0, 'sort_order': domainsArray.length}, idToken)
+            call_rest_api(uri, 'POST', {'domain_name': newDomainName, 'closed': 0, 'sort_order': domainsArray.length}, idToken)
                 .then(result => {
                     if (result.httpStatus.httpStatus === 200) {
                         let newDomainsArray = [...domainsArray];

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -28,7 +28,7 @@ export function useDomains(creatorFk, { closed, fields = 'id,domain_name,sort_or
     const { idToken } = useContext(AuthContext);
 
     const closedParam = closed !== undefined ? `&closed=${closed}` : '';
-    const uri = `${darwinUri}/domains?creator_fk=${creatorFk}&fields=${fields}${closedParam}`;
+    const uri = `${darwinUri}/domains?fields=${fields}${closedParam}`;
     const queryKey = closed === 0 ? domainKeys.open(creatorFk)
         : closed === undefined ? domainKeys.withClosed(creatorFk)
         : domainKeys.all(creatorFk);
@@ -45,7 +45,7 @@ export function useAreas(creatorFk, domainId, { closed, fields = 'id,area_name,d
     const { idToken } = useContext(AuthContext);
 
     const closedParam = closed !== undefined ? `&closed=${closed}` : '';
-    const uri = `${darwinUri}/areas?creator_fk=${creatorFk}&domain_fk=${domainId}&fields=${fields}${closedParam}`;
+    const uri = `${darwinUri}/areas?domain_fk=${domainId}&fields=${fields}${closedParam}`;
     const queryKey = closed === 0 ? areaKeys.byDomainOpen(creatorFk, domainId)
         : closed === undefined ? areaKeys.byDomainWithClosed(creatorFk, domainId)
         : areaKeys.byDomain(creatorFk, domainId);
@@ -61,7 +61,7 @@ export function useAllAreas(creatorFk, { fields = 'id,domain_fk', enabled = true
     const { darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
 
-    const uri = `${darwinUri}/areas?creator_fk=${creatorFk}&fields=${fields}`;
+    const uri = `${darwinUri}/areas?fields=${fields}`;
 
     return useQuery({
         queryKey: areaKeys.all(creatorFk),
@@ -74,7 +74,7 @@ export function useTasks(creatorFk, areaId, { done = 0, fields = 'id,priority,do
     const { darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
 
-    const uri = `${darwinUri}/tasks?creator_fk=${creatorFk}&done=${done}&area_fk=${areaId}&fields=${fields}`;
+    const uri = `${darwinUri}/tasks?done=${done}&area_fk=${areaId}&fields=${fields}`;
     const queryKey = taskKeys.byAreaOpen(creatorFk, areaId);
 
     return useQuery({
@@ -88,7 +88,7 @@ export function useTasksDone(creatorFk, startStr, endStr, { fields = 'id,priorit
     const { darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
 
-    const uri = `${darwinUri}/tasks?creator_fk=${creatorFk}&done=1&filter_ts=(done_ts,${startStr},${endStr})&fields=${fields}`;
+    const uri = `${darwinUri}/tasks?done=1&filter_ts=(done_ts,${startStr},${endStr})&fields=${fields}`;
     const queryKey = taskKeys.done(creatorFk, `${startStr}_${endStr}`);
 
     return useQuery({
@@ -102,7 +102,7 @@ export function useTaskCounts(creatorFk, { enabled = true } = {}) {
     const { darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
 
-    const uri = `${darwinUri}/tasks?creator_fk=${creatorFk}&fields=count(*),area_fk`;
+    const uri = `${darwinUri}/tasks?fields=count(*),area_fk`;
     const queryKey = taskKeys.counts(creatorFk);
 
     return useQuery({
@@ -117,7 +117,7 @@ export function useProjects(creatorFk, { closed, fields = 'id,project_name,sort_
     const { idToken } = useContext(AuthContext);
 
     const closedParam = closed !== undefined ? `&closed=${closed}` : '';
-    const uri = `${darwinUri}/projects?creator_fk=${creatorFk}&fields=${fields}${closedParam}`;
+    const uri = `${darwinUri}/projects?fields=${fields}${closedParam}`;
     const queryKey = closed === 0 ? projectKeys.open(creatorFk)
         : closed === undefined ? projectKeys.withClosed(creatorFk)
         : projectKeys.all(creatorFk);
@@ -134,7 +134,7 @@ export function useCategories(creatorFk, projectId, { closed, fields = 'id,categ
     const { idToken } = useContext(AuthContext);
 
     const closedParam = closed !== undefined ? `&closed=${closed}` : '';
-    const uri = `${darwinUri}/categories?creator_fk=${creatorFk}&project_fk=${projectId}&fields=${fields}${closedParam}`;
+    const uri = `${darwinUri}/categories?project_fk=${projectId}&fields=${fields}${closedParam}`;
     const queryKey = closed === 0 ? categoryKeys.byProjectOpen(creatorFk, projectId)
         : closed === undefined ? categoryKeys.byProjectWithClosed(creatorFk, projectId)
         : categoryKeys.byProject(creatorFk, projectId);
@@ -151,7 +151,7 @@ export function usePriorities(creatorFk, categoryId, { closed, fields = 'id,titl
     const { idToken } = useContext(AuthContext);
 
     const closedParam = closed !== undefined ? `&closed=${closed}` : '';
-    const uri = `${darwinUri}/priorities?creator_fk=${creatorFk}&category_fk=${categoryId}&fields=${fields}${closedParam}`;
+    const uri = `${darwinUri}/priorities?category_fk=${categoryId}&fields=${fields}${closedParam}`;
     const queryKey = closed === 0 ? priorityKeys.byCategoryOpen(creatorFk, categoryId)
         : closed === undefined ? priorityKeys.byCategoryWithClosed(creatorFk, categoryId)
         : priorityKeys.byCategory(creatorFk, categoryId);
@@ -167,7 +167,7 @@ export function useSessions(creatorFk, { enabled = true } = {}) {
     const { darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
 
-    const uri = `${darwinUri}/swarm_sessions?creator_fk=${creatorFk}`;
+    const uri = `${darwinUri}/swarm_sessions`;
     const queryKey = sessionKeys.all(creatorFk);
 
     return useQuery({
@@ -198,7 +198,7 @@ export function usePrioritiesDone(creatorFk, startStr, endStr, { fields = 'id,ti
     const { darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
 
-    const uri = `${darwinUri}/priorities?creator_fk=${creatorFk}&closed=1&filter_ts=(completed_at,${startStr},${endStr})&fields=${fields}`;
+    const uri = `${darwinUri}/priorities?closed=1&filter_ts=(completed_at,${startStr},${endStr})&fields=${fields}`;
     const queryKey = priorityKeys.done(creatorFk, `${startStr}_${endStr}`);
 
     return useQuery({
@@ -212,7 +212,7 @@ export function useDevServers(creatorFk, { enabled = true } = {}) {
     const { darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
 
-    const uri = `${darwinUri}/dev_servers?creator_fk=${creatorFk}`;
+    const uri = `${darwinUri}/dev_servers`;
     const queryKey = devServerKeys.all(creatorFk);
 
     return useQuery({

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -6,11 +6,11 @@ import call_rest_api from '../RestApi/RestApi';
  */
 export async function fetchExportData(darwinUri, userName, idToken, profile) {
     const [domainsRes, areasRes, tasksRes, prioritiesRes, sessionsRes] = await Promise.all([
-        call_rest_api(`${darwinUri}/domains?creator_fk=${userName}`, 'GET', '', idToken),
-        call_rest_api(`${darwinUri}/areas?creator_fk=${userName}`, 'GET', '', idToken),
-        call_rest_api(`${darwinUri}/tasks?creator_fk=${userName}`, 'GET', '', idToken),
-        call_rest_api(`${darwinUri}/priorities?creator_fk=${userName}`, 'GET', '', idToken),
-        call_rest_api(`${darwinUri}/swarm_sessions?creator_fk=${userName}`, 'GET', '', idToken),
+        call_rest_api(`${darwinUri}/domains`, 'GET', '', idToken),
+        call_rest_api(`${darwinUri}/areas`, 'GET', '', idToken),
+        call_rest_api(`${darwinUri}/tasks`, 'GET', '', idToken),
+        call_rest_api(`${darwinUri}/priorities`, 'GET', '', idToken),
+        call_rest_api(`${darwinUri}/swarm_sessions`, 'GET', '', idToken),
     ]);
 
     const domains = domainsRes.data || [];


### PR DESCRIPTION
## Summary
- Remove `creator_fk` from all frontend API calls — backend now enforces identity from JWT
- Remove `creator_fk=` query parameter from 12 hooks in useDataQueries.js, 1 direct call in DayView, 5 export service calls
- Remove `creator_fk` from 3 POST request bodies (domain/project creation)
- Remove `creator_fk` from 17 template objects across 6 components
- Keep `creatorFk` in hook signatures (needed for TanStack Query keys and `enabled` guards)
- Keep `creator_fk` in `fields=` QSP (response field selection, not a filter)

## Files changed
- `src/hooks/useDataQueries.js` — Remove creator_fk= from 12 hook URIs
- `src/CalendarView/DayView.jsx` — Remove creator_fk= from direct API call
- `src/services/exportService.js` — Remove creator_fk= from 5 GET calls
- `src/TaskPlanView/TaskPlanView.jsx` — Remove creator_fk from POST body
- `src/AreaEdit/AreaEdit.jsx` — Remove creator_fk from POST body
- `src/SwarmView/SwarmView.jsx` — Remove creator_fk from POST body
- `src/DomainEdit/DomainEdit.jsx` — Remove creator_fk from 2 templates
- `src/TaskPlanView/AreaTabPanel.jsx` — Remove creator_fk from 3 templates
- `src/TaskPlanView/TaskCard.jsx` — Remove creator_fk from 3 templates
- `src/AreaEdit/AreaEditTabPanel.jsx` — Remove creator_fk from 3 templates
- `src/SwarmView/CategoryTabPanel.jsx` — Remove creator_fk from 3 templates
- `src/SwarmView/CategoryCard.jsx` — Remove creator_fk from 3 templates

## Testing
- Frontend build: clean (vite build succeeds)
- E2E: will run post-deploy against production

## Deploy notes
- **Deploy Lambda-Rest FIRST** (PR #16 in AWS-Lambda-REST-API)
- Then deploy this Darwin frontend
- Deploy order is critical: old frontend + new Lambda = safe; new frontend + old Lambda = data leak

## References
- Related PR: https://github.com/BillWilliams79/AWS-Lambda-REST-API/pull/16 (backend security enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)