### PR TITLE
Swarm visualizer stops rendering some start indicators

### DIFF
--- a/src/CalendarFC/TimeSeriesView.jsx
+++ b/src/CalendarFC/TimeSeriesView.jsx
@@ -42,6 +42,34 @@ const assignRows = (chips, minGapPct) => {
     return out;
 };
 
+// ─────────── Vertical start-bar x-position (Swarm mode) ─────────────────────
+// Returns the SVG x-coordinate string for the vertical start tick, or null
+// when the tick should not render for this chip. The tick is the thin bar
+// that marks when a session started.
+//
+// Rules:
+//   • 'clamped'                 → null (tick skipped; horizontal dashed line conveys it).
+//   • 'left'                    → one gap left of bubble center.
+//   • 'normal', gap ≥ threshold → at startPct (aligns vertically with cluster-mates
+//                                  in req #2341).
+//   • 'normal', gap <  threshold → one gap left of bubble center (req #2336 —
+//                                   when start ≈ met, the SVG tick at startPct
+//                                   lands under the bubble's z-index and disappears).
+//   • 'normal', startPct null    → null (no session start to mark).
+//   • unknown markerMode         → null.
+// Exported for unit-test coverage.
+export const swarmStartBarX = (markerMode, leftPct, startPct, gapPx, closeThresholdPct) => {
+    if (markerMode === 'clamped') return null;
+    if (markerMode === 'left') return `calc(${leftPct}% - ${gapPx}px)`;
+    if (markerMode === 'normal' && startPct !== null && startPct !== undefined) {
+        const gapPct = leftPct - startPct;
+        return gapPct < closeThresholdPct
+            ? `calc(${leftPct}% - ${gapPx}px)`
+            : `${startPct}%`;
+    }
+    return null;
+};
+
 // ─────────── Swarm-lane layout (Swarm mode) ───────────────────────────────────
 // Each (requirement, session) pair — or bare requirement with no session — gets
 // its own row. Sorted by completed_at ascending so row 0 = earliest (bottom) and
