### PR TITLE
fix: preflight check Photos DMG download URL

### DIFF
--- a/src/photo-browser/PhotoSettingsView.jsx
+++ b/src/photo-browser/PhotoSettingsView.jsx
@@ -38,6 +38,7 @@ const PhotoSettingsView = () => {
         () => localStorage.getItem(FEATURE_KEY) !== 'false'
     );
     const [clearing, setClearing] = useState(false);
+    const [downloadError, setDownloadError] = useState(null);
     const [proxyStatus, setProxyStatus] = useState(null); // null=checking, { available, assetCount? }
 
     // Load meta from IDB on mount
@@ -137,11 +138,29 @@ const PhotoSettingsView = () => {
                         <Button
                             variant="contained"
                             size="small"
-                            onClick={() => window.open('https://www.darwin.one/downloads/Darwin-Photos.dmg', '_blank')}
+                            onClick={async () => {
+                                setDownloadError(null);
+                                const url = 'https://www.darwin.one/downloads/Darwin-Photos.dmg';
+                                try {
+                                    const resp = await fetch(url, { method: 'HEAD' });
+                                    if (resp.ok) {
+                                        window.open(url, '_blank');
+                                    } else {
+                                        setDownloadError('Download not available — the DMG has not been published yet.');
+                                    }
+                                } catch {
+                                    setDownloadError('Could not reach darwin.one — check your internet connection.');
+                                }
+                            }}
                             sx={{ mb: 1 }}
                         >
                             Download Darwin Photos
                         </Button>
+                        {downloadError && (
+                            <Alert severity="warning" sx={{ mb: 1 }} onClose={() => setDownloadError(null)}>
+                                {downloadError}
+                            </Alert>
+                        )}
                         <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
                             1. Open the .dmg and drag Darwin Photos to Applications.
                         </Typography>


### PR DESCRIPTION
## Summary
- Download button in PhotoSettingsView now HEAD-checks the DMG URL before opening
- Shows a dismissible warning Alert if the DMG hasn't been published to S3 (404) or if darwin.one is unreachable
- Prevents users on new machines from hitting a silent 404 page during initial Photos app setup

Priority: #1918

## Test plan
- [ ] Remove DMG from S3 (`aws s3 rm s3://www.darwin.one/downloads/Darwin-Photos.dmg`), click Download — verify warning appears
- [ ] Re-upload DMG, click Download — verify DMG downloads normally
- [ ] Disconnect network, click Download — verify connection error warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)