### PR TITLE
Visualizer - sidewalk title overlap

### DIFF
--- a/src/CalendarFC/TimeSeriesView.css
+++ b/src/CalendarFC/TimeSeriesView.css
@@ -132,18 +132,21 @@
     padding: 0;
     background: transparent;
 }
-/* Row 1 — date (with inline count pill) */
+/* Row 1 — date (with inline count pill).
+   height + label line-height pinned so the inline count pill (line-height: 1.4)
+   can't push the label past the row's declared bottom into Row 2 below. */
 .ts-bead-sidewalk .ts-bead-days {
     top: 8px;
     left: 8px;
     right: 8px;
-    height: 18px;
+    height: 20px;
 }
 .ts-bead-sidewalk .ts-bead-day-label {
     display: inline-flex;
     align-items: center;
     gap: 6px;
     font-size: 0.82rem;
+    line-height: 1.2;
 }
 .ts-bead-day-count-inline {
     display: inline-block;
@@ -163,9 +166,11 @@ body.darwin-dark .ts-bead-day-count-inline {
     color: #81c784;
 }
 
-/* Row 2 — time axis */
+/* Row 2 — time axis. Pushed down so the tick-labels (12pm, 3pm…) have
+   ≥10px of clear whitespace below the date row. Date row ends around y=28,
+   tick-label top starts at y=46. */
 .ts-bead-sidewalk .ts-bead-timeline {
-    top: 30px;
+    top: 46px;
     bottom: auto;
     left: 0;
     right: 0;
@@ -185,15 +190,16 @@ body.darwin-dark .ts-bead-day-count-inline {
     margin-top: 0;
     margin-bottom: 2px;
 }
-/* Vertical dividers span only the bubble area (below the chrome). */
+/* Vertical dividers span only the bubble area (below the chrome). Moves
+   with the timeline so the dividers still start just below the tick-line. */
 .ts-bead-sidewalk .ts-bead-divider {
-    top: 50px;
+    top: 68px;
     bottom: 10px;
     height: auto;
 }
 /* Wire — short axis line just under the time ticks, above bubble area. */
 .ts-bead-sidewalk .ts-bead-wire {
-    top: 50px;
+    top: 68px;
     bottom: auto;
     left: 0;
     right: 0;

--- a/src/CalendarFC/TimeSeriesView.jsx
+++ b/src/CalendarFC/TimeSeriesView.jsx
@@ -270,9 +270,9 @@ const BeadRow = ({
     // top-down sidewalk layout we use topHeader instead (pixels from TOP).
     const LAYOUT_DAY      = { bubbleOffset: 86, baseHeight: 172 };
     const LAYOUT_WEEK     = { bubbleOffset: 68, baseHeight: 116 };
-    // Sidewalk keeps bottom-up bubble stacking (earliest met = bottom, latest = top)
-    // just like Day/Week; only the chrome moves to the top of the panel. Fixed 400px
-    // so every panel looks identical.
+    // Sidewalk: chrome (date + time axis) pinned at the top; bubbles stack
+    // bottom-up below it. Panel height grows to fit the stack — no false
+    // bottom, so days with many bubbles don't overflow the chrome.
     const LAYOUT_SIDEWALK = { bubbleOffset: 20, baseHeight: sidewalkHeight || 400 };
     const { bubbleOffset, baseHeight } =
         sidewalkPanel ? LAYOUT_SIDEWALK
@@ -388,14 +388,13 @@ const BeadRow = ({
     const rowSpacing = Math.max(16, Math.round((circleDiameter + 4) * spaceMul));
 
     // Vertical height — must clear the date label at the top by at least half a
-    // bubble so the tallest bubble never crowds the date.
-    const dateBottom   = isWeekView ? 26 : 46;
+    // bubble so the tallest bubble never crowds the date. Sidewalk's top chrome
+    // (date + time axis + wire) is taller than Day/Week's so it reserves ~70px.
+    const dateBottom   = sidewalkPanel ? 80 : isWeekView ? 26 : 46;
     const dateClearance = Math.ceil(circleDiameter / 2) + 4;
-    const height = sidewalkPanel
-        ? baseHeight                                    // fixed uniform panels
-        : Math.max(baseHeight,
-                   maxStackRow * rowSpacing + bubbleOffset + circleDiameter
-                   + dateBottom + dateClearance);
+    const height = Math.max(baseHeight,
+                            maxStackRow * rowSpacing + bubbleOffset + circleDiameter
+                            + dateBottom + dateClearance);
 
     // Unified bottom-anchored bubble positioning — earliest met (row 0) always at
     // the bottom, latest at the top, in Day/Week and Sidewalk alike.
@@ -852,7 +851,6 @@ const Sidewalk = ({ centerDate, onCenterDateChange, ...rowProps }) => {
                          style={{ width: frameWidth || '100%', flex: `0 0 ${frameWidth || 1}px` }}>
                         <BeadRow selectedDate={d}
                                  sidewalkPanel={true}
-                                 sidewalkHeight={400}
                                  {...rowProps} />
                     </Box>
                 ))}


### PR DESCRIPTION
## Summary
- Req 2331: sidewalk title overlap — reserve whitespace between date row and time axis
- chore: init swarm session feature/2331-visualizer-sidewalk-title-overlap-1

## Files changed
```
 src/CalendarFC/TimeSeriesView.css | 20 +++++++++++++-------
 src/CalendarFC/TimeSeriesView.jsx | 20 +++++++++-----------
 2 files changed, 22 insertions(+), 18 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)