### PR TITLE
req #2341: Visualizer: start time alignment

### DIFF
--- a/src/CalendarFC/TimeSeriesView.jsx
+++ b/src/CalendarFC/TimeSeriesView.jsx
@@ -10,6 +10,7 @@ import {
     DEFAULT_SPACE, getSpaceMultiplier,
     DEFAULT_ZOOM, getZoomHours, ZOOM_HOURS,
     indexSessionsByRequirement,
+    clusterSessionsByStartTime,
 } from './timeSeriesSizes';
 import './TimeSeriesView.css';
 
@@ -217,6 +218,8 @@ const BeadRow = ({
     crossDays = [], onChipClick, isWeekView = false,
     sidewalkPanel = false,   // when true → top-down layout + seamless 24h panel
     sidewalkHeight,
+    canonicalStartById,      // Map<string sessionId, ISO started_at> — swarm alignment
+    clusterSizeById,         // Map<string sessionId, n members in its cluster>
 }) => {
     const window36h = beadWindow === '36h';
     // Sidewalk panels: each panel shows exactly the 24h day, no hidden outer
@@ -285,6 +288,11 @@ const BeadRow = ({
     //   'left'    — no session at all OR started_at ≈ completed_at; vertical bar
     //               immediately left of bubble (sessions always start before they end)
     const CLOSE_THRESHOLD_PCT = 1.5;
+    // Below this horizontal-gap %, the drawable line is shorter than the 7px
+    // arrowhead — the arrow overlaps / swamps the bubble. Drop markerEnd and
+    // render a plain line instead. Must be ≥ CLOSE_THRESHOLD_PCT so aligned-cluster
+    // chips (which force 'normal' even at tiny gaps) still skip the arrow.
+    const ARROW_OMIT_THRESHOLD_PCT = 2.5;
     const drawChips = useMemo(() => {
         if (vizKey !== 'swarm') return windowChips;
         const out = [];
@@ -304,16 +312,27 @@ const BeadRow = ({
                 continue;
             }
             for (const s of sess) {
-                const rawStart = xPctFn(s.started_at, timezone, selectedDate);
+                // Swarm alignment (req #2341): if this session is part of a
+                // multi-member cluster, every member uses the cluster's canonical
+                // earliest started_at so vertical start-bars line up. Singletons
+                // keep their own started_at and the existing 'left' heuristic.
+                const sKey = String(s.id);
+                const canonicalStartedAt =
+                    canonicalStartById?.get(sKey) ?? s.started_at;
+                const clusterN = clusterSizeById?.get(sKey) ?? 1;
+                const isAligned = clusterN > 1;
+
+                const rawStart = xPctFn(canonicalStartedAt, timezone, selectedDate);
                 let startPct = rawStart;
                 let startClamped = false;
                 let markerMode = 'normal';
-                if (startPct === null && s.started_at) {
+                if (startPct === null && canonicalStartedAt) {
                     startPct = 0;
                     startClamped = true;
                     markerMode = 'clamped';
                 } else if (
                     startPct !== null &&
+                    !isAligned &&
                     Math.abs(chip.leftPct - startPct) < CLOSE_THRESHOLD_PCT
                 ) {
                     markerMode = 'left';   // start ≈ met → bar hugs the bubble's left side
@@ -329,7 +348,8 @@ const BeadRow = ({
             }
         }
         return out;
-    }, [vizKey, windowChips, sessionsByReq, xPctFn, timezone, selectedDate]);
+    }, [vizKey, windowChips, sessionsByReq, xPctFn, timezone, selectedDate,
+        canonicalStartById, clusterSizeById]);
 
     // Placement: cluster-stack for Bead, swarm-lane for Swarm.
     const placed = vizKey === 'swarm' ? assignSwarmLanes(drawChips) : assignRows(drawChips, 1.2);
@@ -488,6 +508,11 @@ const BeadRow = ({
                     {placed.map(chip => {
                         if (chip.markerMode !== 'normal' && chip.markerMode !== 'clamped') return null;
                         const yCenter = bubbleCenterCss(chip.row);
+                        // Omit the arrowhead when the line would be shorter than
+                        // the arrow itself — happens for cluster-aligned chips
+                        // whose canonical start sits close to the met bubble.
+                        const gapPct = chip.leftPct - chip.startPct;
+                        const showArrow = gapPct >= ARROW_OMIT_THRESHOLD_PCT;
                         return (
                             <line
                                 key={`line-${chip.chipKey}`}
@@ -499,7 +524,7 @@ const BeadRow = ({
                                 y2={yCenter}
                                 stroke="rgba(96,125,139,0.85)"
                                 strokeWidth="1.5"
-                                markerEnd={`url(#ts-swarm-arrow-${selectedDate})`}
+                                markerEnd={showArrow ? `url(#ts-swarm-arrow-${selectedDate})` : undefined}
                             />
                         );
                     })}
@@ -854,6 +879,14 @@ const TimeSeriesView = ({
         return weekDates(selectedDate); // Mon..Sun ascending
     }, [isWeekView, selectedDate]);
 
+    // Swarm start-time clustering (req #2341) — computed once per session-array
+    // change and threaded to every BeadRow / cross-day calculation so all members
+    // of a 3-minute launch cluster share one canonical start X.
+    const { canonicalStartById, clusterSizeById } = useMemo(() => {
+        const { canonical, clusterSize } = clusterSessionsByStartTime(sessions);
+        return { canonicalStartById: canonical, clusterSizeById: clusterSize };
+    }, [sessions]);
+
     // Cross-day session lines — only matters in Week + Swarm mode. For each
     // session whose started_at and linked requirement's completed_at fall on
     // different days within the visible week, build a per-day entry so BeadRow
@@ -928,8 +961,12 @@ const TimeSeriesView = ({
 
                 // Start day entry — partial dashed line from startPct → 100%,
                 // plus a vertical start bar at startPct with a tooltip.
+                // Use the cluster's canonical started_at (req #2341) so cross-day
+                // cluster members share the same X on the start day.
                 if (dateSet.has(startDay)) {
-                    const startPct = bead36hXPct(s.started_at, timezone, startDay);
+                    const canonicalStart =
+                        canonicalStartById.get(String(s.id)) ?? s.started_at;
+                    const startPct = bead36hXPct(canonicalStart, timezone, startDay);
                     if (startPct !== null) {
                         const arr = map.get(startDay) || [];
                         arr.push({ sessionId: s.id, role: 'start', lane: endLane, pct: startPct, card });
@@ -949,7 +986,8 @@ const TimeSeriesView = ({
             }
         }
         return map;
-    }, [isWeekView, vizKey, rowDates, requirements, sessions, timezone, categoryList]);
+    }, [isWeekView, vizKey, rowDates, requirements, sessions, timezone,
+        categoryList, canonicalStartById]);
 
     return (
         <Box className="ts-view" data-testid="time-series-view" data-week={isWeekView ? '1' : '0'}>
@@ -971,6 +1009,8 @@ const TimeSeriesView = ({
                     categoryList={categoryList}
                     isWeekView={false}
                     onChipClick={onChipClick}
+                    canonicalStartById={canonicalStartById}
+                    clusterSizeById={clusterSizeById}
                 />
             ) : (
                 <Box className={`ts-rows ${isWeekView ? 'ts-rows-week' : ''}`}>
@@ -991,6 +1031,8 @@ const TimeSeriesView = ({
                             isWeekView={isWeekView}
                             crossDays={crossDayMap.get(d) || []}
                             onChipClick={onChipClick}
+                            canonicalStartById={canonicalStartById}
+                            clusterSizeById={clusterSizeById}
                         />
                     ))}
                 </Box>

--- a/src/CalendarFC/__tests__/timeSeriesSizes.test.js
+++ b/src/CalendarFC/__tests__/timeSeriesSizes.test.js
@@ -8,6 +8,7 @@ import {
     VIZ_KEYS, DEFAULT_VIZ,
     SPACE_KEYS, DEFAULT_SPACE, SPACE_MULTIPLIERS, getSpaceMultiplier,
     ZOOM_KEYS, DEFAULT_ZOOM, ZOOM_HOURS, getZoomHours,
+    SWARM_CLUSTER_WINDOW_MS, clusterSessionsByStartTime,
 } from '../timeSeriesSizes';
 
 describe('Font size option A/B/C/D', () => {
@@ -248,6 +249,137 @@ describe('Space option 1/2/3/4 — bubble whitespace multiplier', () => {
         expect(getSpaceMultiplier(null)).toBe(SPACE_MULTIPLIERS[DEFAULT_SPACE]);
         expect(getSpaceMultiplier(undefined)).toBe(SPACE_MULTIPLIERS[DEFAULT_SPACE]);
         expect(getSpaceMultiplier(99)).toBe(SPACE_MULTIPLIERS[DEFAULT_SPACE]);
+    });
+});
+
+// ─── clusterSessionsByStartTime (req #2341 — Visualizer start-time alignment) ────
+describe('clusterSessionsByStartTime', () => {
+    const mk = (id, startedAt) => ({ id, started_at: startedAt });
+
+    it('returns empty maps for null / undefined / empty / non-array input', () => {
+        for (const v of [null, undefined, [], 'nope', 42]) {
+            const { canonical, clusterSize } = clusterSessionsByStartTime(v);
+            expect(canonical.size).toBe(0);
+            expect(clusterSize.size).toBe(0);
+        }
+    });
+
+    it('exposes a 3-minute default window constant', () => {
+        expect(SWARM_CLUSTER_WINDOW_MS).toBe(3 * 60 * 1000);
+    });
+
+    it('single session → singleton cluster, canonical = own started_at, size = 1', () => {
+        const { canonical, clusterSize } = clusterSessionsByStartTime([
+            mk(10, '2026-04-17T09:00:00Z'),
+        ]);
+        expect(canonical.get('10')).toBe('2026-04-17T09:00:00Z');
+        expect(clusterSize.get('10')).toBe(1);
+    });
+
+    it('two sessions within 3 min → same cluster, canonical = earliest, size = 2', () => {
+        const { canonical, clusterSize } = clusterSessionsByStartTime([
+            mk(1, '2026-04-17T09:00:00Z'),
+            mk(2, '2026-04-17T09:02:30Z'),
+        ]);
+        expect(canonical.get('1')).toBe('2026-04-17T09:00:00Z');
+        expect(canonical.get('2')).toBe('2026-04-17T09:00:00Z');
+        expect(clusterSize.get('1')).toBe(2);
+        expect(clusterSize.get('2')).toBe(2);
+    });
+
+    it('two sessions > 3 min apart → two singleton clusters', () => {
+        const { canonical, clusterSize } = clusterSessionsByStartTime([
+            mk(1, '2026-04-17T09:00:00Z'),
+            mk(2, '2026-04-17T09:04:00Z'),
+        ]);
+        expect(canonical.get('1')).toBe('2026-04-17T09:00:00Z');
+        expect(canonical.get('2')).toBe('2026-04-17T09:04:00Z');
+        expect(clusterSize.get('1')).toBe(1);
+        expect(clusterSize.get('2')).toBe(1);
+    });
+
+    it('transitive chain (0, +2, +4 min) collapses into one cluster', () => {
+        const { canonical, clusterSize } = clusterSessionsByStartTime([
+            mk(1, '2026-04-17T09:00:00Z'),
+            mk(2, '2026-04-17T09:02:00Z'),
+            mk(3, '2026-04-17T09:04:00Z'),
+        ]);
+        expect(canonical.get('1')).toBe('2026-04-17T09:00:00Z');
+        expect(canonical.get('2')).toBe('2026-04-17T09:00:00Z');
+        expect(canonical.get('3')).toBe('2026-04-17T09:00:00Z');
+        expect(clusterSize.get('1')).toBe(3);
+        expect(clusterSize.get('2')).toBe(3);
+        expect(clusterSize.get('3')).toBe(3);
+    });
+
+    it('unsorted input still clusters correctly', () => {
+        const { canonical, clusterSize } = clusterSessionsByStartTime([
+            mk(3, '2026-04-17T09:04:00Z'),
+            mk(1, '2026-04-17T09:00:00Z'),
+            mk(2, '2026-04-17T09:02:00Z'),
+        ]);
+        expect(canonical.get('1')).toBe('2026-04-17T09:00:00Z');
+        expect(canonical.get('2')).toBe('2026-04-17T09:00:00Z');
+        expect(canonical.get('3')).toBe('2026-04-17T09:00:00Z');
+        expect(clusterSize.get('1')).toBe(3);
+    });
+
+    it('sessions with null / missing started_at are excluded', () => {
+        const { canonical, clusterSize } = clusterSessionsByStartTime([
+            mk(1, '2026-04-17T09:00:00Z'),
+            mk(2, null),
+            mk(3, undefined),
+            mk(4, ''),
+            mk(5, '2026-04-17T09:01:00Z'),
+        ]);
+        expect(canonical.has('2')).toBe(false);
+        expect(canonical.has('3')).toBe(false);
+        expect(canonical.has('4')).toBe(false);
+        expect(canonical.get('1')).toBe('2026-04-17T09:00:00Z');
+        expect(canonical.get('5')).toBe('2026-04-17T09:00:00Z');
+        expect(clusterSize.get('1')).toBe(2);
+    });
+
+    it('sessions with invalid started_at are excluded', () => {
+        const { canonical, clusterSize } = clusterSessionsByStartTime([
+            mk(1, '2026-04-17T09:00:00Z'),
+            mk(2, 'not-a-date'),
+        ]);
+        expect(canonical.has('2')).toBe(false);
+        expect(clusterSize.get('1')).toBe(1);
+    });
+
+    it('threshold override splits a pair that the default would have merged', () => {
+        const sessions = [
+            mk(1, '2026-04-17T09:00:00Z'),
+            mk(2, '2026-04-17T09:02:30Z'),
+        ];
+        const tight = clusterSessionsByStartTime(sessions, 60 * 1000); // 1 min
+        expect(tight.canonical.get('1')).toBe('2026-04-17T09:00:00Z');
+        expect(tight.canonical.get('2')).toBe('2026-04-17T09:02:30Z');
+        expect(tight.clusterSize.get('1')).toBe(1);
+        expect(tight.clusterSize.get('2')).toBe(1);
+    });
+
+    it('string ids are supported and keyed consistently as strings', () => {
+        const { canonical, clusterSize } = clusterSessionsByStartTime([
+            { id: 'abc', started_at: '2026-04-17T09:00:00Z' },
+            { id: 42,    started_at: '2026-04-17T09:01:00Z' },
+        ]);
+        expect(canonical.get('abc')).toBe('2026-04-17T09:00:00Z');
+        expect(canonical.get('42')).toBe('2026-04-17T09:00:00Z');
+        expect(clusterSize.get('abc')).toBe(2);
+        expect(clusterSize.get('42')).toBe(2);
+    });
+
+    it('malformed entries (null, missing id) are skipped silently', () => {
+        const { canonical, clusterSize } = clusterSessionsByStartTime([
+            null,
+            { started_at: '2026-04-17T09:00:00Z' }, // no id
+            mk(7, '2026-04-17T09:01:00Z'),
+        ]);
+        expect(canonical.size).toBe(1);
+        expect(clusterSize.get('7')).toBe(1);
     });
 });
 

--- a/src/CalendarFC/timeSeriesSizes.js
+++ b/src/CalendarFC/timeSeriesSizes.js
@@ -97,3 +97,47 @@ export const VIZ_KEYS = ['bead', 'swarm'];
 export const VIZ_LABELS = { bead: 'Bead', swarm: 'Swarm' };
 export const DEFAULT_VIZ = 'bead';
 
+// ── Swarm start-time clustering (req #2341) ─────────────────────────────────────
+// Sessions whose started_at fall within this window are treated as a single swarm
+// and share one canonical start X so their vertical start-bars line up.
+export const SWARM_CLUSTER_WINDOW_MS = 3 * 60 * 1000;   // 3 minutes
+
+// Group sessions by proximity of started_at. Any two sessions whose starts are
+// within `thresholdMs` of each other belong to the same cluster (transitive).
+// Returns:
+//   canonical    — Map<string sessionId, ISO started_at of earliest in cluster>
+//   clusterSize  — Map<string sessionId, number of members in its cluster>
+// Sessions with null/invalid started_at are excluded silently.
+export function clusterSessionsByStartTime(sessions, thresholdMs = SWARM_CLUSTER_WINDOW_MS) {
+    const canonical = new Map();
+    const clusterSize = new Map();
+    if (!Array.isArray(sessions) || sessions.length === 0) return { canonical, clusterSize };
+
+    const valid = [];
+    for (const s of sessions) {
+        if (!s || s.id == null || !s.started_at) continue;
+        const ms = new Date(s.started_at).getTime();
+        if (Number.isNaN(ms)) continue;
+        valid.push({ id: String(s.id), startedAt: s.started_at, startMs: ms });
+    }
+    valid.sort((a, b) => a.startMs - b.startMs || a.id.localeCompare(b.id));
+
+    let cur = null;
+    const clusters = [];
+    for (const item of valid) {
+        if (!cur || item.startMs - cur.lastMs > thresholdMs) {
+            cur = { minStartedAt: item.startedAt, lastMs: item.startMs, members: [] };
+            clusters.push(cur);
+        }
+        cur.members.push(item.id);
+        cur.lastMs = item.startMs;
+    }
+    for (const c of clusters) {
+        for (const id of c.members) {
+            canonical.set(id, c.minStartedAt);
+            clusterSize.set(id, c.members.length);
+        }
+    }
+    return { canonical, clusterSize };
+}
+


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-04-19T09:51:19Z
- chore: init swarm session feature/2341-visualizer-start-time-alignment-1

## Files changed
```
 src/CalendarFC/TimeSeriesView.jsx                |  54 ++++++++--
 src/CalendarFC/__tests__/timeSeriesSizes.test.js | 132 +++++++++++++++++++++++
 src/CalendarFC/timeSeriesSizes.js                |  44 ++++++++
 3 files changed, 224 insertions(+), 6 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)