### PR TITLE
Select display sessions by status

### DIFF
--- a/src/SwarmView/SessionsView.jsx
+++ b/src/SwarmView/SessionsView.jsx
@@ -1,7 +1,7 @@
 import '../index.css';
 import AuthContext from '../Context/AuthContext';
 import { useSessions, useDevServers } from '../hooks/useDataQueries';
-import { useShowClosedStore } from '../stores/useShowClosedStore';
+import { useShowClosedStore, ALL_SESSION_STATUSES } from '../stores/useShowClosedStore';
 import { formatDateTime, formatDate } from '../utils/dateFormat';
 import { DataGrid, GridToolbar } from '@mui/x-data-grid';
 
@@ -16,7 +16,7 @@ import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { CircularProgress, Typography, FormControlLabel, Switch } from '@mui/material';
+import { CircularProgress, Typography } from '@mui/material';
 
 const swarmStatusChipProps = (status) => {
     switch (status) {
@@ -138,8 +138,8 @@ const SessionsView = () => {
 
     const { data: sessionsArray } = useSessions(profile?.userName);
     const { data: devServersData } = useDevServers(profile?.userName);
-    const showClosedSessions = useShowClosedStore(s => s.showClosedSessions);
-    const toggleShowClosedSessions = useShowClosedStore(s => s.toggleShowClosedSessions);
+    const sessionStatusFilter = useShowClosedStore(s => s.sessionStatusFilter);
+    const toggleSessionStatus = useShowClosedStore(s => s.toggleSessionStatus);
 
     const devServerMap = useMemo(() => {
         if (!devServersData) return {};
@@ -152,9 +152,9 @@ const SessionsView = () => {
         ? sessionsArray.map(s => ({ ...s, dev_server_port: devServerMap[s.id] || null }))
         : null;
 
-    const filteredSessions = enrichedSessions && !showClosedSessions
-        ? enrichedSessions.filter(s => s.swarm_status !== 'completed')
-        : enrichedSessions;
+    const filteredSessions = enrichedSessions
+        ? enrichedSessions.filter(s => sessionStatusFilter.includes(s.swarm_status))
+        : null;
 
     const sortedSessions = filteredSessions
         ? [...filteredSessions].sort((a, b) => b.id - a.id)
@@ -162,14 +162,30 @@ const SessionsView = () => {
 
     return (
         <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1, flexWrap: 'wrap', gap: 1 }}>
                 <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ flex: 1 }}>Swarm Sessions</Typography>
-                <FormControlLabel
-                    control={<Switch checked={showClosedSessions} onChange={toggleShowClosedSessions} size="small" />}
-                    label="Show Completed"
-                    data-testid="toggle-show-closed-sessions"
-                    sx={{ mr: 1 }}
-                />
+                <Stack direction="row" spacing={0.5} data-testid="session-status-filter">
+                    {ALL_SESSION_STATUSES.map(status => {
+                        const selected = sessionStatusFilter.includes(status);
+                        const chipProps = swarmStatusChipProps(status);
+                        return (
+                            <Chip
+                                key={status}
+                                label={status}
+                                size="small"
+                                onClick={() => toggleSessionStatus(status)}
+                                {...(selected ? chipProps : { variant: 'outlined' })}
+                                sx={{
+                                    ...(selected ? chipProps.sx : {}),
+                                    ...(!selected && { opacity: 0.5 }),
+                                    cursor: 'pointer',
+                                    textTransform: 'capitalize',
+                                }}
+                                data-testid={`filter-chip-${status}`}
+                            />
+                        );
+                    })}
+                </Stack>
             </Box>
 
             {!sessionsArray ? (

--- a/src/stores/useShowClosedStore.js
+++ b/src/stores/useShowClosedStore.js
@@ -1,20 +1,42 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+export const ALL_SESSION_STATUSES = ['starting', 'active', 'paused', 'completing', 'completed'];
+export const DEFAULT_SESSION_STATUSES = ['starting', 'active', 'paused', 'completing'];
+
 export const useShowClosedStore = create(
     persist(
         (set) => ({
             showClosedPriorities: false,
-            showClosedSessions: false,
+            sessionStatusFilter: DEFAULT_SESSION_STATUSES,
 
             toggleShowClosedPriorities: () =>
                 set((state) => ({ showClosedPriorities: !state.showClosedPriorities })),
 
-            toggleShowClosedSessions: () =>
-                set((state) => ({ showClosedSessions: !state.showClosedSessions })),
+            toggleSessionStatus: (status) =>
+                set((state) => {
+                    const current = state.sessionStatusFilter;
+                    if (current.includes(status)) {
+                        return { sessionStatusFilter: current.filter(s => s !== status) };
+                    }
+                    return { sessionStatusFilter: [...current, status] };
+                }),
         }),
         {
             name: 'darwin_show_closed',
+            version: 1,
+            migrate: (persisted, version) => {
+                if (version === 0) {
+                    const { showClosedSessions, ...rest } = persisted;
+                    return {
+                        ...rest,
+                        sessionStatusFilter: showClosedSessions
+                            ? ALL_SESSION_STATUSES
+                            : DEFAULT_SESSION_STATUSES,
+                    };
+                }
+                return persisted;
+            },
         }
     )
 );


### PR DESCRIPTION
## Summary
- Replace binary "Show Completed" switch with 5 independently-selectable status filter chips (starting, active, paused, completing, completed)
- Each chip uses the same color scheme as the DataGrid Status column — full color when selected, outlined + dimmed when deselected
- Default filter shows all statuses except completed
- All chips can be deselected (empty filter shows no sessions)
- Zustand persist migration (v0→v1) converts old `showClosedSessions` boolean to new `sessionStatusFilter` array

## Files changed
- `src/stores/useShowClosedStore.js` — Added `ALL_SESSION_STATUSES`/`DEFAULT_SESSION_STATUSES` constants, replaced `showClosedSessions` boolean with `sessionStatusFilter` array + `toggleSessionStatus` action, added persist migration
- `src/SwarmView/SessionsView.jsx` — Replaced `FormControlLabel`+`Switch` with `Stack` of `Chip` components, updated filter logic to use `sessionStatusFilter.includes()`, removed unused imports

## Testing
- Build verified: `vite build` passes
- No existing E2E tests reference removed elements (`toggle-show-closed-sessions`)
- SWM-20/SWM-22 use `sessions-datagrid` testid (preserved) with active/starting sessions (in default filter)

## Deploy notes
- Darwin only (frontend change)

## References
- Roadmap item #347: Select display sessions by status

🤖 Generated with [Claude Code](https://claude.com/claude-code)