### PR TITLE
Roadmap Create -> Single View

### DIFF
--- a/src/SwarmView/CategoryCard.jsx
+++ b/src/SwarmView/CategoryCard.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useContext, useRef, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import PriorityRow from './PriorityRow';
 import PriorityDeleteDialog from './PriorityDeleteDialog';
@@ -38,6 +39,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
 
     const revertDragTabSwitch = useSwarmTabStore(s => s.revertDragTabSwitch);
 
+    const navigate = useNavigate();
     const { idToken, profile } = useContext(AuthContext);
     const { darwinUri } = useContext(AppContext);
     const queryClient = useQueryClient();
@@ -458,6 +460,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
                     newPrioritiesArray.push({'id':'', 'title':'', 'in_progress': 0, 'closed': 0, 'scheduled': 0, 'category_fk': category.id, 'sort_order': null });
                     setPrioritiesArray(newPrioritiesArray);
                     queryClient.invalidateQueries({ queryKey: priorityKeys.all(profile.userName) });
+                    navigate(`/swarm/priority/${result.data[0].id}`);
                 } else if (result.httpStatus.httpStatus === 201) {
                     queryClient.invalidateQueries({ queryKey: priorityKeys.all(profile.userName) });
                 } else {

--- a/src/SwarmView/detail/PriorityDetail.jsx
+++ b/src/SwarmView/detail/PriorityDetail.jsx
@@ -172,7 +172,7 @@ const PriorityDetail = () => {
                 <Button variant="outlined"
                         onClick={() => navigate(sessions.length === 1 ? `/swarm/session/${sessions[0].id}` : '/swarm')}
                         data-testid="btn-back-to-swarm">
-                    {sessions.length === 1 ? 'Go to Session' : 'Back to Swarm'}
+                    {sessions.length === 1 ? 'Go to Session' : 'Back to Roadmap'}
                 </Button>
             </Box>
 


### PR DESCRIPTION
## Summary
- Auto-navigate to the priority detail view (`/swarm/priority/:id`) after creating a new roadmap priority, so the user can immediately write a description
- Fix "Back to Swarm" button text to "Back to Roadmap" on the PriorityDetail page

## Files changed
- `src/SwarmView/CategoryCard.jsx` — Added `useNavigate` hook; after successful POST in `savePriority()`, navigate to the new priority's detail view
- `src/SwarmView/detail/PriorityDetail.jsx` — Changed button text from "Back to Swarm" to "Back to Roadmap" (kept `data-testid` unchanged)

## Testing
- Local E2E: skipped per user request
- No existing tests affected (SWM-21 tests SwarmSessionDetail, not PriorityDetail)

## Deploy notes
- Darwin frontend only — no backend changes

## References
- Roadmap item #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)