### PR TITLE
visualizer loses track of starting points

### DIFF
--- a/src/CalendarFC/TimeSeriesView.jsx
+++ b/src/CalendarFC/TimeSeriesView.jsx
@@ -82,23 +82,19 @@ const assignRows = (chips, minGapPct) => {
 //
 // Rules:
 //   • 'clamped'                 → null (tick skipped; horizontal dashed line conveys it).
-//   • 'left'                    → one gap left of bubble center.
-//   • 'normal', gap ≥ threshold → at startPct (aligns vertically with cluster-mates
-//                                  in req #2341).
-//   • 'normal', gap <  threshold → one gap left of bubble center (req #2336 —
-//                                   when start ≈ met, the SVG tick at startPct
-//                                   lands under the bubble's z-index and disappears).
-//   • 'normal', startPct null    → null (no session start to mark).
-//   • unknown markerMode         → null.
+//   • 'left'                    → one gap left of bubble center (no line drawn, so
+//                                  the tick sits right at the bubble).
+//   • 'normal', startPct valid  → at startPct (left edge of the horizontal line —
+//                                  aligns vertically with cluster-mates per req #2341
+//                                  and matches the line's start visually, req #2398).
+//   • 'normal', startPct null   → null (no session start to mark).
+//   • unknown markerMode        → null.
 // Exported for unit-test coverage.
-export const swarmStartBarX = (markerMode, leftPct, startPct, gapPx, closeThresholdPct) => {
+export const swarmStartBarX = (markerMode, leftPct, startPct, gapPx) => {
     if (markerMode === 'clamped') return null;
     if (markerMode === 'left') return `calc(${leftPct}% - ${gapPx}px)`;
     if (markerMode === 'normal' && startPct !== null && startPct !== undefined) {
-        const gapPct = leftPct - startPct;
-        return gapPct < closeThresholdPct
-            ? `calc(${leftPct}% - ${gapPx}px)`
-            : `${startPct}%`;
+        return `${startPct}%`;
     }
     return null;
 };
@@ -170,7 +166,8 @@ export const weekDates = (dateStr) => {
 // All zoom levels position the same chips at the same % within their base
 // window, so switching 24h ↔ 36h never moves a chip — the 24h view just
 // rejects anything that falls in the hidden outer bands.
-const positionFor = (completedAt, timezone, selectedDate, baseHours, visibleHours) => {
+// Exported for unit-test coverage of the 24h↔36h transition.
+export const positionFor = (completedAt, timezone, selectedDate, baseHours, visibleHours) => {
     const chipDay  = toLocaleDateString(completedAt, timezone);
     const chipFrac = getTimeOfDayFraction(completedAt, timezone);
     if (chipDay === null || chipFrac === null) return null;
@@ -596,17 +593,17 @@ const BeadRow = ({
                         );
                     })}
                     {/* Vertical start bar — position depends on markerMode:
-                        'normal'  → at startPct (OR left-of-bubble when start ≈ met, so
-                                    aligned-cluster close-met bars don't hide behind their
-                                    own bubble — req #2336)
-                        'left'    → immediately left of bubble (no session OR start ≈ met)
+                        'normal'  → at startPct (left edge of the horizontal line;
+                                    aligns cluster-mates vertically, req #2341/#2398)
+                        'left'    → immediately left of bubble (no session OR start ≈ met;
+                                    no horizontal line drawn)
                         'clamped' → skipped (horizontal dashed line already conveys it) */}
                     {placed.map(chip => {
                         const halfBar = Math.max(6, circleDiameter / 2);
                         const y1 = `calc(100% - ${chip.row * rowSpacing + bubbleOffset + circleDiameter / 2 - halfBar}px)`;
                         const y2 = `calc(100% - ${chip.row * rowSpacing + bubbleOffset + circleDiameter / 2 + halfBar}px)`;
                         const gap = circleDiameter / 2 + 3;
-                        const x = swarmStartBarX(chip.markerMode, chip.leftPct, chip.startPct, gap, CLOSE_THRESHOLD_PCT);
+                        const x = swarmStartBarX(chip.markerMode, chip.leftPct, chip.startPct, gap);
                         if (x === null) return null;
                         return (
                             <line

--- a/src/CalendarFC/__tests__/timeSeriesSizes.test.js
+++ b/src/CalendarFC/__tests__/timeSeriesSizes.test.js
@@ -385,7 +385,152 @@ describe('clusterSessionsByStartTime', () => {
 
 // ─── assignSwarmLanes: each chip gets its own row, sorted by completed_at asc.
 // Row 0 = earliest met = bottom; higher rows = later met = top. ─────────────────
-import { assignSwarmLanes, weekDates, centeredDateRange, swarmStartBarX } from '../TimeSeriesView';
+import { assignSwarmLanes, weekDates, centeredDateRange, swarmStartBarX, positionFor } from '../TimeSeriesView';
+
+// ─── clusterSessionsByStartTime — MySQL-format parsing (req #2398) ─────────────
+// Regression guard: before the fix, clusterSessionsByStartTime parsed
+// started_at with raw `new Date(...)`, which treats MySQL "YYYY-MM-DD HH:MM:SS"
+// as LOCAL time, while every other consumer in the visualizer (positionFor,
+// toLocaleDateString, formatCardDateTime) uses toDate() which correctly
+// interprets that format as UTC (by appending 'Z'). The mismatch could skew
+// cluster membership when two sessions' local-vs-UTC offsets fell across the
+// 3-minute cluster threshold, or when DST transitions changed the offset.
+describe('clusterSessionsByStartTime — MySQL-format UTC parsing', () => {
+    it('treats MySQL-format started_at ("YYYY-MM-DD HH:MM:SS") as UTC', () => {
+        // Same UTC instant expressed both ways — must cluster as one.
+        const { canonical, clusterSize } = clusterSessionsByStartTime([
+            { id: 'mysql', started_at: '2026-04-21 01:55:00' },          // MySQL UTC
+            { id: 'iso',   started_at: '2026-04-21T01:55:30.000Z' },     // ISO UTC, 30s later
+        ]);
+        // 30-second gap < 3-min cluster window → same cluster of size 2.
+        expect(clusterSize.get('mysql')).toBe(2);
+        expect(clusterSize.get('iso')).toBe(2);
+        // Canonical is the earlier one (mysql @ 01:55:00 UTC).
+        expect(canonical.get('mysql')).toBe('2026-04-21 01:55:00');
+        expect(canonical.get('iso')).toBe('2026-04-21 01:55:00');
+    });
+
+    it('splits MySQL-format sessions > 3 min apart in UTC', () => {
+        const { clusterSize } = clusterSessionsByStartTime([
+            { id: 'a', started_at: '2026-04-21 01:55:00' },
+            { id: 'b', started_at: '2026-04-21 02:00:00' },   // 5 min later UTC
+        ]);
+        expect(clusterSize.get('a')).toBe(1);
+        expect(clusterSize.get('b')).toBe(1);
+    });
+
+    it('falls back to Date constructor for non-MySQL strings', () => {
+        // Plain ISO, numeric, etc — still parsed correctly.
+        const { canonical } = clusterSessionsByStartTime([
+            { id: 'a', started_at: '2026-04-21T05:00:00Z' },
+            { id: 'b', started_at: '2026-04-21T05:02:00Z' },
+        ]);
+        expect(canonical.get('a')).toBe('2026-04-21T05:00:00Z');
+        expect(canonical.get('b')).toBe('2026-04-21T05:00:00Z');
+    });
+});
+
+// ─── positionFor — 24h ↔ 36h transition (req #2398) ───────────────────────────
+// Guard rails: the specific scenario described in the bug — reqs closing in the
+// wee hours of the NEXT day become visible when the window widens 24h → 36h.
+// Both the met bubble AND the session's start position must produce valid
+// percentages inside the 36h band so the vertical start-bar renders.
+describe('positionFor — 24h ↔ 36h transition (req #2398)', () => {
+    const TZ = 'UTC';
+    const SEL = '2026-04-20';   // selectedDate (today)
+
+    // Helper — shorthand for the 36h baseHours the non-sidewalk paths use.
+    const at24 = (t) => positionFor(t, TZ, SEL, 36, 24);
+    const at36 = (t) => positionFor(t, TZ, SEL, 36, 36);
+
+    it('req closing at 02:00 next day → hidden at 24h, visible at 36h', () => {
+        const t = '2026-04-21 02:00:00';   // 14h past noon of SEL
+        expect(at24(t)).toBeNull();
+        const p36 = at36(t);
+        expect(p36).not.toBeNull();
+        expect(p36).toBeGreaterThan(0);
+        expect(p36).toBeLessThan(100);
+    });
+
+    it('session starting 5 min before (01:55 next day) → hidden at 24h, visible at 36h', () => {
+        const t = '2026-04-21 01:55:00';   // 13.92h past noon of SEL
+        expect(at24(t)).toBeNull();
+        const p36 = at36(t);
+        expect(p36).not.toBeNull();
+        expect(p36).toBeGreaterThan(0);
+        expect(p36).toBeLessThan(100);
+    });
+
+    it('short-window pair (start 01:55, met 02:00) → both visible at 36h with start before met', () => {
+        const startPct = at36('2026-04-21 01:55:00');
+        const metPct   = at36('2026-04-21 02:00:00');
+        expect(startPct).not.toBeNull();
+        expect(metPct).not.toBeNull();
+        // Start must be LEFT OF met on the axis.
+        expect(startPct).toBeLessThan(metPct);
+        // Gap is small (5 min) — under the 1.5% CLOSE_THRESHOLD used for
+        // markerMode='left' selection.
+        expect(metPct - startPct).toBeLessThan(1.5);
+        expect(metPct - startPct).toBeGreaterThan(0);
+    });
+
+    it('session started before the 36h window → null (clamped path), met still visible', () => {
+        // 2pm on selectedDate-1 = 22h before noon of SEL, beyond ±18h 36h band.
+        const early = at36('2026-04-19 10:00:00');
+        expect(early).toBeNull();
+        // Met at 02:00 next day is still visible → bubble renders, dashed
+        // clamped line conveys the off-window start.
+        expect(at36('2026-04-21 02:00:00')).not.toBeNull();
+    });
+});
+
+// ─── swarmStartBarX — short-window rendering guarantee (req #2398) ─────────────
+// The specific failure mode was reported as "start points do not re-render for
+// the ones that had short windows between swarm start and requirement met."
+// This set of assertions pins down the exact (leftPct, startPct) combinations
+// produced by the 36h-edge short-window scenario and proves each produces a
+// non-null x-coordinate, so the vertical start bar DOES render.
+describe('swarmStartBarX — short-window rendering (req #2398)', () => {
+    const GAP = 9;
+    const THRESHOLD = 1.5;
+
+    it('short-window singleton at right edge → left mode, non-null bar x', () => {
+        // Representative numbers from positionFor simulation for req #2398
+        // scenario (met 02:00 next day, session started 01:55 next day):
+        const leftPct  = 88.889;
+        const startPct = 88.657;
+        // Gap = 0.23% < threshold, not aligned → markerMode='left'.
+        const x = swarmStartBarX('left', leftPct, startPct, GAP, THRESHOLD);
+        expect(x).not.toBeNull();
+        expect(x).toBe('calc(88.889% - 9px)');
+    });
+
+    it('cluster of 3 short-window sessions at right edge → all bars align at canonical startPct', () => {
+        // Three reqs: met at 02:00, 02:10, 03:00 next day. Cluster canonical
+        // start = 01:55 (all three sessions within 3 min). clusterSize>1 →
+        // isAligned=true → markerMode stays 'normal'. The bar MUST render at
+        // canonicalStartPct (left edge of its horizontal line) so all three
+        // cluster-mates' bars sit at the same x — that's the whole point of
+        // req #2341 alignment, and the bug in req #2398 was the old gap-shift
+        // branch breaking this for short-gap members.
+        const canonicalStartPct = 88.657;   // 01:55 canonical
+
+        expect(swarmStartBarX('normal', 88.889, canonicalStartPct, GAP))
+            .toBe('88.657%');
+        expect(swarmStartBarX('normal', 89.352, canonicalStartPct, GAP))
+            .toBe('88.657%');
+        expect(swarmStartBarX('normal', 91.667, canonicalStartPct, GAP))
+            .toBe('88.657%');
+    });
+
+    it('short-window singleton just inside window → bar stays inside container', () => {
+        // Tight edge case: bubble at 99%, bar would shift to calc(99% - 9px).
+        // Still a valid position, still renders (container is 100% wide).
+        const x = swarmStartBarX('left', 99.0, 98.95, GAP, THRESHOLD);
+        expect(x).not.toBeNull();
+        expect(x).toBe('calc(99% - 9px)');
+    });
+});
 
 // ─── swarmStartBarX — vertical start-tick x-coordinate selector (req #2336) ───
 describe('swarmStartBarX (vertical start-tick positioning)', () => {
@@ -418,26 +563,28 @@ describe('swarmStartBarX (vertical start-tick positioning)', () => {
         });
     });
 
-    describe('markerMode=normal, close start (gap < threshold) — req #2336 fix', () => {
-        it('shifts bar left of bubble when start ≈ met (prevents hidden-under-bubble)', () => {
-            // Gap = 50 - 49 = 1%, below 1.5% threshold. Pre-fix: bar at 49% lands
-            // under the bubble at 50% (bubble spans 50% ± 6px). Post-fix: bar
-            // shifted to leftPct - gap so it's visible.
-            expect(swarmStartBarX('normal', 50, 49, GAP, THRESHOLD)).toBe('calc(50% - 9px)');
+    describe('markerMode=normal, close start (gap < threshold) — req #2398 fix', () => {
+        // Req #2398: when markerMode='normal' the horizontal line is drawn from
+        // startPct to leftPct. The vertical tick MUST sit at startPct (the line's
+        // left edge), never at the bubble end — the old gap-shift from req #2336
+        // put it next to the bubble, which visually misrepresents where the
+        // session started and breaks cluster-mate alignment.
+        it('renders at startPct when start is close to met (line shows the gap)', () => {
+            // Gap = 50 - 49 = 1%. Bar at 49% = left edge of the horizontal line.
+            expect(swarmStartBarX('normal', 50, 49, GAP)).toBe('49%');
         });
 
-        it('shifts bar left of bubble even when startPct === leftPct exactly', () => {
-            // Gap = 0, fully below threshold. Bar must shift or disappears.
-            expect(swarmStartBarX('normal', 30, 30, GAP, THRESHOLD)).toBe('calc(30% - 9px)');
+        it('renders at startPct even when startPct === leftPct exactly', () => {
+            // Degenerate zero-length line — still place the tick where the line is.
+            expect(swarmStartBarX('normal', 30, 30, GAP)).toBe('30%');
         });
 
-        it('applies to aligned-cluster chips (req #2341 markerMode="normal" forced at tiny gap)', () => {
-            // An aligned-cluster member with start ≈ met is kept as 'normal' so
-            // it aligns vertically with its distant-start cluster-mates. Without
-            // the req #2336 fix, its bar at startPct lands inside its own bubble
-            // and disappears — leaving the other cluster members' bars visible
-            // but this one apparently "gone".
-            expect(swarmStartBarX('normal', 65, 64.2, GAP, THRESHOLD)).toBe('calc(65% - 9px)');
+        it('aligned-cluster chip with tiny own-gap renders at canonical startPct', () => {
+            // An aligned-cluster member is kept as 'normal' so it aligns
+            // vertically with its cluster-mates (req #2341). The tick sits at
+            // startPct (canonical cluster start) — that's the whole alignment
+            // guarantee req #2398 restored.
+            expect(swarmStartBarX('normal', 65, 64.2, GAP)).toBe('64.2%');
         });
     });
 
@@ -460,12 +607,12 @@ describe('swarmStartBarX (vertical start-tick positioning)', () => {
         // Regression guard — bug #2336 was perceived as "toggle causes
         // indicators to disappear". The selector must return identical
         // results no matter how many times it's called.
-        const a = swarmStartBarX('normal', 50, 49, GAP, THRESHOLD);
-        const b = swarmStartBarX('normal', 50, 49, GAP, THRESHOLD);
-        const c = swarmStartBarX('normal', 50, 49, GAP, THRESHOLD);
+        const a = swarmStartBarX('normal', 50, 49, GAP);
+        const b = swarmStartBarX('normal', 50, 49, GAP);
+        const c = swarmStartBarX('normal', 50, 49, GAP);
         expect(a).toBe(b);
         expect(b).toBe(c);
-        expect(a).toBe('calc(50% - 9px)');
+        expect(a).toBe('49%');
     });
 });
 

--- a/src/CalendarFC/timeSeriesSizes.js
+++ b/src/CalendarFC/timeSeriesSizes.js
@@ -102,6 +102,21 @@ export const DEFAULT_VIZ = 'bead';
 // and share one canonical start X so their vertical start-bars line up.
 export const SWARM_CLUSTER_WINDOW_MS = 3 * 60 * 1000;   // 3 minutes
 
+// Parse a started_at/completed_at value the same way the rest of the
+// visualizer does (utils/dateFormat.toDate): MySQL-format "YYYY-MM-DD HH:MM:SS"
+// is UTC-stored and must be given an explicit `Z`, otherwise `new Date(...)`
+// parses it in the browser's local tz — which silently disagrees with
+// positionFor/toLocaleDateString and skews relative deltas across DST
+// boundaries. Kept local to this module so timeSeriesSizes stays standalone
+// (no circular dep with the dateFormat utility).
+function parseStartedAtMs(value) {
+    if (!value) return NaN;
+    if (typeof value === 'string' && value.includes(' ') && !value.includes('T')) {
+        return new Date(value.replace(' ', 'T') + 'Z').getTime();
+    }
+    return new Date(value).getTime();
+}
+
 // Group sessions by proximity of started_at. Any two sessions whose starts are
 // within `thresholdMs` of each other belong to the same cluster (transitive).
 // Returns:
@@ -116,7 +131,7 @@ export function clusterSessionsByStartTime(sessions, thresholdMs = SWARM_CLUSTER
     const valid = [];
     for (const s of sessions) {
         if (!s || s.id == null || !s.started_at) continue;
-        const ms = new Date(s.started_at).getTime();
+        const ms = parseStartedAtMs(s.started_at);
         if (Number.isNaN(ms)) continue;
         valid.push({ id: String(s.id), startedAt: s.started_at, startMs: ms });
     }


### PR DESCRIPTION
## Summary
- merge(req #2398/#2399): reconcile swarmStartBarX docblock + close-gap tests
- fix(swarm-viz): start-tick bar at startPct for aligned clusters (req #2398)
- chore: init swarm session feature/2398-visualizer-loses-track-of-starting-1

## Files changed
```
 src/CalendarFC/TimeSeriesView.jsx                |  33 ++--
 src/CalendarFC/__tests__/timeSeriesSizes.test.js | 195 +++++++++++++++++++----
 src/CalendarFC/timeSeriesSizes.js                |  17 +-
 3 files changed, 200 insertions(+), 45 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)