### PR TITLE
Visualizer sets start bar time wrong

### DIFF
--- a/src/CalendarFC/TimeSeriesView.jsx
+++ b/src/CalendarFC/TimeSeriesView.jsx
@@ -82,23 +82,26 @@ const assignRows = (chips, minGapPct) => {
 //
 // Rules:
 //   • 'clamped'                 → null (tick skipped; horizontal dashed line conveys it).
-//   • 'left'                    → one gap left of bubble center.
-//   • 'normal', gap ≥ threshold → at startPct (aligns vertically with cluster-mates
-//                                  in req #2341).
-//   • 'normal', gap <  threshold → one gap left of bubble center (req #2336 —
-//                                   when start ≈ met, the SVG tick at startPct
-//                                   lands under the bubble's z-index and disappears).
+//   • 'left'                    → one gap left of bubble center (no duration line
+//                                  is drawn in this mode — the bar IS the visual).
+//   • 'normal', startPct valid  → at startPct. A duration line is drawn from
+//                                  startPct to the bubble; the bar MUST coincide
+//                                  with the line's left end or the visualization
+//                                  lies (req #2399: bar was incorrectly bubble-
+//                                  hugged when aligned-cluster gap was < 1.5%,
+//                                  leaving the duration line dangling past it).
+//                                  The non-aligned close-start case is handled
+//                                  upstream in drawChips by switching markerMode
+//                                  to 'left', so this branch never needs a
+//                                  bubble-hug fallback of its own.
 //   • 'normal', startPct null    → null (no session start to mark).
 //   • unknown markerMode         → null.
 // Exported for unit-test coverage.
-export const swarmStartBarX = (markerMode, leftPct, startPct, gapPx, closeThresholdPct) => {
+export const swarmStartBarX = (markerMode, leftPct, startPct, gapPx) => {
     if (markerMode === 'clamped') return null;
     if (markerMode === 'left') return `calc(${leftPct}% - ${gapPx}px)`;
     if (markerMode === 'normal' && startPct !== null && startPct !== undefined) {
-        const gapPct = leftPct - startPct;
-        return gapPct < closeThresholdPct
-            ? `calc(${leftPct}% - ${gapPx}px)`
-            : `${startPct}%`;
+        return `${startPct}%`;
     }
     return null;
 };
@@ -596,17 +599,19 @@ const BeadRow = ({
                         );
                     })}
                     {/* Vertical start bar — position depends on markerMode:
-                        'normal'  → at startPct (OR left-of-bubble when start ≈ met, so
-                                    aligned-cluster close-met bars don't hide behind their
-                                    own bubble — req #2336)
-                        'left'    → immediately left of bubble (no session OR start ≈ met)
+                        'normal'  → at startPct (coincides with the left end of the
+                                    duration line; req #2399 retired the close-gap
+                                    bubble-hug shortcut that dangled the line past
+                                    the bar for aligned-cluster members)
+                        'left'    → immediately left of bubble (no session OR start ≈ met
+                                    on a non-aligned chip — no duration line drawn)
                         'clamped' → skipped (horizontal dashed line already conveys it) */}
                     {placed.map(chip => {
                         const halfBar = Math.max(6, circleDiameter / 2);
                         const y1 = `calc(100% - ${chip.row * rowSpacing + bubbleOffset + circleDiameter / 2 - halfBar}px)`;
                         const y2 = `calc(100% - ${chip.row * rowSpacing + bubbleOffset + circleDiameter / 2 + halfBar}px)`;
                         const gap = circleDiameter / 2 + 3;
-                        const x = swarmStartBarX(chip.markerMode, chip.leftPct, chip.startPct, gap, CLOSE_THRESHOLD_PCT);
+                        const x = swarmStartBarX(chip.markerMode, chip.leftPct, chip.startPct, gap);
                         if (x === null) return null;
                         return (
                             <line

--- a/src/CalendarFC/__tests__/timeSeriesSizes.test.js
+++ b/src/CalendarFC/__tests__/timeSeriesSizes.test.js
@@ -387,85 +387,99 @@ describe('clusterSessionsByStartTime', () => {
 // Row 0 = earliest met = bottom; higher rows = later met = top. ─────────────────
 import { assignSwarmLanes, weekDates, centeredDateRange, swarmStartBarX } from '../TimeSeriesView';
 
-// ─── swarmStartBarX — vertical start-tick x-coordinate selector (req #2336) ───
+// ─── swarmStartBarX — vertical start-tick x-coordinate selector ──────────────
+// Contract (simplified by req #2399):
+//   'normal' always returns startPct when startPct is valid. A duration line
+//   is drawn from startPct to the bubble in 'normal' mode, so the bar MUST
+//   coincide with the line's left end. The close-gap bubble-hug shortcut
+//   introduced by req #2336 was reachable ONLY for aligned-cluster chips
+//   (the !isAligned close-gap case already switches markerMode to 'left'
+//   upstream in drawChips), and for those chips it lied about where the
+//   session started — dangling the duration line past the bar.
 describe('swarmStartBarX (vertical start-tick positioning)', () => {
     const GAP = 9;          // circleDiameter=12 → gap = 12/2 + 3 = 9
-    const THRESHOLD = 1.5;  // CLOSE_THRESHOLD_PCT
 
     describe('markerMode=clamped', () => {
         it('returns null (horizontal dashed line already conveys start)', () => {
-            expect(swarmStartBarX('clamped', 50, 0, GAP, THRESHOLD)).toBeNull();
-            expect(swarmStartBarX('clamped', 50, null, GAP, THRESHOLD)).toBeNull();
+            expect(swarmStartBarX('clamped', 50, 0, GAP)).toBeNull();
+            expect(swarmStartBarX('clamped', 50, null, GAP)).toBeNull();
         });
     });
 
     describe('markerMode=left', () => {
         it('always renders one gap left of the bubble', () => {
-            expect(swarmStartBarX('left', 50, null, GAP, THRESHOLD)).toBe('calc(50% - 9px)');
-            expect(swarmStartBarX('left', 25, 24.5, GAP, THRESHOLD)).toBe('calc(25% - 9px)');
+            expect(swarmStartBarX('left', 50, null, GAP)).toBe('calc(50% - 9px)');
+            expect(swarmStartBarX('left', 25, 24.5, GAP)).toBe('calc(25% - 9px)');
         });
     });
 
-    describe('markerMode=normal, distant start (gap ≥ threshold)', () => {
-        it('renders at startPct so cluster-mates align vertically (req #2341)', () => {
-            // Gap = 50 - 40 = 10%, well above 1.5% threshold → align at startPct.
-            expect(swarmStartBarX('normal', 50, 40, GAP, THRESHOLD)).toBe('40%');
+    describe('markerMode=normal', () => {
+        it('renders at startPct for a distant start (cluster alignment, req #2341)', () => {
+            // Gap = 50 - 40 = 10% — obviously well clear of the bubble.
+            expect(swarmStartBarX('normal', 50, 40, GAP)).toBe('40%');
         });
 
-        it('renders at startPct right at threshold', () => {
-            // Gap = 50 - 48.5 = 1.5%, NOT less than threshold → at startPct.
-            expect(swarmStartBarX('normal', 50, 48.5, GAP, THRESHOLD)).toBe('48.5%');
-        });
-    });
-
-    describe('markerMode=normal, close start (gap < threshold) — req #2336 fix', () => {
-        it('shifts bar left of bubble when start ≈ met (prevents hidden-under-bubble)', () => {
-            // Gap = 50 - 49 = 1%, below 1.5% threshold. Pre-fix: bar at 49% lands
-            // under the bubble at 50% (bubble spans 50% ± 6px). Post-fix: bar
-            // shifted to leftPct - gap so it's visible.
-            expect(swarmStartBarX('normal', 50, 49, GAP, THRESHOLD)).toBe('calc(50% - 9px)');
+        it('renders at startPct right at the old 1.5% boundary', () => {
+            // Gap = 1.5%. Same answer as anywhere else now that the close-gap
+            // bubble-hug shortcut is gone.
+            expect(swarmStartBarX('normal', 50, 48.5, GAP)).toBe('48.5%');
         });
 
-        it('shifts bar left of bubble even when startPct === leftPct exactly', () => {
-            // Gap = 0, fully below threshold. Bar must shift or disappears.
-            expect(swarmStartBarX('normal', 30, 30, GAP, THRESHOLD)).toBe('calc(30% - 9px)');
+        it('renders at startPct for an aligned-cluster close-gap chip (req #2399 fix)', () => {
+            // The reqs 2330/2336/2381 reproducer: three swarm sessions started
+            // within 7 s of each other on 2026-04-20 (single cluster → every
+            // chip has isAligned=true). In Day view (baseHours=36) their
+            // start→met gaps landed at 1.01%, 1.37%, and 1.45% — all below
+            // the old 1.5% CLOSE_THRESHOLD_PCT. Pre-fix the bar was shoved
+            // to leftPct - gap (bubble-hug) while the duration line continued
+            // to extend from startPct to the bubble — producing a visible
+            // line to the RIGHT of the supposed "start" bar. Post-fix the
+            // bar coincides with the line's left end.
+            expect(swarmStartBarX('normal', 50, 48.99, GAP)).toBe('48.99%');   // gap 1.01%
+            expect(swarmStartBarX('normal', 50, 48.63, GAP)).toBe('48.63%');   // gap 1.37%
+            expect(swarmStartBarX('normal', 50, 48.55, GAP)).toBe('48.55%');   // gap 1.45%
         });
 
-        it('applies to aligned-cluster chips (req #2341 markerMode="normal" forced at tiny gap)', () => {
-            // An aligned-cluster member with start ≈ met is kept as 'normal' so
-            // it aligns vertically with its distant-start cluster-mates. Without
-            // the req #2336 fix, its bar at startPct lands inside its own bubble
-            // and disappears — leaving the other cluster members' bars visible
-            // but this one apparently "gone".
-            expect(swarmStartBarX('normal', 65, 64.2, GAP, THRESHOLD)).toBe('calc(65% - 9px)');
+        it('renders at startPct even when startPct === leftPct exactly', () => {
+            // Zero-gap 'normal' only happens for aligned-cluster chips whose
+            // canonical start == their own met time (rare, but possible at
+            // coarse time resolution). Bar at startPct is the honest answer;
+            // if it overlaps the bubble, the cluster-mates' bars at the same
+            // X still convey the alignment.
+            expect(swarmStartBarX('normal', 30, 30, GAP)).toBe('30%');
+        });
+
+        it('renders at startPct for an aligned-cluster tiny-gap chip (pre-#2399 regression)', () => {
+            // Gap = 0.8% — was the req #2336 "bar hides under bubble" case.
+            // Req #2399 accepts that tradeoff: the duration line + cluster-
+            // mate alignment are more important than eliminating every case
+            // where a thin bar partially overlaps a small bubble.
+            expect(swarmStartBarX('normal', 65, 64.2, GAP)).toBe('64.2%');
         });
     });
 
     describe('markerMode=normal with null startPct', () => {
         it('returns null (no session start to mark)', () => {
-            expect(swarmStartBarX('normal', 50, null, GAP, THRESHOLD)).toBeNull();
-            expect(swarmStartBarX('normal', 50, undefined, GAP, THRESHOLD)).toBeNull();
+            expect(swarmStartBarX('normal', 50, null, GAP)).toBeNull();
+            expect(swarmStartBarX('normal', 50, undefined, GAP)).toBeNull();
         });
     });
 
     describe('unknown markerMode', () => {
         it('returns null', () => {
-            expect(swarmStartBarX(undefined, 50, 40, GAP, THRESHOLD)).toBeNull();
-            expect(swarmStartBarX('', 50, 40, GAP, THRESHOLD)).toBeNull();
-            expect(swarmStartBarX('bogus', 50, 40, GAP, THRESHOLD)).toBeNull();
+            expect(swarmStartBarX(undefined, 50, 40, GAP)).toBeNull();
+            expect(swarmStartBarX('', 50, 40, GAP)).toBeNull();
+            expect(swarmStartBarX('bogus', 50, 40, GAP)).toBeNull();
         });
     });
 
     it('deterministic across repeated calls (no hidden state)', () => {
-        // Regression guard — bug #2336 was perceived as "toggle causes
-        // indicators to disappear". The selector must return identical
-        // results no matter how many times it's called.
-        const a = swarmStartBarX('normal', 50, 49, GAP, THRESHOLD);
-        const b = swarmStartBarX('normal', 50, 49, GAP, THRESHOLD);
-        const c = swarmStartBarX('normal', 50, 49, GAP, THRESHOLD);
+        const a = swarmStartBarX('normal', 50, 49, GAP);
+        const b = swarmStartBarX('normal', 50, 49, GAP);
+        const c = swarmStartBarX('normal', 50, 49, GAP);
         expect(a).toBe(b);
         expect(b).toBe(c);
-        expect(a).toBe('calc(50% - 9px)');
+        expect(a).toBe('49%');
     });
 });
 


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-04-21T11:41:43Z
- chore: init swarm session feature/2399-visualizer-sets-start-bar-time-1

## Files changed
```
 src/CalendarFC/TimeSeriesView.jsx                | 37 +++++----
 src/CalendarFC/__tests__/timeSeriesSizes.test.js | 98 ++++++++++++++----------
 2 files changed, 77 insertions(+), 58 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)