### PR TITLE
put a branch type selector like how we do status chips

### DIFF
--- a/src/BuildVisualizer/BuildPatternToolbar.jsx
+++ b/src/BuildVisualizer/BuildPatternToolbar.jsx
@@ -1,10 +1,12 @@
 import { useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -13,10 +15,11 @@ import DialogActions from '@mui/material/DialogActions';
 import TextField from '@mui/material/TextField';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
+import { BRANCH_TYPES, branchTypeChipProps, branchTypeLabel } from './branchTypeChipStyles';
 
 const today = () => new Date().toISOString().slice(0, 10);
 
-const BuildPatternToolbar = ({ lib }) => {
+const BuildPatternToolbar = ({ lib, selectedTypes, onToggleType }) => {
     const fileInputRef = useRef(null);
     const [saveAsOpen, setSaveAsOpen] = useState(false);
     const [saveAsName, setSaveAsName] = useState('');
@@ -141,6 +144,36 @@ const BuildPatternToolbar = ({ lib }) => {
             >
                 Delete
             </Button>
+            <Box sx={{ flex: 1 }} />
+            {selectedTypes && onToggleType && (
+                <Stack
+                    direction="row"
+                    spacing={0.5}
+                    flexWrap="wrap"
+                    useFlexGap
+                    data-testid="branch-type-filter"
+                >
+                    {BRANCH_TYPES.map(type => {
+                        const selected = selectedTypes.includes(type);
+                        const chipProps = branchTypeChipProps(type);
+                        return (
+                            <Chip
+                                key={type}
+                                label={branchTypeLabel(type)}
+                                size="small"
+                                onClick={() => onToggleType(type)}
+                                {...(selected ? chipProps : { variant: 'outlined' })}
+                                sx={{
+                                    ...(selected ? chipProps.sx : {}),
+                                    ...(!selected && { opacity: 0.5 }),
+                                    cursor: 'pointer',
+                                }}
+                                data-testid={`branch-type-chip-${type}`}
+                            />
+                        );
+                    })}
+                </Stack>
+            )}
             <Box sx={{ flex: 1 }} />
             <Button size="small" onClick={handleExport} data-testid="bv-export">Export</Button>
             <Button size="small" onClick={handleImportClick} data-testid="bv-import">Import</Button>

--- a/src/BuildVisualizer/BuildVisualizerPage.jsx
+++ b/src/BuildVisualizer/BuildVisualizerPage.jsx
@@ -1,19 +1,45 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import BuildPatternToolbar from './BuildPatternToolbar';
 import { usePatternLibrary } from './usePatternLibrary';
+import { BRANCH_TYPES } from './branchTypeChipStyles';
 
 const BuildVisualizerPage = () => {
     const iframeRef = useRef(null);
     const iframeReady = useRef(false);
     const prevActiveIdRef = useRef(null);
     const lib = usePatternLibrary();
+    // All branch types start selected — deselecting hides that type (and any
+    // descendants rooted on it) in the iframe renderer.
+    const [selectedTypes, setSelectedTypes] = useState(() => [...BRANCH_TYPES]);
+    // Mirror selectedTypes into a ref so the bv:ready handler can read the
+    // latest value without forcing the message-listener effect to re-register
+    // on every chip toggle.
+    const selectedTypesRef = useRef(selectedTypes);
+    useEffect(() => { selectedTypesRef.current = selectedTypes; }, [selectedTypes]);
+
+    const toggleType = useCallback((type) => {
+        setSelectedTypes(prev =>
+            prev.includes(type) ? prev.filter(t => t !== type) : [...prev, type]
+        );
+    }, []);
 
     const postLoad = useCallback((data) => {
         const win = iframeRef.current?.contentWindow;
         if (!win || !data) return;
         win.postMessage({ type: 'bv:load', data }, window.location.origin);
+    }, []);
+
+    const postFilter = useCallback((selected) => {
+        const win = iframeRef.current?.contentWindow;
+        if (!win) return;
+        // Send the deselected types — the iframe hides ONLY the types listed
+        // here, leaving any branch type not in the chip rail visible by
+        // default. Keeps the iframe robust to REGISTRY entries added without
+        // a corresponding chip.
+        const hidden = BRANCH_TYPES.filter(t => !selected.includes(t));
+        win.postMessage({ type: 'bv:filter', hidden }, window.location.origin);
     }, []);
 
     useEffect(() => {
@@ -27,6 +53,7 @@ const BuildVisualizerPage = () => {
                     prevActiveIdRef.current = lib.activeId;
                     postLoad(lib.activePattern.data);
                 }
+                postFilter(selectedTypesRef.current);
             } else if (msg.type === 'bv:changed') {
                 if (msg.data && typeof msg.data === 'object') {
                     lib.saveActiveData(msg.data);
@@ -35,7 +62,14 @@ const BuildVisualizerPage = () => {
         };
         window.addEventListener('message', onMessage);
         return () => window.removeEventListener('message', onMessage);
-    }, [lib, postLoad]);
+    }, [lib, postLoad, postFilter]);
+
+    // Push filter to iframe on every chip toggle (no-op until iframe is ready —
+    // the bv:ready handler covers the initial post once the iframe boots).
+    useEffect(() => {
+        if (!iframeReady.current) return;
+        postFilter(selectedTypes);
+    }, [selectedTypes, postFilter]);
 
     // Push the active pattern into the iframe ONLY when the user switches to
     // a different pattern. Data-within-active-pattern saves originate from the
@@ -59,7 +93,11 @@ const BuildVisualizerPage = () => {
                 overflow: 'hidden',
             }}
         >
-            <BuildPatternToolbar lib={lib} />
+            <BuildPatternToolbar
+                lib={lib}
+                selectedTypes={selectedTypes}
+                onToggleType={toggleType}
+            />
             {lib.isReady ? (
                 <iframe
                     ref={iframeRef}

--- a/src/BuildVisualizer/__tests__/branchTypeChipStyles.test.js
+++ b/src/BuildVisualizer/__tests__/branchTypeChipStyles.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+    BRANCH_TYPES,
+    branchTypeChipProps,
+    branchTypeLabel,
+} from '../branchTypeChipStyles';
+
+describe('BRANCH_TYPES', () => {
+    it('lists the six non-main branch types in REGISTRY (Topology/build-visualizer/app.js)', () => {
+        expect(BRANCH_TYPES).toEqual([
+            'release',
+            'sample-release',
+            'hotfix',
+            'bootleg',
+            'csr',
+            'development',
+        ]);
+    });
+    it('has no duplicates', () => {
+        expect(new Set(BRANCH_TYPES).size).toBe(BRANCH_TYPES.length);
+    });
+    it('does not include "main" — main is always visible and not a chip', () => {
+        expect(BRANCH_TYPES).not.toContain('main');
+    });
+});
+
+describe('branchTypeChipProps', () => {
+    it.each(BRANCH_TYPES)('returns a coloured sx for type %s', (type) => {
+        const props = branchTypeChipProps(type);
+        expect(props.sx).toBeDefined();
+        expect(props.sx.bgcolor).toMatch(/^#[0-9a-f]{6}$/i);
+        expect(props.sx.color).toMatch(/^#[0-9a-f]{3}$/i);
+    });
+    it('returns a default fallback for unknown types', () => {
+        expect(branchTypeChipProps('not-a-type')).toEqual({ color: 'default' });
+    });
+});
+
+describe('branchTypeLabel', () => {
+    it.each([
+        ['release',         'Release'],
+        ['sample-release',  'Sample Release'],
+        ['hotfix',          'Hot Fix'],
+        ['bootleg',         'Bootleg'],
+        ['csr',             'CSR'],
+        ['development',     'Development'],
+    ])('formats %s as %s', (type, expected) => {
+        expect(branchTypeLabel(type)).toBe(expected);
+    });
+    it('returns the raw type for unknown values', () => {
+        expect(branchTypeLabel('mystery')).toBe('mystery');
+    });
+});

--- a/src/BuildVisualizer/branchTypeChipStyles.js
+++ b/src/BuildVisualizer/branchTypeChipStyles.js
@@ -1,0 +1,41 @@
+// Shared styling + labeling for branch-type filter chips on the Build
+// Visualizer toolbar. Mirrors SwarmView/statusChipStyles.js so the two
+// chip rails feel like the same UI grammar.
+//
+// Order matters: the toolbar renders chips in BRANCH_TYPES order, which
+// matches the visual stacking of the diagram (above-main types first,
+// below-main last). Keep in sync with REGISTRY in
+// Topology/build-visualizer/app.js.
+
+export const BRANCH_TYPES = [
+    'release',
+    'sample-release',
+    'hotfix',
+    'bootleg',
+    'csr',
+    'development',
+];
+
+export const branchTypeChipProps = (type) => {
+    switch (type) {
+        case 'release':         return { sx: { bgcolor: '#2e7d32', color: '#fff' } };
+        case 'sample-release':  return { sx: { bgcolor: '#00897b', color: '#fff' } };
+        case 'hotfix':          return { sx: { bgcolor: '#d32f2f', color: '#fff' } };
+        case 'bootleg':         return { sx: { bgcolor: '#6d4c41', color: '#fff' } };
+        case 'csr':             return { sx: { bgcolor: '#1976d2', color: '#fff' } };
+        case 'development':     return { sx: { bgcolor: '#fbc02d', color: '#000' } };
+        default:                return { color: 'default' };
+    }
+};
+
+export const branchTypeLabel = (type) => {
+    switch (type) {
+        case 'release':         return 'Release';
+        case 'sample-release':  return 'Sample Release';
+        case 'hotfix':          return 'Hot Fix';
+        case 'bootleg':         return 'Bootleg';
+        case 'csr':             return 'CSR';
+        case 'development':     return 'Development';
+        default:                return type;
+    }
+};


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2599-put-a-branch-type-selector-like-how-1
- wip(2599): pre-merge save — Darwin chip rail
- chore: init swarm session feature/2599-put-a-branch-type-selector-like-how-1

## Files changed
```
 src/BuildVisualizer/BuildPatternToolbar.jsx        | 35 +++++++++++++-
 src/BuildVisualizer/BuildVisualizerPage.jsx        | 44 ++++++++++++++++--
 .../__tests__/branchTypeChipStyles.test.js         | 53 ++++++++++++++++++++++
 src/BuildVisualizer/branchTypeChipStyles.js        | 41 +++++++++++++++++
 4 files changed, 169 insertions(+), 4 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Related PRs (req #2599): https://github.com/BillWilliams79/DarwinAI-Config/pull/266 · https://github.com/BillWilliams79/Darwin/pull/551 · https://github.com/BillWilliams79/Topology/pull/41