### PR TITLE
Darwin color change when debug server running

### DIFF
--- a/src/NavBar/NavBarSidebar.jsx
+++ b/src/NavBar/NavBarSidebar.jsx
@@ -31,6 +31,9 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 const ACCENT = '#E91E63';
 const BG_ACTIVE = 'rgba(233, 30, 99, 0.12)';
 
+const isDev = import.meta.env.MODE === 'development';
+const DEV_BORDER = isDev ? '4px solid #FF6B35' : 'none';
+
 const NavBarSidebar = () => {
     const { idToken } = useContext(AuthContext);
     const location = useLocation();
@@ -153,6 +156,7 @@ const NavBarSidebar = () => {
 
         return (
             <>
+                {isDev && <Box sx={{ position: 'fixed', top: 0, left: 0, right: 0, height: '4px', bgcolor: '#FF6B35', zIndex: 1300 }} />}
                 <Box
                     className="app-navbar"
                     sx={{ width, flexShrink: 0, transition: 'width 0.2s ease', height: '100vh', position: 'sticky', top: 0 }}
@@ -259,7 +263,7 @@ const NavBarSidebar = () => {
             <AppBar
                 position="static"
                 className="app-navbar"
-                sx={{ bgcolor: 'black' }}
+                sx={{ bgcolor: 'black', borderTop: DEV_BORDER }}
             >
                 <Toolbar variant="dense" sx={{ minHeight: 48 }}>
                     <IconButton


### PR DESCRIPTION
## Summary
- Add 4px orange (#FF6B35) top border to the Darwin navbar to visually distinguish a local dev server from production
- Desktop: fixed full-width bar spanning the entire viewport width (position: fixed, zIndex 1300)
- Mobile: borderTop on the AppBar (naturally full-width)
- Zero production impact: gated by \`import.meta.env.MODE === 'development'\`, which Vite hard-codes to \`'production'\` in production builds — the element is not rendered and is tree-shaken from the bundle

## Files changed
- \`src/NavBar/NavBarSidebar.jsx\` — added \`isDev\` / \`DEV_BORDER\` constants; fixed-position desktop bar; mobile AppBar borderTop

## Testing
- Local E2E: skipped (minor visual-only change, no logic affected)
- Manually verified: orange bar visible on dev server, absent in prod builds by design

## Deploy notes
- Darwin frontend only

## References
- Roadmap item #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)