### PR TITLE
[PAUSED] Solar — Enphase IQ Gateway Integration

### DIFF
--- a/src/NavBar/ProfileContent.jsx
+++ b/src/NavBar/ProfileContent.jsx
@@ -37,6 +37,7 @@ const ProfileContent = ({ onClose }) => {
     const [appTasks, setAppTasks] = useState(Number(profile?.app_tasks ?? 1));
     const [appMaps, setAppMaps] = useState(Number(profile?.app_maps ?? 1));
     const [appSwarm, setAppSwarm] = useState(Number(profile?.app_swarm ?? 0));
+    const [appSolar, setAppSolar] = useState(Number(profile?.app_solar ?? 0));
 
     const timezoneOptions = useMemo(() => getTimezoneList(), []);
     const selectedTimezone = timezoneOptions.find(tz => tz.value === timezone) || null;
@@ -47,6 +48,7 @@ const ProfileContent = ({ onClose }) => {
     const savedAppTasksRef = useRef(Number(profile?.app_tasks ?? 1));
     const savedAppMapsRef = useRef(Number(profile?.app_maps ?? 1));
     const savedAppSwarmRef = useRef(Number(profile?.app_swarm ?? 0));
+    const savedAppSolarRef = useRef(Number(profile?.app_solar ?? 0));
 
     // Fetch fresh profile from DB on mount — stale localStorage must not be authoritative
     useEffect(() => {
@@ -60,12 +62,14 @@ const ProfileContent = ({ onClose }) => {
                     setAppTasks(Number(db.app_tasks ?? 1));
                     setAppMaps(Number(db.app_maps ?? 1));
                     setAppSwarm(Number(db.app_swarm ?? 0));
+                    setAppSolar(Number(db.app_solar ?? 0));
                     savedNameRef.current = db.name || '';
                     savedTimezoneRef.current = db.timezone || '';
                     savedThemeModeRef.current = db.theme_mode || 'light';
                     savedAppTasksRef.current = Number(db.app_tasks ?? 1);
                     savedAppMapsRef.current = Number(db.app_maps ?? 1);
                     savedAppSwarmRef.current = Number(db.app_swarm ?? 0);
+                    savedAppSolarRef.current = Number(db.app_solar ?? 0);
                     const updated = { ...profile, ...db };
                     setProfile(updated);
                     localStorage.setItem('darwin-profile', JSON.stringify(updated));
@@ -75,16 +79,16 @@ const ProfileContent = ({ onClose }) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [idToken]);
 
-    const saveProfile = useCallback((newName, newTimezone, newThemeMode, newAppTasks, newAppMaps, newAppSwarm) => {
+    const saveProfile = useCallback((newName, newTimezone, newThemeMode, newAppTasks, newAppMaps, newAppSwarm, newAppSolar) => {
         if (newName === savedNameRef.current && newTimezone === savedTimezoneRef.current
             && newThemeMode === savedThemeModeRef.current
             && newAppTasks === savedAppTasksRef.current && newAppMaps === savedAppMapsRef.current
-            && newAppSwarm === savedAppSwarmRef.current) return;
+            && newAppSwarm === savedAppSwarmRef.current && newAppSolar === savedAppSolarRef.current) return;
 
         const uri = `${darwinUri}/profiles`;
         call_rest_api(uri, 'PUT', [{
             id: profile.id, name: newName, timezone: newTimezone, theme_mode: newThemeMode,
-            app_tasks: newAppTasks, app_maps: newAppMaps, app_swarm: newAppSwarm,
+            app_tasks: newAppTasks, app_maps: newAppMaps, app_swarm: newAppSwarm, app_solar: newAppSolar,
         }], idToken)
             .then(result => {
                 if (result.httpStatus.httpStatus === 200 || result.httpStatus.httpStatus === 204) {
@@ -94,9 +98,10 @@ const ProfileContent = ({ onClose }) => {
                     savedAppTasksRef.current = newAppTasks;
                     savedAppMapsRef.current = newAppMaps;
                     savedAppSwarmRef.current = newAppSwarm;
+                    savedAppSolarRef.current = newAppSolar;
                     const updated = {
                         ...profile, name: newName, timezone: newTimezone, theme_mode: newThemeMode,
-                        app_tasks: newAppTasks, app_maps: newAppMaps, app_swarm: newAppSwarm,
+                        app_tasks: newAppTasks, app_maps: newAppMaps, app_swarm: newAppSwarm, app_solar: newAppSolar,
                     };
                     setProfile(updated);
                     localStorage.setItem('darwin-profile', JSON.stringify(updated));
@@ -156,7 +161,7 @@ const ProfileContent = ({ onClose }) => {
             <TextField  label="Name"
                         value={name}
                         onChange={(e) => setName(e.target.value)}
-                        onBlur={() => saveProfile(name, timezone, themeMode, appTasks, appMaps, appSwarm)}
+                        onBlur={() => saveProfile(name, timezone, themeMode, appTasks, appMaps, appSwarm, appSolar)}
                         id="Name"
                         key="Name"
                         variant="outlined"
@@ -175,7 +180,7 @@ const ProfileContent = ({ onClose }) => {
                         onChange={(e, newValue) => {
                             const newTz = newValue?.value || '';
                             setTimezone(newTz);
-                            saveProfile(name, newTz, themeMode, appTasks, appMaps, appSwarm);
+                            saveProfile(name, newTz, themeMode, appTasks, appMaps, appSwarm, appSolar);
                         }}
                         isOptionEqualToValue={(option, value) => option.value === value.value}
                         renderInput={(params) => (
@@ -191,10 +196,11 @@ const ProfileContent = ({ onClose }) => {
                     {[
                         { key: 'tasks', label: 'Tasks', value: appTasks, setValue: setAppTasks },
                         { key: 'maps', label: 'Maps', value: appMaps, setValue: setAppMaps },
+                        { key: 'solar', label: 'Solar', value: appSolar, setValue: setAppSolar },
                         { key: 'swarm', label: 'Swarm', value: appSwarm, setValue: setAppSwarm },
                     ].map((app) => {
                         const enabled = app.value === 1;
-                        const enabledCount = [appTasks, appMaps, appSwarm].filter(v => v === 1).length;
+                        const enabledCount = [appTasks, appMaps, appSolar, appSwarm].filter(v => v === 1).length;
 
                         const handleToggle = () => {
                             if (enabled && enabledCount <= 1) return;
@@ -203,7 +209,8 @@ const ProfileContent = ({ onClose }) => {
                             const newTasks = app.key === 'tasks' ? newVal : appTasks;
                             const newMaps = app.key === 'maps' ? newVal : appMaps;
                             const newSwarm = app.key === 'swarm' ? newVal : appSwarm;
-                            saveProfile(name, timezone, themeMode, newTasks, newMaps, newSwarm);
+                            const newSolar = app.key === 'solar' ? newVal : appSolar;
+                            saveProfile(name, timezone, themeMode, newTasks, newMaps, newSwarm, newSolar);
                         };
 
                         const renderPreview = () => {
@@ -231,6 +238,33 @@ const ProfileContent = ({ onClose }) => {
                                                 stroke={enabled ? '#1976d2' : '#bbb'} strokeWidth="2.5" strokeLinecap="round" />
                                             <circle cx="8" cy="32" r="3" fill={enabled ? '#e91e63' : '#ccc'} />
                                             <circle cx="52" cy="8" r="3" fill={enabled ? '#4caf50' : '#ccc'} />
+                                        </svg>
+                                    </Box>
+                                );
+                            }
+                            if (app.key === 'solar') {
+                                const panelColor = enabled ? '#4caf50' : '#888';
+                                const sunColor = enabled ? '#ff9800' : '#aaa';
+                                return (
+                                    <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', p: 0.5 }}>
+                                        <svg width="60" height="40" viewBox="0 0 60 40">
+                                            {/* Sun */}
+                                            <circle cx="50" cy="8" r="5" fill={sunColor} />
+                                            {[0, 45, 90, 135, 180, 225, 270, 315].map((angle) => (
+                                                <line key={angle}
+                                                    x1={50 + 7 * Math.cos(angle * Math.PI / 180)}
+                                                    y1={8 + 7 * Math.sin(angle * Math.PI / 180)}
+                                                    x2={50 + 9 * Math.cos(angle * Math.PI / 180)}
+                                                    y2={8 + 9 * Math.sin(angle * Math.PI / 180)}
+                                                    stroke={sunColor} strokeWidth="1" strokeLinecap="round" />
+                                            ))}
+                                            {/* 4x2 panel grid */}
+                                            {[0, 1, 2, 3].map((col) => [0, 1].map((row) => (
+                                                <rect key={`${col}-${row}`}
+                                                    x={4 + col * 12} y={16 + row * 10}
+                                                    width="10" height="8" rx="1"
+                                                    fill={panelColor} opacity={0.7 + row * 0.15} />
+                                            )))}
                                         </svg>
                                     </Box>
                                 );
@@ -328,7 +362,7 @@ const ProfileContent = ({ onClose }) => {
 
                         return (
                             <Box key={m}
-                                onClick={() => { setThemeMode(m); saveProfile(name, timezone, m, appTasks, appMaps, appSwarm); }}
+                                onClick={() => { setThemeMode(m); saveProfile(name, timezone, m, appTasks, appMaps, appSwarm, appSolar); }}
                                 sx={{
                                     cursor: 'pointer', textAlign: 'center',
                                     '&:hover .theme-thumb': { borderColor: 'primary.main' },
@@ -390,7 +424,7 @@ const ProfileContent = ({ onClose }) => {
             <ExportDialog
                 open={exportDialogOpen}
                 onClose={() => setExportDialogOpen(false)}
-                enabledApps={{ tasks: appTasks === 1, maps: appMaps === 1, swarm: appSwarm === 1 }}
+                enabledApps={{ tasks: appTasks === 1, maps: appMaps === 1, solar: appSolar === 1, swarm: appSwarm === 1 }}
                 onExport={handleExport}
                 exporting={exporting}
             />

--- a/src/NavBar/navConfig.js
+++ b/src/NavBar/navConfig.js
@@ -6,10 +6,12 @@ import DnsIcon from '@mui/icons-material/Dns';
 import PedalBikeIcon from '@mui/icons-material/PedalBike';
 import RepeatIcon from '@mui/icons-material/Repeat';
 import RouteIcon from '@mui/icons-material/Route';
+import WbSunnyIcon from '@mui/icons-material/WbSunny';
 
 export const NAV_GROUPS = [
     { id: 'tasks', label: 'TASKS' },
     { id: 'maps', label: 'MAPS' },
+    { id: 'solar', label: 'SOLAR' },
     { id: 'swarm', label: 'SWARM' },
 ];
 
@@ -17,6 +19,7 @@ export const NAV_GROUPS = [
 export const GROUP_PROFILE_KEY = {
     tasks: 'app_tasks',
     maps: 'app_maps',
+    solar: 'app_solar',
     swarm: 'app_swarm',
 };
 
@@ -25,6 +28,7 @@ export const NAV_LINKS = [
     { path: '/recurring', label: 'Recurring', icon: RepeatIcon, group: 'tasks' },
     { path: '/calview', label: 'Calendar', icon: CalendarMonthIcon, group: 'tasks' },
     { path: '/maps', label: 'Maps', icon: RouteIcon, group: 'maps' },
+    { path: '/solar', label: 'Solar', icon: WbSunnyIcon, group: 'solar' },
     { path: '/swarm', label: 'Roadmap', icon: MapIcon, group: 'swarm' },
     { path: '/swarm/sessions', label: 'Sessions', icon: HubIcon, group: 'swarm' },
     { path: '/devservers', label: 'Dev Servers', icon: DnsIcon, group: 'swarm' },

--- a/src/Solar/SolarGridDetail.jsx
+++ b/src/Solar/SolarGridDetail.jsx
@@ -1,0 +1,40 @@
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import { formatVoltage, formatCurrent, formatPowerFactor, formatWatts } from '../utils/solarFormat';
+
+const DetailItem = ({ label, value }) => (
+    <Box sx={{ textAlign: 'center', minWidth: 80 }}>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.25 }}>
+            {label}
+        </Typography>
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            {value}
+        </Typography>
+    </Box>
+);
+
+const SolarGridDetail = ({ productionDetail }) => {
+    if (!productionDetail) return null;
+
+    return (
+        <Paper elevation={0} sx={{
+            bgcolor: 'rgba(42, 39, 35, 0.88)',
+            backdropFilter: 'blur(6px)',
+            border: '1px solid rgba(255,255,255,0.10)',
+            borderRadius: 2,
+            px: 3,
+            py: 1.5,
+        }}>
+            <Box sx={{ display: 'flex', gap: 4, flexWrap: 'wrap', justifyContent: 'center' }}>
+                <DetailItem label="Voltage" value={formatVoltage(productionDetail.rmsVoltage)} />
+                <DetailItem label="Current" value={formatCurrent(productionDetail.rmsCurrent)} />
+                <DetailItem label="Power Factor" value={formatPowerFactor(productionDetail.pwrFactor)} />
+                <DetailItem label="Apparent Power" value={productionDetail.apprntPwr != null ? `${Math.round(productionDetail.apprntPwr)} VA` : '—'} />
+                <DetailItem label="Reactive Power" value={productionDetail.reactPwr != null ? `${productionDetail.reactPwr.toFixed(1)} VAR` : '—'} />
+            </Box>
+        </Paper>
+    );
+};
+
+export default SolarGridDetail;

--- a/src/Solar/SolarPage.jsx
+++ b/src/Solar/SolarPage.jsx
@@ -1,0 +1,64 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import WifiOffIcon from '@mui/icons-material/WifiOff';
+import useSolarPolling from '../hooks/useSolarPolling';
+import SolarStats from './SolarStats';
+import SolarGridDetail from './SolarGridDetail';
+import SolarPanelGrid from './SolarPanelGrid';
+
+const SolarPage = () => {
+    const { production, productionDetail, inverters, error, loading, lastUpdated } = useSolarPolling();
+
+    const hasData = production || inverters;
+
+    if (loading && !hasData) {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 10 }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    if (error && !hasData) {
+        return (
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mt: 10, gap: 2 }}>
+                <WifiOffIcon sx={{ fontSize: 48, color: 'text.disabled' }} />
+                <Typography variant="h6" color="text.secondary">
+                    Solar data unavailable
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                    The local Enphase proxy may not be running.
+                </Typography>
+                <Typography variant="caption" color="text.disabled">
+                    Start it with: node solar/proxy.js
+                </Typography>
+            </Box>
+        );
+    }
+
+    return (
+        <Box sx={{ mt: 3, px: 2, maxWidth: 900, mx: 'auto' }}>
+            {error && hasData && (
+                <Alert severity="warning" sx={{ mb: 2 }}>
+                    Live updates paused — last updated {lastUpdated ? new Date(lastUpdated).toLocaleTimeString() : 'unknown'}
+                </Alert>
+            )}
+
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
+                <SolarStats production={production} />
+                <SolarGridDetail productionDetail={productionDetail} />
+                <SolarPanelGrid inverters={inverters} />
+            </Box>
+
+            {lastUpdated && !error && (
+                <Typography variant="caption" color="text.disabled" sx={{ display: 'block', mt: 2, textAlign: 'right' }}>
+                    Updated {new Date(lastUpdated).toLocaleTimeString()}
+                </Typography>
+            )}
+        </Box>
+    );
+};
+
+export default SolarPage;

--- a/src/Solar/SolarPanelGrid.jsx
+++ b/src/Solar/SolarPanelGrid.jsx
@@ -1,0 +1,134 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
+import { SOLAR_CONFIG } from '../config/solar';
+import { formatWatts } from '../utils/solarFormat';
+
+const DARWIN_RED = '#E91E63';
+const DARWIN_RED_DIM = 'rgba(233, 30, 99, 0.15)';
+
+const panelAnimation = {
+    '@keyframes panel-glow': {
+        '0%, 100%': { opacity: 0.85 },
+        '50%': { opacity: 1 },
+    },
+};
+
+const SolarPanelGrid = ({ inverters }) => {
+    if (!inverters || inverters.length === 0) return null;
+
+    const totalWatts = inverters.reduce((sum, inv) => sum + (inv.lastReportWatts || 0), 0);
+
+    return (
+        <Box sx={panelAnimation}>
+            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mb: 1.5 }}>
+                <Typography variant="body1" sx={{ fontWeight: 600 }}>
+                    Solar Array
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                    {SOLAR_CONFIG.panelCount} Panels &middot; {formatWatts(totalWatts)}
+                </Typography>
+            </Box>
+            <Box sx={{
+                display: 'grid',
+                gridTemplateColumns: `repeat(${SOLAR_CONFIG.gridCols}, 1fr)`,
+                gap: 0.75,
+                maxWidth: 800,
+            }}>
+                {inverters.map((inv) => {
+                    const isActive = inv.lastReportWatts > 0;
+                    const pct = inv.maxReportWatts ? Math.round((inv.lastReportWatts / inv.maxReportWatts) * 100) : 0;
+                    const opacity = isActive ? 0.2 + (pct / 100) * 0.4 : 0.08;
+                    const lastReport = inv.lastReportDate
+                        ? new Date(inv.lastReportDate * 1000).toLocaleTimeString()
+                        : 'Unknown';
+
+                    return (
+                        <Tooltip
+                            key={inv.serialNumber}
+                            enterDelay={400}
+                            enterNextDelay={200}
+                            title={
+                                <Box sx={{ fontSize: 12 }}>
+                                    <Box sx={{ fontWeight: 600, mb: 0.5 }}>SN: {inv.serialNumber}</Box>
+                                    <Box>Now: {inv.lastReportWatts} W ({pct}%)</Box>
+                                    <Box>Max: {inv.maxReportWatts} W</Box>
+                                    <Box>Last: {lastReport}</Box>
+                                </Box>
+                            }
+                        >
+                            <Box sx={{
+                                aspectRatio: '3 / 4',
+                                borderRadius: 1,
+                                bgcolor: '#1a1816',
+                                border: '2px solid',
+                                borderColor: isActive ? 'rgba(233, 30, 99, 0.25)' : 'rgba(255,255,255,0.06)',
+                                position: 'relative',
+                                overflow: 'hidden',
+                                cursor: 'pointer',
+                                display: 'flex',
+                                flexDirection: 'column',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                gap: '2px',
+                                '&:hover': { borderColor: DARWIN_RED },
+                            }}>
+                                {/* Panel grid lines */}
+                                <Box sx={{
+                                    position: 'absolute',
+                                    inset: 3,
+                                    display: 'grid',
+                                    gridTemplateColumns: '1fr 1fr',
+                                    gridTemplateRows: '1fr 1fr 1fr',
+                                    gap: '1px',
+                                    opacity: 0.12,
+                                    '& > div': { border: '0.5px solid rgba(255,255,255,0.3)' },
+                                }}>
+                                    {[...Array(6)].map((_, i) => <div key={i} />)}
+                                </Box>
+                                {/* Color overlay */}
+                                <Box sx={{
+                                    position: 'absolute',
+                                    inset: 0,
+                                    bgcolor: DARWIN_RED,
+                                    opacity,
+                                    ...(isActive && { animation: 'panel-glow 3s ease-in-out infinite' }),
+                                }} />
+                                {/* Current watts */}
+                                <Typography sx={{
+                                    position: 'relative',
+                                    zIndex: 1,
+                                    fontWeight: 700,
+                                    fontSize: 20,
+                                    lineHeight: 1,
+                                    color: isActive ? '#fff' : 'rgba(255,255,255,0.3)',
+                                    textShadow: isActive ? `0 1px 4px rgba(0,0,0,0.6)` : 'none',
+                                }}>
+                                    {inv.lastReportWatts}
+                                    <Typography component="span" sx={{ fontSize: 12, fontWeight: 500, ml: '1px' }}>W</Typography>
+                                </Typography>
+                                {/* Daily kWh per panel */}
+                                {/* % of panel max */}
+                                {isActive && (
+                                    <Typography sx={{
+                                        position: 'relative',
+                                        zIndex: 1,
+                                        fontSize: 16,
+                                        lineHeight: 1,
+                                        color: 'rgba(255,255,255,0.55)',
+                                        fontWeight: 600,
+                                    }}>
+                                        {pct}
+                                        <Typography component="span" sx={{ fontSize: 10, fontWeight: 500, ml: '1px' }}>%</Typography>
+                                    </Typography>
+                                )}
+                            </Box>
+                        </Tooltip>
+                    );
+                })}
+            </Box>
+        </Box>
+    );
+};
+
+export default SolarPanelGrid;

--- a/src/Solar/SolarStats.jsx
+++ b/src/Solar/SolarStats.jsx
@@ -1,0 +1,123 @@
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import WbSunnyIcon from '@mui/icons-material/WbSunny';
+import { SOLAR_CONFIG } from '../config/solar';
+import { formatWatts, formatKwh, formatSavings, formatPercentOfPeak } from '../utils/solarFormat';
+import { useSolarSettingsStore } from '../stores/useSolarSettingsStore';
+import { useState } from 'react';
+
+const cardSx = {
+    bgcolor: 'rgba(42, 39, 35, 0.88)',
+    backdropFilter: 'blur(6px)',
+    border: '1px solid rgba(255,255,255,0.10)',
+    p: 2,
+    borderRadius: 2,
+    minWidth: 160,
+    flex: 1,
+};
+
+const sunAnimation = {
+    '@keyframes sun-pulse': {
+        '0%, 100%': { filter: 'drop-shadow(0 0 4px #ff9800)' },
+        '50%': { filter: 'drop-shadow(0 0 12px #ffb74d)' },
+    },
+};
+
+const SolarStats = ({ production }) => {
+    const ratePerKwh = useSolarSettingsStore(s => s.ratePerKwh);
+    const setRatePerKwh = useSolarSettingsStore(s => s.setRatePerKwh);
+    const [editingRate, setEditingRate] = useState(false);
+    const [rateInput, setRateInput] = useState(String(ratePerKwh));
+
+    const isProducing = production?.wattsNow > 0;
+
+    const handleRateBlur = () => {
+        const parsed = parseFloat(rateInput);
+        if (!isNaN(parsed) && parsed > 0) {
+            setRatePerKwh(parsed);
+        } else {
+            setRateInput(String(ratePerKwh));
+        }
+        setEditingRate(false);
+    };
+
+    return (
+        <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', ...sunAnimation }}>
+            {/* Producing Now */}
+            <Paper elevation={0} sx={cardSx}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <WbSunnyIcon sx={{
+                        color: isProducing ? '#ff9800' : 'text.disabled',
+                        fontSize: 20,
+                        ...(isProducing && { animation: 'sun-pulse 2s ease-in-out infinite' }),
+                    }} />
+                    <Typography variant="caption" color="text.secondary">Producing Now</Typography>
+                </Box>
+                <Typography variant="h4" sx={{ fontWeight: 600 }}>
+                    {formatWatts(production?.wattsNow)}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                    {formatPercentOfPeak(production?.wattsNow, SOLAR_CONFIG.peakCapacityWatts)} of peak
+                </Typography>
+            </Paper>
+
+            {/* Today */}
+            <Paper elevation={0} sx={cardSx}>
+                <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+                    Today
+                </Typography>
+                <Typography variant="h4" sx={{ fontWeight: 600 }}>
+                    {formatKwh(production?.wattHoursToday)}
+                </Typography>
+            </Paper>
+
+            {/* This Week */}
+            <Paper elevation={0} sx={cardSx}>
+                <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+                    This Week
+                </Typography>
+                <Typography variant="h4" sx={{ fontWeight: 600 }}>
+                    {formatKwh(production?.wattHoursSevenDays)}
+                </Typography>
+            </Paper>
+
+            {/* Lifetime */}
+            <Paper elevation={0} sx={cardSx}>
+                <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+                    Lifetime
+                </Typography>
+                <Typography variant="h4" sx={{ fontWeight: 600 }}>
+                    {formatKwh(production?.wattHoursLifetime)}
+                </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+                    <Typography variant="caption" color="text.secondary">
+                        {formatSavings(production?.wattHoursLifetime, ratePerKwh)} saved @
+                    </Typography>
+                    {editingRate ? (
+                        <TextField
+                            size="small"
+                            value={rateInput}
+                            onChange={e => setRateInput(e.target.value)}
+                            onBlur={handleRateBlur}
+                            onKeyDown={e => e.key === 'Enter' && handleRateBlur()}
+                            autoFocus
+                            sx={{ width: 70, '& input': { fontSize: 12, p: '2px 6px' } }}
+                        />
+                    ) : (
+                        <Typography
+                            variant="caption"
+                            sx={{ color: 'primary.main', cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+                            onClick={() => { setRateInput(String(ratePerKwh)); setEditingRate(true); }}
+                        >
+                            ${ratePerKwh}/kWh
+                        </Typography>
+                    )}
+                </Box>
+            </Paper>
+        </Box>
+    );
+};
+
+export default SolarStats;

--- a/src/config/solar.js
+++ b/src/config/solar.js
@@ -1,0 +1,12 @@
+export const SOLAR_CONFIG = {
+    proxyUrl: import.meta.env.VITE_ENPHASE_PROXY_URL || 'http://localhost:8089',
+    productionEndpoint: '/enphase/api/v1/production',
+    productionDetailEndpoint: '/enphase/production.json',
+    invertersEndpoint: '/enphase/api/v1/production/inverters',
+    peakCapacityWatts: 11100,
+    panelCount: 32,
+    gridRows: 4,
+    gridCols: 8,
+    defaultRatePerKwh: 0.30,
+    pollIntervalMs: 15000,
+};

--- a/src/hooks/useSolarPolling.js
+++ b/src/hooks/useSolarPolling.js
@@ -1,0 +1,62 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { fetchProduction, fetchProductionDetail, fetchInverters } from '../services/enphaseService';
+import { SOLAR_CONFIG } from '../config/solar';
+
+export default function useSolarPolling(intervalMs = SOLAR_CONFIG.pollIntervalMs) {
+    const [production, setProduction] = useState(null);
+    const [productionDetail, setProductionDetail] = useState(null);
+    const [inverters, setInverters] = useState(null);
+    const [error, setError] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [lastUpdated, setLastUpdated] = useState(null);
+    const mountedRef = useRef(true);
+
+    const poll = useCallback(async () => {
+        const results = await Promise.allSettled([
+            fetchProduction(),
+            fetchProductionDetail(),
+            fetchInverters(),
+        ]);
+
+        if (!mountedRef.current) return;
+
+        const [prodResult, detailResult, invResult] = results;
+
+        let anySuccess = false;
+
+        if (prodResult.status === 'fulfilled') {
+            setProduction(prodResult.value);
+            anySuccess = true;
+        }
+        if (detailResult.status === 'fulfilled') {
+            setProductionDetail(detailResult.value);
+            anySuccess = true;
+        }
+        if (invResult.status === 'fulfilled') {
+            setInverters(invResult.value);
+            anySuccess = true;
+        }
+
+        if (anySuccess) {
+            setError(null);
+            setLastUpdated(Date.now());
+        } else {
+            const msg = prodResult.reason?.message || 'Solar data unavailable — proxy may not be running';
+            setError(msg);
+        }
+
+        setLoading(false);
+    }, []);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        poll();
+        const id = setInterval(poll, intervalMs);
+        return () => {
+            mountedRef.current = false;
+            clearInterval(id);
+        };
+    }, [poll, intervalMs]);
+
+    return { production, productionDetail, inverters, error, loading, lastUpdated };
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -35,6 +35,7 @@ import SetupWizard from './SetupWizard/SetupWizard';
 import RecurringPlanView from './RecurringTaskEdit/RecurringPlanView';
 import MapsPage from './Maps/MapsPage';
 import CyclemeterImport from './CyclemeterImport/CyclemeterImport';
+import SolarPage from './Solar/SolarPage';
 
 import RouteDetailView from './RouteCards/RouteDetailView';
 import MapRouteSettingsView from './Maps/MapRouteSettingsView';
@@ -98,6 +99,9 @@ root.render(
                                                          </AuthenticatedRoute>} />
                     <Route path="recurring" element= {<AuthenticatedRoute>
                                                              <RecurringPlanView />
+                                                         </AuthenticatedRoute>} />
+                    <Route path="solar" element= {<AuthenticatedRoute>
+                                                             <SolarPage />
                                                          </AuthenticatedRoute>} />
                     <Route path="maps" element= {<AuthenticatedRoute>
                                                              <MapsPage />

--- a/src/services/__tests__/enphaseService.test.js
+++ b/src/services/__tests__/enphaseService.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchProduction, fetchProductionDetail, fetchInverters } from '../enphaseService';
+
+const PROXY_URL = 'http://localhost:8089';
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('fetchProduction', () => {
+    it('returns parsed production data on success', async () => {
+        const mockData = { wattHoursToday: 8126, wattHoursSevenDays: 369263, wattHoursLifetime: 8071061, wattsNow: 262 };
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: () => Promise.resolve(mockData) });
+
+        const result = await fetchProduction(PROXY_URL);
+        expect(result).toEqual(mockData);
+        expect(fetch).toHaveBeenCalledWith(
+            `${PROXY_URL}/enphase/api/v1/production`,
+            expect.objectContaining({ signal: expect.any(AbortSignal) })
+        );
+    });
+
+    it('throws on non-200 response', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 502 });
+        await expect(fetchProduction(PROXY_URL)).rejects.toThrow('Enphase API error (502)');
+    });
+
+    it('throws on network error', async () => {
+        vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'));
+        await expect(fetchProduction(PROXY_URL)).rejects.toThrow('Failed to fetch');
+    });
+});
+
+describe('fetchProductionDetail', () => {
+    it('extracts EIM data from production.json response', async () => {
+        const mockResponse = {
+            production: [
+                { type: 'inverters', activeCount: 32 },
+                { type: 'eim', wNow: 251.6, whToday: 8129, whLifetime: 8071064, rmsVoltage: 244.4, rmsCurrent: 22.6, pwrFactor: 0.09, reactPwr: -37.4, apprntPwr: 2760 },
+            ],
+            consumption: [],
+        };
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: () => Promise.resolve(mockResponse) });
+
+        const result = await fetchProductionDetail(PROXY_URL);
+        expect(result).toEqual({
+            wNow: 251.6,
+            whToday: 8129,
+            whLifetime: 8071064,
+            rmsVoltage: 244.4,
+            rmsCurrent: 22.6,
+            pwrFactor: 0.09,
+            reactPwr: -37.4,
+            apprntPwr: 2760,
+        });
+    });
+
+    it('throws when no EIM data found', async () => {
+        const mockResponse = { production: [{ type: 'inverters' }] };
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: () => Promise.resolve(mockResponse) });
+        await expect(fetchProductionDetail(PROXY_URL)).rejects.toThrow('No production EIM data found');
+    });
+
+    it('throws on non-200 response', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 401 });
+        await expect(fetchProductionDetail(PROXY_URL)).rejects.toThrow('Enphase API error (401)');
+    });
+});
+
+describe('fetchInverters', () => {
+    it('returns inverter array on success', async () => {
+        const mockInverters = [
+            { serialNumber: '202308154676', lastReportDate: 1775007673, devType: 1, lastReportWatts: 20, maxReportWatts: 347 },
+            { serialNumber: '202308154677', lastReportDate: 1775007673, devType: 1, lastReportWatts: 300, maxReportWatts: 356 },
+        ];
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: () => Promise.resolve(mockInverters) });
+
+        const result = await fetchInverters(PROXY_URL);
+        expect(result).toHaveLength(2);
+        expect(result[0].serialNumber).toBe('202308154676');
+    });
+
+    it('throws on non-200 response', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 500 });
+        await expect(fetchInverters(PROXY_URL)).rejects.toThrow('Enphase API error (500)');
+    });
+
+    it('throws on network error', async () => {
+        vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Network failure'));
+        await expect(fetchInverters(PROXY_URL)).rejects.toThrow('Network failure');
+    });
+});

--- a/src/services/enphaseService.js
+++ b/src/services/enphaseService.js
@@ -1,0 +1,43 @@
+import { SOLAR_CONFIG } from '../config/solar';
+
+const TIMEOUT_MS = 10000;
+
+async function fetchWithTimeout(url) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    try {
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok) {
+            throw new Error(`Enphase API error (${res.status})`);
+        }
+        return await res.json();
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}
+
+export async function fetchProduction(proxyUrl = SOLAR_CONFIG.proxyUrl) {
+    return fetchWithTimeout(`${proxyUrl}${SOLAR_CONFIG.productionEndpoint}`);
+}
+
+export async function fetchProductionDetail(proxyUrl = SOLAR_CONFIG.proxyUrl) {
+    const data = await fetchWithTimeout(`${proxyUrl}${SOLAR_CONFIG.productionDetailEndpoint}`);
+    const eim = data.production?.find(p => p.type === 'eim');
+    if (!eim) {
+        throw new Error('No production EIM data found');
+    }
+    return {
+        wNow: eim.wNow,
+        whToday: eim.whToday,
+        whLifetime: eim.whLifetime,
+        rmsVoltage: eim.rmsVoltage,
+        rmsCurrent: eim.rmsCurrent,
+        pwrFactor: eim.pwrFactor,
+        reactPwr: eim.reactPwr,
+        apprntPwr: eim.apprntPwr,
+    };
+}
+
+export async function fetchInverters(proxyUrl = SOLAR_CONFIG.proxyUrl) {
+    return fetchWithTimeout(`${proxyUrl}${SOLAR_CONFIG.invertersEndpoint}`);
+}

--- a/src/stores/useSolarSettingsStore.js
+++ b/src/stores/useSolarSettingsStore.js
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export const useSolarSettingsStore = create(
+    persist(
+        (set) => ({
+            ratePerKwh: 0.30,
+            setRatePerKwh: (rate) => set({ ratePerKwh: rate }),
+        }),
+        { name: 'darwin_solar_settings' }
+    )
+);

--- a/src/utils/__tests__/solarFormat.test.js
+++ b/src/utils/__tests__/solarFormat.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+    formatWatts, formatKwh, formatSavings, formatPercentOfPeak,
+    formatVoltage, formatCurrent, formatPowerFactor,
+    getInverterStatus, getInverterColor,
+} from '../solarFormat';
+
+describe('formatWatts', () => {
+    it('formats zero', () => expect(formatWatts(0)).toBe('0 W'));
+    it('formats small value', () => expect(formatWatts(262)).toBe('262 W'));
+    it('formats large value with commas', () => expect(formatWatts(11100)).toBe('11,100 W'));
+    it('rounds decimals', () => expect(formatWatts(251.6)).toBe('252 W'));
+    it('returns dash for null', () => expect(formatWatts(null)).toBe('—'));
+    it('returns dash for undefined', () => expect(formatWatts(undefined)).toBe('—'));
+});
+
+describe('formatKwh', () => {
+    it('converts watt-hours to kWh', () => expect(formatKwh(8126)).toBe('8.1 kWh'));
+    it('formats large lifetime', () => expect(formatKwh(8071061)).toBe('8,071.1 kWh'));
+    it('formats zero', () => expect(formatKwh(0)).toBe('0.0 kWh'));
+    it('returns dash for null', () => expect(formatKwh(null)).toBe('—'));
+});
+
+describe('formatSavings', () => {
+    it('calculates savings at default rate', () => expect(formatSavings(8071061, 0.30)).toBe('$2,421.32'));
+    it('calculates daily savings', () => expect(formatSavings(8126, 0.30)).toBe('$2.44'));
+    it('returns dash for null wattHours', () => expect(formatSavings(null, 0.30)).toBe('—'));
+    it('returns dash for null rate', () => expect(formatSavings(8000, null)).toBe('—'));
+});
+
+describe('formatPercentOfPeak', () => {
+    it('formats full peak', () => expect(formatPercentOfPeak(11100, 11100)).toBe('100%'));
+    it('formats partial', () => expect(formatPercentOfPeak(262, 11100)).toBe('2%'));
+    it('formats zero', () => expect(formatPercentOfPeak(0, 11100)).toBe('0%'));
+    it('returns dash for null watts', () => expect(formatPercentOfPeak(null, 11100)).toBe('—'));
+    it('returns dash for zero peak', () => expect(formatPercentOfPeak(100, 0)).toBe('—'));
+});
+
+describe('formatVoltage', () => {
+    it('formats voltage', () => expect(formatVoltage(244.4)).toBe('244.4 V'));
+    it('returns dash for null', () => expect(formatVoltage(null)).toBe('—'));
+});
+
+describe('formatCurrent', () => {
+    it('formats current', () => expect(formatCurrent(22.6)).toBe('22.6 A'));
+    it('returns dash for null', () => expect(formatCurrent(null)).toBe('—'));
+});
+
+describe('formatPowerFactor', () => {
+    it('formats power factor', () => expect(formatPowerFactor(0.09)).toBe('0.09'));
+    it('formats unity', () => expect(formatPowerFactor(1.0)).toBe('1.00'));
+    it('returns dash for null', () => expect(formatPowerFactor(null)).toBe('—'));
+});
+
+describe('getInverterStatus', () => {
+    it('returns green for >80% output', () => expect(getInverterStatus(300, 347)).toBe('green'));
+    it('returns green at exactly 80%', () => expect(getInverterStatus(80, 100)).toBe('green'));
+    it('returns yellow for 50-80%', () => expect(getInverterStatus(200, 347)).toBe('yellow'));
+    it('returns yellow at exactly 50%', () => expect(getInverterStatus(50, 100)).toBe('yellow'));
+    it('returns orange for <50%', () => expect(getInverterStatus(20, 347)).toBe('orange'));
+    it('returns red for 0 watts', () => expect(getInverterStatus(0, 347)).toBe('red'));
+    it('returns red for null watts', () => expect(getInverterStatus(null, 347)).toBe('red'));
+    it('returns red for zero maxWatts', () => expect(getInverterStatus(100, 0)).toBe('red'));
+});
+
+describe('getInverterColor', () => {
+    it('maps green to hex', () => expect(getInverterColor('green')).toBe('#4caf50'));
+    it('maps yellow to hex', () => expect(getInverterColor('yellow')).toBe('#ff9800'));
+    it('maps orange to hex', () => expect(getInverterColor('orange')).toBe('#f57c00'));
+    it('maps red to hex', () => expect(getInverterColor('red')).toBe('#f44336'));
+    it('defaults to red for unknown', () => expect(getInverterColor('unknown')).toBe('#f44336'));
+});

--- a/src/utils/solarFormat.js
+++ b/src/utils/solarFormat.js
@@ -1,0 +1,55 @@
+export function formatWatts(watts) {
+    if (watts == null) return '—';
+    return `${Math.round(watts).toLocaleString()} W`;
+}
+
+export function formatKwh(wattHours) {
+    if (wattHours == null) return '—';
+    const kwh = wattHours / 1000;
+    return `${kwh.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })} kWh`;
+}
+
+export function formatSavings(wattHours, ratePerKwh) {
+    if (wattHours == null || ratePerKwh == null) return '—';
+    const amount = (wattHours / 1000) * ratePerKwh;
+    return `$${amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export function formatPercentOfPeak(watts, peakWatts) {
+    if (watts == null || !peakWatts) return '—';
+    return `${Math.round((watts / peakWatts) * 100)}%`;
+}
+
+export function formatVoltage(voltage) {
+    if (voltage == null) return '—';
+    return `${voltage.toFixed(1)} V`;
+}
+
+export function formatCurrent(current) {
+    if (current == null) return '—';
+    return `${current.toFixed(1)} A`;
+}
+
+export function formatPowerFactor(pf) {
+    if (pf == null) return '—';
+    return pf.toFixed(2);
+}
+
+export function getInverterStatus(watts, maxWatts) {
+    if (watts == null || watts === 0) return 'red';
+    if (!maxWatts || maxWatts === 0) return 'red';
+    const pct = watts / maxWatts;
+    if (pct >= 0.8) return 'green';
+    if (pct >= 0.5) return 'yellow';
+    return 'orange';
+}
+
+export function getInverterColor(status) {
+    const colors = {
+        green: '#4caf50',
+        yellow: '#ff9800',
+        orange: '#f57c00',
+        red: '#f44336',
+    };
+    return colors[status] || colors.red;
+}


### PR DESCRIPTION
## Context

**Source**: roadmap priority #1872
**Branch**: `feature/solar-enphase-iq-gateway-integration-1`

## Status: PAUSED

**Paused**: 2026-04-02

## What was done
- Schema migration 037: `app_solar` column added to profiles (applied to both darwin_dev and production)
- Config, service layer, utils for Enphase local API (3 endpoints: production, production detail, inverters)
- Polling hook (`useSolarPolling`) with 15s interval and graceful degradation
- Zustand store for $/kWh rate setting (localStorage persisted)
- Solar dashboard UI: SolarPage, SolarStats (4 stat cards), SolarGridDetail (voltage/current/power factor), SolarPanelGrid (32-panel visual grid with Darwin red theme)
- Navigation integration: SOLAR nav group, route, ProfileContent toggle with SVG preview
- 48 unit tests passing (9 service + 39 format)
- Production DB migration applied
- Created future priorities: #1880 (standalone proxy binary), #1885 (Watt API cloud integration)

## What remains
- Manual UI review with live proxy data (proxy wasn't running during review)
- Visual polish based on live data feedback
- Per-panel daily kWh display (blocked — requires Watt API cloud integration or local accumulation)

## Resume instructions
1. `/swarm-resume solar-enphase-iq-gateway-integration-1` — recreates worktree from the remote branch, un-pauses the PR
2. Or manually: `git worktree add wt-solar-enphase-iq-gateway-integration-1/Darwin feature/solar-enphase-iq-gateway-integration-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)