### PR TITLE
Customer Release Events + SQL-backed Build Visualizer (follow-up to #2604)

### DIFF
--- a/src/BuildVisualizer/BuildVisualizerControls.jsx
+++ b/src/BuildVisualizer/BuildVisualizerControls.jsx
@@ -32,6 +32,14 @@ import {
 // theme is light the visualizer always renders light and the picker is hidden
 // — there's only one sensible color scheme to offer in that case. Dark mode
 // exposes the six dark variants.
+const RELEASE_STYLE_LABELS = {
+    1: 'Gold Star',
+    2: 'Halo',
+    3: 'Pennant',
+    4: 'Sunburst',
+    5: 'Chip Row',
+};
+
 const BuildVisualizerControls = ({
     lib,
     selectedTypes,
@@ -41,14 +49,23 @@ const BuildVisualizerControls = ({
     appMode,
     darkVariant,
     onChangeDarkVariant,
+    showReleases,
+    onToggleShowReleases,
+    releaseStyle,
+    onChangeReleaseStyle,
 }) => {
     const [snack, setSnack] = useState(null);
     const [themeAnchor, setThemeAnchor] = useState(null);
+    const [releaseStyleAnchor, setReleaseStyleAnchor] = useState(null);
     const showSnack = (severity, message) => setSnack({ severity, message });
     const closeSnack = () => setSnack(null);
 
     const staggerChipProps = staggerOn
         ? { sx: { bgcolor: 'text.primary', color: 'background.paper' } }
+        : { variant: 'outlined' };
+
+    const releasesChipProps = showReleases
+        ? { sx: { bgcolor: 'warning.main', color: 'background.paper' } }
         : { variant: 'outlined' };
 
     const showThemePicker = appMode === 'dark' && Boolean(onChangeDarkVariant);
@@ -57,6 +74,15 @@ const BuildVisualizerControls = ({
     const selectVariant = (variant) => {
         closeThemeMenu();
         if (variant !== darkVariant) onChangeDarkVariant?.(variant);
+    };
+
+    const showReleaseControls =
+        Boolean(onToggleShowReleases) && Boolean(onChangeReleaseStyle);
+    const openReleaseStyleMenu = (e) => setReleaseStyleAnchor(e.currentTarget);
+    const closeReleaseStyleMenu = () => setReleaseStyleAnchor(null);
+    const selectReleaseStyle = (v) => {
+        closeReleaseStyleMenu();
+        if (v !== releaseStyle) onChangeReleaseStyle?.(v);
     };
 
     return (
@@ -126,6 +152,62 @@ const BuildVisualizerControls = ({
                             aria-pressed={staggerOn ? 'true' : 'false'}
                             data-testid="bv-stagger-toggle"
                         />
+                    </>
+                )}
+
+                {showReleaseControls && (
+                    <>
+                        <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+                        <Chip
+                            label="Releases"
+                            size="small"
+                            onClick={onToggleShowReleases}
+                            {...releasesChipProps}
+                            sx={{
+                                ...(showReleases ? releasesChipProps.sx : {}),
+                                cursor: 'pointer',
+                            }}
+                            aria-pressed={showReleases ? 'true' : 'false'}
+                            data-testid="bv-releases-toggle"
+                        />
+                        <Chip
+                            label={`Style: ${RELEASE_STYLE_LABELS[releaseStyle] || 'Gold Star'}`}
+                            size="small"
+                            onClick={openReleaseStyleMenu}
+                            variant="outlined"
+                            disabled={!showReleases}
+                            sx={{ cursor: showReleases ? 'pointer' : 'not-allowed' }}
+                            aria-haspopup="true"
+                            aria-expanded={Boolean(releaseStyleAnchor) ? 'true' : undefined}
+                            data-testid="bv-release-style-chip"
+                        />
+                        <Menu
+                            anchorEl={releaseStyleAnchor}
+                            open={Boolean(releaseStyleAnchor)}
+                            onClose={closeReleaseStyleMenu}
+                            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                            slotProps={{ paper: { sx: { minWidth: 180 } } }}
+                        >
+                            {[1, 2, 3, 4, 5].map(v => (
+                                <MenuItem
+                                    key={v}
+                                    selected={v === releaseStyle}
+                                    onClick={() => selectReleaseStyle(v)}
+                                    data-testid={`bv-release-style-option-${v}`}
+                                >
+                                    <ListItemIcon>
+                                        {v === releaseStyle ? <CheckIcon fontSize="small" /> : <Box sx={{ width: 20 }} />}
+                                    </ListItemIcon>
+                                    <ListItemText
+                                        primary={`${v}. ${RELEASE_STYLE_LABELS[v]}`}
+                                        primaryTypographyProps={{
+                                            sx: v === releaseStyle ? { fontWeight: 600 } : undefined,
+                                        }}
+                                    />
+                                </MenuItem>
+                            ))}
+                        </Menu>
                     </>
                 )}
 

--- a/src/BuildVisualizer/BuildVisualizerPage.jsx
+++ b/src/BuildVisualizer/BuildVisualizerPage.jsx
@@ -38,6 +38,36 @@ const VERSION_LANES_STORAGE_KEY = 'darwin.buildVisualizer.versionLanes.v1';
 // when the app is in dark mode, and only lists dark variants.
 const DARK_VARIANT_STORAGE_KEY = 'darwin.buildVisualizer.darkVariant.v1';
 
+// Release-event overlay state (req #2606). Keys match the iframe's
+// localStorage so standalone mode and embedded mode agree on the boot value.
+const SHOW_RELEASES_STORAGE_KEY = 'darwin.bv.showReleases';
+const RELEASE_STYLE_STORAGE_KEY = 'darwin.bv.releaseStyle';
+
+const readShowReleases = () => {
+    try {
+        return window.localStorage.getItem(SHOW_RELEASES_STORAGE_KEY) !== 'off';
+    } catch (_) { return true; }
+};
+
+const writeShowReleases = (value) => {
+    try {
+        window.localStorage.setItem(SHOW_RELEASES_STORAGE_KEY, value ? 'on' : 'off');
+    } catch (_) { /* private mode — accept transient state */ }
+};
+
+const readReleaseStyle = () => {
+    try {
+        const v = parseInt(window.localStorage.getItem(RELEASE_STYLE_STORAGE_KEY) || '', 10);
+        return Number.isFinite(v) && v >= 1 && v <= 5 ? v : 1;
+    } catch (_) { return 1; }
+};
+
+const writeReleaseStyle = (value) => {
+    try {
+        window.localStorage.setItem(RELEASE_STYLE_STORAGE_KEY, String(value));
+    } catch (_) { /* private mode — accept transient state */ }
+};
+
 const readVersionLanes = () => {
     try {
         return window.localStorage.getItem(VERSION_LANES_STORAGE_KEY) !== 'off';
@@ -97,6 +127,16 @@ const BuildVisualizerPage = () => {
     const [staggerOn, setStaggerOn] = useState(() => readVersionLanes());
     const staggerOnRef = useRef(staggerOn);
     useEffect(() => { staggerOnRef.current = staggerOn; }, [staggerOn]);
+
+    // Release-event overlay toolbar state (req #2606). React shell owns the UI;
+    // iframe owns the renderer. localStorage keeps the boot value stable so
+    // standalone mode and embedded mode agree on first paint.
+    const [showReleases, setShowReleases] = useState(() => readShowReleases());
+    const [releaseStyle, setReleaseStyle] = useState(() => readReleaseStyle());
+    const showReleasesRef = useRef(showReleases);
+    const releaseStyleRef = useRef(releaseStyle);
+    useEffect(() => { showReleasesRef.current = showReleases; }, [showReleases]);
+    useEffect(() => { releaseStyleRef.current = releaseStyle; }, [releaseStyle]);
 
     // Dark variant + transport-aware theme (req #2621).
     //   • `darkVariant` is the user's chosen DARK theme. Default Charcoal.
@@ -165,8 +205,30 @@ const BuildVisualizerPage = () => {
         win.postMessage({ type: 'bv:set-theme', variant }, window.location.origin);
     }, []);
 
+    const postShowReleases = useCallback((value) => {
+        const win = iframeRef.current?.contentWindow;
+        if (!win) return;
+        win.postMessage({ type: 'bv:set-show-releases', value }, window.location.origin);
+    }, []);
+
+    const postReleaseStyle = useCallback((value) => {
+        const win = iframeRef.current?.contentWindow;
+        if (!win) return;
+        win.postMessage({ type: 'bv:set-release-style', value }, window.location.origin);
+    }, []);
+
     const toggleStagger = useCallback(() => {
         setStaggerOn(prev => !prev);
+    }, []);
+
+    const toggleShowReleases = useCallback(() => {
+        setShowReleases(prev => !prev);
+    }, []);
+
+    const changeReleaseStyle = useCallback((v) => {
+        const num = Number(v);
+        if (!Number.isInteger(num) || num < 1 || num > 5) return;
+        setReleaseStyle(num);
     }, []);
 
     useEffect(() => {
@@ -183,6 +245,16 @@ const BuildVisualizerPage = () => {
                 postFilter(selectedTypesRef.current);
                 postVersionLanes(staggerOnRef.current);
                 postTheme(iframeThemeRef.current);
+                postShowReleases(showReleasesRef.current);
+                postReleaseStyle(releaseStyleRef.current);
+            } else if (msg.type === 'bv:release-overlay-state') {
+                // Iframe announced its boot value. Adopt only when it differs
+                // from the value we already hold so we don't re-render on echo.
+                const nextShow = !!msg.showReleases;
+                const v = Number(msg.releaseStyle);
+                const nextStyle = Number.isInteger(v) && v >= 1 && v <= 5 ? v : 1;
+                if (nextShow !== showReleasesRef.current) setShowReleases(nextShow);
+                if (nextStyle !== releaseStyleRef.current) setReleaseStyle(nextStyle);
             } else if (msg.type === 'bv:changed') {
                 if (msg.data && typeof msg.data === 'object') {
                     lib.saveActiveData(msg.data);
@@ -204,7 +276,7 @@ const BuildVisualizerPage = () => {
         };
         window.addEventListener('message', onMessage);
         return () => window.removeEventListener('message', onMessage);
-    }, [lib, postLoad, postFilter, postVersionLanes, postTheme]);
+    }, [lib, postLoad, postFilter, postVersionLanes, postTheme, postShowReleases, postReleaseStyle]);
 
     // Push filter to iframe on every chip toggle (no-op until iframe is ready —
     // the bv:ready handler covers the initial post once the iframe boots).
@@ -227,6 +299,18 @@ const BuildVisualizerPage = () => {
         if (!iframeReady.current) return;
         postVersionLanes(staggerOn);
     }, [staggerOn, postVersionLanes]);
+
+    // Req #2606 — persist + push release-overlay state on every change.
+    useEffect(() => { writeShowReleases(showReleases); }, [showReleases]);
+    useEffect(() => { writeReleaseStyle(releaseStyle); }, [releaseStyle]);
+    useEffect(() => {
+        if (!iframeReady.current) return;
+        postShowReleases(showReleases);
+    }, [showReleases, postShowReleases]);
+    useEffect(() => {
+        if (!iframeReady.current) return;
+        postReleaseStyle(releaseStyle);
+    }, [releaseStyle, postReleaseStyle]);
 
     // Push theme to iframe whenever the resolved value changes — either
     // because the user picked a different dark variant OR Darwin's app
@@ -288,6 +372,10 @@ const BuildVisualizerPage = () => {
                 appMode={effectiveMode}
                 darkVariant={darkVariant}
                 onChangeDarkVariant={changeDarkVariant}
+                showReleases={showReleases}
+                onToggleShowReleases={toggleShowReleases}
+                releaseStyle={releaseStyle}
+                onChangeReleaseStyle={changeReleaseStyle}
             />
             {lib.isReady ? (
                 <iframe

--- a/src/CustomerReleases/CustomerReleasesPage.jsx
+++ b/src/CustomerReleases/CustomerReleasesPage.jsx
@@ -1,0 +1,308 @@
+// /customer-releases — Customer Release Events landing page (req #2606).
+//
+// DataGrid lists every customer_releases row. Customers are joined client-side
+// via useAllCustomers; builds are joined via useAllBuilds (we surface
+// build_number + branch_number for a readable identifier). Add/Edit/Delete
+// dialogs mirror the Customers page pattern.
+
+import { useContext, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useSearchParams } from 'react-router-dom';
+
+import AuthContext from '../Context/AuthContext';
+import AppContext from '../Context/AppContext';
+import {
+    useAllCustomerReleases,
+    useAllCustomers,
+    useAllBuilds,
+} from '../hooks/useDataQueries';
+import { customerReleaseKeys } from '../hooks/useQueryKeys';
+import { useSnackBarStore } from '../stores/useSnackBarStore';
+import {
+    createCustomerRelease,
+    updateCustomerRelease,
+    deleteCustomerRelease,
+} from './customerReleasesApi';
+
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+const TABLE_WIDTH = 1100;
+const formatDate = (v) => v ? new Date(v).toLocaleDateString() : '';
+
+function buildLabel(b) {
+    if (!b) return '';
+    if (b.build_number != null) {
+        const tail = b.branch_number ? `.${b.branch_number}` : '';
+        return `#${b.build_number}${tail}`;
+    }
+    return `id:${b.id}`;
+}
+
+export default function CustomerReleasesPage() {
+    const { idToken, profile } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
+    const queryClient = useQueryClient();
+    const showError = useSnackBarStore(s => s.showError);
+
+    const creatorFk = profile?.userName;
+    const [searchParams, setSearchParams] = useSearchParams();
+    const customerFkFilter = parseInt(searchParams.get('customer_fk') || '', 10);
+    const hasCustomerFilter = Number.isFinite(customerFkFilter);
+
+    const { data: releases = [], isLoading } = useAllCustomerReleases(creatorFk);
+    const { data: customers = [] } = useAllCustomers(creatorFk);
+    const { data: builds = [] } = useAllBuilds(creatorFk);
+
+    const customerById = useMemo(
+        () => Object.fromEntries(customers.map(c => [c.id, c])), [customers]);
+    const buildById = useMemo(
+        () => Object.fromEntries(builds.map(b => [b.id, b])), [builds]);
+
+    const rows = useMemo(() => {
+        const enriched = releases.map(r => ({
+            ...r,
+            customer_name: customerById[r.customer_fk]?.customer_name || `id:${r.customer_fk}`,
+            build_label: buildLabel(buildById[r.build_fk]),
+        }));
+        return hasCustomerFilter
+            ? enriched.filter(r => r.customer_fk === customerFkFilter)
+            : enriched;
+    }, [releases, customerById, buildById, hasCustomerFilter, customerFkFilter]);
+
+    const filterCustomerName = hasCustomerFilter
+        ? customerById[customerFkFilter]?.customer_name || `id:${customerFkFilter}`
+        : null;
+
+    const clearCustomerFilter = () => {
+        const next = new URLSearchParams(searchParams);
+        next.delete('customer_fk');
+        setSearchParams(next, { replace: true });
+    };
+
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [editTarget, setEditTarget] = useState(null);
+    const [formCustomer, setFormCustomer] = useState('');
+    const [formBuild, setFormBuild] = useState('');
+    const [formNotes, setFormNotes] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+
+    const openCreate = () => {
+        setEditTarget(null);
+        setFormCustomer('');
+        setFormBuild('');
+        setFormNotes('');
+        setDialogOpen(true);
+    };
+
+    const openEdit = (row) => {
+        setEditTarget(row);
+        setFormCustomer(String(row.customer_fk));
+        setFormBuild(String(row.build_fk));
+        setFormNotes(row.release_notes || '');
+        setDialogOpen(true);
+    };
+
+    const handleSubmit = async () => {
+        if (!formCustomer || !formBuild) {
+            showError('Customer and Build are required');
+            return;
+        }
+        setSubmitting(true);
+        try {
+            if (editTarget) {
+                await updateCustomerRelease(darwinUri, idToken, editTarget.id, {
+                    customer_fk: Number(formCustomer),
+                    build_fk: Number(formBuild),
+                    release_notes: formNotes.trim() || null,
+                });
+            } else {
+                await createCustomerRelease(darwinUri, idToken, {
+                    customer_fk: Number(formCustomer),
+                    build_fk: Number(formBuild),
+                    release_notes: formNotes.trim() || null,
+                });
+            }
+            queryClient.invalidateQueries({ queryKey: customerReleaseKeys.all(creatorFk) });
+            setDialogOpen(false);
+        } catch (err) {
+            showError(err.message || 'Save failed');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const handleDelete = async (row) => {
+        if (!window.confirm(`Delete release of "${row.customer_name}" → ${row.build_label}?`)) return;
+        try {
+            await deleteCustomerRelease(darwinUri, idToken, row.id);
+            queryClient.invalidateQueries({ queryKey: customerReleaseKeys.all(creatorFk) });
+        } catch (err) {
+            showError(err.message || 'Delete failed');
+        }
+    };
+
+    const columns = [
+        { field: 'id', headerName: 'ID', width: 70 },
+        { field: 'customer_name', headerName: 'Customer', flex: 1, minWidth: 160 },
+        { field: 'build_label', headerName: 'Build', width: 110 },
+        { field: 'release_notes', headerName: 'Notes', flex: 2, minWidth: 220 },
+        { field: 'create_ts', headerName: 'Created', width: 130, valueFormatter: formatDate },
+        {
+            field: 'actions',
+            headerName: '',
+            width: 110,
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            renderCell: (params) => (
+                <Stack direction="row" spacing={0.5}>
+                    <Tooltip title="Edit">
+                        <IconButton
+                            size="small"
+                            data-testid={`release-edit-${params.row.id}`}
+                            onClick={(e) => { e.stopPropagation(); openEdit(params.row); }}
+                        >
+                            <EditIcon fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete">
+                        <IconButton
+                            size="small"
+                            data-testid={`release-delete-${params.row.id}`}
+                            onClick={(e) => { e.stopPropagation(); handleDelete(params.row); }}
+                        >
+                            <DeleteIcon fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                </Stack>
+            ),
+        },
+    ];
+
+    return (
+        <Box sx={{ gridArea: 'content', p: 2, width: '100%', overflow: 'auto' }}>
+            <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2, maxWidth: TABLE_WIDTH }}>
+                {hasCustomerFilter ? (
+                    <Chip
+                        label={`Filter: ${filterCustomerName}`}
+                        onDelete={clearCustomerFilter}
+                        color="primary"
+                        size="small"
+                        data-testid="release-customer-filter-chip"
+                    />
+                ) : (
+                    <Box />
+                )}
+                <Button
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={openCreate}
+                    data-testid="release-add"
+                >
+                    Add release
+                </Button>
+            </Stack>
+
+            {isLoading ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+                    <CircularProgress />
+                </Box>
+            ) : (
+                <Box sx={{ maxWidth: TABLE_WIDTH, width: '100%' }}>
+                    <DataGrid
+                        autoHeight
+                        rows={rows}
+                        columns={columns}
+                        getRowId={(r) => r.id}
+                        slots={{ toolbar: GridToolbar }}
+                        slotProps={{ toolbar: { showQuickFilter: true } }}
+                        initialState={{
+                            pagination: { paginationModel: { pageSize: 25 } },
+                            sorting: { sortModel: [{ field: 'create_ts', sort: 'desc' }] },
+                        }}
+                        pageSizeOptions={[10, 25, 50]}
+                        disableRowSelectionOnClick
+                        data-testid="customer-releases-table"
+                    />
+                </Box>
+            )}
+
+            <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="sm" fullWidth>
+                <DialogTitle>{editTarget ? 'Edit release' : 'Add release'}</DialogTitle>
+                <DialogContent>
+                    <Stack spacing={2} sx={{ mt: 1 }}>
+                        <FormControl fullWidth required>
+                            <InputLabel id="customer-label">Customer</InputLabel>
+                            <Select
+                                labelId="customer-label"
+                                label="Customer"
+                                value={formCustomer}
+                                onChange={(e) => setFormCustomer(e.target.value)}
+                                data-testid="release-customer-select"
+                            >
+                                {customers.map(c => (
+                                    <MenuItem key={c.id} value={String(c.id)}>{c.customer_name}</MenuItem>
+                                ))}
+                            </Select>
+                        </FormControl>
+                        <FormControl fullWidth required>
+                            <InputLabel id="build-label">Build</InputLabel>
+                            <Select
+                                labelId="build-label"
+                                label="Build"
+                                value={formBuild}
+                                onChange={(e) => setFormBuild(e.target.value)}
+                                data-testid="release-build-select"
+                            >
+                                {builds.map(b => (
+                                    <MenuItem key={b.id} value={String(b.id)}>
+                                        {buildLabel(b)} (id {b.id})
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </FormControl>
+                        <TextField
+                            label="Release notes"
+                            value={formNotes}
+                            onChange={(e) => setFormNotes(e.target.value)}
+                            fullWidth
+                            multiline
+                            minRows={2}
+                            data-testid="release-notes-input"
+                        />
+                    </Stack>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setDialogOpen(false)} disabled={submitting}>Cancel</Button>
+                    <Button
+                        variant="contained"
+                        onClick={handleSubmit}
+                        disabled={submitting}
+                        data-testid="release-save"
+                    >
+                        {editTarget ? 'Save' : 'Create'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </Box>
+    );
+}

--- a/src/CustomerReleases/customerReleasesApi.js
+++ b/src/CustomerReleases/customerReleasesApi.js
@@ -1,0 +1,34 @@
+// Mutation utilities for customer_releases (req #2606).
+// Mirrors src/Customers/customersApi.js — call_rest_api + assertOk; callers
+// invalidate TanStack Query keys via queryClient.invalidateQueries.
+
+import call_rest_api from '../RestApi/RestApi';
+
+const isOk = (status) => status === 200 || status === 201 || status === 204;
+
+function assertOk(result, action) {
+    const status = result.httpStatus?.httpStatus;
+    if (!isOk(status)) {
+        const msg = result.httpStatus?.httpMessage || 'unknown';
+        throw new Error(`${action} failed: HTTP ${status} ${msg}`);
+    }
+    return result.data;
+}
+
+export async function createCustomerRelease(darwinUri, idToken, { customer_fk, build_fk, release_notes = null }) {
+    const r = await call_rest_api(`${darwinUri}/customer_releases`, 'POST',
+        { customer_fk, build_fk, release_notes }, idToken);
+    return assertOk(r, 'createCustomerRelease');
+}
+
+export async function updateCustomerRelease(darwinUri, idToken, id, fields) {
+    const r = await call_rest_api(`${darwinUri}/customer_releases`, 'PUT',
+        [{ id, ...fields }], idToken);
+    return assertOk(r, 'updateCustomerRelease');
+}
+
+export async function deleteCustomerRelease(darwinUri, idToken, id) {
+    const r = await call_rest_api(`${darwinUri}/customer_releases`, 'DELETE',
+        { id }, idToken);
+    return assertOk(r, 'deleteCustomerRelease');
+}

--- a/src/Customers/CustomersPage.jsx
+++ b/src/Customers/CustomersPage.jsx
@@ -5,12 +5,13 @@
 // Visualizer attaches `customer-release` branches to build dots to convey
 // which customer received which sprint or end-release build.
 
-import { useContext, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 
 import AuthContext from '../Context/AuthContext';
 import AppContext from '../Context/AppContext';
-import { useAllCustomers } from '../hooks/useDataQueries';
+import { useAllCustomers, useAllCustomerReleases } from '../hooks/useDataQueries';
 import { customerKeys } from '../hooks/useQueryKeys';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
 import { createCustomer, updateCustomer, deleteCustomer } from './customersApi';
@@ -42,7 +43,20 @@ export default function CustomersPage() {
     const showError = useSnackBarStore(s => s.showError);
 
     const creatorFk = profile?.userName;
+    const navigate = useNavigate();
     const { data: customers = [], isLoading } = useAllCustomers(creatorFk);
+    const { data: releases = [] } = useAllCustomerReleases(creatorFk);
+
+    const releaseCountByCustomer = useMemo(() => {
+        const m = {};
+        for (const r of releases) m[r.customer_fk] = (m[r.customer_fk] || 0) + 1;
+        return m;
+    }, [releases]);
+
+    const rows = useMemo(() => customers.map(c => ({
+        ...c,
+        release_count: releaseCountByCustomer[c.id] || 0,
+    })), [customers, releaseCountByCustomer]);
 
     const [dialogOpen, setDialogOpen] = useState(false);
     const [editTarget, setEditTarget] = useState(null);
@@ -109,6 +123,31 @@ export default function CustomersPage() {
         { field: 'customer_name', headerName: 'Customer', flex: 1, minWidth: 180 },
         { field: 'description', headerName: 'Description', flex: 2, minWidth: 260 },
         {
+            field: 'release_count',
+            headerName: 'Releases',
+            width: 100,
+            type: 'number',
+            renderCell: (params) => (
+                <Box
+                    component="span"
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        navigate(`/customer-releases?customer_fk=${params.row.id}`);
+                    }}
+                    sx={{
+                        cursor: 'pointer',
+                        textDecoration: params.value > 0 ? 'underline' : 'none',
+                        color: params.value > 0 ? 'primary.main' : 'text.secondary',
+                    }}
+                    data-testid={`customer-releases-link-${params.row.id}`}
+                >
+                    {params.value}
+                </Box>
+            ),
+        },
+        {
             field: 'create_ts',
             headerName: 'Created',
             width: 130,
@@ -168,7 +207,7 @@ export default function CustomersPage() {
                 <Box sx={{ maxWidth: TABLE_WIDTH, width: '100%' }}>
                     <DataGrid
                         autoHeight
-                        rows={customers}
+                        rows={rows}
                         columns={columns}
                         getRowId={(r) => r.id}
                         slots={{ toolbar: GridToolbar }}

--- a/src/NavBar/navConfig.js
+++ b/src/NavBar/navConfig.js
@@ -55,6 +55,7 @@ export const NAV_LINKS = [
         { path: '/systems2', label: 'NVLink', icon: AccountTreeIcon, group: 'systems' },
         { path: '/build-visualizer', label: 'Build Visualizer', icon: TimelineIcon, group: 'systems' },
         { path: '/customers', label: 'Customers', icon: BusinessIcon, group: 'systems' },
+        { path: '/customer-releases', label: 'Customer Releases', icon: BusinessIcon, group: 'systems' },
     ] : []),
     { path: '/swarm', label: 'Requirements', icon: MapIcon, group: 'swarm' },
     { path: '/swarm/sessions', label: 'Sessions', icon: HubIcon, group: 'swarm' },

--- a/src/hooks/__tests__/customerReleaseKeys.test.js
+++ b/src/hooks/__tests__/customerReleaseKeys.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { customerReleaseKeys } from '../useQueryKeys';
+
+describe('customerReleaseKeys (req #2606)', () => {
+    it('all() partitions cache by creator_fk', () => {
+        expect(customerReleaseKeys.all('alice')).toEqual(['customer_releases', 'alice']);
+        expect(customerReleaseKeys.all('bob')).toEqual(['customer_releases', 'bob']);
+        expect(customerReleaseKeys.all('alice'))
+            .not.toEqual(customerReleaseKeys.all('bob'));
+    });
+
+    it('byBuild() includes buildId in the key', () => {
+        const k = customerReleaseKeys.byBuild('alice', 42);
+        expect(k).toEqual(['customer_releases', 'alice', { buildId: 42 }]);
+    });
+
+    it('byCustomer() and byBuild() are prefix-compatible with all() for invalidation', () => {
+        // TanStack Query prefix-match: invalidating customerReleaseKeys.all()
+        // also invalidates byBuild() and byCustomer() because both start
+        // with all() as a prefix.
+        const allKey = customerReleaseKeys.all('alice');
+        const byBuildKey = customerReleaseKeys.byBuild('alice', 42);
+        const byCustomerKey = customerReleaseKeys.byCustomer('alice', 3);
+        expect(byBuildKey.slice(0, allKey.length)).toEqual(allKey);
+        expect(byCustomerKey.slice(0, allKey.length)).toEqual(allKey);
+    });
+});

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useContext } from 'react';
 import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
-import { domainKeys, areaKeys, taskKeys, projectKeys, categoryKeys, requirementKeys, priorityCardOrderKeys, recurringTaskKeys, mapRunKeys, mapRouteKeys, mapCoordinateKeys, mapViewKeys, mapPartnerKeys, mapRunPartnerKeys, featureKeys, testCaseKeys, featureTestCaseKeys, testPlanKeys, testPlanCaseKeys, testRunKeys, testResultKeys, customerKeys } from './useQueryKeys';
+import { domainKeys, areaKeys, taskKeys, projectKeys, categoryKeys, requirementKeys, priorityCardOrderKeys, recurringTaskKeys, mapRunKeys, mapRouteKeys, mapCoordinateKeys, mapViewKeys, mapPartnerKeys, mapRunPartnerKeys, featureKeys, testCaseKeys, featureTestCaseKeys, testPlanKeys, testPlanCaseKeys, testRunKeys, testResultKeys, customerKeys, buildProjectKeys, branchKeys, buildKeys, customerReleaseKeys } from './useQueryKeys';
 import { devServers, sessions, swarmStarts, swarmStartSessions } from './factory/devopsQueries';
 // `fetchEntity` is shared with the factory so both layers handle REST errors
 // identically (req #2593).
@@ -622,5 +622,72 @@ export function useCustomerById(creatorFk, id, { enabled = true } = {}) {
         queryKey,
         queryFn: () => fetchEntity(uri, idToken),
         enabled: enabled && !!id && !!idToken,
+    });
+}
+
+// ----- build_projects / branches / builds / customer_releases (req #2606) -----
+
+const BUILD_PROJECT_DEFAULT_FIELDS = 'id,title,description,project_status,trunk_branch_fk,category_fk,creator_fk,create_ts';
+const BRANCH_DEFAULT_FIELDS        = 'id,project_fk,branch_type,name,major,minor,parent_build_fk,side,row_order,label_end,sort_order,creator_fk';
+const BUILD_DEFAULT_FIELDS         = 'id,branch_fk,position,build_number,branch_number,dot_color,approved_for_release,creator_fk';
+const CUSTOMER_RELEASE_DEFAULT_FIELDS = 'id,customer_fk,build_fk,release_notes,creator_fk,create_ts,update_ts';
+
+export function useAllBuildProjects(creatorFk, { fields = BUILD_PROJECT_DEFAULT_FIELDS, enabled = true } = {}) {
+    const { darwinUri } = useContext(AppContext);
+    const { idToken } = useContext(AuthContext);
+    const uri = `${darwinUri}/build_projects?fields=${fields}`;
+    const queryKey = [...buildProjectKeys.all(creatorFk), { fields }];
+    return useQuery({
+        queryKey,
+        queryFn: () => fetchEntity(uri, idToken),
+        enabled: enabled && !!creatorFk && !!idToken,
+    });
+}
+
+export function useAllBranches(creatorFk, { fields = BRANCH_DEFAULT_FIELDS, enabled = true } = {}) {
+    const { darwinUri } = useContext(AppContext);
+    const { idToken } = useContext(AuthContext);
+    const uri = `${darwinUri}/branches?fields=${fields}`;
+    const queryKey = [...branchKeys.all(creatorFk), { fields }];
+    return useQuery({
+        queryKey,
+        queryFn: () => fetchEntity(uri, idToken),
+        enabled: enabled && !!creatorFk && !!idToken,
+    });
+}
+
+export function useAllBuilds(creatorFk, { fields = BUILD_DEFAULT_FIELDS, enabled = true } = {}) {
+    const { darwinUri } = useContext(AppContext);
+    const { idToken } = useContext(AuthContext);
+    const uri = `${darwinUri}/builds?fields=${fields}`;
+    const queryKey = [...buildKeys.all(creatorFk), { fields }];
+    return useQuery({
+        queryKey,
+        queryFn: () => fetchEntity(uri, idToken),
+        enabled: enabled && !!creatorFk && !!idToken,
+    });
+}
+
+export function useAllCustomerReleases(creatorFk, { fields = CUSTOMER_RELEASE_DEFAULT_FIELDS, enabled = true } = {}) {
+    const { darwinUri } = useContext(AppContext);
+    const { idToken } = useContext(AuthContext);
+    const uri = `${darwinUri}/customer_releases?fields=${fields}`;
+    const queryKey = [...customerReleaseKeys.all(creatorFk), { fields }];
+    return useQuery({
+        queryKey,
+        queryFn: () => fetchEntity(uri, idToken),
+        enabled: enabled && !!creatorFk && !!idToken,
+    });
+}
+
+export function useCustomerReleasesByBuild(creatorFk, buildId, { enabled = true } = {}) {
+    const { darwinUri } = useContext(AppContext);
+    const { idToken } = useContext(AuthContext);
+    const uri = `${darwinUri}/customer_releases?build_fk=${buildId}&fields=${CUSTOMER_RELEASE_DEFAULT_FIELDS}`;
+    const queryKey = customerReleaseKeys.byBuild(creatorFk, buildId);
+    return useQuery({
+        queryKey,
+        queryFn: () => fetchEntity(uri, idToken),
+        enabled: enabled && !!creatorFk && !!buildId && !!idToken,
     });
 }

--- a/src/hooks/useQueryKeys.js
+++ b/src/hooks/useQueryKeys.js
@@ -144,3 +144,26 @@ export const customerKeys = {
     all: (creatorFk) => ['customers', creatorFk],
     byId: (creatorFk, id) => ['customers', creatorFk, { id }],
 };
+
+// Req #2606 — Customer Release Events + SQL-backed Build Visualizer.
+export const buildProjectKeys = {
+    all: (creatorFk) => ['build_projects', creatorFk],
+    byId: (creatorFk, id) => ['build_projects', creatorFk, { id }],
+};
+
+export const branchKeys = {
+    all: (creatorFk) => ['branches', creatorFk],
+    byProject: (creatorFk, projectId) => ['branches', creatorFk, { projectId }],
+};
+
+export const buildKeys = {
+    all: (creatorFk) => ['builds', creatorFk],
+    byBranch: (creatorFk, branchId) => ['builds', creatorFk, { branchId }],
+    byId: (creatorFk, id) => ['builds', creatorFk, { id }],
+};
+
+export const customerReleaseKeys = {
+    all: (creatorFk) => ['customer_releases', creatorFk],
+    byBuild: (creatorFk, buildId) => ['customer_releases', creatorFk, { buildId }],
+    byCustomer: (creatorFk, customerId) => ['customer_releases', creatorFk, { customerId }],
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -50,6 +50,7 @@ import SwarmStartDetail from './SwarmStarts/SwarmStartDetail';
 import SystemsPage2 from './Systems/SystemsPage2';
 import BuildVisualizerPage from './BuildVisualizer/BuildVisualizerPage';
 import CustomersPage from './Customers/CustomersPage';
+import CustomerReleasesPage from './CustomerReleases/CustomerReleasesPage';
 
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
@@ -155,6 +156,9 @@ root.render(
                                                          </AuthenticatedRoute>} />
                     <Route path="customers" element= {<AuthenticatedRoute>
                                                              <CustomersPage />
+                                                         </AuthenticatedRoute>} />
+                    <Route path="customer-releases" element= {<AuthenticatedRoute>
+                                                             <CustomerReleasesPage />
                                                          </AuthenticatedRoute>} />
                     {import.meta.env.DEV && <>
                       <Route path="systems2" element= {<AuthenticatedRoute>


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2606-customer-release-events-sql-backed-2
- feat(2606): customer release events + visualization variants
- chore: init swarm session feature/2606-customer-release-events-sql-backed-2

## Files changed
```
 src/BuildVisualizer/BuildVisualizerControls.jsx |  82 +++++++
 src/BuildVisualizer/BuildVisualizerPage.jsx     |  90 ++++++-
 src/CustomerReleases/CustomerReleasesPage.jsx   | 308 ++++++++++++++++++++++++
 src/CustomerReleases/customerReleasesApi.js     |  34 +++
 src/Customers/CustomersPage.jsx                 |  45 +++-
 src/NavBar/navConfig.js                         |   1 +
 src/hooks/__tests__/customerReleaseKeys.test.js |  27 +++
 src/hooks/useDataQueries.js                     |  69 +++++-
 src/hooks/useQueryKeys.js                       |  23 ++
 src/index.jsx                                   |   4 +
 10 files changed, 678 insertions(+), 5 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)