### PR TITLE
Plan page - focus switch to new task in new area

### DIFF
--- a/src/TaskPlanView/AreaTabPanel.jsx
+++ b/src/TaskPlanView/AreaTabPanel.jsx
@@ -33,6 +33,7 @@ const AreaTabPanel = ( { domain, domainIndex, activeTab } ) => {
     const queryClient = useQueryClient();
 
     const [areasArray, setAreasArray] = useState()
+    const [newlyCreatedAreaId, setNewlyCreatedAreaId] = useState(null)
 
     const showError = useSnackBarStore(s => s.showError);
 
@@ -139,6 +140,7 @@ const AreaTabPanel = ( { domain, domainIndex, activeTab } ) => {
                     let newSortOrder = result.data[0].sort_order + 1;
                     newAreasArray.push({'id':'', 'area_name':'', 'closed': 0, 'domain_fk': domain.id, 'creator_fk': profile.userName, 'sort_order': newSortOrder });
                     setAreasArray(newAreasArray);
+                    setNewlyCreatedAreaId(result.data[0].id);
                     queryClient.invalidateQueries({ queryKey: areaKeys.all(profile.userName) });
 
                 } else if (result.httpStatus.httpStatus === 201) {
@@ -437,7 +439,9 @@ const AreaTabPanel = ( { domain, domainIndex, activeTab } ) => {
                                            moveCard,
                                            persistAreaOrder,
                                            removeArea,
-                                           isTemplate: area.id === '',}}/>
+                                           isTemplate: area.id === '',
+                                           autoFocusTemplate: newlyCreatedAreaId !== null && area.id === newlyCreatedAreaId,
+                                           clearAutoFocusTemplate: () => setNewlyCreatedAreaId(null),}}/>
                         ))}
                     </Box>
                 }

--- a/src/TaskPlanView/TaskCard.jsx
+++ b/src/TaskPlanView/TaskCard.jsx
@@ -37,7 +37,7 @@ import CardContent from '@mui/material/CardContent';
 import { CircularProgress } from '@mui/material';
 
 
-const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlur, clickCardClosed, clickCardDelete, moveCard, persistAreaOrder, removeArea, isTemplate }) => {
+const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlur, clickCardClosed, clickCardDelete, moveCard, persistAreaOrder, removeArea, isTemplate, autoFocusTemplate, clearAutoFocusTemplate }) => {
 
     const revertDragTabSwitch = useDragTabStore(s => s.revertDragTabSwitch);
 
@@ -52,6 +52,15 @@ const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlu
     // Guards against race condition: priority/done clicks during in-flight POST
     const savingRef = useRef(false);
     const pendingMutationsRef = useRef({});
+
+    // Focus template task description when this is a newly created area
+    useEffect(() => {
+        if (autoFocusTemplate && tasksArray && cardRef.current) {
+            const textarea = cardRef.current.querySelector('[data-testid="task-template"] [name="description"]');
+            if (textarea) textarea.focus();
+            clearAutoFocusTemplate();
+        }
+    }, [autoFocusTemplate, tasksArray]);
 
     // Sort mode: 'priority' (default) or 'hand' — persisted in DB (areas.sort_mode)
     const [sortMode, setSortMode] = useState(area.sort_mode || 'priority');

--- a/tests/tests/area.spec.ts
+++ b/tests/tests/area.spec.ts
@@ -79,6 +79,38 @@ test.describe.serial('Area Management', () => {
     if (created) createdAreaIds.push(created.id);
   });
 
+  test('AREA-01b: new area template task gets focus', async ({ page }) => {
+    const areaName = uniqueName('FocusArea');
+    const panel = await goToTestDomain(page);
+
+    const templateCard = panel.getByTestId('area-card-template');
+    await expect(templateCard).toBeVisible({ timeout: 5000 });
+
+    const areaNameField = templateCard.locator('[name="area-name"]');
+    await areaNameField.fill(areaName);
+    await areaNameField.press('Enter');
+
+    // Wait for the new area card to appear with its tasks loaded
+    await page.waitForTimeout(2000);
+
+    // Find the newly created area card (not template) containing our area name
+    const newAreaCard = panel.locator('[data-testid^="area-card-"]:not([data-testid="area-card-template"])').filter({ hasText: areaName });
+    await expect(newAreaCard).toBeVisible({ timeout: 5000 });
+
+    // The template task's description input in the new area should be focused
+    const templateTaskField = newAreaCard.getByTestId('task-template').locator('[name="description"]');
+    await expect(templateTaskField).toBeFocused({ timeout: 3000 });
+
+    // Track for cleanup
+    const sub = process.env.E2E_TEST_COGNITO_SUB!;
+    const areas = await apiCall(
+      `areas?creator_fk=${sub}&domain_fk=${testDomainId}&closed=0`,
+      'GET', '', idToken,
+    ) as Array<{ id: string; area_name: string }>;
+    const created = areas?.find(a => a.area_name === areaName);
+    if (created) createdAreaIds.push(created.id);
+  });
+
   test('AREA-02: close area via card menu', async ({ page }) => {
     const areaName = uniqueName('CloseArea');
 


### PR DESCRIPTION
## Summary
- Auto-focus the template task's description input when a new area is created on the Plan page
- After typing an area name and pressing Enter, the cursor automatically lands in the new area's task input field, eliminating the need to manually click into it
- Uses a `newlyCreatedAreaId` state signal threaded through AreaTabPanel → TaskCard, with imperative DOM-based focus in a useEffect

## Files changed
- `src/TaskPlanView/AreaTabPanel.jsx` — Added `newlyCreatedAreaId` state, set on area creation, pass `autoFocusTemplate`/`clearAutoFocusTemplate` props to TaskCard
- `src/TaskPlanView/TaskCard.jsx` — Accept new props, useEffect focuses template task via DOM query when area is newly created
- `tests/tests/area.spec.ts` — New AREA-01b test verifying focus lands on template task after area creation

## Testing
- Local E2E: 86/89 passing (3 pre-existing failures: AREA-03 flaky DnD, ERR-01 snackbar, TASK-08 template disabled)
- New AREA-01b test passes consistently

## Deploy notes
- Darwin frontend only (no backend changes)

## References
- Roadmap priority #257: Plan page - focus should switch to new task in new area

🤖 Generated with [Claude Code](https://claude.com/claude-code)