### PR TITLE
swarm session cleanup

### DIFF
--- a/src/SwarmView/SessionsView.jsx
+++ b/src/SwarmView/SessionsView.jsx
@@ -99,8 +99,6 @@ const getSessionColumns = (navigate, timezone) => [
                     data-testid={`session-launch-${params.row.id}`} />
             : '—',
     },
-    { field: 'task_name',    headerName: 'Task',        width: 200, flex: 1 },
-    { field: 'branch',       headerName: 'Branch',      width: 200 },
     {
         field: 'started_at',
         headerName: 'Started',

--- a/tests/tests/swarm.spec.ts
+++ b/tests/tests/swarm.spec.ts
@@ -183,8 +183,9 @@ test.describe('Swarm View', () => {
   test('SWM-20: /swarm/sessions DataGrid renders with test session', async ({ page }) => {
     await page.goto('/swarm/sessions');
     await expect(page.getByTestId('sessions-datagrid')).toBeVisible({ timeout: 10000 });
-    // The DataGrid should contain our test session's task_name (.first() for prior-run orphans)
-    await expect(page.getByText('e2e-test-task').first()).toBeVisible({ timeout: 10000 });
+    // The DataGrid should contain our test session's title (.first() for prior-run orphans)
+    // Req #2507 removed the Task and Branch columns; title is the surviving label column.
+    await expect(page.getByText('E2E Test Session').first()).toBeVisible({ timeout: 10000 });
   });
 
   test('SWM-22: SessionsView Source column shows issue link', async ({ page }) => {


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-05-07T07:25:56Z
- chore: init swarm session feature/2507-swarm-session-cleanup-1

## Files changed
```
 src/SwarmView/SessionsView.jsx | 2 --
 tests/tests/swarm.spec.ts      | 5 +++--
 2 files changed, 3 insertions(+), 4 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)