### PR TITLE
Sidewalk renders all requirements from bottom up again

### DIFF
--- a/src/CalendarFC/TimeSeriesView.jsx
+++ b/src/CalendarFC/TimeSeriesView.jsx
@@ -50,14 +50,23 @@ export const countChipsForDate = (requirements, sessions, date, timezone, vizKey
 // ─────────── Cluster-stack layout (Bead mode) ─────────────────────────────────
 // Chips sorted by leftPct. If a chip is within minGapPct of the previous chip,
 // it extends the stack upward; otherwise a new stack begins at row 0.
+//
+// `topDown` reverses the walk direction (descending leftPct). Sidewalk mode uses
+// this so the latest chip in a cluster gets row 0 — the row rendered closest to
+// the wire (which is at the TOP of a sidewalk panel). Cluster-gap detection uses
+// |Δ leftPct| so the direction of traversal doesn't change what counts as a
+// cluster. Exported for unit-test coverage.
 const MAX_ROWS = 24;
-const assignRows = (chips, minGapPct) => {
-    const sorted = [...chips].sort((a, b) => a.leftPct - b.leftPct);
+export const assignRows = (chips, minGapPct, topDown = false) => {
+    const sorted = [...chips].sort((a, b) =>
+        topDown ? b.leftPct - a.leftPct : a.leftPct - b.leftPct
+    );
     const out = [];
     let stackRow = -1;
-    let lastPct = -Infinity;
+    let lastPct = null;
     for (const chip of sorted) {
-        const isCluster = chip.leftPct - lastPct < minGapPct;
+        const isCluster = lastPct !== null
+            && Math.abs(chip.leftPct - lastPct) < minGapPct;
         if (isCluster) {
             const nextRow = stackRow + 1;
             if (nextRow < MAX_ROWS) {
@@ -105,16 +114,21 @@ export const swarmStartBarX = (markerMode, leftPct, startPct, gapPx, closeThresh
 
 // ─────────── Swarm-lane layout (Swarm mode) ───────────────────────────────────
 // Each (requirement, session) pair — or bare requirement with no session — gets
-// its own row. Sorted by completed_at ascending so row 0 = earliest (bottom) and
-// the highest row = latest (top). Long-running swarms bubble toward the top.
+// its own row. Sorted by completed_at so row 0 is the chip rendered closest to
+// the wire:
+//   topDown=false (Day / Week) — ascending: row 0 = earliest (wire is at bottom).
+//   topDown=true  (Sidewalk)   — descending: row 0 = latest   (wire is at top).
+// Long-running swarms bubble away from the wire regardless of direction.
 // Exported for unit-test coverage.
-export const assignSwarmLanes = (chips) => {
+export const assignSwarmLanes = (chips, topDown = false) => {
     const sorted = [...chips].sort((a, b) => {
         const aT = a.completed_at ? new Date(a.completed_at).getTime() : 0;
         const bT = b.completed_at ? new Date(b.completed_at).getTime() : 0;
-        if (aT !== bT) return aT - bT;
-        // tiebreak: stable by chipKey / id for deterministic ordering
-        return String(a.chipKey || a.id).localeCompare(String(b.chipKey || b.id));
+        if (aT !== bT) return topDown ? bT - aT : aT - bT;
+        // tiebreak: stable by chipKey / id for deterministic ordering, mirroring
+        // the primary sort direction so ties flow the same way as the time sort.
+        const key = String(a.chipKey || a.id).localeCompare(String(b.chipKey || b.id));
+        return topDown ? -key : key;
     });
     return sorted.map((chip, idx) => ({ ...chip, row: idx }));
 };
@@ -298,14 +312,15 @@ const BeadRow = ({
     // Layout constants:
     //   Day view     — roomy; bubble sits above the wire/X-axis with clearance.
     //   Week view    — compressed so 7 rows fit.
-    //   Sidewalk     — top-down flow: date + x-axis at top, bubbles stream down.
-    // bubbleOffset is the CSS bottom for row 0 in bottom-up layouts. For the
-    // top-down sidewalk layout we use topHeader instead (pixels from TOP).
+    //   Sidewalk     — top-down flow: wire/timeline pinned at top, bubbles stream
+    //                  down from there with the LATEST chip at row 0 just below
+    //                  the wire.
+    // bubbleOffset is the CSS bottom for row 0 in the bottom-anchored layouts
+    // (Day / Week). Sidewalk uses top-anchored positioning (see bubbleYCss
+    // below) so its bubbleOffset is the bottom-padding of the panel instead —
+    // kept only so the height formula below still computes a sane lower bound.
     const LAYOUT_DAY      = { bubbleOffset: 86, baseHeight: 172 };
     const LAYOUT_WEEK     = { bubbleOffset: 68, baseHeight: 116 };
-    // Sidewalk: chrome (date + time axis) pinned at the top; bubbles stack
-    // bottom-up below it. Panel height grows to fit the stack — no false
-    // bottom, so days with many bubbles don't overflow the chrome.
     const LAYOUT_SIDEWALK = { bubbleOffset: 20, baseHeight: sidewalkHeight || 400 };
     const { bubbleOffset, baseHeight } =
         sidewalkPanel ? LAYOUT_SIDEWALK
@@ -413,7 +428,15 @@ const BeadRow = ({
         canonicalStartById, clusterSizeById]);
 
     // Placement: cluster-stack for Bead, swarm-lane for Swarm.
-    const placed = vizKey === 'swarm' ? assignSwarmLanes(drawChips) : assignRows(drawChips, 1.2);
+    //
+    // In Sidewalk the wire is at the TOP of the panel, so row 0 — the row
+    // rendered closest to the wire — must hold the LATEST chip. Thread
+    // `topDown = sidewalkPanel` through both assigners so they emit rows in
+    // the direction the layout below wants.
+    const topDown = sidewalkPanel;
+    const placed = vizKey === 'swarm'
+        ? assignSwarmLanes(drawChips, topDown)
+        : assignRows(drawChips, 1.2, topDown);
     const maxStackRow = placed.length ? Math.max(...placed.map(c => c.row)) : 0;
 
     // Space multiplier (Day view only — Week stays tight so 7 rows still fit).
@@ -422,24 +445,29 @@ const BeadRow = ({
 
     // Vertical height — must clear the top chrome by at least half a bubble so
     // the tallest bubble never crowds the date / time-axis header. Same formula
-    // for every layout; only the chrome-bottom offset changes:
+    // for every layout; only the chrome offset changes:
     //   Day      → 46 (date band at top 26 + height 20)
     //   Week     → 26 (no date chrome above the row)
     //   Sidewalk → 80 (wire at CSS top: 68 after whitespace expansion for
-    //                   req #2331/#2364, plus breathing room before bubbles).
+    //                   req #2331/#2364, plus ~12px breathing room before row 0).
     // Panel uniformity in the Sidewalk strip is handled by the parent, which
     // passes a precomputed `sidewalkHeight` sized to the busiest day's lanes.
-    const chromeBottom  = sidewalkPanel ? 80 : (isWeekView ? 26 : 46);
+    const chromeOffset  = sidewalkPanel ? 80 : (isWeekView ? 26 : 46);
     const dateClearance = Math.ceil(circleDiameter / 2) + 4;
     const height = Math.max(baseHeight,
                             maxStackRow * rowSpacing + bubbleOffset + circleDiameter
-                            + chromeBottom + dateClearance);
+                            + chromeOffset + dateClearance);
 
-    // Unified bottom-anchored bubble positioning — earliest met (row 0) always at
-    // the bottom, latest at the top, in Day/Week and Sidewalk alike.
-    const bubbleYCss      = (row) => ({ bottom: `${row * rowSpacing + bubbleOffset}px` });
-    const bubbleCenterCss = (row) =>
-        `calc(100% - ${row * rowSpacing + bubbleOffset + circleDiameter / 2}px)`;
+    // Bubble positioning — top-anchored in Sidewalk (wire at top, row 0 = latest
+    // right below it) and bottom-anchored in Day/Week (wire at bottom, row 0 =
+    // earliest right above it). Either way row 0 renders closest to the wire;
+    // the row-assignment direction above decides which chip lands there.
+    const bubbleYCss      = sidewalkPanel
+        ? (row) => ({ top:    `${chromeOffset + row * rowSpacing}px` })
+        : (row) => ({ bottom: `${bubbleOffset + row * rowSpacing}px` });
+    const bubbleCenterCss = sidewalkPanel
+        ? (row) => `${chromeOffset + row * rowSpacing + circleDiameter / 2}px`
+        : (row) => `calc(100% - ${row * rowSpacing + bubbleOffset + circleDiameter / 2}px)`;
 
     const nowPct = useMemo(() => {
         const now = new Date().toISOString();
@@ -603,8 +631,18 @@ const BeadRow = ({
                         'clamped' → skipped (horizontal dashed line already conveys it) */}
                     {placed.map(chip => {
                         const halfBar = Math.max(6, circleDiameter / 2);
-                        const y1 = `calc(100% - ${chip.row * rowSpacing + bubbleOffset + circleDiameter / 2 - halfBar}px)`;
-                        const y2 = `calc(100% - ${chip.row * rowSpacing + bubbleOffset + circleDiameter / 2 + halfBar}px)`;
+                        // Bar endpoints are bubble-center ± halfBar. The center
+                        // is already expressed in the active anchoring by
+                        // bubbleCenterCss — top-anchored `${N}px` for sidewalk,
+                        // `calc(100% - ${N}px)` for Day/Week — so the bar
+                        // follows row 0 to whichever edge the wire is on.
+                        const yStride = chip.row * rowSpacing + circleDiameter / 2;
+                        const y1 = sidewalkPanel
+                            ? `${chromeOffset + yStride - halfBar}px`
+                            : `calc(100% - ${bubbleOffset + yStride - halfBar}px)`;
+                        const y2 = sidewalkPanel
+                            ? `${chromeOffset + yStride + halfBar}px`
+                            : `calc(100% - ${bubbleOffset + yStride + halfBar}px)`;
                         const gap = circleDiameter / 2 + 3;
                         const x = swarmStartBarX(chip.markerMode, chip.leftPct, chip.startPct, gap, CLOSE_THRESHOLD_PCT);
                         if (x === null) return null;
@@ -724,14 +762,14 @@ const Sidewalk = ({ centerDate, onCenterDateChange, ...rowProps }) => {
 
     // Uniform panel height — sized to the busiest day in the visible strip so
     // every panel shows all its lanes below the top chrome. Mirrors BeadRow's
-    // height formula (sidewalk branch: chromeBottom=50, bubbleOffset=20).
+    // height formula (sidewalk branch: chromeOffset=80, bubbleOffset=20).
     // Single-pass bucket via indexChipsByDate so 21-day strips stay O(R+S+D)
     // instead of O(D × (R+S)) — matters during scroll, when requirements
     // refetches churn this memo.
     const sidewalkHeight = useMemo(() => {
         const BASE_HEIGHT   = 400;
         const bubbleOffset  = 20;
-        const chromeBottom  = 80;   // matches BeadRow's sidewalk chromeBottom (wire top:68 + padding)
+        const chromeOffset  = 80;   // matches BeadRow's sidewalk chromeOffset (wire top:68 + padding)
         const dateClearance = Math.ceil(circleDiameter / 2) + 4;
         const spaceMul      = getSpaceMultiplier(spaceKey);
         const rowSpacing    = Math.max(16, Math.round((circleDiameter + 4) * spaceMul));
@@ -744,7 +782,7 @@ const Sidewalk = ({ centerDate, onCenterDateChange, ...rowProps }) => {
         const maxStackRow = Math.max(0, maxChips - 1);
         return Math.max(
             BASE_HEIGHT,
-            maxStackRow * rowSpacing + bubbleOffset + circleDiameter + chromeBottom + dateClearance,
+            maxStackRow * rowSpacing + bubbleOffset + circleDiameter + chromeOffset + dateClearance,
         );
     }, [dates, requirements, sessions, timezone, vizKey, circleDiameter, spaceKey]);
 

--- a/src/CalendarFC/__tests__/timeSeriesSizes.test.js
+++ b/src/CalendarFC/__tests__/timeSeriesSizes.test.js
@@ -384,8 +384,10 @@ describe('clusterSessionsByStartTime', () => {
 });
 
 // ─── assignSwarmLanes: each chip gets its own row, sorted by completed_at asc.
-// Row 0 = earliest met = bottom; higher rows = later met = top. ─────────────────
-import { assignSwarmLanes, weekDates, centeredDateRange, swarmStartBarX } from '../TimeSeriesView';
+// Row 0 = earliest met = bottom; higher rows = later met = top.
+// topDown=true reverses the order so the latest gets row 0 (Sidewalk mode —
+// wire sits at the top of the panel, so row 0 renders closest to it). ──────────
+import { assignSwarmLanes, assignRows, weekDates, centeredDateRange, swarmStartBarX } from '../TimeSeriesView';
 
 // ─── swarmStartBarX — vertical start-tick x-coordinate selector (req #2336) ───
 describe('swarmStartBarX (vertical start-tick positioning)', () => {
@@ -517,6 +519,152 @@ describe('assignSwarmLanes (Swarm Visualizer lane order)', () => {
         expect(new Set(rows).size).toBe(10);
         expect(Math.min(...rows)).toBe(0);
         expect(Math.max(...rows)).toBe(9);
+    });
+
+    // ─── topDown=true (req #2400 — Sidewalk) ───────────────────────────────
+    // Sidewalk renders the wire at the TOP of each panel. Row 0 is the row
+    // closest to the wire, so it must hold the LATEST chip. Assigner emits
+    // rows descending by completed_at.
+    describe('topDown=true (Sidewalk — latest = row 0)', () => {
+        it('orders chips by completed_at descending so row 0 = latest', () => {
+            const input = [
+                mk('a', '2026-04-17 09:00:00'),
+                mk('c', '2026-04-17 18:00:00'),
+                mk('b', '2026-04-17 12:00:00'),
+            ];
+            const out = assignSwarmLanes(input, true);
+            // c (18:00) is latest → row 0; a (09:00) is earliest → row 2
+            expect(out.map(c => c.chipKey)).toEqual(['c', 'b', 'a']);
+            expect(out.map(c => c.row)).toEqual([0, 1, 2]);
+        });
+
+        it('ties broken deterministically by chipKey in reverse', () => {
+            const input = [
+                mk('a', '2026-04-17 10:00:00'),
+                mk('m', '2026-04-17 10:00:00'),
+                mk('z', '2026-04-17 10:00:00'),
+            ];
+            // When completed_at ties, topDown reverses the chipKey tie-break
+            // too so the overall ordering mirrors the primary sort direction.
+            expect(assignSwarmLanes(input, true).map(c => c.chipKey))
+                .toEqual(['z', 'm', 'a']);
+        });
+
+        it('missing completed_at lands at the BOTTOM of the stack (highest row)', () => {
+            const input = [
+                mk('withStamp', '2026-04-17 10:00:00'),
+                mk('blank', null),
+            ];
+            const out = assignSwarmLanes(input, true);
+            // Blank treated as epoch 0 → oldest → furthest from wire.
+            expect(out[0].chipKey).toBe('withStamp'); // row 0 (top, near wire)
+            expect(out[1].chipKey).toBe('blank');     // row 1 (bottom)
+        });
+
+        it('topDown=false (default) is unchanged', () => {
+            // Regression guard — Day/Week mode keeps ascending lanes.
+            const input = [
+                mk('c', '2026-04-17 18:00:00'),
+                mk('a', '2026-04-17 09:00:00'),
+            ];
+            expect(assignSwarmLanes(input).map(c => c.chipKey)).toEqual(['a', 'c']);
+            expect(assignSwarmLanes(input, false).map(c => c.chipKey)).toEqual(['a', 'c']);
+        });
+    });
+});
+
+// ─── assignRows: bead-mode cluster stack. Chips close in leftPct stack at
+// rows 0, 1, 2…; otherwise a new stack begins at row 0. topDown=true reverses
+// the walk direction so in a cluster the latest (highest leftPct) lands at
+// row 0 (closest to the wire in Sidewalk's top-anchored layout). ───────────────
+describe('assignRows (Bead cluster-stack)', () => {
+    const mk = (id, leftPct) => ({ id, leftPct });
+    const MIN_GAP = 1.2;
+
+    it('returns empty array for empty input', () => {
+        expect(assignRows([], MIN_GAP)).toEqual([]);
+    });
+
+    it('single chip → row 0, single-stack', () => {
+        expect(assignRows([mk('a', 50)], MIN_GAP)).toEqual([
+            expect.objectContaining({ id: 'a', row: 0 }),
+        ]);
+    });
+
+    it('chips far apart each start a fresh row-0 stack', () => {
+        const out = assignRows([mk('a', 10), mk('b', 40), mk('c', 70)], MIN_GAP);
+        expect(out.map(c => [c.id, c.row])).toEqual([
+            ['a', 0], ['b', 0], ['c', 0],
+        ]);
+    });
+
+    it('chips closer than minGapPct stack upward — first-in-cluster at row 0', () => {
+        // Default (topDown=false): ascending leftPct walk.
+        const out = assignRows(
+            [mk('a', 50), mk('b', 50.5), mk('c', 51.0), mk('d', 80)],
+            MIN_GAP,
+        );
+        expect(out.find(c => c.id === 'a').row).toBe(0);
+        expect(out.find(c => c.id === 'b').row).toBe(1);
+        expect(out.find(c => c.id === 'c').row).toBe(2);
+        expect(out.find(c => c.id === 'd').row).toBe(0); // new stack, far from c
+    });
+
+    it('topDown=true reverses the walk — latest-in-cluster at row 0', () => {
+        // Same input as above; topDown sorts descending by leftPct.
+        const out = assignRows(
+            [mk('a', 50), mk('b', 50.5), mk('c', 51.0), mk('d', 80)],
+            MIN_GAP,
+            true,
+        );
+        // d (80) is its own stack at row 0.
+        // Within the 50..51 cluster, c (51.0) is now first in the descending
+        // walk so gets row 0, then b (50.5) row 1, then a (50) row 2.
+        expect(out.find(c => c.id === 'd').row).toBe(0);
+        expect(out.find(c => c.id === 'c').row).toBe(0);
+        expect(out.find(c => c.id === 'b').row).toBe(1);
+        expect(out.find(c => c.id === 'a').row).toBe(2);
+    });
+
+    it('topDown cluster-gap detection uses |Δ leftPct| — cluster survives reversal', () => {
+        // A cluster that would be detected ascending MUST also be detected
+        // descending. Use gaps just under MIN_GAP (=1.2): [60, 61, 62].
+        const ascending = assignRows(
+            [mk('a', 60), mk('b', 61), mk('c', 62)],
+            MIN_GAP,
+        );
+        const descending = assignRows(
+            [mk('a', 60), mk('b', 61), mk('c', 62)],
+            MIN_GAP,
+            true,
+        );
+        // Ascending: a=0, b=1, c=2  (a starts stack, b/c extend).
+        // Descending: c=0, b=1, a=2 (c starts stack, b/a extend).
+        expect(ascending.find(c => c.id === 'a').row).toBe(0);
+        expect(ascending.find(c => c.id === 'c').row).toBe(2);
+        expect(descending.find(c => c.id === 'c').row).toBe(0);
+        expect(descending.find(c => c.id === 'a').row).toBe(2);
+    });
+
+    it('clamps stacks at MAX_ROWS (24) — 25+ clustered chips land at row 23', () => {
+        const chips = Array.from({ length: 26 }, (_, i) =>
+            mk(`r${i}`, 50 + i * 0.1)  // gaps of 0.1 well under 1.2 threshold
+        );
+        const out = assignRows(chips, MIN_GAP);
+        const maxRow = Math.max(...out.map(c => c.row));
+        expect(maxRow).toBe(23);
+    });
+
+    it('clamp at MAX_ROWS still applies when topDown=true', () => {
+        // Same oversize cluster, descending walk — the clamp is direction-
+        // independent but worth a regression guard so Sidewalk doesn't grow
+        // a 25-row panel by accident.
+        const chips = Array.from({ length: 26 }, (_, i) =>
+            mk(`r${i}`, 50 + i * 0.1)
+        );
+        const out = assignRows(chips, MIN_GAP, true);
+        const maxRow = Math.max(...out.map(c => c.row));
+        expect(maxRow).toBe(23);
     });
 });
 


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-04-23T18:24:51Z
- wip(Darwin): 2026-04-23T18:23:58Z
- chore: init swarm session feature/2400-sidewalk-renders-all-requirements-1

## Files changed
```
 src/CalendarFC/TimeSeriesView.jsx                | 102 ++++++++++-----
 src/CalendarFC/__tests__/timeSeriesSizes.test.js | 152 ++++++++++++++++++++++-
 2 files changed, 220 insertions(+), 34 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)