### PR TITLE
visualizer requirement card display of autonomy

### DIFF
--- a/src/SwarmView/CategoryCard.jsx
+++ b/src/SwarmView/CategoryCard.jsx
@@ -424,6 +424,30 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
         return {requirement: requirement.id};
     };
 
+    // Optimistically apply `updates` to every requirement cache for this creator
+    // (byCategory, byStatus, done, etc.) so downstream views — including the
+    // Visualizer's `useRequirementsDone` cache (req #2381) — reflect the mutation
+    // without waiting for a refetch. Returns a revert fn that restores every
+    // snapshot captured before the write.
+    //
+    // The updater returns the same `old` reference when no row matches `requirementId`,
+    // so unrelated caches (e.g. counts aggregates) don't trigger spurious re-renders.
+    const writeThroughRequirementCaches = (requirementId, updates) => {
+        const prefix = requirementKeys.all(profile.userName);
+        queryClient.cancelQueries({ queryKey: prefix });
+        const snapshots = queryClient.getQueriesData({ queryKey: prefix });
+        queryClient.setQueriesData({ queryKey: prefix }, (old) => {
+            if (!Array.isArray(old)) return old;
+            if (!old.some(r => r.id === requirementId)) return old;
+            return old.map(r => r.id === requirementId ? { ...r, ...updates } : r);
+        });
+        return () => {
+            for (const [key, data] of snapshots) {
+                queryClient.setQueryData(key, data);
+            }
+        };
+    };
+
     const STATUS_CYCLE = ['authoring', 'approved', 'swarm_ready'];
     const statusClick = (requirementIndex, requirementId) => {
         const current = requirementsArray[requirementIndex].requirement_status;
@@ -432,37 +456,23 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
         const next = STATUS_CYCLE[(idx + 1) % STATUS_CYCLE.length];
 
         if (requirementId !== '') {
-            // Optimistic cache update — prevent TanStack refetches (e.g. from a concurrent
-            // invalidateQueries on requirementKeys.all) from clobbering the local mutation.
+            // Optimistic write-through across every requirement cache (req #2381).
             // Snapshot BEFORE any local-state mutation: requirementsArray and the cache
             // share object references (useEffect seeds from serverRequirements via shallow
             // copy), so in-place mutation would poison the snapshot.
-            const withClosedKey = requirementKeys.byCategoryWithClosed(profile.userName, category.id);
-            const openKey = requirementKeys.byCategoryOpen(profile.userName, category.id);
-            queryClient.cancelQueries({ queryKey: withClosedKey });
-            queryClient.cancelQueries({ queryKey: openKey });
-            const previousWithClosed = queryClient.getQueryData(withClosedKey);
-            const previousOpen = queryClient.getQueryData(openKey);
-            const updateCache = (old) => {
-                if (!Array.isArray(old)) return old;
-                return old.map(r => r.id === requirementId ? { ...r, requirement_status: next } : r);
-            };
-            queryClient.setQueryData(withClosedKey, updateCache);
-            queryClient.setQueryData(openKey, updateCache);
+            const revert = writeThroughRequirementCaches(requirementId, { requirement_status: next });
 
             let uri = `${darwinUri}/requirements`;
             call_rest_api(uri, 'PUT', [{'id': requirementId, 'requirement_status': next}], idToken)
                 .then(result => {
                     if (result.httpStatus.httpStatus !== 200 && result.httpStatus.httpStatus !== 204) {
-                        queryClient.setQueryData(withClosedKey, previousWithClosed);
-                        queryClient.setQueryData(openKey, previousOpen);
+                        revert();
                         setRequirementsArray(prev => prev.map(r =>
                             r.id === requirementId ? { ...r, requirement_status: current } : r));
                         showError(result, "Unable to change requirement status");
                     }
                 }).catch(error => {
-                    queryClient.setQueryData(withClosedKey, previousWithClosed);
-                    queryClient.setQueryData(openKey, previousOpen);
+                    revert();
                     setRequirementsArray(prev => prev.map(r =>
                         r.id === requirementId ? { ...r, requirement_status: current } : r));
                     showError(error, "Unable to change requirement status");
@@ -483,33 +493,21 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
         const next = COORD_CYCLE[(idx + 1) % COORD_CYCLE.length];
 
         if (requirementId !== '') {
-            // Optimistic cache update — see statusClick above for snapshot-ordering rationale.
-            const withClosedKey = requirementKeys.byCategoryWithClosed(profile.userName, category.id);
-            const openKey = requirementKeys.byCategoryOpen(profile.userName, category.id);
-            queryClient.cancelQueries({ queryKey: withClosedKey });
-            queryClient.cancelQueries({ queryKey: openKey });
-            const previousWithClosed = queryClient.getQueryData(withClosedKey);
-            const previousOpen = queryClient.getQueryData(openKey);
-            const updateCache = (old) => {
-                if (!Array.isArray(old)) return old;
-                return old.map(r => r.id === requirementId ? { ...r, coordination_type: next } : r);
-            };
-            queryClient.setQueryData(withClosedKey, updateCache);
-            queryClient.setQueryData(openKey, updateCache);
+            // Write-through to every requirement cache (req #2381) — see statusClick
+            // for snapshot-ordering rationale.
+            const revert = writeThroughRequirementCaches(requirementId, { coordination_type: next });
 
             let uri = `${darwinUri}/requirements`;
             call_rest_api(uri, 'PUT', [{'id': requirementId, 'coordination_type': next === null ? 'NULL' : next}], idToken)
                 .then(result => {
                     if (result.httpStatus.httpStatus !== 200 && result.httpStatus.httpStatus !== 204) {
-                        queryClient.setQueryData(withClosedKey, previousWithClosed);
-                        queryClient.setQueryData(openKey, previousOpen);
+                        revert();
                         setRequirementsArray(prev => prev.map(r =>
                             r.id === requirementId ? { ...r, coordination_type: current } : r));
                         showError(result, "Unable to change coordination type");
                     }
                 }).catch(error => {
-                    queryClient.setQueryData(withClosedKey, previousWithClosed);
-                    queryClient.setQueryData(openKey, previousOpen);
+                    revert();
                     setRequirementsArray(prev => prev.map(r =>
                         r.id === requirementId ? { ...r, coordination_type: current } : r));
                     showError(error, "Unable to change coordination type");

--- a/src/TaskPlanView/SwarmStartCard.jsx
+++ b/src/TaskPlanView/SwarmStartCard.jsx
@@ -156,20 +156,53 @@ const SwarmStartCard = () => {
         }
     });
 
+    // Optimistically apply `updates` to every requirement cache for this creator
+    // (byCategory, byStatus, done, etc.) so downstream views — including the
+    // Visualizer's `useRequirementsDone` cache (req #2381) — reflect the mutation
+    // without waiting for a refetch. Returns a revert fn that restores every
+    // snapshot captured before the write.
+    //
+    // IMPORTANT: call this BEFORE any local-state mutation. requirementsArray and
+    // the TanStack cache share object references (useEffect seeds via `[...serverRequirements]`
+    // — shallow copy of the array, not the objects), so in-place mutation of a row
+    // would poison the snapshot captured here.
+    //
+    // The updater returns the same `old` reference when no row matches `requirementId`,
+    // so unrelated caches (e.g. counts aggregates) don't trigger spurious re-renders.
+    const writeThroughRequirementCaches = (requirementId, updates) => {
+        const prefix = requirementKeys.all(profile.userName);
+        queryClient.cancelQueries({ queryKey: prefix });
+        const snapshots = queryClient.getQueriesData({ queryKey: prefix });
+        queryClient.setQueriesData({ queryKey: prefix }, (old) => {
+            if (!Array.isArray(old)) return old;
+            if (!old.some(r => r.id === requirementId)) return old;
+            return old.map(r => r.id === requirementId ? { ...r, ...updates } : r);
+        });
+        return () => {
+            for (const [key, data] of snapshots) {
+                queryClient.setQueryData(key, data);
+            }
+        };
+    };
+
     // Status click — items cycle off the selected status leave the card.
     const STATUS_CYCLE = ['authoring', 'approved', 'swarm_ready'];
     const statusClick = (requirementIndex, requirementId) => {
-        const newRequirementsArray = [...requirementsArray];
-        const current = newRequirementsArray[requirementIndex].requirement_status;
+        const current = requirementsArray[requirementIndex].requirement_status;
         const idx = STATUS_CYCLE.indexOf(current);
         if (idx === -1) return;
         const next = STATUS_CYCLE[(idx + 1) % STATUS_CYCLE.length];
-        newRequirementsArray[requirementIndex].requirement_status = next;
+
+        // Capture cache snapshots BEFORE touching local state (shared refs, see helper comment).
+        const revert = writeThroughRequirementCaches(requirementId, { requirement_status: next });
 
         call_rest_api(`${darwinUri}/requirements`, 'PUT',
             [{ id: requirementId, requirement_status: next }], idToken)
             .then(result => {
                 if (result.httpStatus.httpStatus !== 200 && result.httpStatus.httpStatus !== 204) {
+                    revert();
+                    setRequirementsArray(prev => prev ? prev.map(r =>
+                        r.id === requirementId ? { ...r, requirement_status: current } : r) : prev);
                     showError(result, 'Unable to change requirement status');
                 } else {
                     // Item no longer matches the card's aggregate status — remove it.
@@ -178,28 +211,47 @@ const SwarmStartCard = () => {
                         queryClient.invalidateQueries({ queryKey: requirementKeys.all(profile.userName) });
                     }
                 }
-            }).catch(error => showError(error, 'Unable to change requirement status'));
+            }).catch(error => {
+                revert();
+                setRequirementsArray(prev => prev ? prev.map(r =>
+                    r.id === requirementId ? { ...r, requirement_status: current } : r) : prev);
+                showError(error, 'Unable to change requirement status');
+            });
 
-        setRequirementsArray(newRequirementsArray);
+        // Immutable local update — new object at the target index rather than in-place
+        // mutation on a cache-shared object reference.
+        setRequirementsArray(prev => prev ? prev.map((r, i) =>
+            i === requirementIndex ? { ...r, requirement_status: next } : r) : prev);
     };
 
     // Coordination click — mirrors CategoryCard
     const COORD_CYCLE = [null, 'planned', 'implemented', 'deployed'];
     const coordinationClick = (requirementIndex, requirementId) => {
-        const newRequirementsArray = [...requirementsArray];
-        const current = newRequirementsArray[requirementIndex].coordination_type || null;
+        const current = requirementsArray[requirementIndex].coordination_type || null;
         const idx = COORD_CYCLE.indexOf(current);
         const next = COORD_CYCLE[(idx + 1) % COORD_CYCLE.length];
-        newRequirementsArray[requirementIndex].coordination_type = next;
-        setRequirementsArray(newRequirementsArray);
+
+        // Capture cache snapshots BEFORE touching local state (shared refs, see helper comment).
+        const revert = writeThroughRequirementCaches(requirementId, { coordination_type: next });
 
         call_rest_api(`${darwinUri}/requirements`, 'PUT',
             [{ id: requirementId, coordination_type: next === null ? 'NULL' : next }], idToken)
             .then(result => {
                 if (result.httpStatus.httpStatus !== 200 && result.httpStatus.httpStatus !== 204) {
+                    revert();
+                    setRequirementsArray(prev => prev ? prev.map(r =>
+                        r.id === requirementId ? { ...r, coordination_type: current } : r) : prev);
                     showError(result, 'Unable to change coordination type');
                 }
-            }).catch(error => showError(error, 'Unable to change coordination type'));
+            }).catch(error => {
+                revert();
+                setRequirementsArray(prev => prev ? prev.map(r =>
+                    r.id === requirementId ? { ...r, coordination_type: current } : r) : prev);
+                showError(error, 'Unable to change coordination type');
+            });
+
+        setRequirementsArray(prev => prev ? prev.map((r, i) =>
+            i === requirementIndex ? { ...r, coordination_type: next } : r) : prev);
     };
 
     // Title editing — mirrors CategoryCard (PUT only, no POST/template)


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2381-visualizer-requirement-card-display-1
- Fix Visualizer showing stale coordination_type (req #2381)
- chore: init swarm session feature/2381-visualizer-requirement-card-display-1

## Files changed
```
 src/SwarmView/CategoryCard.jsx      | 68 +++++++++++++++++------------------
 src/TaskPlanView/SwarmStartCard.jsx | 72 +++++++++++++++++++++++++++++++------
 2 files changed, 95 insertions(+), 45 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)