### PR TITLE
Fix E2E task tests failing on production

### DIFF
--- a/tests/helpers/api.ts
+++ b/tests/helpers/api.ts
@@ -11,25 +11,35 @@ export async function getIdToken(page: Page): Promise<string> {
   return tokenCookie.value;
 }
 
-/** Call the Darwin REST API directly (bypasses the UI). */
+/** Call the Darwin REST API directly (bypasses the UI).
+ *  Retries up to 3 times on server errors (5xx) to handle Lambda cold starts. */
 export async function apiCall(
   table: string,
   method: string,
   body: unknown,
   idToken: string,
+  retries = 3,
 ): Promise<unknown> {
-  const res = await fetch(`${DARWIN_API}/${table}`, {
-    method,
-    headers: { Authorization: idToken },
-    body: method === 'GET' ? undefined : JSON.stringify(body),
-  });
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    const res = await fetch(`${DARWIN_API}/${table}`, {
+      method,
+      headers: { Authorization: idToken },
+      body: method === 'GET' ? undefined : JSON.stringify(body),
+    });
 
-  const text = await res.text();
-  // Lambda responses are single-encoded JSON.
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
+    const text = await res.text();
+
+    if (res.status >= 500 && attempt < retries) {
+      await new Promise(r => setTimeout(r, 2000 * attempt));
+      continue;
+    }
+
+    // Lambda responses are single-encoded JSON.
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
   }
 }
 

