### PR TITLE
req #2566

### DIFF
--- a/src/CalendarFC/TimeSeriesView.css
+++ b/src/CalendarFC/TimeSeriesView.css
@@ -387,7 +387,16 @@ body.darwin-dark .ts-bead-day-count-inline {
    "Title" toggle is on. Absolutely positioned at the parent group's right edge
    so the bubble itself stays centered on leftPct regardless of label length.
    pointer-events: none keeps the bubble's click/hover responsive when the
-   label overflows the dot's hit area. */
+   label overflows the dot's hit area.
+
+   req #2566 — opaque background + small inset padding + rounded corners so
+   the dashed/solid swarm-line that passes under the label (cross-day full-
+   width middle-role lines, plus other chips' duration lines on the same row)
+   is hidden behind the title text. The chip's OWN duration line stops at its
+   bubble's left edge, so the lines that show through come from neighbors,
+   not from this chip itself. Label sits at z-index 2 over the SVG layer
+   (z-index 1); the solid background is what does the occlusion, not the
+   stacking order alone. */
 .ts-bead-label {
     position: absolute;
     left: 100%;
@@ -395,18 +404,22 @@ body.darwin-dark .ts-bead-day-count-inline {
     transform: translateY(-50%);
     margin-left: 6px;
     max-width: 440px;
+    padding: 1px 6px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     font-size: 0.74rem;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.78);
+    background: #ffffff;
+    border-radius: 4px;
     font-family: 'Roboto', sans-serif;
     pointer-events: none;
     z-index: 2;
 }
 body.darwin-dark .ts-bead-label {
     color: rgba(255, 255, 255, 0.85);
+    background: #141210;
 }
 
 /* Swarm Visualizer — SVG overlay for session-start → bubble lines */

--- a/tests/tests/swarm-visualizer.spec.ts
+++ b/tests/tests/swarm-visualizer.spec.ts
@@ -212,4 +212,42 @@ test.describe('Swarm Visualizer — Bead / Swarm / Sidewalk toolbar on /swarm', 
         await page.getByTestId('timeseries-data-coordination').click();
         await expect(page.getByTestId('timeseries-data-coordination')).toHaveAttribute('aria-pressed', 'true');
     });
+
+    // req #2566 — when the toolbar "Title" toggle is on, the title label sits
+    // to the right of the bubble. The dashed swarm-duration line passes
+    // through the bubble's vertical center, which is the same Y as the label.
+    // The label must paint an opaque background so the dashed line is hidden
+    // beneath the text (z-index alone isn't enough — the SVG line draws
+    // through any element with a transparent background).
+    test('TS-11: Title labels paint an opaque background that hides the dashed duration line (req #2566)', async ({ page }) => {
+        await page.goto('/swarm');
+        await page.evaluate((d) => {
+            localStorage.setItem('darwin_swarm_visualizer', JSON.stringify({
+                state: {
+                    viewType: 'day',
+                    currentDate: d,
+                    vizKey: 'bead',
+                    beadWindow: '24h',
+                    sidewalkOn: false,
+                    elevatorOn: false,
+                    dataKey: 'category',
+                    titlesOn: true,
+                },
+                version: 3,
+            }));
+            localStorage.setItem('darwin-swarm-view', 'visualizer');
+        }, testDate);
+        await page.reload();
+        await expect(page.getByTestId('ts-bead')).toBeVisible({ timeout: 10000 });
+
+        const id = createdRequirementIds[0];
+        const label = page.getByTestId(`ts-bead-label-${id}`);
+        await expect(label).toBeVisible({ timeout: 5000 });
+
+        const bg = await label.evaluate((el) => getComputedStyle(el).backgroundColor);
+        // Must be a real color (not the default `rgba(0, 0, 0, 0)` / `transparent`)
+        // so the dashed line behind the bubble is fully occluded.
+        expect(bg).not.toBe('rgba(0, 0, 0, 0)');
+        expect(bg).not.toBe('transparent');
+    });
 });


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2566-visualizer-title-overwrites-dashed-1
- req #2566: visualizer title labels paint opaque background to hide swarm-line
- chore: init swarm session feature/2566-visualizer-title-overwrites-dashed-1

## Files changed
```
 src/CalendarFC/TimeSeriesView.css    | 15 +++++++++++++-
 tests/tests/swarm-visualizer.spec.ts | 38 ++++++++++++++++++++++++++++++++++++
 2 files changed, 52 insertions(+), 1 deletion(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)