### PR TITLE
Tasks without borders

### DIFF
--- a/src/Components/TaskEdit/TaskEdit.jsx
+++ b/src/Components/TaskEdit/TaskEdit.jsx
@@ -21,6 +21,21 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
 
+// Hover style: border invisible at rest, appears on hover, accent on focus.
+// Size 2 density: padding 6.5px 11px (tighter than default 8.5px 14px).
+// Revert reference — Size 1 (original): remove HOVER_SX and DENSITY_STYLE to restore defaults.
+const HOVER_SX = {
+    '& .MuiOutlinedInput-root': {
+        '& .MuiOutlinedInput-notchedOutline': {
+            borderColor: 'transparent',
+            transition: 'border-color 150ms',
+        },
+        '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: 'text.disabled' },
+        '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: 'primary.main' },
+    },
+};
+const DENSITY_STYLE = { padding: '6.5px 11px' };
+
 const TaskEdit = ({ supportDrag, dragType = "taskPlan", task, taskIndex, areaId, areaName }) => {
 
     const { priorityClick, doneClick, descriptionChange, descriptionKeyDown,
@@ -169,10 +184,15 @@ const TaskEdit = ({ supportDrag, dragType = "taskPlan", task, taskIndex, areaId,
                         multiline
                         disabled = {areaId !== '' ? false : areaName === '' ? true : false}
                         autoComplete ='off'
-                        sx = {{...(task.done === 1 && !disableStrikethrough && {textDecoration: 'line-through'}),}}
+                        sx = {{
+                            ...(task.done === 1 && !disableStrikethrough && {textDecoration: 'line-through'}),
+                            ...HOVER_SX,
+                        }}
                         size = 'small'
-                        /* inputProps={{ tabIndex: `${taskIndex}` }} */
-                        slotProps={{ htmlInput: { maxLength: 1024 } }}
+                        slotProps={{
+                            htmlInput: { maxLength: 1024 },
+                            input: { style: DENSITY_STYLE },
+                        }}
                         key={`description-${task.id}`}
              />
             { task.id === '' ?


### PR DESCRIPTION
## Summary
- Task description TextFields now use a hover-reveal border pattern: invisible at rest, subtle gray on hover, primary accent on focus
- Tighter density padding (6.5px 11px) replaces the default outlined padding (8.5px 14px) for a more compact task card layout
- Uses `variant="outlined"` throughout so text position never shifts — only the border decoration changes
- Inline style on OutlinedInput root via `slotProps.input.style` ensures padding override beats MUI class specificity

## Files changed
- `src/Components/TaskEdit/TaskEdit.jsx` — Added HOVER_SX (border visibility) and DENSITY_STYLE (padding override) constants; applied to description TextField sx and slotProps

## Testing
- Local E2E: skipped per user request
- Build verification: Vite build passes clean

## Deploy notes
- Darwin frontend only — no backend or schema changes

## References
- Darwin requirement #2009 (Tasks without borders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)