### PR TITLE
Navbar look and feel

### DIFF
--- a/src/NavBar/NavBar.jsx
+++ b/src/NavBar/NavBar.jsx
@@ -1,45 +1,16 @@
-import '../index.css';
-import AuthContext from '../Context/AuthContext';
-
-import React, {useContext} from 'react';
-import { Link } from "react-router-dom"
-
-import AppBar from '@mui/material/AppBar';
-import PedalBikeIcon from '@mui/icons-material/PedalBike';
-import Stack from '@mui/material/Stack';
+import React, { useEffect } from 'react';
+import NavBarSidebar from './NavBarSidebar';
 
 const NavBar = () => {
     console.count('Navbar render');
-    const { idToken } = useContext(AuthContext);
 
-  return (
-    <AppBar className="app-navbar" position="static" sx={{backgroundColor: 'black', padding: 2,  pb: {xs:2, md:3} }}>
-        <Stack direction={{ xs: 'row', md: 'column', }}
-               spacing={1}
-               alignItems={{xs: 'center', md: 'flex-start'}}
-        >
-          {idToken ? (
-            <Link to="/profile" style={{ display: 'flex' }}>
-              <PedalBikeIcon sx={{ color: '#E91E63' }} />
-            </Link>
-          ) : (
-            <PedalBikeIcon sx={{ color: '#E91E63' }} />
-          )}
-          <Link className="nav-title" to="/">
-            Darwin
-          </Link>
-              <>
-                <Link className="nav-link" to="/taskcards"> Plan </Link>
-                <Link className="nav-link" to="/calview"> Calendar </Link>
-                <Link className="nav-link" to="/domainedit"> Domains </Link>
-                <Link className="nav-link" to="/areaedit"> Areas </Link>
-                <Link className="nav-link" to="/swarm"> Roadmap </Link>
-                <Link className="nav-link" to="/swarm/sessions"> Sessions </Link>
-                <Link className="nav-link" to="/devservers"> Dev Servers </Link>
-              </>
-        </Stack>
-    </AppBar>
-  );
+    // Apply layout class to .app-layout
+    useEffect(() => {
+        const el = document.querySelector('.app-layout');
+        if (el) el.classList.add('layout-sidebar');
+    }, []);
+
+    return <NavBarSidebar />;
 };
 
 export default NavBar;

