### PR TITLE
Darwin dev server live link

### DIFF
--- a/src/DevServers/DevServersView.jsx
+++ b/src/DevServers/DevServersView.jsx
@@ -23,6 +23,8 @@ const getDevServerColumns = (navigate, timezone) => [
         width: 100,
         renderCell: (params) => (
             <Chip label={params.value} size="small" color="primary"
+                  component="a" href={`https://localhost:${params.value}`}
+                  target="_blank" rel="noopener" clickable
                   data-testid="chip-dev-server-port" />
         ),
     },
@@ -58,6 +60,8 @@ const DevServerCard = ({ server, navigate, timezone }) => {
             <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
                     <Chip label={`Port ${server.port}`} size="small" color="primary"
+                          component="a" href={`https://localhost:${server.port}`}
+                          target="_blank" rel="noopener" clickable
                           data-testid="chip-dev-server-port" />
                     {server.session_fk ? (
                         <Chip label={`Session #${server.session_fk}`} size="small" variant="outlined"

--- a/src/SwarmView/SessionsView.jsx
+++ b/src/SwarmView/SessionsView.jsx
@@ -55,7 +55,9 @@ const getSessionColumns = (navigate, timezone) => [
         width: 100,
         renderCell: (params) => params.value
             ? <Chip label={params.value} size="small" color="primary"
-                    onClick={(e) => { e.stopPropagation(); navigate('/devservers'); }}
+                    component="a" href={`https://localhost:${params.value}`}
+                    target="_blank" rel="noopener" clickable
+                    onClick={(e) => e.stopPropagation()}
                     data-testid="chip-dev-server-port" />
             : '—',
     },
@@ -108,6 +110,9 @@ const SessionCard = ({ session, navigate, timezone }) => (
                 <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
                     {session.dev_server_port && (
                         <Chip label={`Port ${session.dev_server_port}`} size="small" color="primary"
+                              component="a" href={`https://localhost:${session.dev_server_port}`}
+                              target="_blank" rel="noopener" clickable
+                              onClick={(e) => e.stopPropagation()}
                               data-testid="chip-dev-server-port" />
                     )}
                     {session.worker_count > 0 && (

--- a/src/SwarmView/detail/SwarmSessionDetail.jsx
+++ b/src/SwarmView/detail/SwarmSessionDetail.jsx
@@ -148,7 +148,11 @@ const SwarmSessionDetail = () => {
                                 label={`Port ${ds.port}`}
                                 size="small"
                                 color="primary"
-                                onClick={() => navigate('/devservers')}
+                                component="a"
+                                href={`https://localhost:${ds.port}`}
+                                target="_blank"
+                                rel="noopener"
+                                clickable
                                 data-testid="chip-dev-server-port"
                             />
                         ))}


### PR DESCRIPTION
## Summary
- Port-number Chips across all dev server views now render as clickable `<a>` links to `https://localhost:{port}`, opening in a new tab
- Previously, Chips in SessionsView and SwarmSessionDetail navigated to `/devservers`; DevServersView Chips were display-only
- All 5 Chip instances updated across 3 files

## Files changed
- `src/DevServers/DevServersView.jsx` — DataGrid column + mobile card Chips → clickable links
- `src/SwarmView/SessionsView.jsx` — DataGrid column + mobile card Chips → clickable links (with stopPropagation for row click)
- `src/SwarmView/detail/SwarmSessionDetail.jsx` — Dev Servers section Chip → clickable link

## Testing
- Local E2E: 20/20 passing (dev-servers.spec.ts + swarm.spec.ts)
- No test changes needed — existing `data-testid` attributes preserved

## Deploy notes
- Darwin only — frontend-only change, no backend impact

## References
- Roadmap item #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)