### PR TITLE
Photo view from map back return to exact location

### DIFF
--- a/src/Maps/MapsPage.jsx
+++ b/src/Maps/MapsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useContext, useMemo } from 'react';
+import React, { useState, useCallback, useContext, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -85,6 +85,16 @@ const MapsPage = () => {
 
     // Savable view filter state
     const { activeViewId, setActiveViewId } = useActiveMapViewStore();
+
+    // ── Restore scroll position when returning from photo browser ────────────
+    useEffect(() => {
+        const savedY = sessionStorage.getItem('maps_scrollY');
+        if (savedY !== null) {
+            const y = parseInt(savedY, 10);
+            sessionStorage.removeItem('maps_scrollY');
+            requestAnimationFrame(() => requestAnimationFrame(() => window.scrollTo(0, y)));
+        }
+    }, []);
 
     // Parse active view criteria
     const activeView = views.find(v => v.id === activeViewId) || null;

--- a/src/RouteCards/CycloCompactCard.jsx
+++ b/src/RouteCards/CycloCompactCard.jsx
@@ -6,7 +6,7 @@ import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import DashboardIcon from '@mui/icons-material/Dashboard';
+import PhoneAndroidIcon from '@mui/icons-material/PhoneAndroid';
 
 import { formatDuration } from '../utils/mapDataUtils';
 
@@ -100,14 +100,14 @@ const CycloCompactCard = ({ run, routeName, partners = [], runPartners = [], onC
                 >
                     {routeName || run.activity_name || 'Activity'}
                 </Typography>
-                <Tooltip title="Switch to Classic view">
+                <Tooltip title="Switch to Cyclemeter view">
                     <IconButton
                         size="small"
                         onClick={onToggleStyle}
                         sx={{ color: 'rgba(255,255,255,0.45)', p: 0.25 }}
                         data-testid="map-stats-style-toggle-btn"
                     >
-                        <DashboardIcon fontSize="small" />
+                        <PhoneAndroidIcon fontSize="small" />
                     </IconButton>
                 </Tooltip>
                 <IconButton

--- a/src/RouteCards/MapStatsCard.jsx
+++ b/src/RouteCards/MapStatsCard.jsx
@@ -1,74 +1,27 @@
 import React, { useState } from 'react';
 import Box from '@mui/material/Box';
-import Chip from '@mui/material/Chip';
-import Paper from '@mui/material/Paper';
-import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import Collapse from '@mui/material/Collapse';
 import Tooltip from '@mui/material/Tooltip';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import BarChartIcon from '@mui/icons-material/BarChart';
-import PhoneAndroidIcon from '@mui/icons-material/PhoneAndroid';
-import TableChartIcon from '@mui/icons-material/TableChart';
 
-import { formatDuration } from '../utils/mapDataUtils';
 import CyclemeterStatsCard from './CyclemeterStatsCard';
 import CycloCompactCard from './CycloCompactCard';
 
 const MapStatsCard = ({ run, routeName, partners = [], runPartners = [] }) => {
     const [expanded, setExpanded] = useState(true);
-    const [cardStyle, setCardStyle] = useState(
-        () => localStorage.getItem('mapStatsStyle') || 'darwin'
-    );
+    const [cardStyle, setCardStyle] = useState(() => {
+        const saved = localStorage.getItem('mapStatsStyle');
+        return (saved === 'cyclemeter' || saved === 'compact') ? saved : 'compact';
+    });
 
-    const STYLE_CYCLE = ['darwin', 'cyclemeter', 'compact'];
     const toggleStyle = () => {
-        const idx = STYLE_CYCLE.indexOf(cardStyle);
-        const next = STYLE_CYCLE[(idx + 1) % STYLE_CYCLE.length];
+        const next = cardStyle === 'compact' ? 'cyclemeter' : 'compact';
         localStorage.setItem('mapStatsStyle', next);
         setCardStyle(next);
     };
 
     if (!run) return null;
-
-    // Parse start_time for display
-    const startTimeStr = run.start_time;
-    const startDate = new Date(startTimeStr.endsWith('Z') ? startTimeStr : startTimeStr + 'Z');
-    const month = startDate.getUTCMonth() + 1;
-    const offsetHours = [1, 2, 3, 11, 12].includes(month) ? 8 : 7;
-    const localDate = new Date(startDate.getTime() - offsetHours * 3600 * 1000);
-
-    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    const dateStr = `${days[localDate.getUTCDay()]}, ${months[localDate.getUTCMonth()]} ${localDate.getUTCDate()}, ${localDate.getUTCFullYear()}`;
-    let hours = localDate.getUTCHours();
-    const ampm = hours >= 12 ? 'PM' : 'AM';
-    hours = hours % 12 || 12;
-    const pad2 = n => n < 10 ? '0' + n : String(n);
-    const timeStr = `${pad2(hours)}:${pad2(localDate.getUTCMinutes())} ${ampm}`;
-
-    const distance = Number(run.distance_mi).toFixed(1);
-    const avgSpeed = run.avg_speed_mph != null ? Number(run.avg_speed_mph).toFixed(1) : '—';
-    const maxSpeed = run.max_speed_mph != null ? Number(run.max_speed_mph).toFixed(1) : '—';
-    const ascent = run.ascent_ft != null ? Math.round(Number(run.ascent_ft)) : '—';
-    const descent = run.descent_ft != null ? Math.round(Number(run.descent_ft)) : '—';
-    const rideTime = formatDuration(run.run_time_sec);
-    const stopTime = formatDuration(run.stopped_time_sec || 0);
-    const calories = run.calories != null ? Number(run.calories) : '—';
-
-    const stats = [
-        { label: 'Activity', value: run.activity_name || 'Unknown' },
-        { label: 'Date', value: dateStr },
-        { label: 'Start Time', value: timeStr },
-        { label: 'Distance', value: `${distance} mi` },
-        { label: 'Avg Speed', value: `${avgSpeed} mph` },
-        { label: 'Max Speed', value: `${maxSpeed} mph` },
-        { label: 'Ascent', value: `${ascent} ft` },
-        { label: 'Descent', value: `${descent} ft` },
-        { label: 'Ride Time', value: rideTime },
-        { label: 'Stop Time', value: stopTime },
-        { label: 'Calories', value: calories },
-    ];
 
     const stopEvents = {
         onMouseDown: (e) => e.stopPropagation(),
@@ -99,7 +52,7 @@ const MapStatsCard = ({ run, routeName, partners = [], runPartners = [] }) => {
                         onCollapse={() => setExpanded(false)}
                         onToggleStyle={toggleStyle}
                     />
-                ) : cardStyle === 'compact' ? (
+                ) : (
                     <CycloCompactCard
                         run={run}
                         routeName={routeName}
@@ -108,83 +61,6 @@ const MapStatsCard = ({ run, routeName, partners = [], runPartners = [] }) => {
                         onCollapse={() => setExpanded(false)}
                         onToggleStyle={toggleStyle}
                     />
-                ) : (
-                <Paper
-                    elevation={0}
-                    {...stopEvents}
-                    sx={{
-                        pointerEvents: 'auto',
-                        bgcolor: (theme) => theme.palette.mode === 'dark'
-                            ? 'rgba(42, 39, 35, 0.88)'
-                            : 'rgba(255, 255, 255, 0.90)',
-                        backdropFilter: 'blur(6px)',
-                        color: 'text.primary',
-                        borderRadius: 2,
-                        p: 1.5,
-                        maxWidth: 320,
-                        minWidth: 260,
-                        border: (theme) => theme.palette.mode === 'dark'
-                            ? '1px solid rgba(255,255,255,0.10)'
-                            : '1px solid rgba(0,0,0,0.12)',
-                    }}
-                    data-testid="map-stats-panel"
-                >
-                    {/* Header: route name + style toggle + collapse button */}
-                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
-                        <Typography variant="body2" fontWeight="medium" noWrap sx={{ flex: 1, mr: 1 }}>
-                            {routeName || run.activity_name || 'Activity'}
-                        </Typography>
-                        <Tooltip title="Switch to Cyclemeter view">
-                            <IconButton
-                                size="small"
-                                onClick={(e) => { e.stopPropagation(); toggleStyle(); }}
-                                sx={{ color: 'text.secondary', p: 0.25 }}
-                                data-testid="map-stats-style-toggle-btn"
-                            >
-                                <PhoneAndroidIcon fontSize="small" />
-                            </IconButton>
-                        </Tooltip>
-                        <IconButton
-                            size="small"
-                            onClick={() => setExpanded(false)}
-                            sx={{ color: 'text.secondary', p: 0.25 }}
-                            data-testid="map-stats-collapse-btn"
-                        >
-                            <ExpandMoreIcon fontSize="small" />
-                        </IconButton>
-                    </Box>
-
-                    {/* 2-column stats grid */}
-                    <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '2px 16px' }}>
-                        {stats.map(({ label, value }) => (
-                            <Box key={label} sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
-                                <Typography variant="caption" color="text.secondary" noWrap>{label}</Typography>
-                                <Typography variant="caption" fontWeight="bold" noWrap>{value}</Typography>
-                            </Box>
-                        ))}
-                    </Box>
-
-                    {/* Notes */}
-                    {run.notes && (
-                        <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, fontStyle: 'italic', display: 'block' }}>
-                            {run.notes}
-                        </Typography>
-                    )}
-
-                    {/* Partners */}
-                    {(() => {
-                        const partnerIds = runPartners.filter(rp => rp.map_run_fk === run.id).map(rp => rp.map_partner_fk);
-                        const partnerNames = partners.filter(p => partnerIds.includes(p.id));
-                        if (partnerNames.length === 0) return null;
-                        return (
-                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }} data-testid="partner-chips">
-                                {partnerNames.map(p => (
-                                    <Chip key={p.id} label={p.name} size="small" variant="outlined" sx={{ height: 20, '& .MuiChip-label': { px: 1, fontSize: '0.7rem' } }} />
-                                ))}
-                            </Box>
-                        );
-                    })()}
-                </Paper>
                 )}
             </Collapse>
 