@@ -529,23 +557,18 @@ const BeadRow = ({
                         );
                     })}
                     {/* Vertical start bar — position depends on markerMode:
-                        'normal'  → at startPct
+                        'normal'  → at startPct (OR left-of-bubble when start ≈ met, so
+                                    aligned-cluster close-met bars don't hide behind their
+                                    own bubble — req #2336)
                         'left'    → immediately left of bubble (no session OR start ≈ met)
                         'clamped' → skipped (horizontal dashed line already conveys it) */}
                     {placed.map(chip => {
-                        if (chip.markerMode === 'clamped') return null;
                         const halfBar = Math.max(6, circleDiameter / 2);
                         const y1 = `calc(100% - ${chip.row * rowSpacing + bubbleOffset + circleDiameter / 2 - halfBar}px)`;
                         const y2 = `calc(100% - ${chip.row * rowSpacing + bubbleOffset + circleDiameter / 2 + halfBar}px)`;
                         const gap = circleDiameter / 2 + 3;
-                        let x;
-                        if (chip.markerMode === 'left') {
-                            x = `calc(${chip.leftPct}% - ${gap}px)`;
-                        } else if (chip.markerMode === 'normal' && chip.startPct !== null) {
-                            x = `${chip.startPct}%`;
-                        } else {
-                            return null;
-                        }
+                        const x = swarmStartBarX(chip.markerMode, chip.leftPct, chip.startPct, gap, CLOSE_THRESHOLD_PCT);
+                        if (x === null) return null;
                         return (
                             <line
                                 key={`tick-${chip.chipKey}`}

--- a/src/CalendarFC/__tests__/timeSeriesSizes.test.js
+++ b/src/CalendarFC/__tests__/timeSeriesSizes.test.js
@@ -385,7 +385,89 @@ describe('clusterSessionsByStartTime', () => {
 
 // ─── assignSwarmLanes: each chip gets its own row, sorted by completed_at asc.
 // Row 0 = earliest met = bottom; higher rows = later met = top. ─────────────────
-import { assignSwarmLanes, weekDates, centeredDateRange } from '../TimeSeriesView';
+import { assignSwarmLanes, weekDates, centeredDateRange, swarmStartBarX } from '../TimeSeriesView';
+
+// ─── swarmStartBarX — vertical start-tick x-coordinate selector (req #2336) ───
+describe('swarmStartBarX (vertical start-tick positioning)', () => {
+    const GAP = 9;          // circleDiameter=12 → gap = 12/2 + 3 = 9
+    const THRESHOLD = 1.5;  // CLOSE_THRESHOLD_PCT
+
+    describe('markerMode=clamped', () => {
+        it('returns null (horizontal dashed line already conveys start)', () => {
+            expect(swarmStartBarX('clamped', 50, 0, GAP, THRESHOLD)).toBeNull();
+            expect(swarmStartBarX('clamped', 50, null, GAP, THRESHOLD)).toBeNull();
+        });
+    });
+
+    describe('markerMode=left', () => {
+        it('always renders one gap left of the bubble', () => {
+            expect(swarmStartBarX('left', 50, null, GAP, THRESHOLD)).toBe('calc(50% - 9px)');
+            expect(swarmStartBarX('left', 25, 24.5, GAP, THRESHOLD)).toBe('calc(25% - 9px)');
+        });
+    });
+
+    describe('markerMode=normal, distant start (gap ≥ threshold)', () => {
+        it('renders at startPct so cluster-mates align vertically (req #2341)', () => {
+            // Gap = 50 - 40 = 10%, well above 1.5% threshold → align at startPct.
+            expect(swarmStartBarX('normal', 50, 40, GAP, THRESHOLD)).toBe('40%');
+        });
+
+        it('renders at startPct right at threshold', () => {
+            // Gap = 50 - 48.5 = 1.5%, NOT less than threshold → at startPct.
+            expect(swarmStartBarX('normal', 50, 48.5, GAP, THRESHOLD)).toBe('48.5%');
+        });
+    });
+
+    describe('markerMode=normal, close start (gap < threshold) — req #2336 fix', () => {
+        it('shifts bar left of bubble when start ≈ met (prevents hidden-under-bubble)', () => {
+            // Gap = 50 - 49 = 1%, below 1.5% threshold. Pre-fix: bar at 49% lands
+            // under the bubble at 50% (bubble spans 50% ± 6px). Post-fix: bar
+            // shifted to leftPct - gap so it's visible.
+            expect(swarmStartBarX('normal', 50, 49, GAP, THRESHOLD)).toBe('calc(50% - 9px)');
+        });
+
+        it('shifts bar left of bubble even when startPct === leftPct exactly', () => {
+            // Gap = 0, fully below threshold. Bar must shift or disappears.
+            expect(swarmStartBarX('normal', 30, 30, GAP, THRESHOLD)).toBe('calc(30% - 9px)');
+        });
+
+        it('applies to aligned-cluster chips (req #2341 markerMode="normal" forced at tiny gap)', () => {
+            // An aligned-cluster member with start ≈ met is kept as 'normal' so
+            // it aligns vertically with its distant-start cluster-mates. Without
+            // the req #2336 fix, its bar at startPct lands inside its own bubble
+            // and disappears — leaving the other cluster members' bars visible
+            // but this one apparently "gone".
+            expect(swarmStartBarX('normal', 65, 64.2, GAP, THRESHOLD)).toBe('calc(65% - 9px)');
+        });
+    });
+
+    describe('markerMode=normal with null startPct', () => {
+        it('returns null (no session start to mark)', () => {
+            expect(swarmStartBarX('normal', 50, null, GAP, THRESHOLD)).toBeNull();
+            expect(swarmStartBarX('normal', 50, undefined, GAP, THRESHOLD)).toBeNull();
+        });
+    });
+
+    describe('unknown markerMode', () => {
+        it('returns null', () => {
+            expect(swarmStartBarX(undefined, 50, 40, GAP, THRESHOLD)).toBeNull();
+            expect(swarmStartBarX('', 50, 40, GAP, THRESHOLD)).toBeNull();
+            expect(swarmStartBarX('bogus', 50, 40, GAP, THRESHOLD)).toBeNull();
+        });
+    });
+
+    it('deterministic across repeated calls (no hidden state)', () => {
+        // Regression guard — bug #2336 was perceived as "toggle causes
+        // indicators to disappear". The selector must return identical
+        // results no matter how many times it's called.
+        const a = swarmStartBarX('normal', 50, 49, GAP, THRESHOLD);
+        const b = swarmStartBarX('normal', 50, 49, GAP, THRESHOLD);
+        const c = swarmStartBarX('normal', 50, 49, GAP, THRESHOLD);
+        expect(a).toBe(b);
+        expect(b).toBe(c);
+        expect(a).toBe('calc(50% - 9px)');
+    });
+});
 
 describe('assignSwarmLanes (Swarm Visualizer lane order)', () => {
     const mk = (chipKey, completed_at) => ({ chipKey, id: chipKey, completed_at });


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2336-swarm-visualizer-stops-rendering-1
- req #2336: keep swarm start-bar visible when start is close to met
- chore: init swarm session feature/2336-swarm-visualizer-stops-rendering-1

## Files changed
```
 src/CalendarFC/TimeSeriesView.jsx                | 43 +++++++++---
 src/CalendarFC/__tests__/timeSeriesSizes.test.js | 84 +++++++++++++++++++++++-
 2 files changed, 116 insertions(+), 11 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)