### PR TITLE
Center kebab menu

### DIFF
--- a/src/SwarmView/CategoryCard.jsx
+++ b/src/SwarmView/CategoryCard.jsx
@@ -548,6 +548,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
                                 onClick={handleMenuOpen}
                                 data-testid={`card-menu-${category.id}`}
                                 size="small"
+                                sx={{ maxWidth: "25px", maxHeight: "25px" }}
                             >
                                 <MoreVertIcon />
                             </IconButton>

--- a/src/TaskPlanView/PriorityCard.jsx
+++ b/src/TaskPlanView/PriorityCard.jsx
@@ -314,6 +314,7 @@ const PriorityCard = ({ domainId, areaIds }) => {
                         onClick={handleMenuOpen}
                         data-testid={`priority-card-menu-${domainId}`}
                         size="small"
+                        sx={{ maxWidth: "25px", maxHeight: "25px" }}
                     >
                         <MoreVertIcon />
                     </IconButton>

--- a/src/TaskPlanView/TaskCard.jsx
+++ b/src/TaskPlanView/TaskCard.jsx
@@ -564,6 +564,7 @@ const TaskCard = ({area, areaIndex, domainId, areaChange, areaKeyDown, areaOnBlu
                                 onClick={handleMenuOpen}
                                 data-testid={`card-menu-${area.id}`}
                                 size="small"
+                                sx={{ maxWidth: "25px", maxHeight: "25px" }}
                             >
                                 <MoreVertIcon />
                             </IconButton>


### PR DESCRIPTION
## Summary
- Constrain kebab menu (MoreVert) IconButton to 25x25px in all card headers, matching the trash icon size in task/requirement rows below
- Centers the kebab icon over the trash icon column, giving more space between the area name and the menu button
- Applied consistently to TaskCard, PriorityCard, and CategoryCard

## Files changed
- `src/TaskPlanView/TaskCard.jsx` — added maxWidth/maxHeight constraints to kebab IconButton
- `src/TaskPlanView/PriorityCard.jsx` — added maxWidth/maxHeight constraints to kebab IconButton
- `src/SwarmView/CategoryCard.jsx` — added maxWidth/maxHeight constraints to kebab IconButton

## Testing
- Manual UI review: kebab icon visually centered over trash icon
- E2E tests use data-testid selectors, not affected by size change

## Deploy notes
- Darwin frontend only (S3 + CloudFront)

## References
- Darwin requirement #1922

🤖 Generated with [Claude Code](https://claude.com/claude-code)