### PR TITLE
Test stability improvements

### DIFF
--- a/tests/helpers/api.ts
+++ b/tests/helpers/api.ts
@@ -107,3 +107,65 @@ export async function clickSortMode(page: Page, areaId: string, mode: 'priority'
   await page.getByTestId(`card-menu-${areaId}`).click();
   await page.getByTestId(`sort-${mode}-${areaId}`).click();
 }
+
+/**
+ * Clean up all stale E2E data for the current test user.
+ * Deletes in FK-safe order: priority_sessions → swarm_sessions → projects → domains.
+ * CASCADE handles children (categories/priorities under projects, areas/tasks under domains).
+ * Called once at the start of each test run from auth.setup.ts.
+ */
+export async function cleanupStaleData(idToken: string): Promise<{ domains: number; projects: number; sessions: number }> {
+  const sub = process.env.E2E_TEST_COGNITO_SUB;
+  if (!sub) return { domains: 0, projects: 0, sessions: 0 };
+
+  const summary = { domains: 0, projects: 0, sessions: 0 };
+
+  // 1. Fetch and delete swarm_sessions (and their priority_sessions links)
+  try {
+    const sessions = await apiCall(
+      `swarm_sessions?creator_fk=${sub}&fields=id`, 'GET', '', idToken,
+    ) as Array<{ id: string }>;
+    if (Array.isArray(sessions)) {
+      for (const sess of sessions) {
+        try {
+          // Delete priority_sessions linking to this session
+          await fetch(`${DARWIN_API}/priority_sessions`, {
+            method: 'DELETE',
+            headers: { Authorization: idToken },
+            body: JSON.stringify({ session_fk: sess.id }),
+          });
+        } catch { /* best-effort */ }
+        try { await apiDelete('swarm_sessions', sess.id, idToken); } catch { /* best-effort */ }
+      }
+      summary.sessions = sessions.length;
+    }
+  } catch { /* best-effort */ }
+
+  // 2. Fetch and delete projects (CASCADE handles categories → priorities)
+  try {
+    const projects = await apiCall(
+      `projects?creator_fk=${sub}&fields=id`, 'GET', '', idToken,
+    ) as Array<{ id: string }>;
+    if (Array.isArray(projects)) {
+      for (const proj of projects) {
+        try { await apiDelete('projects', proj.id, idToken); } catch { /* best-effort */ }
+      }
+      summary.projects = projects.length;
+    }
+  } catch { /* best-effort */ }
+
+  // 3. Fetch and delete domains (CASCADE handles areas → tasks)
+  try {
+    const domains = await apiCall(
+      `domains?creator_fk=${sub}&fields=id`, 'GET', '', idToken,
+    ) as Array<{ id: string }>;
+    if (Array.isArray(domains)) {
+      for (const dom of domains) {
+        try { await apiDelete('domains', dom.id, idToken); } catch { /* best-effort */ }
+      }
+      summary.domains = domains.length;
+    }
+  } catch { /* best-effort */ }
+
+  return summary;
+}

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     {
       name: 'setup',
       testMatch: /auth\.setup\.ts/,
+      timeout: 60000,
     },
     {
       name: 'chromium',

--- a/tests/tests/auth.setup.ts
+++ b/tests/tests/auth.setup.ts
@@ -1,5 +1,6 @@
 import { test as setup, expect } from '@playwright/test';
 import { getAuthTokens, buildProfileFromToken } from '../helpers/auth';
+import { cleanupStaleData } from '../helpers/api';
 
 const STORAGE_STATE = '.auth/user.json';
 
@@ -24,6 +25,13 @@ setup('authenticate', async ({ page }) => {
     document.cookie = `accessToken=${accessToken}; path=/; max-age=86100`;
     document.cookie = `profile=${profileCookie}; path=/; max-age=86100`;
   }, { idToken: tokens.idToken, accessToken: tokens.accessToken, refreshToken: tokens.refreshToken, profileCookie });
+
+  // Clean up stale E2E data from prior interrupted runs
+  const cleanup = await cleanupStaleData(tokens.idToken);
+  const total = cleanup.domains + cleanup.projects + cleanup.sessions;
+  if (total > 0) {
+    console.log(`Pre-test cleanup: ${cleanup.domains} domains, ${cleanup.projects} projects, ${cleanup.sessions} sessions deleted`);
+  }
 
   // Verify authentication works by loading a protected route
   await page.goto('/taskcards');


### PR DESCRIPTION
## Summary
- Add `cleanupStaleData()` helper to E2E test framework — sweeps all stale data for the current test user before each test run
- Integrates cleanup into `auth.setup.ts` (Playwright setup project) so every run starts clean
- Increases setup timeout to 60s to accommodate cleanup with many stale items
- Prevents the stale data accumulation problem (2,377+ orphaned domains) that previously degraded DomainEdit render times

## Files changed
- `tests/helpers/api.ts` — Added `cleanupStaleData()` function (FK-safe delete order: priority_sessions → swarm_sessions → projects → domains)
- `tests/tests/auth.setup.ts` — Call cleanup after auth, log results
- `tests/playwright.config.ts` — Add 60s timeout for setup project

## Testing
- Local E2E: 84/95 passing (11 pre-existing swarm/profile failures)
- Pre-test cleanup verified: cleaned 5 stale projects on first run, 2 more from failed swarm tests on second run

## Deploy notes
- Darwin frontend only — test infrastructure changes, no runtime impact

## References
- Roadmap item #383
- Fixes #143 (auth.setup timeout)
- Related: DarwinSQL PR #17 (cleanup scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)