### PR TITLE
CategoryCard: guard stale concurrent PUT rollback in changeSortMode

### DIFF
--- a/src/SwarmView/CategoryCard.jsx
+++ b/src/SwarmView/CategoryCard.jsx
@@ -51,6 +51,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
 
     const savingRef = useRef(false);
     const pendingMutationsRef = useRef({});
+    const sortModeMutationRef = useRef(0);
 
     const requirementStatusFilter = useShowClosedStore(s => s.requirementStatusFilter);
 
@@ -84,20 +85,26 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
             queryClient.setQueryData(openKey, updateCache);
             queryClient.setQueryData(allKey, updateCache);
 
+            // Concurrent-click guard: a later invocation must not be stomped by an
+            // earlier in-flight PUT's late rollback. Skip rollback + error toast
+            // if a newer mutation has already superseded this one.
+            const mutationId = ++sortModeMutationRef.current;
+            const rollback = (errorArg, message) => {
+                if (sortModeMutationRef.current !== mutationId) return;
+                queryClient.setQueryData(openKey, previousOpen);
+                queryClient.setQueryData(allKey, previousAll);
+                setSortMode(category.sort_mode === 'hand' ? 'hand' : 'process');
+                showError(errorArg, message);
+            };
+
             call_rest_api(`${darwinUri}/categories`, 'PUT', [{ id: category.id, sort_mode: newMode }], idToken)
                 .then(result => {
                     if (result.httpStatus.httpStatus !== 200 && result.httpStatus.httpStatus !== 204) {
-                        queryClient.setQueryData(openKey, previousOpen);
-                        queryClient.setQueryData(allKey, previousAll);
-                        setSortMode(category.sort_mode === 'hand' ? 'hand' : 'process');
-                        showError(result, 'Unable to save sort preference');
+                        rollback(result, 'Unable to save sort preference');
                     }
                 })
                 .catch(error => {
-                    queryClient.setQueryData(openKey, previousOpen);
-                    queryClient.setQueryData(allKey, previousAll);
-                    setSortMode(category.sort_mode === 'hand' ? 'hand' : 'process');
-                    showError(error, 'Unable to save sort preference');
+                    rollback(error, 'Unable to save sort preference');
                 });
         }
     };


### PR DESCRIPTION
## Summary
- Merge master into feature/categorycard-guard-stale-concurrent-1
- fix: guard stale concurrent PUT rollback in changeSortMode (req #2202)
- chore: init swarm session feature/categorycard-guard-stale-concurrent-1

## Files changed
```
 src/SwarmView/CategoryCard.jsx | 24 ++++++++++++++++--------
 1 file changed, 16 insertions(+), 8 deletions(-)
```

## Testing
Tests: skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)