### PR TITLE
Approved and swarm-start chip colors

### DIFF
--- a/src/SwarmView/SwarmView.jsx
+++ b/src/SwarmView/SwarmView.jsx
@@ -33,10 +33,10 @@ const requirementStatusChipProps = (status) => {
     switch (status) {
         case 'authoring':    return { sx: { bgcolor: '#fbc02d', color: '#000' } };
         case 'approved':     return { sx: { bgcolor: '#90caf9', color: '#000' } };
-        case 'swarm_ready':  return { color: 'primary' };
-        case 'development':  return { sx: { bgcolor: '#4caf50', color: '#fff' } };
+        case 'swarm_ready':  return { sx: { bgcolor: '#1976d2', color: '#fff' } };
+        case 'development':  return { sx: { bgcolor: '#81c784', color: '#000' } };
         case 'deferred':     return { sx: { bgcolor: '#ff9800', color: '#fff' } };
-        case 'met':          return { color: 'success' };
+        case 'met':          return { sx: { bgcolor: '#2e7d32', color: '#fff' } };
         default:             return { color: 'default' };
     }
 };

--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -339,9 +339,9 @@ const RequirementDetail = () => {
                     {[
                         { value: 'authoring',   label: 'Authoring', chipSx: { bgcolor: '#fbc02d', color: '#000' } },
                         { value: 'approved',    label: 'Approved',  chipSx: { bgcolor: '#90caf9', color: '#000' } },
-                        { value: 'swarm_ready', label: 'Swarm-Start', color: 'primary' },
-                        { value: 'development', label: 'Dev',       chipSx: { bgcolor: '#4caf50', color: '#fff' } },
-                        { value: 'met',         label: 'Met',       color: 'success' },
+                        { value: 'swarm_ready', label: 'Swarm-Start', chipSx: { bgcolor: '#1976d2', color: '#fff' } },
+                        { value: 'development', label: 'Dev',       chipSx: { bgcolor: '#81c784', color: '#000' } },
+                        { value: 'met',         label: 'Met',       chipSx: { bgcolor: '#2e7d32', color: '#fff' } },
                         { value: 'deferred',    label: 'Deferred',  chipSx: { bgcolor: '#ff9800', color: '#fff' } },
                     ].map(({ value, label, color, chipSx }) => {
                         const selected = currentStatus === value;


### PR DESCRIPTION
## Summary
- Merge remote-tracking branch 'origin/master' into feature/approved-and-swarm-start-chip-colors-1
- fix: use hardcoded chip colors for approved/swarm-start/dev/met status chips
- chore: init swarm session feature/approved-and-swarm-start-chip-colors-1

## Files changed
```
 src/SwarmView/SwarmView.jsx                | 6 +++---
 src/SwarmView/detail/RequirementDetail.jsx | 6 +++---
 2 files changed, 6 insertions(+), 6 deletions(-)
```

## Testing
Tests: skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)