--- a/tests/tests/domain.spec.ts
+++ b/tests/tests/domain.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from '@playwright/test';
 import { getIdToken, apiCall, apiDelete, uniqueName } from '../helpers/api';
 
 test.describe('Domain Management', () => {
+  // Production can be slow due to Lambda cold starts + many domains
+  test.setTimeout(60000);
   // Track domains created during tests for cleanup
   const createdDomainIds: string[] = [];
   let idToken: string;
@@ -26,8 +28,8 @@ test.describe('Domain Management', () => {
     const domainName = uniqueName('Domain');
 
     await page.goto('/taskcards');
-    // Wait for domains to load
-    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    // Wait for domains to load (production can be slow due to Lambda cold starts)
+    await page.waitForSelector('[role="tab"]', { timeout: 30000 });
 
     // Click the "+" tab to open DomainAddDialog (last tab, has no text — just the add icon)
     await page.locator('[role="tab"]').last().click();
@@ -42,12 +44,12 @@ test.describe('Domain Management', () => {
 
     // Verify dialog closes and domain tab appears
     await expect(dialog).not.toBeVisible();
-    await expect(page.getByRole('tab', { name: domainName })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('tab', { name: domainName })).toBeVisible({ timeout: 10000 });
 
     // Extract domain id from the new tab's area card for cleanup
-    // Navigate to the new domain tab and check for an area-card-template
+    // Navigate to the new domain tab and wait for it to stabilize
     await page.getByRole('tab', { name: domainName }).click();
-    await page.waitForTimeout(1000);
+    await page.waitForTimeout(2000);
 
     // Get the domain ID from the API for cleanup
     const sub = process.env.E2E_TEST_COGNITO_SUB!;
@@ -76,7 +78,7 @@ test.describe('Domain Management', () => {
     }
 
     await page.goto('/taskcards');
-    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.waitForSelector('[role="tab"]', { timeout: 30000 });
 
     // The new domain should appear as a tab
     const domainTab = page.getByRole('tab', { name: domainName });

--- a/tests/tests/navigation.spec.ts
+++ b/tests/tests/navigation.spec.ts
@@ -18,8 +18,8 @@ test.describe('Navigation', () => {
     await page.getByRole('link', { name: /areas/i }).click();
     await expect(page).toHaveURL(/\/areaedit/);
 
-    // Navigate to Swarm
-    await page.getByRole('link', { name: /^swarm$/i }).click();
+    // Navigate to Roadmap
+    await page.getByRole('link', { name: /^roadmap$/i }).click();
     await expect(page).toHaveURL(/\/swarm$/);
 
     // Navigate to Dev Servers

--- a/tests/tests/task-dnd.spec.ts
+++ b/tests/tests/task-dnd.spec.ts
@@ -3,6 +3,8 @@ import { getIdToken, apiCall, apiDelete, uniqueName, clickSortMode } from '../he
 import { dragAndDrop } from '../helpers/react-dnd-drag';
 
 test.describe.serial('Task DnD — Hand Sort & Cross Card', () => {
+  // Production can be slow due to Lambda cold starts + many domains
+  test.setTimeout(60000);
   let idToken: string;
   let testDomainId: string;
   const testDomainName = uniqueName('TaskDnD');
@@ -108,9 +110,10 @@ test.describe.serial('Task DnD — Hand Sort & Cross Card', () => {
 
   async function goToTestDomain(page: any) {
     await page.goto('/taskcards');
-    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.waitForSelector('[role="tab"]', { timeout: 30000 });
     await page.getByRole('tab', { name: testDomainName }).click();
-    await page.waitForTimeout(1500);
+    // Wait for area card to render with tasks loaded (not a fixed timeout)
+    await page.waitForSelector(`[data-testid="area-card-${area1Id}"] [data-testid^="task-"]`, { timeout: 15000 });
   }
 
   async function getTaskDescriptions(page: any, areaId: string): Promise<string[]> {

--- a/tests/tests/task.spec.ts
+++ b/tests/tests/task.spec.ts
@@ -3,6 +3,8 @@ import { getIdToken, apiCall, apiDelete, uniqueName } from '../helpers/api';
 import { dragAndDrop } from '../helpers/react-dnd-drag';
 
 test.describe('Task Management', () => {
+  // Production can be slow due to Lambda cold starts + many domains
+  test.setTimeout(60000);
   let idToken: string;
   let testDomainId: string;
   let testAreaId: string;
@@ -49,9 +51,10 @@ test.describe('Task Management', () => {
   /** Navigate to TaskPlanView and select the test domain tab. */
   async function goToTestDomain(page: import('@playwright/test').Page) {
     await page.goto('/taskcards');
-    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.waitForSelector('[role="tab"]', { timeout: 30000 });
     await page.getByRole('tab', { name: testDomainName }).click();
-    await page.waitForTimeout(1000);
+    // Wait for area card to render with tasks loaded (not a fixed timeout)
+    await page.waitForSelector(`[data-testid="area-card-${testAreaId}"] [data-testid^="task-"]`, { timeout: 15000 });
   }
 
   test('TASK-01: create task via template pattern', async ({ page }) => {
@@ -123,7 +126,7 @@ test.describe('Task Management', () => {
 
     // Verify the task disappears after reload (API only fetches done=0)
     await page.reload();
-    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.waitForSelector('[role="tab"]', { timeout: 30000 });
     await page.getByRole('tab', { name: testDomainName }).click();
     await page.waitForTimeout(1500);
     await expect(taskRow).not.toBeVisible({ timeout: 5000 });
@@ -226,7 +229,7 @@ test.describe('Task Management', () => {
 
     // Verify persists after reload
     await page.reload();
-    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
+    await page.waitForSelector('[role="tab"]', { timeout: 30000 });
     await page.getByRole('tab', { name: testDomainName }).click();
     await page.waitForTimeout(1500);
 


### PR DESCRIPTION
## Summary
- **NAV-01**: Update selector from `/^swarm$/i` to `/^roadmap$/i` — link text was renamed to "Roadmap" but test still looked for "Swarm"
- **TASK-03/04/05**: Replace fixed `waitForTimeout(1000)` in `goToTestDomain()` with `waitForSelector` that waits for actual task elements to render in the DOM — eliminates race condition on production where Lambda cold starts cause slow API responses
- **DOM-01**: Increase tab wait timeout from 5s to 10s and stabilize post-dialog timing
- **All specs**: Increase `waitForSelector('[role="tab"]')` from 10s to 30s and add `test.setTimeout(60000)` to handle production Lambda latency
- **apiCall()**: Add retry logic (3 attempts with exponential backoff) on 5xx server errors to handle Lambda cold start timeouts in `beforeAll` setup

## Files changed
- `tests/helpers/api.ts` — retry logic on 5xx in apiCall()
- `tests/tests/navigation.spec.ts` — fix stale "swarm" selector to "roadmap"
- `tests/tests/task.spec.ts` — data-driven waits in goToTestDomain(), increased timeouts
- `tests/tests/task-dnd.spec.ts` — data-driven waits in goToTestDomain(), increased timeouts
- `tests/tests/domain.spec.ts` — increased timeouts, stabilized tab click timing

## Testing
- Targeted tests (14): 14/14 passing on production (`BASE_URL=https://darwin.one`)
- All 5 originally failing tests (NAV-01, TASK-03, TASK-04, TASK-05, DOM-01) now pass

## Deploy notes
- Darwin frontend deploy (test-only changes, no app code modified)

## References
- Fixes #128 (E2E: Task tests fail on production)
- Related: #130 (remaining E2E production failures in other test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)