--- a/src/NavBar/NavBarSidebar.jsx
+++ b/src/NavBar/NavBarSidebar.jsx
@@ -1,0 +1,322 @@
+import React, { useContext, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import AuthContext from '../Context/AuthContext';
+import {
+    NAV_GROUPS, NAV_LINKS, PROFILE_LINK, BIKE_MENU_LINKS,
+    SIDEBAR_WIDTH, SIDEBAR_COLLAPSED_WIDTH,
+} from './navConfig';
+
+import AppBar from '@mui/material/AppBar';
+import BottomNavigation from '@mui/material/BottomNavigation';
+import BottomNavigationAction from '@mui/material/BottomNavigationAction';
+import Box from '@mui/material/Box';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import ListSubheader from '@mui/material/ListSubheader';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Toolbar from '@mui/material/Toolbar';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+
+const ACCENT = '#E91E63';
+const BG_ACTIVE = 'rgba(233, 30, 99, 0.12)';
+
+const NavBarSidebar = () => {
+    const { idToken } = useContext(AuthContext);
+    const location = useLocation();
+    const navigate = useNavigate();
+    const isDesktop = useMediaQuery('(min-width:900px)');
+
+    const [collapsed, setCollapsed] = useState(false);
+    const [bikeAnchor, setBikeAnchor] = useState(null);
+
+    const isActive = (path) => {
+        if (path === '/swarm') return location.pathname === '/swarm';
+        return location.pathname.startsWith(path);
+    };
+
+    const bikeMenuOpen = Boolean(bikeAnchor);
+
+    const handleBikeClick = (e) => {
+        if (idToken) setBikeAnchor(e.currentTarget);
+    };
+
+    const handleBikeClose = () => setBikeAnchor(null);
+
+    const handleBikeNav = (path) => {
+        handleBikeClose();
+        navigate(path);
+    };
+
+    // Shared bicycle menu (used by both desktop and mobile)
+    const bikeMenu = (
+        <Menu
+            anchorEl={bikeAnchor}
+            open={bikeMenuOpen}
+            onClose={handleBikeClose}
+            slotProps={{
+                paper: {
+                    sx: {
+                        bgcolor: '#1a1a1a',
+                        color: 'white',
+                        minWidth: 160,
+                    },
+                },
+            }}
+        >
+            {BIKE_MENU_LINKS.map((link) => {
+                const Icon = link.icon;
+                const active = isActive(link.path);
+                return (
+                    <MenuItem
+                        key={link.path}
+                        onClick={() => handleBikeNav(link.path)}
+                        sx={{
+                            bgcolor: active ? BG_ACTIVE : 'transparent',
+                            '&:hover': { bgcolor: 'rgba(255,255,255,0.08)' },
+                            gap: 1.5,
+                            py: 1,
+                        }}
+                    >
+                        <Icon sx={{ fontSize: 18, color: active ? ACCENT : 'rgba(255,255,255,0.7)' }} />
+                        <Typography sx={{
+                            fontSize: 15,
+                            color: active ? 'white' : 'rgba(255,255,255,0.7)',
+                            fontWeight: active ? 600 : 400,
+                        }}>
+                            {link.label}
+                        </Typography>
+                    </MenuItem>
+                );
+            })}
+        </Menu>
+    );
+
+    const renderNavItem = (link, showText) => {
+        const Icon = link.icon;
+        const active = isActive(link.path);
+        const button = (
+            <ListItemButton
+                key={link.path}
+                component={Link}
+                to={link.path}
+                sx={{
+                    bgcolor: active ? BG_ACTIVE : 'transparent',
+                    borderRight: active ? `3px solid ${ACCENT}` : '3px solid transparent',
+                    py: 0.6,
+                    px: showText ? 1.5 : 1,
+                    minHeight: 36,
+                    justifyContent: showText ? 'initial' : 'center',
+                    '&:hover': { bgcolor: 'rgba(255,255,255,0.08)' },
+                }}
+            >
+                <ListItemIcon sx={{
+                    color: active ? ACCENT : 'rgba(255,255,255,0.7)',
+                    minWidth: showText ? 32 : 'auto',
+                    justifyContent: 'center',
+                }}>
+                    <Icon sx={{ fontSize: 18 }} />
+                </ListItemIcon>
+                {showText && (
+                    <ListItemText
+                        primary={link.label}
+                        primaryTypographyProps={{
+                            fontSize: 15,
+                            color: active ? 'white' : 'rgba(255,255,255,0.7)',
+                            fontWeight: active ? 600 : 400,
+                        }}
+                    />
+                )}
+            </ListItemButton>
+        );
+        return showText ? button : (
+            <Tooltip key={link.path} title={link.label} placement="right">
+                {button}
+            </Tooltip>
+        );
+    };
+
+    // ── Desktop: sidebar with edge collapse arrow ──
+    if (isDesktop) {
+        const showText = !collapsed;
+        const width = collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_WIDTH;
+
+        return (
+            <>
+                <Box
+                    className="app-navbar"
+                    sx={{ width, flexShrink: 0, transition: 'width 0.2s ease', height: '100vh', position: 'sticky', top: 0 }}
+                >
+                    <Box sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        height: '100vh',
+                        bgcolor: 'black',
+                        color: 'white',
+                        overflow: 'hidden',
+                        width,
+                        transition: 'width 0.2s ease',
+                    }}>
+                            {/* Bicycle menu trigger + Darwin title */}
+                            <Box sx={{ px: 1.5, py: 1.5, display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                                <IconButton
+                                    onClick={handleBikeClick}
+                                    size="small"
+                                    data-testid="bike-menu-button"
+                                    sx={{
+                                        p: 0.25,
+                                        color: ACCENT,
+                                        '&:hover': { bgcolor: 'rgba(233,30,99,0.12)' },
+                                    }}
+                                >
+                                    <PROFILE_LINK.icon sx={{ fontSize: 20 }} />
+                                </IconButton>
+                                {showText && (
+                                    <Link to="/" style={{ textDecoration: 'none' }}>
+                                        <Typography sx={{ color: 'white', fontSize: 19, fontFamily: 'Roboto', fontWeight: 500 }}>
+                                            Darwin
+                                        </Typography>
+                                    </Link>
+                                )}
+                            </Box>
+
+                            {/* Primary nav links */}
+                            <List sx={{ flex: 1, pt: 0, pb: 0 }}>
+                                {NAV_GROUPS.map((group) => {
+                                    const groupLinks = NAV_LINKS.filter(l => l.group === group.id);
+                                    return (
+                                        <React.Fragment key={group.id}>
+                                            {showText && (
+                                                <ListSubheader sx={{
+                                                    bgcolor: 'transparent',
+                                                    color: 'rgba(255,255,255,0.5)',
+                                                    fontSize: 12,
+                                                    fontWeight: 700,
+                                                    letterSpacing: 1.5,
+                                                    lineHeight: '28px',
+                                                    pl: 1.5,
+                                                    mt: 0.5,
+                                                }}>
+                                                    {group.label}
+                                                </ListSubheader>
+                                            )}
+                                            {groupLinks.map((link) => renderNavItem(link, showText))}
+                                        </React.Fragment>
+                                    );
+                                })}
+                            </List>
+                    </Box>
+
+                    {/* Google Maps-style edge collapse tab */}
+                    <Box
+                        onClick={() => setCollapsed(c => !c)}
+                        sx={{
+                            position: 'fixed',
+                            left: width,
+                            top: '50vh',
+                            transform: 'translateY(-50%)',
+                            zIndex: 1201,
+                            width: 12,
+                            height: 32,
+                            borderRadius: '0 6px 6px 0',
+                            bgcolor: '#555',
+                            color: 'rgba(255,255,255,0.7)',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            cursor: 'pointer',
+                            '&:hover': { bgcolor: '#777', color: 'white', width: 16 },
+                            transition: 'left 0.2s ease, width 0.15s ease, background-color 0.15s ease',
+                        }}
+                    >
+                        {collapsed
+                            ? <ChevronRightIcon sx={{ fontSize: 14 }} />
+                            : <ChevronLeftIcon sx={{ fontSize: 14 }} />
+                        }
+                    </Box>
+                </Box>
+                {bikeMenu}
+            </>
+        );
+    }
+
+    // ── Mobile: top bar with bicycle + bottom nav ──
+    const bottomNavValue = NAV_LINKS.findIndex(l => isActive(l.path));
+
+    return (
+        <>
+            {/* Slim top bar */}
+            <AppBar
+                position="static"
+                className="app-navbar"
+                sx={{ bgcolor: 'black' }}
+            >
+                <Toolbar variant="dense" sx={{ minHeight: 48 }}>
+                    <IconButton
+                        edge="start"
+                        onClick={handleBikeClick}
+                        data-testid="bike-menu-button"
+                        sx={{ color: ACCENT }}
+                    >
+                        <PROFILE_LINK.icon />
+                    </IconButton>
+                    <Link to="/" style={{ textDecoration: 'none', marginLeft: 8 }}>
+                        <Typography sx={{ color: 'white', fontSize: 18, fontFamily: 'Roboto', fontWeight: 500 }}>
+                            Darwin
+                        </Typography>
+                    </Link>
+                </Toolbar>
+            </AppBar>
+
+            {/* Bicycle popover menu */}
+            {bikeMenu}
+
+            {/* Bottom navigation — all 5 primary links */}
+            <Paper
+                sx={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 1200 }}
+                elevation={3}
+            >
+                <BottomNavigation
+                    value={bottomNavValue >= 0 ? bottomNavValue : false}
+                    onChange={(_, newValue) => {
+                        navigate(NAV_LINKS[newValue].path);
+                    }}
+                    sx={{
+                        bgcolor: '#111',
+                        '& .MuiBottomNavigationAction-root': {
+                            color: 'rgba(255,255,255,0.5)',
+                            minWidth: 'auto',
+                            px: 0.5,
+                        },
+                        '& .Mui-selected': {
+                            color: ACCENT,
+                        },
+                    }}
+                >
+                    {NAV_LINKS.map((link) => {
+                        const Icon = link.icon;
+                        return (
+                            <BottomNavigationAction
+                                key={link.path}
+                                label={link.label}
+                                icon={<Icon />}
+                            />
+                        );
+                    })}
+                </BottomNavigation>
+            </Paper>
+        </>
+    );
+};
+
+export default NavBarSidebar;

