### PR TITLE
req #2710

### DIFF
--- a/src/SwarmStarts/SwarmStartDetail.jsx
+++ b/src/SwarmStarts/SwarmStartDetail.jsx
@@ -187,7 +187,7 @@ export default function SwarmStartDetail() {
                             sx={{ fontFamily: 'monospace',
                                    bgcolor: 'action.hover',
                                    px: 1.5, py: 1, borderRadius: 1 }}>
-                    /swarm-start {row.arguments || <em>(empty — all swarm-ready)</em>}
+                    /swarm-start{row.arguments ? ` ${row.arguments}` : ''}
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap' }}>
                     {row.autonomy_filter && (

--- a/src/SwarmStarts/SwarmStartsPage.jsx
+++ b/src/SwarmStarts/SwarmStartsPage.jsx
@@ -123,14 +123,15 @@ export default function SwarmStartsPage() {
             headerName: 'Arguments',
             width: 390,
             renderCell: (params) => (
-                <Tooltip title={params.value || '(empty — all swarm-ready)'}>
+                <Tooltip title={params.value || '—'}>
                     <Typography variant="body2" component="span"
                                 sx={{ fontFamily: 'monospace',
                                        overflow: 'hidden',
                                        textOverflow: 'ellipsis',
-                                       whiteSpace: 'nowrap' }}
+                                       whiteSpace: 'nowrap',
+                                       ...(params.value ? {} : { color: 'text.secondary' }) }}
                                 data-testid={`swarm-start-args-${params.row.id}`}>
-                        {params.value || <em>(empty)</em>}
+                        {params.value || '—'}
                     </Typography>
                 </Tooltip>
             ),

--- a/src/SwarmStarts/SwarmStartsStatsView.jsx
+++ b/src/SwarmStarts/SwarmStartsStatsView.jsx
@@ -88,9 +88,9 @@ export function computeSwarmStartStats(rows) {
             }
         }
 
-        // Patterns: group by raw arguments string (empty/null → '(empty)')
+        // Patterns: group by raw arguments string (empty/null → '—' per req #2710)
         const argsKey = (row.arguments == null || row.arguments === '')
-            ? '(empty)'
+            ? '—'
             : row.arguments;
         const existing = patterns.get(argsKey) || {
             pattern: argsKey, invocations: 0, sessions: 0, wallSum: 0, wallCount: 0,

--- a/src/SwarmStarts/__tests__/swarmStartsStats.test.js
+++ b/src/SwarmStarts/__tests__/swarmStartsStats.test.js
@@ -105,7 +105,7 @@ describe('computeSwarmStartStats (req #2686)', () => {
         const s = computeSwarmStartStats(rows);
         expect(s.topPatterns.length).toBeGreaterThan(0);
         expect(s.topPatterns[0]).toMatchObject({ pattern: 'auto', invocations: 3, sessions: 6 });
-        const empty = s.topPatterns.find(p => p.pattern === '(empty)');
+        const empty = s.topPatterns.find(p => p.pattern === '—');
         expect(empty).toMatchObject({ invocations: 2, sessions: 5 });
         const planned = s.topPatterns.find(p => p.pattern === 'planned');
         expect(planned).toMatchObject({ invocations: 1, sessions: 1 });

--- a/src/SwarmView/detail/SwarmSessionDetail.jsx
+++ b/src/SwarmView/detail/SwarmSessionDetail.jsx
@@ -135,16 +135,10 @@ const SwarmSessionDetail = () => {
                                       onClick={() => navigate(`/swarm/swarm-starts/${swarmStart.id}`)}
                                       sx={{ cursor: 'pointer', mr: 1 }}
                                       data-testid="session-launched-by-chip" />
-                                {swarmStart.arguments
-                                    ? <Typography component="span" variant="body2"
-                                                  sx={{ fontFamily: 'monospace', color: 'text.secondary' }}>
-                                          /swarm-start {swarmStart.arguments}
-                                      </Typography>
-                                    : <Typography component="span" variant="body2"
-                                                  sx={{ fontStyle: 'italic', color: 'text.secondary' }}>
-                                          /swarm-start (empty — all swarm-ready)
-                                      </Typography>
-                                }
+                                <Typography component="span" variant="body2"
+                                            sx={{ fontFamily: 'monospace', color: 'text.secondary' }}>
+                                    /swarm-start{swarmStart.arguments ? ` ${swarmStart.arguments}` : ''}
+                                </Typography>
                             </Typography>
                         </Box>
                     }


### PR DESCRIPTION
## Summary
- feat: swarm-starts replace (empty) with em-dash (req #2710)
- chore: init swarm session feature/2710-swarm-starts-replace-empty-1

## Files changed
```
 src/SwarmStarts/SwarmStartDetail.jsx               |  2 +-
 src/SwarmStarts/SwarmStartsPage.jsx                |  7 ++++---
 src/SwarmStarts/SwarmStartsStatsView.jsx           |  4 ++--
 src/SwarmStarts/__tests__/swarmStartsStats.test.js |  2 +-
 src/SwarmView/detail/SwarmSessionDetail.jsx        | 14 ++++----------
 5 files changed, 12 insertions(+), 17 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)