### PR TITLE
Re-import CM database failed

### DIFF
--- a/src/CyclemeterImport/CyclemeterImport.jsx
+++ b/src/CyclemeterImport/CyclemeterImport.jsx
@@ -120,7 +120,29 @@ const CyclemeterImport = () => {
                         const config = buildConfig();
                         const result = await runPipelineForFormat(buffer, config, info.format);
                         console.log('[Import] Auto-process complete. Runs:', result.stats.totalRuns, 'Points:', result.stats.totalExtracted);
-                        setStats(result.stats);
+
+                        // Dedup check for single-file formats
+                        let newCount = result.stats.totalRuns;
+                        let skippedCount = 0;
+                        try {
+                            const cutoffResult = await call_rest_api(
+                                `${darwinUri}/map_runs?fields=start_time&source=${info.source}&sort=start_time:desc`,
+                                'GET', null, idToken
+                            );
+                            const cutoffDate = cutoffResult.data?.[0]?.start_time || null;
+                            if (cutoffDate) {
+                                const minimalRuns = result.rawStartTimes.map(st => ({ startTime: st }));
+                                const dedup = filterNewRunsByCutoff(minimalRuns, cutoffDate);
+                                newCount = dedup.newRuns.length;
+                                skippedCount = dedup.skippedCount;
+                            }
+                        } catch (e) {
+                            if (e?.httpStatus?.httpStatus !== 404) {
+                                console.warn('[Import] Dedup check failed, showing total count:', e);
+                            }
+                        }
+
+                        setStats({ ...result.stats, newCount, skippedCount });
                     } catch (pipeErr) {
                         console.error('[Import] Auto-process error:', pipeErr);
                         setError(pipeErr.message || 'Pipeline failed');
@@ -173,7 +195,30 @@ const CyclemeterImport = () => {
             console.log('[Import] Starting pipeline for format:', formatInfo.format);
             const result = await runPipelineForFormat(buffer, config, formatInfo.format);
             console.log('[Import] Pipeline complete. Runs:', result.stats.totalRuns, 'Points:', result.stats.totalExtracted);
-            setStats(result.stats);
+
+            // Dedup check: how many activities will actually be imported?
+            let newCount = result.stats.totalRuns;
+            let skippedCount = 0;
+            try {
+                const cutoffResult = await call_rest_api(
+                    `${darwinUri}/map_runs?fields=start_time&source=${formatInfo.source}&sort=start_time:desc`,
+                    'GET', null, idToken
+                );
+                const cutoffDate = cutoffResult.data?.[0]?.start_time || null;
+                if (cutoffDate) {
+                    const minimalRuns = result.rawStartTimes.map(st => ({ startTime: st }));
+                    const dedup = filterNewRunsByCutoff(minimalRuns, cutoffDate);
+                    newCount = dedup.newRuns.length;
+                    skippedCount = dedup.skippedCount;
+                }
+            } catch (e) {
+                if (e?.httpStatus?.httpStatus !== 404) {
+                    console.warn('[Import] Dedup check failed, showing total count:', e);
+                }
+                // 404 = no prior imports → all runs are new (default)
+            }
+
+            setStats({ ...result.stats, newCount, skippedCount });
         } catch (err) {
             console.error('[Import] Pipeline error:', err);
             setError(err.message || 'Pipeline failed');
@@ -390,9 +435,7 @@ const CyclemeterImport = () => {
 
             setSnackbar({
                 open: true,
-                message: skippedCount > 0
-                    ? `Saved ${completed} new activities (${skippedCount} already imported, skipped)`
-                    : `Saved ${completed} activities to Darwin`,
+                message: `Saved ${completed} new activities to Darwin`,
                 severity: 'success',
             });
 
@@ -664,7 +707,10 @@ const CyclemeterImport = () => {
                     <Typography variant="subtitle2" gutterBottom>Results</Typography>
                     <Box component="table" sx={{ '& td': { pr: 3, py: 0.3 } }}>
                         <tbody>
-                            <tr><td>Total Activities</td><td><strong>{stats.totalRuns}</strong></td></tr>
+                            <tr><td>Activities to Import</td><td><strong>{stats.newCount ?? stats.totalRuns}</strong></td></tr>
+                            {stats.skippedCount > 0 && (
+                                <tr><td>Already Imported</td><td>{stats.skippedCount}</td></tr>
+                            )}
                             <tr><td>Total Distance</td><td><strong>{stats.totalDistance} miles</strong></td></tr>
                             <tr><td>GPS Points Extracted</td><td><strong>{stats.totalExtracted.toLocaleString()}</strong></td></tr>
                             <tr><td>GPS Points Trimmed</td><td><strong>{(stats.totalTrimmed ?? 0).toLocaleString()}</strong></td></tr>

--- a/src/cyclemeter/__tests__/sqlMapper.test.js
+++ b/src/cyclemeter/__tests__/sqlMapper.test.js
@@ -147,4 +147,21 @@ describe('filterNewRunsByCutoff', () => {
         expect(newRuns).toHaveLength(0);
         expect(skippedCount).toBe(0);
     });
+
+    it('excludes the cutoff run when startTime has fractional seconds (re-import dedup)', () => {
+        // SQLite stores fractional seconds; MySQL DATETIME doesn't. The cutoff returned from
+        // MySQL for the last-imported run at "2025-03-15 08:00:00.123" is truncated to
+        // "2025-03-15 08:00:00". Without stripping, that run appears "newer" than the cutoff
+        // and is incorrectly re-imported, causing a duplicate key error (500) on map_runs POST.
+        const runsWithMs = [
+            makeRun('2025-01-01 10:00:00.000'),
+            makeRun('2025-03-15 08:00:00.123'),  // last-imported run with sub-second precision
+            makeRun('2025-06-01 12:00:00.456'),  // genuinely new run
+        ];
+        // Cutoff returned from MySQL — whole seconds only, no fractional part
+        const { newRuns, skippedCount } = filterNewRunsByCutoff(runsWithMs, '2025-03-15 08:00:00');
+        expect(newRuns).toHaveLength(1);
+        expect(skippedCount).toBe(2);
+        expect(newRuns[0].startTime).toBe('2025-06-01 12:00:00.456');
+    });
 });

--- a/src/cyclemeter/index.js
+++ b/src/cyclemeter/index.js
@@ -67,13 +67,18 @@ export async function runPipelineForFormat(buffer, config, format) {
     const runs = await extractor(buffer, config);
 
     precisionOptimizer(runs, config.precision);
+
+    // Capture raw startTimes before formatRunData mutates them (converts to Date objects).
+    // Used by the import UI for dedup count without re-parsing the source file.
+    const rawStartTimes = runs.map(run => run.startTime);
+
     formatRunData(runs);
     distanceOptimizer(runs, config.minDelta);
 
     const kml = generateKml(runs, config);
     const stats = computeStats(runs);
 
-    return { runs, stats, kml };
+    return { runs, stats, kml, rawStartTimes };
 }
 
 /**

--- a/src/cyclemeter/sqlMapper.js
+++ b/src/cyclemeter/sqlMapper.js
@@ -25,7 +25,7 @@ export function mapRunToSql(run, mapRouteFk = null, source = 'cyclemeter') {
         map_route_fk: mapRouteFk,
         activity_id: run.activityID,
         activity_name: run.activityName,
-        start_time: run.startTime,  // Raw UTC string from source
+        start_time: run.startTime ? run.startTime.replace(/\.\d+$/, '') : run.startTime,
         run_time_sec: Math.floor(run.runTime),
         stopped_time_sec: Math.min(Math.floor(run.stoppedTime), MAX_STOPPED_TIME),
         distance_mi: imperial ? imperial.distance : Math.round(run.distance * METERS_TO_MILES * 10) / 10,
@@ -92,6 +92,13 @@ export function normalizeRouteName(name) {
 export function filterNewRunsByCutoff(rawRuns, cutoffDate) {
     if (!cutoffDate) return { newRuns: rawRuns, skippedCount: 0 };
     const cutoff = new Date(cutoffDate);
-    const newRuns = rawRuns.filter(run => new Date(run.startTime) > cutoff);
+    const newRuns = rawRuns.filter(run => {
+        // Strip fractional seconds before comparing — MySQL DATETIME truncates sub-second
+        // precision, so the stored cutoff has no milliseconds. Without stripping, the last
+        // imported run's fractional part causes a false "newer than cutoff" result,
+        // re-importing it and triggering a duplicate key error (500) on map_runs POST.
+        const runStart = new Date(run.startTime.replace(/\.\d+$/, ''));
+        return runStart > cutoff;
+    });
     return { newRuns, skippedCount: rawRuns.length - newRuns.length };
 }


### PR DESCRIPTION
## Summary
- **Fix re-import failure**: `filterNewRunsByCutoff` compared SQLite timestamps (fractional seconds) against MySQL DATETIME cutoffs (whole seconds), causing the last-imported run to appear "newer" than its cutoff. This triggered a duplicate key error (500) on `map_runs` bulk POST during re-import.
- **Strip fractional seconds** in both the dedup comparison (`filterNewRunsByCutoff`) and at storage time (`mapRunToSql`) to ensure consistent precision.
- **Dedup-aware stats panel**: After processing, the import page now shows "Activities to Import" (dedup-filtered count) instead of "Total Activities" (raw file count), with an "Already Imported" row when prior imports exist.
- **Simplified snackbar**: Save success message now just says "Saved N new activities to Darwin" since already-imported count is visible in the stats panel.

## Files changed
- `src/cyclemeter/sqlMapper.js` — Strip fractional seconds in `filterNewRunsByCutoff` comparison and `mapRunToSql` storage
- `src/cyclemeter/__tests__/sqlMapper.test.js` — Regression test for fractional-second dedup edge case
- `src/cyclemeter/index.js` — Return `rawStartTimes` from `runPipelineForFormat` for dedup count
- `src/CyclemeterImport/CyclemeterImport.jsx` — Dedup API call after processing, updated stats display, simplified snackbar

## Testing
- Unit tests: 343/343 passing
- Manual: re-import of Meter.db with 4 new activities succeeded (previously failed with 500)

## Deploy notes
- Darwin only (frontend change, no Lambda/DB changes)

## References
- Requirement #2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)