### PR TITLE
req #2650

### DIFF
--- a/src/CalendarFC/TimeSeriesView.jsx
+++ b/src/CalendarFC/TimeSeriesView.jsx
@@ -144,6 +144,22 @@ export const swarmStartBarX = (markerMode, leftPct, startPct, gapPx) => {
 // |          |          |   off the left edge, no vertical start bar     |
 // | null     | null     | skip — neither end visible on this panel        |
 //
+// Session statuses that suppress phantom-chip rendering (req #2650).
+// A "phantom" represents the in-progress portion of a session; statuses that
+// indicate the session is NOT actively running must not produce one:
+//   • null/empty   — session lacks a status, nothing to surface.
+//   • 'completed'  — the work is drawn as a real (non-phantom) chip when its
+//                    requirement's completed_at lands in the window.
+//   • 'paused'     — the user explicitly paused the session; it must not
+//                    appear as today's "unfinished business" until resumed.
+// Blacklist, not whitelist: any future session status defaults to rendering,
+// which is the safer failure mode (callers extend the list as needed).
+// Exported for unit-test coverage.
+export const isHiddenSwarmStatus = (status) => {
+    if (!status) return true;
+    return status === 'completed' || status === 'paused';
+};
+
 // Exported for unit-test coverage.
 export const computePhantomPlacement = (startPct, nowPct) => {
     const startIn = startPct !== null && startPct !== undefined;
@@ -613,7 +629,8 @@ const BeadRow = ({
     // session, its requirement) pair where:
     //   • the session is linked to a swarm_start via the junction
     //   • the swarm_start has a started_at that falls in this panel's window
-    //   • the session's swarm_status is not 'completed'
+    //   • the session's swarm_status is not "hidden" — see
+    //     isHiddenSwarmStatus (null/'completed'/'paused' per req #2650).
     //
     // Each phantom carries the FULL requirement datacard payload (title,
     // category, coordination, etc.) so its hover tooltip is identical in shape
@@ -657,7 +674,7 @@ const BeadRow = ({
             for (const sid of linked) {
                 const s = sessionById.get(sid);
                 if (!s) continue;
-                if (!s.swarm_status || s.swarm_status === 'completed') continue;
+                if (isHiddenSwarmStatus(s.swarm_status)) continue;
                 const reqId = parseSessionRequirementId(s.source_ref);
                 const r = reqId && requirementById ? requirementById.get(reqId) : null;
                 // If the session's requirement has already completed_at set

--- a/src/CalendarFC/__tests__/timeSeriesSizes.test.js
+++ b/src/CalendarFC/__tests__/timeSeriesSizes.test.js
@@ -389,7 +389,7 @@ describe('clusterSessionsByStartTime', () => {
 // Row 0 = earliest met = bottom; higher rows = later met = top.
 // topDown=true reverses the order so the latest gets row 0 (Sidewalk mode —
 // wire sits at the top of the panel, so row 0 renders closest to it). ──────────
-import { assignSwarmLanes, assignRows, weekDates, centeredDateRange, swarmStartBarX, positionFor, computePhantomPlacement } from '../TimeSeriesView';
+import { assignSwarmLanes, assignRows, weekDates, centeredDateRange, swarmStartBarX, positionFor, computePhantomPlacement, isHiddenSwarmStatus } from '../TimeSeriesView';
 
 // ─── clusterSessionsByStartTime — MySQL-format parsing (req #2398) ─────────────
 // Regression guard: before the fix, clusterSessionsByStartTime parsed
@@ -1192,5 +1192,47 @@ describe('computePhantomPlacement (in-progress phantom placement, req #2649)', (
         // still a Case A (start at startPct, head at 0).
         const p = computePhantomPlacement(30, 0);
         expect(p).toEqual({ phantomStartPct: 30, phantomLeftPct: 0, startClamped: false });
+    });
+});
+
+// ─── isHiddenSwarmStatus (req #2650) ─────────────────────────────────────────
+// The phantom-chip filter in SwarmVisualizer skips sessions whose status
+// indicates they are NOT actively in progress. Pre-#2650 the filter only
+// skipped 'completed', so a session a user explicitly paused continued to
+// surface as today's "unfinished business" — repro: req #2555 (deferred) +
+// session #1938 (paused) bleeding onto today's panel four days after pause.
+// The helper centralises the skip list so future statuses can be added in
+// one place.
+describe('isHiddenSwarmStatus (phantom-chip skip filter, req #2650)', () => {
+    it('hides null / undefined / empty status', () => {
+        expect(isHiddenSwarmStatus(null)).toBe(true);
+        expect(isHiddenSwarmStatus(undefined)).toBe(true);
+        expect(isHiddenSwarmStatus('')).toBe(true);
+    });
+
+    it("hides 'completed' (work is drawn as a real chip, not a phantom)", () => {
+        expect(isHiddenSwarmStatus('completed')).toBe(true);
+    });
+
+    it("hides 'paused' (req #2650 — user paused; not unfinished business today)", () => {
+        expect(isHiddenSwarmStatus('paused')).toBe(true);
+    });
+
+    it("shows 'active' (the canonical in-progress status)", () => {
+        expect(isHiddenSwarmStatus('active')).toBe(false);
+    });
+
+    it("shows other in-progress lifecycle statuses (starting, review, completing)", () => {
+        expect(isHiddenSwarmStatus('starting')).toBe(false);
+        expect(isHiddenSwarmStatus('review')).toBe(false);
+        expect(isHiddenSwarmStatus('completing')).toBe(false);
+    });
+
+    it('shows unknown / future statuses (blacklist semantics — safer to render)', () => {
+        // Forward-compatibility: a new status (e.g. 'queued') defaults to
+        // rendering, not hiding. Adding it to the blacklist is a deliberate
+        // act when a real "do not phantom this" case appears.
+        expect(isHiddenSwarmStatus('queued')).toBe(false);
+        expect(isHiddenSwarmStatus('blocked')).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-05-26T22:46:34Z
- chore: init swarm session feature/2650-fix-open-sessions-1

## Files changed
```
 src/CalendarFC/TimeSeriesView.jsx                | 21 +++++++++--
 src/CalendarFC/__tests__/timeSeriesSizes.test.js | 44 +++++++++++++++++++++++-
 2 files changed, 62 insertions(+), 3 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related PRs: BillWilliams79/DarwinAI-Config#308