### PR TITLE
Hide Scale Up View Selector

### DIFF
--- a/src/Systems/SystemsPage2.jsx
+++ b/src/Systems/SystemsPage2.jsx
@@ -5,7 +5,7 @@ const SystemsPage2 = () => {
         <Box sx={{ gridArea: 'content', height: '100vh', width: '100%', overflow: 'hidden' }}>
             <iframe
                 src="/systems2/nvlink_topology.html"
-                title="NVLink Scale Up Network"
+                title="NVLink System Views"
                 style={{ width: '100%', height: '100%', border: 'none', display: 'block' }}
             />
         </Box>


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2652-hide-scale-up-view-selector-1
- wip(Darwin): 2026-05-26T23:13:05Z
- chore: init swarm session feature/2652-hide-scale-up-view-selector-1

## Files changed
```
 src/Systems/SystemsPage2.jsx | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)