### PR TITLE
Fix text select vs drag conflict in priorities/tasks

### DIFF
--- a/src/Components/TaskEdit/TaskEdit.jsx
+++ b/src/Components/TaskEdit/TaskEdit.jsx
@@ -164,6 +164,20 @@ const TaskEdit = ({ supportDrag, task, taskIndex, areaId, areaName }) => {
                         onChange = {(event) => descriptionChange(event, taskIndex) }
                         onKeyDown = {(event) => descriptionKeyDown(event, taskIndex, task.id)}
                         onBlur = {(event) => descriptionOnBlur(event, taskIndex, task.id)}
+                        onPointerDown={(e) => {
+                            const draggables = [];
+                            let el = e.currentTarget;
+                            while (el) {
+                                if (el.getAttribute('draggable') === 'true') {
+                                    draggables.push(el);
+                                    el.removeAttribute('draggable');
+                                }
+                                el = el.parentElement;
+                            }
+                            document.addEventListener('pointerup', () => {
+                                draggables.forEach(d => d.setAttribute('draggable', 'true'));
+                            }, { once: true });
+                        }}
                         multiline
                         disabled = {areaId !== '' ? false : areaName === '' ? true : false}
                         autoComplete ='off'

--- a/src/SwarmView/PriorityRow.jsx
+++ b/src/SwarmView/PriorityRow.jsx
@@ -202,6 +202,20 @@ const PriorityRow = ({ supportDrag, priority, priorityIndex, categoryId, categor
                         onChange = {(event) => titleChange(event, priorityIndex) }
                         onKeyDown = {(event) => titleKeyDown(event, priorityIndex, priority.id)}
                         onBlur = {(event) => titleOnBlur(event, priorityIndex, priority.id)}
+                        onPointerDown={(e) => {
+                            const draggables = [];
+                            let el = e.currentTarget;
+                            while (el) {
+                                if (el.getAttribute('draggable') === 'true') {
+                                    draggables.push(el);
+                                    el.removeAttribute('draggable');
+                                }
+                                el = el.parentElement;
+                            }
+                            document.addEventListener('pointerup', () => {
+                                draggables.forEach(d => d.setAttribute('draggable', 'true'));
+                            }, { once: true });
+                        }}
                         multiline
                         disabled = {categoryId !== '' ? false : categoryName === '' ? true : false}
                         autoComplete ='off'


### PR DESCRIPTION
## Summary
- Fix text selection failing when clicking in TextField padding areas (space between text and border)
- Root cause: MUI TextField wrapper `<div>`s don't get browser's native form-element priority over `draggable="true"` ancestors, so clicks on padding initiate drag instead of text selection
- Solution: `onPointerDown` handler temporarily removes `draggable` from all ancestor elements, restoring on `pointerup` — this lets the browser treat the entire TextField area as a text-selection zone

## Files changed
- `src/Components/TaskEdit/TaskEdit.jsx` — added `onPointerDown` handler to task description TextField
- `src/SwarmView/PriorityRow.jsx` — added `onPointerDown` handler to priority title TextField

## Testing
- Local E2E: 92/95 passing (3 pre-existing failures unrelated to this change)
- All 6 DnD tests (DND-01 through DND-06) passed — drag from non-TextField areas unaffected
- Manual verification: text selection works in padding areas, drag works from checkboxes/icons/row numbers

## Deploy notes
- Darwin only (frontend-only change, no backend/DB changes)

## References
- Roadmap priority #365: "Try to select priorities/task text and it starts a drag"

🤖 Generated with [Claude Code](https://claude.com/claude-code)