### PR TITLE
dev_servers + swarm operational tables: route reads to darwin in dev mode

### DIFF
--- a/src/Context/AppContext.jsx
+++ b/src/Context/AppContext.jsx
@@ -28,14 +28,25 @@ if (isDev) {
     }
 }
 
+const API_BASE = 'https://k5j0ftr527.execute-api.us-west-1.amazonaws.com/eng';
+
+// `darwinOpsUri` always points at the production `darwin` schema regardless of
+// dev/prod build mode. Operational tables (`dev_servers`, `swarm_sessions`,
+// `swarm_starts`, `swarm_start_sessions`) are written by the MCP daemon
+// (hard-wired to `DB_NAME=darwin`) and are machine-singleton infrastructure —
+// they were never meant to participate in the prod/dev USER-data split that
+// `darwinUri` honors. Req #2697.
+const DARWIN_OPS_URI = `${API_BASE}/darwin`;
+
 // Context provider for general application data, URI and color schemes
 export const AppContextProvider = ({ children }) => {
 
-    const [darwinUri, setDarwinUri] = useState(`https://k5j0ftr527.execute-api.us-west-1.amazonaws.com/eng/${database}`);
+    const [darwinUri, setDarwinUri] = useState(`${API_BASE}/${database}`);
 
     return (
         <AppContext.Provider value={{
             darwinUri, setDarwinUri, database,
+            darwinOpsUri: DARWIN_OPS_URI,
         }} >
             {children}
         </AppContext.Provider>

--- a/src/NavBar/ProfileContent.jsx
+++ b/src/NavBar/ProfileContent.jsx
@@ -25,7 +25,7 @@ import PersonAddOutlined from '@mui/icons-material/PersonAddOutlined';
 const ProfileContent = ({ onClose }) => {
 
     const { idToken, profile, setProfile } = useContext(AuthContext);
-    const { darwinUri } = useContext(AppContext);
+    const { darwinUri, darwinOpsUri } = useContext(AppContext);
     const { themeMode, setThemeMode } = useContext(ThemeContext);
     const showError = useSnackBarStore(s => s.showError);
     const navigate = useNavigate();
@@ -152,7 +152,7 @@ const ProfileContent = ({ onClose }) => {
     const handleExport = async (selectedApps) => {
         setExporting(true);
         try {
-            const data = await fetchExportData(darwinUri, profile.userName, idToken, profile, selectedApps);
+            const data = await fetchExportData(darwinUri, darwinOpsUri, profile.userName, idToken, profile, selectedApps);
             const date = new Date().toISOString().slice(0, 10);
             downloadJson(data, `darwin-export-${date}.json`);
         } catch (err) {

--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -84,7 +84,7 @@ const RequirementDetail = () => {
     const backLabel = fromCalendar ? 'Back to Calendar' : 'Back to Roadmap';
     const { idToken, profile } = useContext(AuthContext);
     const timezone = profile?.timezone;
-    const { darwinUri } = useContext(AppContext);
+    const { darwinUri, darwinOpsUri } = useContext(AppContext);
 
     const [requirement, setRequirement] = useState(isNew ? {
         id: null,
@@ -153,7 +153,8 @@ const RequirementDetail = () => {
                     ? ''
                     : `&requirement_status=(${siblingStatuses.join(',')})`;
                 const [sessionsResult, siblingsResult, categoryResult] = await Promise.all([
-                    call_rest_api(`${darwinUri}/swarm_sessions?source_ref=requirement:${p.id}`, 'GET', '', idToken).catch(() => null),
+                    // Req #2697 — `swarm_sessions` is an operational table; always read from `darwin`.
+                    call_rest_api(`${darwinOpsUri}/swarm_sessions?source_ref=requirement:${p.id}`, 'GET', '', idToken).catch(() => null),
                     call_rest_api(`${darwinUri}/requirements?category_fk=${p.category_fk}&fields=id,requirement_status,completed_at,deferred_at,started_at${siblingFilter}`, 'GET', '', idToken).catch(() => null),
                     call_rest_api(`${darwinUri}/categories?id=${p.category_fk}&fields=id,sort_mode`, 'GET', '', idToken).catch(() => null),
                 ]);
@@ -177,7 +178,7 @@ const RequirementDetail = () => {
         };
 
         fetchData();
-    }, [id, idToken, darwinUri, siblingStatuses.join()]);
+    }, [id, idToken, darwinUri, darwinOpsUri, siblingStatuses.join()]);
 
     const saveField = (field, value) => {
         if (isNew) return;  // draft — nothing is saved until category is picked

--- a/src/SwarmView/detail/SwarmSessionDetail.jsx
+++ b/src/SwarmView/detail/SwarmSessionDetail.jsx
@@ -41,7 +41,7 @@ const SwarmSessionDetail = () => {
     const location = useLocation();
 
     const { idToken, profile } = useContext(AuthContext);
-    const { darwinUri } = useContext(AppContext);
+    const { darwinOpsUri } = useContext(AppContext);
     const queryClient = useQueryClient();
     const showError = useSnackBarStore(s => s.showError);
 
@@ -67,7 +67,8 @@ const SwarmSessionDetail = () => {
 
     const sessionDelete = useConfirmDialog({
         onConfirm: ({ sessionId }) => {
-            const uri = `${darwinUri}/swarm_sessions`;
+            // Req #2697 — operational tables live exclusively in `darwin`.
+            const uri = `${darwinOpsUri}/swarm_sessions`;
             call_rest_api(uri, 'DELETE', { id: sessionId }, idToken)
                 .then(result => {
                     if (result.httpStatus.httpStatus === 200) {

--- a/src/hooks/__tests__/createEntityQueriesOpsUrl.test.js
+++ b/src/hooks/__tests__/createEntityQueriesOpsUrl.test.js
@@ -1,0 +1,138 @@
+// Req #2697 — regression guard for the operational-table URL routing.
+//
+// Pre-#2697: a dev-mode build pointing AppContext.database at `darwin_dev`
+// caused every operational-table read (`dev_servers`, `swarm_sessions`,
+// `swarm_starts`, `swarm_start_sessions`) to silently return 0 rows because
+// the MCP daemon writes them exclusively to the production `darwin` schema.
+//
+// The fix: `ops: true` in the entity config makes the factory pick
+// `darwinOpsUri` (always `/darwin`) from AppContext instead of `darwinUri`
+// (which honors the dev/prod split). These tests assert the actual REST URL
+// every factory hook builds depending on the `ops` flag.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.mock factories are hoisted above imports, so the mock fn must be
+// declared via vi.hoisted() (also hoisted) to be in scope.
+const { callRestApiMock } = vi.hoisted(() => ({
+    callRestApiMock: vi.fn().mockResolvedValue({
+        data: [],
+        httpStatus: { httpStatus: 200 },
+    }),
+}));
+vi.mock('../../RestApi/RestApi', () => ({
+    default: callRestApiMock,
+}));
+
+// Stub useQuery so it fires queryFn synchronously when enabled.
+vi.mock('@tanstack/react-query', () => ({
+    useQuery: ({ queryFn, enabled }) => {
+        if (enabled) queryFn();
+        return { data: null, isLoading: false };
+    },
+}));
+
+// Stub useContext so it returns the right context value for each Context.
+// The factory uses default-export AppContext + AuthContext as the keys.
+const TEST_DARWIN_URI    = 'https://api.test/eng/darwin_dev';
+const TEST_DARWIN_OPS_URI = 'https://api.test/eng/darwin';
+
+// Identity-based context registry. We populate it after the production
+// modules import their AppContext/AuthContext defaults so we can map
+// each context to the test value the factory should see.
+const { ctxRegistry } = vi.hoisted(() => ({ ctxRegistry: new Map() }));
+
+vi.mock('react', async () => {
+    const actual = await vi.importActual('react');
+    return {
+        ...actual,
+        useContext: (ctx) => ctxRegistry.get(ctx) || {},
+    };
+});
+
+// Imports must come AFTER vi.mock declarations so they bind to the stubs.
+import AppContext from '../../Context/AppContext';
+import AuthContext from '../../Context/AuthContext';
+import { createEntityQueries } from '../factory/createEntityQueries';
+
+ctxRegistry.set(AppContext, { darwinUri: TEST_DARWIN_URI, darwinOpsUri: TEST_DARWIN_OPS_URI });
+ctxRegistry.set(AuthContext, { idToken: 'test-token' });
+
+beforeEach(() => {
+    callRestApiMock.mockClear();
+});
+
+describe('createEntityQueries — ops:true routes URLs to darwinOpsUri', () => {
+    it('useAll uses darwinOpsUri when ops:true', () => {
+        const e = createEntityQueries({ entity: 'dev_servers', ops: true });
+        e.useAll('alice');
+        expect(callRestApiMock).toHaveBeenCalledTimes(1);
+        const url = callRestApiMock.mock.calls[0][0];
+        expect(url).toContain(`${TEST_DARWIN_OPS_URI}/dev_servers`);
+        expect(url).not.toContain('darwin_dev');
+    });
+
+    it('useById uses darwinOpsUri when ops:true', () => {
+        const e = createEntityQueries({ entity: 'swarm_sessions', ops: true, byIdCreatorScoped: false });
+        e.useById(42);
+        const url = callRestApiMock.mock.calls[0][0];
+        expect(url).toContain(`${TEST_DARWIN_OPS_URI}/swarm_sessions?id=42`);
+        expect(url).not.toContain('darwin_dev');
+    });
+
+    it('useBy<FK> uses darwinOpsUri when ops:true', () => {
+        const e = createEntityQueries({
+            entity: 'dev_servers',
+            ops: true,
+            foreignKeys: [{ field: 'session_fk', as: 'session', creatorScoped: false }],
+        });
+        e.useBySession(7);
+        const url = callRestApiMock.mock.calls[0][0];
+        expect(url).toContain(`${TEST_DARWIN_OPS_URI}/dev_servers?session_fk=7`);
+        expect(url).not.toContain('darwin_dev');
+    });
+});
+
+describe('createEntityQueries — default (ops:false) still uses darwinUri', () => {
+    it('useAll uses darwinUri (dev_dev schema honored) when ops flag omitted', () => {
+        const e = createEntityQueries({ entity: 'widgets' });
+        e.useAll('alice');
+        const url = callRestApiMock.mock.calls[0][0];
+        expect(url).toContain(`${TEST_DARWIN_URI}/widgets`);
+    });
+});
+
+describe('createEntityQueries — wired devops blocks route correctly', () => {
+    // Imported here so vi.mock declarations above are in effect.
+    it('devServers.useAll hits the production darwin schema', async () => {
+        const { devServers } = await import('../factory/devopsQueries');
+        devServers.useAll('alice');
+        const url = callRestApiMock.mock.calls[0][0];
+        expect(url).toContain(`${TEST_DARWIN_OPS_URI}/dev_servers`);
+        expect(url).not.toContain('darwin_dev');
+    });
+
+    it('sessions.useAll hits the production darwin schema', async () => {
+        const { sessions } = await import('../factory/devopsQueries');
+        sessions.useAll('alice');
+        const url = callRestApiMock.mock.calls[0][0];
+        expect(url).toContain(`${TEST_DARWIN_OPS_URI}/swarm_sessions`);
+        expect(url).not.toContain('darwin_dev');
+    });
+
+    it('swarmStarts.useAll hits the production darwin schema', async () => {
+        const { swarmStarts } = await import('../factory/devopsQueries');
+        swarmStarts.useAll('alice');
+        const url = callRestApiMock.mock.calls[0][0];
+        expect(url).toContain(`${TEST_DARWIN_OPS_URI}/swarm_starts`);
+        expect(url).not.toContain('darwin_dev');
+    });
+
+    it('swarmStartSessions.useAll hits the production darwin schema', async () => {
+        const { swarmStartSessions } = await import('../factory/devopsQueries');
+        swarmStartSessions.useAll('alice');
+        const url = callRestApiMock.mock.calls[0][0];
+        expect(url).toContain(`${TEST_DARWIN_OPS_URI}/swarm_start_sessions`);
+        expect(url).not.toContain('darwin_dev');
+    });
+});

--- a/src/hooks/factory/createEntityQueries.js
+++ b/src/hooks/factory/createEntityQueries.js
@@ -59,6 +59,11 @@ export function createEntityQueries({
     byIdCreatorScoped = true,
     byIdReturnsArray = false,
     foreignKeys = [],
+    // Req #2697 — operational tables (`dev_servers`, `swarm_sessions`,
+    // `swarm_starts`, `swarm_start_sessions`) live exclusively in the
+    // production `darwin` schema regardless of dev/prod mode. Set `ops: true`
+    // and the factory picks `darwinOpsUri` from AppContext for every URL.
+    ops = false,
 }) {
     if (!entity) throw new Error('createEntityQueries: entity is required');
 
@@ -89,14 +94,15 @@ export function createEntityQueries({
     // ----- hooks -----
 
     function useAll(creatorFk, options = {}) {
-        const { darwinUri } = useContext(AppContext);
+        const { darwinUri, darwinOpsUri } = useContext(AppContext);
         const { idToken } = useContext(AuthContext);
         const { fields = defaultFields, sort = defaultSort, enabled = true, staleTime } = options;
 
+        const uriRoot = ops ? darwinOpsUri : darwinUri;
         const params = [];
         if (fields) params.push(`fields=${fields}`);
         if (sort) params.push(`sort=${sort}`);
-        const uri = params.length ? `${darwinUri}/${entity}?${params.join('&')}` : `${darwinUri}/${entity}`;
+        const uri = params.length ? `${uriRoot}/${entity}?${params.join('&')}` : `${uriRoot}/${entity}`;
 
         const baseKey = keys.all(creatorFk);
         const queryKey = fieldsInKey && fields ? [...baseKey, { fields }] : baseKey;
@@ -120,13 +126,14 @@ export function createEntityQueries({
             [id, options = {}] = args;
             creatorFk = null;
         }
-        const { darwinUri } = useContext(AppContext);
+        const { darwinUri, darwinOpsUri } = useContext(AppContext);
         const { idToken } = useContext(AuthContext);
         const { fields, enabled = true } = options;
 
+        const uriRoot = ops ? darwinOpsUri : darwinUri;
         const params = [`id=${id}`];
         if (fields) params.push(`fields=${fields}`);
-        const uri = `${darwinUri}/${entity}?${params.join('&')}`;
+        const uri = `${uriRoot}/${entity}?${params.join('&')}`;
 
         const queryKey = byIdCreatorScoped ? keys.byId(creatorFk, id) : keys.byId(id);
 
@@ -161,13 +168,14 @@ export function createEntityQueries({
                 [id, options = {}] = args;
                 creatorFk = null;
             }
-            const { darwinUri } = useContext(AppContext);
+            const { darwinUri, darwinOpsUri } = useContext(AppContext);
             const { idToken } = useContext(AuthContext);
             const { fields = defaultFields, enabled = true } = options;
 
+            const uriRoot = ops ? darwinOpsUri : darwinUri;
             const params = [`${fk.field}=${id}`];
             if (fields) params.push(`fields=${fields}`);
-            const uri = `${darwinUri}/${entity}?${params.join('&')}`;
+            const uri = `${uriRoot}/${entity}?${params.join('&')}`;
 
             const queryKey = creatorScoped ? keyFn(creatorFk, id) : keyFn(id);
 

--- a/src/hooks/factory/devopsQueries.js
+++ b/src/hooks/factory/devopsQueries.js
@@ -5,6 +5,14 @@
 // Every existing hook signature, URL, cache key, and `enabled` predicate is
 // preserved byte-for-byte by the factory output; parity is locked down by
 // __tests__/devopsQueriesParity.test.js.
+//
+// Req #2697 — `ops: true` on every block here. These four tables live
+// exclusively in the production `darwin` schema (the MCP daemon's
+// `DB_NAME=darwin` is hard-wired). The factory routes their reads through
+// `darwinOpsUri` instead of `darwinUri` so dev-mode builds (where
+// `darwinUri` ends in `/darwin_dev` per req #2683) still see real rows.
+// A future devops table that genuinely IS per-database (e.g. recurring_tasks)
+// would omit `ops` and inherit the default `darwinUri` routing.
 
 import { createEntityQueries } from './createEntityQueries';
 
@@ -15,6 +23,7 @@ import { createEntityQueries } from './createEntityQueries';
 // ---------------------------------------------------------------------------
 export const devServers = createEntityQueries({
     entity: 'dev_servers',
+    ops: true,
     foreignKeys: [
         // `keyParam: 'sessionId'` preserves the legacy `devServerKeys.bySession(id)`
         // cache-key shape `['dev_servers', { sessionId }]`. New devops entities
@@ -30,6 +39,7 @@ export const devServers = createEntityQueries({
 // ---------------------------------------------------------------------------
 export const sessions = createEntityQueries({
     entity: 'swarm_sessions',
+    ops: true,
     byIdCreatorScoped: false,
 });
 
@@ -45,6 +55,7 @@ const SWARM_START_DEFAULT_FIELDS =
 
 export const swarmStarts = createEntityQueries({
     entity: 'swarm_starts',
+    ops: true,
     defaultFields: SWARM_START_DEFAULT_FIELDS,
     fieldsInKey: true,
     defaultSort: 'started_at:desc',
@@ -56,5 +67,6 @@ export const swarmStarts = createEntityQueries({
 // ---------------------------------------------------------------------------
 export const swarmStartSessions = createEntityQueries({
     entity: 'swarm_start_sessions',
+    ops: true,
     defaultFields: 'swarm_start_fk,session_fk',
 });

--- a/src/services/__tests__/exportService.test.js
+++ b/src/services/__tests__/exportService.test.js
@@ -8,7 +8,10 @@ vi.mock('../../RestApi/RestApi', () => ({
 
 import call_rest_api from '../../RestApi/RestApi';
 
-const DARWIN_URI = 'https://api.example.com/darwin';
+// Distinct URIs so the test surface catches any regression that reverts an
+// ops-table read to `darwinUri` (req #2697).
+const DARWIN_URI     = 'https://api.example.com/darwin_dev';
+const DARWIN_OPS_URI = 'https://api.example.com/darwin';
 const ID_TOKEN = 'mock-token';
 const PROFILE = {
     name: 'Test User',
@@ -44,7 +47,7 @@ beforeEach(() => {
 describe('fetchExportData', () => {
     it('returns v2.0 with selectedApps metadata', async () => {
         mockApi({});
-        const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, {
+        const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, {
             tasks: false, maps: false, swarm: false,
         });
         expect(result.exportVersion).toBe('2.0');
@@ -54,7 +57,7 @@ describe('fetchExportData', () => {
 
     it('exports profile with all fields', async () => {
         mockApi({});
-        const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, {
+        const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, {
             tasks: false, maps: false, swarm: false,
         });
         expect(result.profile).toEqual({
@@ -72,7 +75,7 @@ describe('fetchExportData', () => {
 
     it('omits app keys when not selected', async () => {
         mockApi({});
-        const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, {
+        const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, {
             tasks: false, maps: false, swarm: false,
         });
         expect(result.domains).toBeUndefined();
@@ -93,7 +96,7 @@ describe('fetchExportData', () => {
                 '/recurring_tasks': [{ id: 200, description: 'RT1', recurrence: 'daily', anchor_date: '2026-01-01', area_fk: 10, priority: 0, accumulate: 0, insert_position: 'bottom', active: 1, last_generated: null, create_ts: 't', update_ts: null }],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
 
             expect(result.domains).toHaveLength(1);
             expect(result.domains[0].areas).toHaveLength(1);
@@ -121,14 +124,14 @@ describe('fetchExportData', () => {
                 '/recurring_tasks': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.domains[0].areas[0].tasks[0].description).toBe('T1');
             expect(result.domains[1].areas[0].tasks[0].description).toBe('T2');
         });
 
         it('handles 404 (empty tables) gracefully', async () => {
             mockApi({}); // All tables return 404
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.domains).toEqual([]);
             expect(result.recurringTasks).toEqual([]);
         });
@@ -149,7 +152,7 @@ describe('fetchExportData', () => {
                 '/map_run_partners': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
 
             expect(result.mapRoutes).toHaveLength(1);
             expect(result.mapRoutes[0].runs).toHaveLength(1);
@@ -167,7 +170,7 @@ describe('fetchExportData', () => {
                 '/map_run_partners': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.unassignedRuns[0].coordinates).toBeUndefined();
             // No coordinate API calls should have been made
             const coordCalls = call_rest_api.mock.calls.filter(c => c[0].includes('map_coordinates'));
@@ -187,7 +190,7 @@ describe('fetchExportData', () => {
                 '/map_run_partners': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, {
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, {
                 ...SELECTED, mapsGps: true,
             });
 
@@ -206,7 +209,7 @@ describe('fetchExportData', () => {
                 '/map_run_partners': [{ map_run_fk: 10, map_partner_fk: 1, create_ts: 't' }],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.mapViews).toHaveLength(1);
             expect(result.mapPartners).toHaveLength(1);
             expect(result.mapRunPartners).toHaveLength(1);
@@ -225,12 +228,31 @@ describe('fetchExportData', () => {
                 '/categories': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.requirements[0].requirement_status).toBe('authoring');
             expect(result.requirements[0].coordination_type).toBe('implemented');
             expect(result.requirements[0].deferred_at).toBe('2026-03-01');
             expect(result.requirements[0].project_fk).toBe(5);
             expect(result.requirements[0].category_fk).toBe(10);
+        });
+
+        // Req #2697 regression guard — swarm_sessions is an operational table,
+        // must be fetched from darwinOpsUri (production `darwin`), never from
+        // darwinUri (which honors the dev/prod USER-data split).
+        it('reads swarm_sessions from darwinOpsUri (production darwin) not darwinUri', async () => {
+            mockApi({
+                '/requirements': [],
+                '/swarm_sessions': [],
+                '/projects': [],
+                '/categories': [],
+            });
+
+            await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+
+            const sessionCall = call_rest_api.mock.calls.find(c => c[0].includes('swarm_sessions'));
+            expect(sessionCall).toBeDefined();
+            expect(sessionCall[0]).toContain(DARWIN_OPS_URI);
+            expect(sessionCall[0]).not.toContain('darwin_dev');
         });
 
         it('exports swarm session with review status transparently', async () => {
@@ -241,7 +263,7 @@ describe('fetchExportData', () => {
                 '/categories': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.swarmSessions[0].swarm_status).toBe('review');
         });
 
@@ -253,7 +275,7 @@ describe('fetchExportData', () => {
                 '/categories': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.requirements[0].coordination_type).toBeNull();
         });
 
@@ -265,7 +287,7 @@ describe('fetchExportData', () => {
                 '/categories': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             const s = result.swarmSessions[0];
             expect(s.completed_at).toBe('t2');
             expect(s.start_summary).toBe('Started work');
@@ -282,7 +304,7 @@ describe('fetchExportData', () => {
                 '/categories': [{ id: 1, category_name: 'Cat1', project_fk: 1, sort_order: 1, sort_mode: 'hand', color: '#ff0000', closed: 0, create_ts: 't', update_ts: null }],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.projects[0].project_name).toBe('Proj1');
             expect(result.projects[0].closed).toBe(0);
             expect(result.categories[0].category_name).toBe('Cat1');
@@ -314,7 +336,7 @@ describe('fetchExportData', () => {
                 }],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.features).toHaveLength(1);
             expect(result.features[0].feature_status).toBe('active');
             expect(result.features[0].description).toContain('Given');
@@ -350,7 +372,7 @@ describe('fetchExportData', () => {
                 '/categories': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, {
+            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, {
                 tasks: true, maps: true, swarm: true,
             });
 

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -2,13 +2,14 @@ import call_rest_api from '../RestApi/RestApi';
 
 /**
  * Fetch all user data for selected apps and assemble into nested hierarchy.
- * @param {string} darwinUri - API base URL
+ * @param {string} darwinUri - API base URL (USER-data tables; dev-mode = darwin_dev)
+ * @param {string} darwinOpsUri - API base URL for operational tables (always darwin per req #2697)
  * @param {string} userName - Cognito username (creator_fk filter)
  * @param {string} idToken - Auth token
  * @param {object} profile - User profile object
  * @param {object} selectedApps - { tasks: boolean, maps: boolean, swarm: boolean }
  */
-export async function fetchExportData(darwinUri, userName, idToken, profile, selectedApps) {
+export async function fetchExportData(darwinUri, darwinOpsUri, userName, idToken, profile, selectedApps) {
     // Lambda-Rest returns 404 when a table has no rows — treat as empty array, not error.
     const safeGet = async (url) => {
         try {
@@ -218,7 +219,8 @@ export async function fetchExportData(darwinUri, userName, idToken, profile, sel
         const [requirements, swarmSessions, projects, categories,
                features, testCases, testPlans] = await Promise.all([
             safeGet(`${darwinUri}/requirements`),
-            safeGet(`${darwinUri}/swarm_sessions`),
+            // Req #2697 — `swarm_sessions` is an operational table; always read from `darwin`.
+            safeGet(`${darwinOpsUri}/swarm_sessions`),
             safeGet(`${darwinUri}/projects`),
             safeGet(`${darwinUri}/categories`),
             safeGet(`${darwinUri}/features`),


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-05-27T08:25:22Z
- chore: init swarm session feature/2697-dev-servers-swarm-operational

## Files changed
```
 src/Context/AppContext.jsx                         |  13 +-
 src/NavBar/ProfileContent.jsx                      |   4 +-
 src/SwarmView/detail/RequirementDetail.jsx         |   7 +-
 src/SwarmView/detail/SwarmSessionDetail.jsx        |   5 +-
 .../__tests__/createEntityQueriesOpsUrl.test.js    | 138 +++++++++++++++++++++
 src/hooks/factory/createEntityQueries.js           |  20 ++-
 src/hooks/factory/devopsQueries.js                 |  12 ++
 src/services/__tests__/exportService.test.js       |  58 ++++++---
 src/services/exportService.js                      |   8 +-
 9 files changed, 230 insertions(+), 35 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)