### PR TITLE
CM format map info card time font size too large

### DIFF
--- a/Darwin
+++ b/Darwin
@@ -1,0 +1,1 @@
+/Users/billw/Projects/DarwinAI/Darwin

--- a/src/RouteCards/CyclemeterStatsCard.jsx
+++ b/src/RouteCards/CyclemeterStatsCard.jsx
@@ -310,7 +310,7 @@ const CyclemeterStatsCard = ({ run, routeName, onCollapse, onToggleStyle }) => {
             {/* ── Row 6: This Year | Clock ──────────────────────────────── */}
             <StatRow>
                 <StatCell label="THIS YEAR"  value={ty}           unit="miles" color="#3399FF" />
-                <StatCell label="CLOCK"      value={clockStr(now)} unit=""      color="#FFFFFF" fontSize="2.15rem" />
+                <StatCell label="CLOCK"      value={clockStr(now)} unit=""      color="#FFFFFF" fontSize="1.85rem" />
             </StatRow>
 
             {/* ── Footer ─────────────────────────────────────────────────── */}


### PR DESCRIPTION
## Summary
- feat: cm-format-map-info-card-time-font-size-too-large-1 — chore: init swarm session feature/cm-format-map-info-card-time-font-size-too-large-1
- chore: init swarm session feature/cm-format-map-info-card-time-font-size-too-large-1

## Files changed
```
 Darwin                                 | 1 +
 src/RouteCards/CyclemeterStatsCard.jsx | 2 +-
 2 files changed, 2 insertions(+), 1 deletion(-)
```

## Testing
Tests: skipped per user request

🤖 Generated with [Claude Code](https://claude.com/claude-code)