### PR TITLE
Track .env.local — public URLs only (req #2232 Phase 3)

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,3 @@
+HTTPS=true
+REACT_APP_LOGIN_REDIRECT=https://localhost:3000/loggedin/
+REACT_APP_LOGOUT_REDIRECT=https://localhost:3000/

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@
 # misc
 .DS_Store
 .devserver
-.env.local
 .env.development.local
 .env.test.local
 .env.production.local


### PR DESCRIPTION
## Summary

- Un-ignore `.env.local` in `.gitignore`
- Track `.env.local` — contents verified as public URLs only (`HTTPS=true`, localhost redirects)

## Why

Part of req #2232 Anti-Fragile DarwinAI-Config Phase 3. The final Phase 3 refactor eliminates every file-level special case from `/hygiene` — including the Darwin-specific `.env` copy in `/hygiene checkout` step 7. That step exists only because `.env.local` was gitignored. Once it's tracked, the step is pure vestige and gets deleted.

`.env` was already tracked (since CRA→Vite migration). This brings `.env.local` in line with it.

## Test plan

- [ ] CI green (no test changes; just file tracking).
- [ ] Local dev server still picks up `.env.local` (it's Vite-convention, so loading is unchanged).
- [ ] After merge: Phase 3 PR on DarwinAI-Config removes `/hygiene checkout` step 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)