### PR TITLE
Calendar: always open on today on mount

### DIFF
--- a/src/CalendarFC/CalendarFC.jsx
+++ b/src/CalendarFC/CalendarFC.jsx
@@ -73,7 +73,6 @@ const CalendarFC = () => {
 
     // ── Desktop persisted state ──────────────────────────────────────────────
     const savedViewType = useCalendarViewStore(s => s.viewType);
-    const savedDate = useCalendarViewStore(s => s.currentDate);
     const savedMode = useCalendarViewStore(s => s.mode);
     const setCalendarView = useCalendarViewStore(s => s.setCalendarView);
     const setPersistedMode = useCalendarViewStore(s => s.setMode);
@@ -858,7 +857,7 @@ const CalendarFC = () => {
                             ref={calendarRef}
                             plugins={[dayGridPlugin, interactionPlugin]}
                             initialView={desktopView}
-                            initialDate={savedDate || undefined}
+                            initialDate={todayStr}
                             headerToolbar={false}
                             events={events}
                             editable={hasDraggable}


### PR DESCRIPTION
## Summary
- `CalendarFC` was reading the persisted `currentDate` from `useCalendarViewStore` when calling `<FullCalendar initialDate={...}>`, so the calendar opened on whatever month/week/day the user last navigated to (sometimes weeks or months in the past).
- Now passes `todayStr` (already memoized in the component) on every mount.
- In-page prev/next still work and still persist via `handleDatesSet` — the persisted date just isn't read on remount anymore. Removed the now-unused `savedDate` selector.

## Test plan
- [ ] Navigate to /calendar — verify it opens on today's month with today highlighted
- [ ] Use prev/next arrows to move to a different month, navigate away, come back — should reset to today
- [ ] Switch view (Month / Week / Day) — should still anchor on today
- [ ] Mobile: scrolls to today on initial load (unchanged behavior, separate code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)