--- a/src/NavBar/navConfig.js
+++ b/src/NavBar/navConfig.js
@@ -1,0 +1,38 @@
+import ViewKanbanIcon from '@mui/icons-material/ViewKanban';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
+import CategoryIcon from '@mui/icons-material/Category';
+import MapIcon from '@mui/icons-material/Map';
+import HubIcon from '@mui/icons-material/Hub';
+import DnsIcon from '@mui/icons-material/Dns';
+import PedalBikeIcon from '@mui/icons-material/PedalBike';
+
+export const NAV_GROUPS = [
+    { id: 'tasks', label: 'TASKS' },
+    { id: 'swarm', label: 'SWARM' },
+];
+
+export const NAV_LINKS = [
+    { path: '/taskcards', label: 'Plan', icon: ViewKanbanIcon, group: 'tasks' },
+    { path: '/calview', label: 'Calendar', icon: CalendarMonthIcon, group: 'tasks' },
+    { path: '/swarm', label: 'Roadmap', icon: MapIcon, group: 'swarm' },
+    { path: '/swarm/sessions', label: 'Sessions', icon: HubIcon, group: 'swarm' },
+    { path: '/devservers', label: 'Dev Servers', icon: DnsIcon, group: 'swarm' },
+];
+
+// Secondary links — accessed via bicycle menu
+export const MORE_LINKS = [
+    { path: '/domainedit', label: 'Domains', icon: AccountTreeIcon },
+    { path: '/areaedit', label: 'Areas', icon: CategoryIcon },
+];
+
+export const PROFILE_LINK = { path: '/profile', label: 'Profile', icon: PedalBikeIcon };
+
+// Bicycle menu items (Profile + secondary links)
+export const BIKE_MENU_LINKS = [
+    PROFILE_LINK,
+    ...MORE_LINKS,
+];
+
+export const SIDEBAR_WIDTH = 180;
+export const SIDEBAR_COLLAPSED_WIDTH = 64;