--- a/src/RouteCards/RouteCard.jsx
+++ b/src/RouteCards/RouteCard.jsx
@@ -163,7 +163,7 @@ const RouteCard = ({ run, routeName, routes, allRuns, partners = [], runPartners
         e.stopPropagation();
         const [savedIndex, meta, proxy] = await Promise.all([loadIndex(), loadMeta(), checkPhotosProxy()]);
         if (proxy.available && savedIndex && meta?.fileCount !== proxy.assetCount) startScan();
-        if (savedIndex) navigate(`/maps/photos/${run.id}`);
+        if (savedIndex) { sessionStorage.setItem('maps_scrollY', String(window.scrollY)); navigate(`/maps/photos/${run.id}`); }
         else if (proxy.available) { startScan(); navigate('/maps/settings/photos'); }
         else navigate('/maps/settings/photos');
     };
@@ -205,7 +205,7 @@ const RouteCard = ({ run, routeName, routes, allRuns, partners = [], runPartners
                 </Box>
 
                 {/* Thumbnail — the only clickable element that navigates */}
-                <Box onClick={() => navigate(`/maps/${run.id}`)} sx={{ cursor: 'pointer' }} data-testid="route-card-thumbnail">
+                <Box onClick={() => { sessionStorage.setItem('maps_scrollY', String(window.scrollY)); navigate(`/maps/${run.id}`); }} sx={{ cursor: 'pointer' }} data-testid="route-card-thumbnail">
                     <RouteMapThumbnail runId={run.id} />
                 </Box>
 

--- a/src/RouteCards/RouteDetailView.jsx
+++ b/src/RouteCards/RouteDetailView.jsx
@@ -102,6 +102,7 @@ const RouteDetailView = () => {
             startScan();
         }
         if (savedIndex) {
+            sessionStorage.setItem('maps_scrollY', String(window.scrollY));
             navigate(`/maps/photos/${runId}`);
         } else if (proxy.available) {
             startScan();


### PR DESCRIPTION
## Summary
- **Scroll position restoration**: Save/restore scroll position when navigating from MapsPage route cards to PhotoBrowser or RouteDetailView and back. Uses sessionStorage + double requestAnimationFrame pattern (same as CalendarFC). Applies to photo icon click, card thumbnail click, and RouteDetailView photo navigation.
- **Map info card simplification**: Removed the darwin B&W card mode entirely. Default is now the compact cyclemeter-colored card. Phone icon on compact card toggles to full cyclemeter mirror card. Two-mode toggle (compact ↔ cyclemeter) replaces the previous three-mode cycle.

## Files changed
- `src/Maps/MapsPage.jsx` — Added useEffect for scroll position restoration on mount
- `src/RouteCards/RouteCard.jsx` — Save scroll position before navigating to photos or route detail
- `src/RouteCards/RouteDetailView.jsx` — Save scroll position before navigating to photos
- `src/RouteCards/MapStatsCard.jsx` — Removed darwin B&W card mode, simplified to compact/cyclemeter toggle (~100 lines removed)
- `src/RouteCards/CycloCompactCard.jsx` — Changed toggle icon to PhoneAndroidIcon, updated tooltip

## Testing
- Skipped per user request

## Deploy notes
- Darwin frontend only (S3 + CloudFront)

## References
- Priority #1913 — Photo view from map back return to exact location
- Priority #1919 — Map info card: default to compact cyclemeter, remove darwin B&W mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)