### PR TITLE
Move calendar to its own header line in the navbar

### DIFF
--- a/src/NavBar/NavBarSidebar.jsx
+++ b/src/NavBar/NavBarSidebar.jsx
@@ -165,7 +165,7 @@ const NavBarSidebar = () => {
                                     const groupLinks = visibleLinks.filter(l => l.group === group.id);
                                     return (
                                         <React.Fragment key={group.id}>
-                                            {showText && (
+                                            {showText && group.label && (
                                                 <ListSubheader sx={{
                                                     bgcolor: 'transparent',
                                                     color: 'rgba(255,255,255,0.5)',

--- a/src/NavBar/navConfig.js
+++ b/src/NavBar/navConfig.js
@@ -8,6 +8,7 @@ import RepeatIcon from '@mui/icons-material/Repeat';
 import RouteIcon from '@mui/icons-material/Route';
 
 export const NAV_GROUPS = [
+    { id: 'calendar', label: '' },
     { id: 'tasks', label: 'TASKS' },
     { id: 'maps', label: 'MAPS' },
     { id: 'swarm', label: 'SWARM' },
@@ -23,7 +24,7 @@ export const GROUP_PROFILE_KEY = {
 export const NAV_LINKS = [
     { path: '/taskcards', label: 'Plan', icon: ViewKanbanIcon, group: 'tasks' },
     { path: '/recurring', label: 'Recurring', icon: RepeatIcon, group: 'tasks' },
-    { path: '/calview', label: 'Calendar', icon: CalendarMonthIcon, group: 'tasks' },
+    { path: '/calview', label: 'Calendar', icon: CalendarMonthIcon, group: 'calendar' },
     { path: '/maps', label: 'Maps', icon: RouteIcon, group: 'maps' },
     { path: '/swarm', label: 'Roadmap', icon: MapIcon, group: 'swarm' },
     { path: '/swarm/sessions', label: 'Sessions', icon: HubIcon, group: 'swarm' },


### PR DESCRIPTION
## Summary
- feat: move-calendar-to-its-own-header-line-in-the-navbar-1 — chore: init swarm session feature/move-calendar-to-its-own-header-line-in-the-navbar-1
- chore: init swarm session feature/move-calendar-to-its-own-header-line-in-the-navbar-1

## Files changed
```
 src/NavBar/NavBarSidebar.jsx | 2 +-
 src/NavBar/navConfig.js      | 3 ++-
 2 files changed, 3 insertions(+), 2 deletions(-)
```

## Testing
Tests: skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)