--- a/src/QueryClient/QueryClientSetup.jsx
+++ b/src/QueryClient/QueryClientSetup.jsx
@@ -1,5 +1,4 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -17,7 +16,6 @@ export { queryClient };
 const QueryClientSetup = ({ children }) => (
     <QueryClientProvider client={queryClient}>
         {children}
-        <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
 );
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,25 +1,29 @@
-
-@media screen and (max-width: 899px) {
-  .app-layout {
+/* Base layout */
+.app-layout {
     display: grid;
+}
+
+/* Option A: Sidebar layout (default) */
+@media screen and (max-width: 899px) {
+  .app-layout.layout-sidebar {
     grid-template-columns: repeat(auto-fit, 1fr);
     grid-template-areas:
     "nav-bar"
     "title__"
     "content";
-    padding-bottom: 1px;
+    padding-bottom: 56px;  /* space for fixed bottom nav */
   }
 }
 
 @media screen and (min-width: 900px) {
-    .app-layout {
-        display: grid;
+    .app-layout.layout-sidebar {
         grid-template-columns: min-content auto;
         grid-template-areas:
           "nav-bar title__"
           "nav-bar content";
       }
 }
+
 
 .app-content-planpage {
     grid-area: content;
@@ -149,18 +153,4 @@
 .task-description-done {
     border: none;
     text-decoration: line-through;
-}
-
-.nav-title {
-    color: white;
-    text-decoration: none;
-    font-family: 'Roboto';
-    font-size: 20px;
-}
-
-.nav-link {
-    color: white;
-    text-decoration: none;
-    font-family: 'Roboto';
-    font-size: 16px;
 }

--- a/tests/tests/navigation.spec.ts
+++ b/tests/tests/navigation.spec.ts
@@ -10,12 +10,14 @@ test.describe('Navigation', () => {
     await page.getByRole('link', { name: /calendar/i }).click();
     await expect(page).toHaveURL(/\/calview/);
 
-    // Navigate to Domains
-    await page.getByRole('link', { name: /domains/i }).click();
+    // Navigate to Domains (inside bike menu)
+    await page.getByTestId('bike-menu-button').click();
+    await page.getByRole('menuitem', { name: /domains/i }).click();
     await expect(page).toHaveURL(/\/domainedit/);
 
-    // Navigate to Areas
-    await page.getByRole('link', { name: /areas/i }).click();
+    // Navigate to Areas (inside bike menu)
+    await page.getByTestId('bike-menu-button').click();
+    await page.getByRole('menuitem', { name: /areas/i }).click();
     await expect(page).toHaveURL(/\/areaedit/);
 
     // Navigate to Roadmap (links to /swarm)

--- a/tests/tests/profile.spec.ts
+++ b/tests/tests/profile.spec.ts
@@ -7,8 +7,10 @@ test.describe('Profile', () => {
     await page.goto('/taskcards');
     await page.waitForSelector('[role="tab"]', { timeout: 10000 });
 
-    // Click the bike icon link in the NavBar (Link to="/profile" wrapping PedalBikeIcon)
-    await page.locator('a[href="/profile"]').click();
+    // Open the bike menu (Profile/Domains/Areas are inside it)
+    await page.getByTestId('bike-menu-button').click();
+    // Click the Profile menu item
+    await page.getByRole('menuitem', { name: /profile/i }).click();
 
     // Verify navigation to /profile
     await expect(page).toHaveURL(/\/profile/);

--- a/tests/tests/working-domain.spec.ts
+++ b/tests/tests/working-domain.spec.ts
@@ -85,8 +85,9 @@ test.describe('Working Domain Persistence', () => {
 
     await expect(tabA).toHaveAttribute('aria-selected', 'true');
 
-    // Navigate to Area editor
-    await page.getByRole('link', { name: /areas/i }).click();
+    // Navigate to Area editor (inside bike menu)
+    await page.getByTestId('bike-menu-button').click();
+    await page.getByRole('menuitem', { name: /areas/i }).click();
     await expect(page).toHaveURL(/\/areaedit/);
     await page.waitForSelector('[role="tab"]', { timeout: 15000 });
 


### PR DESCRIPTION
## Summary
- Redesigned navbar from flat link list to collapsible sidebar with grouped navigation (TASKS: Plan, Calendar; SWARM: Roadmap, Sessions, Dev Servers)
- Desktop: permanent sidebar with icons + text, Google Maps-style edge tab for collapse/expand, black background extending full viewport height
- Mobile (<900px): slim top bar + fixed bottom navigation with all 5 primary links
- Bicycle icon opens popover menu for secondary items: Profile, Domains, Areas
- Removed React Query Devtools floating button (dev-only, unused)
- Removed unused `.nav-title` and `.nav-link` CSS classes

## Files changed
- `src/NavBar/navConfig.js` — NEW: centralized nav link definitions, groups, icons, routes
- `src/NavBar/NavBarSidebar.jsx` — NEW: collapsible sidebar component (desktop + mobile hybrid)
- `src/NavBar/NavBar.jsx` — Rewritten: delegates to NavBarSidebar, applies layout class
- `src/index.css` — Updated grid layout for sidebar variant, removed unused nav classes
- `src/QueryClient/QueryClientSetup.jsx` — Removed React Query Devtools import
- `tests/tests/navigation.spec.ts` — Updated: Domains/Areas clicks via bike menu
- `tests/tests/profile.spec.ts` — Updated: Profile click via bike menu
- `tests/tests/working-domain.spec.ts` — Updated: Areas click via bike menu

## Testing
- Build: passing (vite build)
- Manual UI review: verified both desktop and mobile at multiple widths
- E2E test updates: 3 tests updated for new nav structure (NAV-01, PROF-01, WD-02)

## Deploy notes
- Darwin frontend only — no backend changes

## References
- Roadmap item #372: Navbar look and feel

🤖 Generated with [Claude Code](https://claude.com/claude-code)