### PR TITLE
Build Visualizer Polish 3

### DIFF
--- a/src/BuildVisualizer/BuildVisualizerCanvas.jsx
+++ b/src/BuildVisualizer/BuildVisualizerCanvas.jsx
@@ -13,6 +13,7 @@ import Typography from '@mui/material/Typography';
 
 import { computeLayout } from './d3LayoutEngine';
 import { BRANCH_TYPES } from './branchTypeChipStyles';
+import { computeHiddenBranchIds } from './visibilityRules';
 import paletteFor from './d3ThemePalettes';
 import { frameView } from './frameStrategies';
 import { starColorFor } from './starColors';
@@ -123,6 +124,7 @@ const BuildVisualizerCanvas = ({
     onBuildClick,
     onBuildLeave,
     onBranchClick,
+    onEmptyAnchorClick,
     resetViewNonce,
 }) => {
     const themeKey = appMode === 'dark'
@@ -132,14 +134,11 @@ const BuildVisualizerCanvas = ({
 
     const hiddenBranchIds = useMemo(() => {
         if (!model?.branches?.length) return new Set();
-        const allTypes = new Set(BRANCH_TYPES);
-        const allowedTypes = new Set(selectedTypes || BRANCH_TYPES);
-        allowedTypes.add('main');
-        const hidden = new Set();
-        for (const b of model.branches) {
-            if (allTypes.has(b.type) && !allowedTypes.has(b.type)) hidden.add(b.id);
-        }
-        return hidden;
+        return computeHiddenBranchIds({
+            branches: model.branches,
+            selectedTypes: selectedTypes || BRANCH_TYPES,
+            allTypes: BRANCH_TYPES,
+        });
     }, [model, selectedTypes]);
 
     const layout = useMemo(
@@ -520,6 +519,38 @@ const BuildVisualizerCanvas = ({
                         );
                     })}
                 </g>
+
+                {/* 3b. Empty-branch anchors — hover targets at the first-build
+                    slot on branches with zero builds. Opens an Execute-Build-only
+                    menu via onEmptyAnchorClick. */}
+                {(layout.emptyAnchors || []).length > 0 && (
+                    <g className="empty-anchors">
+                        {layout.emptyAnchors.map(a => {
+                            const openAnchorMenu = (e) => {
+                                if (dragRef.current.active || dragRef.current.moved) return;
+                                e.stopPropagation();
+                                if (onEmptyAnchorClick) onEmptyAnchorClick(a.branchId, e);
+                            };
+                            return (
+                                <g
+                                    key={`empty-${a.branchId}`}
+                                    style={{ cursor: 'pointer' }}
+                                    onMouseEnter={openAnchorMenu}
+                                    onClick={openAnchorMenu}
+                                    onMouseLeave={() => { if (onBuildLeave) onBuildLeave(); }}
+                                >
+                                    <circle
+                                        cx={a.x}
+                                        cy={a.y}
+                                        r={Math.max(a.radius + 4, 10)}
+                                        fill="transparent"
+                                        pointerEvents="all"
+                                    />
+                                </g>
+                            );
+                        })}
+                    </g>
+                )}
 
                 {/* 4. Release overlays — each carries a hover tooltip with the
                     release event details (req #2741). The tooltip triggers on

--- a/src/BuildVisualizer/BuildVisualizerPage.jsx
+++ b/src/BuildVisualizer/BuildVisualizerPage.jsx
@@ -11,6 +11,7 @@ import Checkbox from '@mui/material/Checkbox';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import Divider from '@mui/material/Divider';
 import Fade from '@mui/material/Fade';
@@ -38,11 +39,14 @@ import {
     isOpenMm,
     openMm,
     takesMainMm,
+    suggestFirstBranchNumber,
+    usedBranchNumbersFor,
 } from './versionEngine';
 import {
     allowedChildTypes,
     canCreate,
     creationGate,
+    needsBranchNumberPrompt,
     GATE_BLOCK,
     GATE_CONFIRM,
 } from './branchEngine';
@@ -50,6 +54,7 @@ import {
     DEFAULT_DARK_VARIANT,
     isThemeVariant,
 } from './themeVariants';
+import { canDeleteBuild, canDeleteBranch } from './deleteRules';
 import ThemeContext from '../Theme/ThemeContext';
 import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
@@ -115,6 +120,15 @@ const BuildVisualizerPage = () => {
     });
     const [releaseDialog, setReleaseDialog] = useState(null);
     const [selectedCustomerIds, setSelectedCustomerIds] = useState([]);
+
+    // Delete confirmation dialog (req #2742). A single dialog driven by a state
+    // object replaces both window.confirm calls. Everything needed to display the
+    // message AND execute the delete is snapshot at open time so the originating
+    // popover/editor can close immediately. The preview box mirrors TaskDeleteDialog:
+    // generic prompt + bordered preview rendering the item with context.
+    const [deleteConfirm, setDeleteConfirm] = useState(null);
+    // shape (build): { kind:'build', sqlId, version, branchName, releaseEventCount, approvedForRelease }
+    // shape (branch): { kind:'branch', sqlId, branchName, typeLabel, buildCount, releaseEventCount }
 
     // Branch-type chip rail.
     const [selectedTypes, setSelectedTypes] = useState(() => [...BRANCH_TYPES]);
@@ -189,6 +203,17 @@ const BuildVisualizerPage = () => {
         });
     }, [cancelCloseDotMenu]);
 
+    // Empty-branch anchor click — opens the dot menu in "empty anchor" mode:
+    // only Execute Build is shown (no buildRecord exists).
+    const handleEmptyAnchorClick = useCallback((branchId, e) => {
+        cancelCloseDotMenu();
+        setDotMenu({
+            emptyBranchId: branchId,
+            mouseX: e.clientX,
+            mouseY: e.clientY,
+        });
+    }, [cancelCloseDotMenu]);
+
     const closeDotMenu = useCallback(() => {
         cancelCloseDotMenu();
         setDotMenu(null);
@@ -211,13 +236,25 @@ const BuildVisualizerPage = () => {
     useEffect(() => {
         setDotMenu(null);
         setBranchEditor(null);
+        setSampleBranchNumPrompt(null);
+        // Also drop the delete-confirm dialog: it snapshots a SQL id from the
+        // outgoing project, so leaving it open across a switch would let its
+        // confirm fire a DELETE against an entity no longer on screen (req #2742).
+        setDeleteConfirm(null);
     }, [projectId]);
 
-    // Look up the branch object for the clicked build.
+    // Look up the branch object for the clicked build (or empty anchor).
     const dotMenuBranch = useMemo(() => {
         if (!dotMenu || !model?.branches) return null;
+        if (dotMenu.emptyBranchId) {
+            return model.branches.find(b => b.id === dotMenu.emptyBranchId) || null;
+        }
+        if (!dotMenu.buildRecord) return null;
         return model.branches.find(b => b.id === dotMenu.buildRecord.branchId) || null;
     }, [dotMenu, model]);
+
+    // True when the dot menu is open in empty-anchor mode (no builds on branch).
+    const isEmptyAnchorMenu = !!dotMenu?.emptyBranchId;
 
     // Resolve the SQL branch id for the clicked build's branch. We need this
     // for POST /builds (adding a build) and POST /branches (creating a branch).
@@ -296,6 +333,19 @@ const BuildVisualizerPage = () => {
         }
         setVersionPrompt(null);
     }, [versionPrompt, vpMajor, vpMinor, darwinUri, idToken, invalidateBuildData]);
+
+    // ─── Sprint branch-number prompt (req #2742) ────────────────────────
+    // When a sample-release is created off a release parent, both share the
+    // same reserved Branch# range + the same frozen Build#, so the default
+    // first Branch# collides. This prompt lets the user choose a free one.
+    const [sampleBranchNumPrompt, setSampleBranchNumPrompt] = useState(null);
+    // shape: { type, parentBuildExtId, parentBuildSqlId, projectId, parentBranchName,
+    //          frozen: {major,minor,build}, suggested, used: [...] }
+    const [sbnValue, setSbnValue] = useState('');
+
+    const sbnParsed = parseInt(sbnValue, 10);
+    const sbnValid = Number.isFinite(sbnParsed) && sbnParsed >= 1;
+    const sbnInUse = sbnValid && sampleBranchNumPrompt?.used?.includes(sbnParsed);
 
     // ─── Branch editor (req #2741) ───────────────────────────────────────
     // Clicking a branch name label (including main's trunk label) opens this
@@ -388,46 +438,140 @@ const BuildVisualizerPage = () => {
         closeDotMenu();
     }, [dotMenu, dotMenuBranch, model, darwinUri, idToken, closeDotMenu, invalidateBuildData, openVersionPrompt]);
 
-    const handleCreateBranch = useCallback(async (type, count = 1) => {
-        if (!dotMenu || !projectId) { closeDotMenu(); return; }
-        // BranchEngine policy gate (§4.7). Submenu already filters to allowed
-        // types; this guards programmatic / stale calls too. Multi-create is
-        // only offered for MULTI_BRANCH_TYPES; clamp accordingly.
-        const parentType = dotMenuBranch?.type || 'main';
-        if (!canCreate(parentType, type).allowed) { closeDotMenu(); return; }
-        const gate = creationGate(type, dotMenu.buildRecord);
-        if (gate.action === GATE_BLOCK) { closeDotMenu(); return; }
-        if (gate.action === GATE_CONFIRM && !window.confirm(gate.message)) { closeDotMenu(); return; }
-        const n = MULTI_BRANCH_TYPES.has(type)
-            ? Math.max(1, Math.min(MAX_BRANCHES_PER_HOLD, Math.floor(count) || 1))
-            : 1;
-        const buildExtId = dotMenu.buildRecord.id;
-        const buildSqlRow = buildSqlIdRef.current.get(buildExtId);
-        if (!buildSqlRow) { closeDotMenu(); return; }
-        const parentBuildSqlId = buildSqlRow.id || buildSqlRow;
-        const label = REGISTRY[type]?.label || type;
-        const parentBuild = fromModelBuild(model.builds?.[buildExtId]);
-        // Sibling ordinal base — each new branch in this batch is the next
-        // same-type sibling off this parent build, so Branch# walks the
-        // reserved range (e.g. hotfix 6000, 6050, 6100 …).
-        const baseOrd0 = (model.branches || [])
-            .filter(b => b.parentBuildId === buildExtId && b.type === type).length;
-        const stamp = Date.now();
+    // ─── Execute builds on an EMPTY branch (req #2742) ──────────────────
+    // The branch exists but has zero builds. The first build uses the branch's
+    // frozen/current version (same as doCreateBranch would), and subsequent
+    // builds in a hold-to-N walk via nextBuildVersion from that seed.
+    const executeBuildsOnEmptyBranch = useCallback(async (count) => {
+        const n = Math.max(1, Math.min(MAX_BUILDS_PER_HOLD, Math.floor(count) || 1));
+        if (!dotMenu?.emptyBranchId || !dotMenuBranch) { closeDotMenu(); return; }
+        const branch = dotMenuBranch;
+        const branchSqlId = branchSqlIdRef.current.get(branch.id);
+        if (!branchSqlId) { closeDotMenu(); return; }
 
-        // `release` carries main's M.m away (§4.2). release isn't a multi type,
-        // so n === 1 here; the handoff runs once after creation.
+        // Resolve the first-build version based on branch type.
+        let firstVersion;
+        if (branch.type === 'main') {
+            // Main — use nextBuildVersion with no lastBuild.
+            const branchMm = { major: branch.major, minor: branch.minor };
+            if (isOpenMm(branchMm)) {
+                closeDotMenu();
+                openVersionPrompt(branchSqlId, branch.name || 'Main');
+                return;
+            }
+            firstVersion = nextBuildVersion({ branchType: 'main', lastBuild: null, branchMm });
+        } else {
+            // Sub-branch — use firstBuildOnNewBranchVersion with parent build.
+            const parentBuild = fromModelBuild(
+                branch.parentBuildId ? model.builds?.[branch.parentBuildId] : null,
+            );
+            if (!parentBuild) { closeDotMenu(); return; }
+
+            const parentBranch = model.branches?.find(b => b.id === branch.parentBranchId);
+            const parentBranchType = parentBranch?.type || 'main';
+
+            // Sprint-branch-number prompt gate: sample-release off release parent.
+            if (needsBranchNumberPrompt({ childType: branch.type, parentBranchType })) {
+                const suggested = suggestFirstBranchNumber({ parentBuild, builds: model.builds });
+                const used = usedBranchNumbersFor({ parentBuild, builds: model.builds });
+                const parentBranchName = String(parentBranch?.name || parentBranchType).replace(/\n/g, ' / ');
+                setSbnValue(String(suggested));
+                setSampleBranchNumPrompt({
+                    type: branch.type,
+                    parentBuildExtId: branch.parentBuildId,
+                    parentBuildSqlId: buildSqlIdRef.current.get(branch.parentBuildId)?.id
+                        || buildSqlIdRef.current.get(branch.parentBuildId),
+                    projectId,
+                    parentBranchName,
+                    frozen: {
+                        major: parentBuild.major ?? 0,
+                        minor: parentBuild.minor ?? 0,
+                        build: parentBuild.build ?? 0,
+                    },
+                    suggested,
+                    used,
+                    parentBuild,
+                    baseOrd0: 0,
+                    // Flag: creating first build on EXISTING empty branch, not a new branch.
+                    emptyBranchSqlId: branchSqlId,
+                    emptyBranchExtId: branch.id,
+                });
+                closeDotMenu();
+                return;
+            }
+
+            // Count same-type siblings off the same parent build (excluding self).
+            const siblingOrd0 = (model.branches || [])
+                .filter(b => b.parentBuildId === branch.parentBuildId
+                    && b.type === branch.type
+                    && b.id !== branch.id)
+                .length;
+            firstVersion = firstBuildOnNewBranchVersion({
+                type: branch.type,
+                parentBuild,
+                siblingOrd0,
+            });
+        }
+
+        // Build the POST chain: first build uses firstVersion, subsequent walk.
+        const posts = [];
+        let lastBuild = firstVersion;
+        const branchMm = { major: firstVersion.major, minor: firstVersion.minor };
+        for (let i = 0; i < n; i++) {
+            const v = i === 0 ? firstVersion : nextBuildVersion({
+                branchType: branch.type,
+                lastBuild,
+                branchMm,
+            });
+            posts.push(call_rest_api(
+                `${darwinUri}/builds`, 'POST',
+                {
+                    branch_fk: branchSqlId,
+                    position: i,
+                    ...toBuildRow(v),
+                    external_id: `${branch.id}-b${i + 1}`,
+                },
+                idToken,
+            ));
+            lastBuild = v;
+        }
+        try {
+            await Promise.all(posts);
+            invalidateBuildData();
+        } catch (err) {
+            console.error('[BuildVisualizer] Execute builds on empty branch failed:', err);
+        }
+        closeDotMenu();
+    }, [dotMenu, dotMenuBranch, model, projectId, darwinUri, idToken, closeDotMenu,
+        invalidateBuildData, openVersionPrompt]);
+
+    // ─── Refactored create-branch helper (req #2742) ─────────────────────
+    // Factored out so the sprint-branch-number prompt can call it with a
+    // user-chosen firstBranchNumOverride. When present (n===1 sample path),
+    // the first build's version is computed normally and then its branchNumber
+    // is replaced with the override. Subsequent builds added later walk
+    // lastBuild.branchNumber + 1 via nextBuildVersion — they continue cleanly.
+    const doCreateBranch = useCallback(async ({
+        type, n, buildExtId, parentBuildSqlId, parentBuild, baseOrd0, pid,
+        firstBranchNumOverride,
+    }) => {
+        const label = REGISTRY[type]?.label || type;
+        const stamp = Date.now();
         const mainSqlId = branchSqlIdRef.current.get('main');
         const doHandoff = takesMainMm(type) && mainSqlId;
 
-        // One independent POST-branch → POST-its-first-build chain per branch;
-        // run them in parallel (distinct external_ids + Branch#s).
         const chains = Array.from({ length: n }, (_, i) => (async () => {
-            const v = firstBuildOnNewBranchVersion({ type, parentBuild, siblingOrd0: baseOrd0 + i });
+            const base = firstBuildOnNewBranchVersion({ type, parentBuild, siblingOrd0: baseOrd0 + i });
+            // When a firstBranchNumOverride is supplied (sprint off release),
+            // replace the computed Branch# with the user's chosen value.
+            const v = (firstBranchNumOverride != null && i === 0)
+                ? { ...base, branchNumber: firstBranchNumOverride }
+                : base;
             const slug = `${type}-${stamp}-${i}`;
             const branchRes = await call_rest_api(
                 `${darwinUri}/branches`, 'POST',
                 {
-                    project_fk: projectId,
+                    project_fk: pid,
                     branch_type: type,
                     name: label,
                     major: v.major,
@@ -454,27 +598,126 @@ const BuildVisualizerPage = () => {
             }
         })());
 
+        await Promise.all(chains);
+        if (doHandoff) {
+            const open = openMm();
+            await call_rest_api(
+                `${darwinUri}/branches`, 'PUT',
+                [{ id: mainSqlId, major: open.major, minor: open.minor }],
+                idToken,
+            );
+            openVersionPrompt(mainSqlId, 'Main');
+        }
+        invalidateBuildData();
+    }, [darwinUri, idToken, invalidateBuildData, openVersionPrompt]);
+
+    const handleCreateBranch = useCallback(async (type, count = 1) => {
+        if (!dotMenu || !projectId) { closeDotMenu(); return; }
+        // BranchEngine policy gate (§4.7). Submenu already filters to allowed
+        // types; this guards programmatic / stale calls too. Multi-create is
+        // only offered for MULTI_BRANCH_TYPES; clamp accordingly.
+        const parentType = dotMenuBranch?.type || 'main';
+        if (!canCreate(parentType, type).allowed) { closeDotMenu(); return; }
+        const gate = creationGate(type, dotMenu.buildRecord);
+        if (gate.action === GATE_BLOCK) { closeDotMenu(); return; }
+        if (gate.action === GATE_CONFIRM && !window.confirm(gate.message)) { closeDotMenu(); return; }
+        const n = MULTI_BRANCH_TYPES.has(type)
+            ? Math.max(1, Math.min(MAX_BRANCHES_PER_HOLD, Math.floor(count) || 1))
+            : 1;
+        const buildExtId = dotMenu.buildRecord.id;
+        const buildSqlRow = buildSqlIdRef.current.get(buildExtId);
+        if (!buildSqlRow) { closeDotMenu(); return; }
+        const parentBuildSqlId = buildSqlRow.id || buildSqlRow;
+        const parentBuild = fromModelBuild(model.builds?.[buildExtId]);
+        const baseOrd0 = (model.branches || [])
+            .filter(b => b.parentBuildId === buildExtId && b.type === type).length;
+
+        // ─── Sprint-branch-number prompt gate (req #2742) ─────────────────
+        // sample-release off a release parent: both share the same Branch#
+        // range + the same frozen Build#. Prompt for a collision-free first
+        // Branch# instead of creating with the default (which collides).
+        if (needsBranchNumberPrompt({ childType: type, parentBranchType: parentType })) {
+            const suggested = suggestFirstBranchNumber({ parentBuild, builds: model.builds });
+            const used = usedBranchNumbersFor({ parentBuild, builds: model.builds });
+            const parentBranchName = String(dotMenuBranch?.name || parentType).replace(/\n/g, ' / ');
+            setSbnValue(String(suggested));
+            setSampleBranchNumPrompt({
+                type,
+                parentBuildExtId: buildExtId,
+                parentBuildSqlId,
+                projectId,
+                parentBranchName,
+                frozen: {
+                    major: parentBuild?.major ?? 0,
+                    minor: parentBuild?.minor ?? 0,
+                    build: parentBuild?.build ?? 0,
+                },
+                suggested,
+                used,
+                parentBuild,
+                baseOrd0,
+            });
+            closeDotMenu();
+            return;
+        }
+
         try {
-            await Promise.all(chains);
-            if (doHandoff) {
-                // Set main open — next build refused until the user assigns M.m.
-                const open = openMm();
-                await call_rest_api(
-                    `${darwinUri}/branches`, 'PUT',
-                    [{ id: mainSqlId, major: open.major, minor: open.minor }],
-                    idToken,
-                );
-                // Prompt ONLY after the open-PUT actually succeeded — otherwise a
-                // failed release-create would pop a dialog that overwrites main's
-                // still-valid M.m on confirm.
-                openVersionPrompt(mainSqlId, 'Main');
-            }
-            invalidateBuildData();
+            await doCreateBranch({
+                type, n, buildExtId, parentBuildSqlId, parentBuild, baseOrd0, pid: projectId,
+            });
         } catch (err) {
             console.error('[BuildVisualizer] Create branch failed:', err);
         }
         closeDotMenu();
-    }, [dotMenu, dotMenuBranch, projectId, model, darwinUri, idToken, closeDotMenu, invalidateBuildData, openVersionPrompt]);
+    }, [dotMenu, dotMenuBranch, projectId, model, darwinUri, idToken, closeDotMenu, invalidateBuildData, openVersionPrompt, doCreateBranch]);
+
+    // Confirm handler for the sprint branch-number prompt. Supports two modes:
+    //   1. Normal: creating a new branch + first build (doCreateBranch).
+    //   2. Empty-branch: adding the first build to an existing empty branch
+    //      (emptyBranchSqlId is set — POST /builds only, no branch creation).
+    const confirmSampleBranchNum = useCallback(async () => {
+        if (!sampleBranchNumPrompt || !sbnValid) return;
+        const {
+            type, parentBuildSqlId, projectId: pid,
+            parentBuild, baseOrd0, parentBuildExtId,
+            emptyBranchSqlId, emptyBranchExtId,
+        } = sampleBranchNumPrompt;
+        try {
+            if (emptyBranchSqlId) {
+                // Mode 2: first build on existing empty branch.
+                const base = firstBuildOnNewBranchVersion({
+                    type, parentBuild, siblingOrd0: baseOrd0,
+                });
+                const v = { ...base, branchNumber: sbnParsed };
+                await call_rest_api(
+                    `${darwinUri}/builds`, 'POST',
+                    {
+                        branch_fk: emptyBranchSqlId,
+                        position: 0,
+                        ...toBuildRow(v),
+                        external_id: `${emptyBranchExtId}-b1`,
+                    },
+                    idToken,
+                );
+                invalidateBuildData();
+            } else {
+                // Mode 1: create new branch + first build.
+                await doCreateBranch({
+                    type,
+                    n: 1,
+                    buildExtId: parentBuildExtId,
+                    parentBuildSqlId,
+                    parentBuild,
+                    baseOrd0,
+                    pid,
+                    firstBranchNumOverride: sbnParsed,
+                });
+            }
+        } catch (err) {
+            console.error('[BuildVisualizer] Create sprint branch failed:', err);
+        }
+        setSampleBranchNumPrompt(null);
+    }, [sampleBranchNumPrompt, sbnValid, sbnParsed, doCreateBranch, darwinUri, idToken, invalidateBuildData]);
 
     const handleToggleApproved = useCallback(async () => {
         if (!dotMenu) return;
@@ -506,6 +749,81 @@ const BuildVisualizerPage = () => {
         setSelectedCustomerIds([]);
         closeDotMenu();
     }, [dotMenu, closeDotMenu]);
+
+    // Delete build (req #2742). Gated by canDeleteBuild — last build on a
+    // multi-build branch with no child branches parented off it. Opens the
+    // delete confirmation dialog; the actual DELETE runs from confirmDelete.
+    const handleDeleteBuild = useCallback(() => {
+        if (!dotMenu || !dotMenuBranch) return;
+        const buildExtId = dotMenu.buildRecord.id;
+        const version = dotMenu.buildRecord.version || buildExtId;
+        const row = buildSqlIdRef.current.get(buildExtId);
+        const sqlId = row?.id || row;
+        if (!sqlId) { closeDotMenu(); return; }
+        const releaseEventCount = (model?.releaseEvents?.[buildExtId] || []).length;
+        const branchName = String(dotMenuBranch.name || dotMenuBranch.id).replace(/\n/g, ' / ');
+        setDeleteConfirm({
+            kind: 'build',
+            sqlId: Number(sqlId),
+            version,
+            branchName,
+            releaseEventCount,
+            approvedForRelease: !!dotMenu.buildRecord.approvedForRelease,
+        });
+        closeDotMenu();
+    }, [dotMenu, dotMenuBranch, model, closeDotMenu]);
+
+    // Delete branch (req #2742). Gated by canDeleteBranch — not main and no
+    // child branches. FK cascade removes builds + customer_releases. Opens the
+    // delete confirmation dialog; the actual DELETE runs from confirmDelete.
+    const handleDeleteBranch = useCallback(() => {
+        if (!branchEditor || !branchEditorBranch) return;
+        const branchName = String(branchEditorBranch.name || branchEditor.branchId).replace(/\n/g, ' / ');
+        const buildCount = branchEditorBranch.buildIds?.length || 0;
+        const sqlId = branchSqlIdRef.current.get(branchEditor.branchId);
+        if (!sqlId) { closeBranchEditor(); return; }
+        // Sum release events across all builds on this branch.
+        const releaseEventCount = (branchEditorBranch.buildIds || []).reduce(
+            (sum, bid) => sum + (model?.releaseEvents?.[bid] || []).length,
+            0,
+        );
+        const typeLabel = REGISTRY[branchEditorBranch.type]?.label || branchEditorBranch.type;
+        setDeleteConfirm({
+            kind: 'branch',
+            sqlId: Number(sqlId),
+            branchName,
+            typeLabel,
+            buildCount,
+            releaseEventCount,
+        });
+        closeBranchEditor();
+    }, [branchEditor, branchEditorBranch, model, closeBranchEditor]);
+
+    // Confirm handler for the delete dialog — executes the actual DELETE,
+    // invalidates the cache, then closes the dialog.
+    const confirmDelete = useCallback(async () => {
+        if (!deleteConfirm) return;
+        const { kind, sqlId } = deleteConfirm;
+        try {
+            if (kind === 'build') {
+                await call_rest_api(
+                    `${darwinUri}/builds`, 'DELETE',
+                    { id: sqlId },
+                    idToken,
+                );
+            } else {
+                await call_rest_api(
+                    `${darwinUri}/branches`, 'DELETE',
+                    { id: sqlId },
+                    idToken,
+                );
+            }
+            invalidateBuildData();
+        } catch (err) {
+            console.error(`[BuildVisualizer] Delete ${kind} failed:`, err);
+        }
+        setDeleteConfirm(null);
+    }, [deleteConfirm, darwinUri, idToken, invalidateBuildData]);
 
     // Branch types available for the "Create branch" submenu — driven by the
     // BranchEngine matrix (§4.7) from the clicked build's branch type.
@@ -612,6 +930,7 @@ const BuildVisualizerPage = () => {
                 onBuildClick={handleBuildClick}
                 onBuildLeave={scheduleCloseDotMenu}
                 onBranchClick={handleBranchClick}
+                onEmptyAnchorClick={handleEmptyAnchorClick}
                 resetViewNonce={resetViewNonce}
             />
 
@@ -646,94 +965,139 @@ const BuildVisualizerPage = () => {
                 sx={{ pointerEvents: 'none' }}
                 data-testid="bv-build-menu"
             >
-                {/* Build Info Card */}
-                <Box sx={{ px: 2, pt: 1, pb: 0.5, pointerEvents: 'none' }}>
-                    <Typography variant="subtitle2" fontWeight={700}>
-                        Build {dotMenu?.buildRecord?.version}
-                    </Typography>
-                    <Typography variant="caption" color="text.secondary" display="block">
-                        {dotMenuBranch ? String(dotMenuBranch.name).replace(/\n/g, ' / ') : ''}
-                    </Typography>
-                    <Typography variant="caption" color="text.secondary" display="block">
-                        {(() => {
-                            const ts = dotMenu && model?.builds?.[dotMenu.buildRecord.id]?.createdAt;
-                            return ts ? new Date(ts).toLocaleString() : '—';
-                        })()}
-                    </Typography>
-                </Box>
-                <Divider />
+                {isEmptyAnchorMenu ? (
+                    /* ─── Empty-anchor mode — Execute Build only ─── */
+                    <>
+                        <Box sx={{ px: 2, pt: 1, pb: 0.5, pointerEvents: 'none' }}>
+                            <Typography variant="subtitle2" fontWeight={700}>
+                                {dotMenuBranch ? String(dotMenuBranch.name).replace(/\n/g, ' / ') : ''}
+                            </Typography>
+                            <Typography variant="caption" color="text.secondary" display="block">
+                                No builds yet
+                            </Typography>
+                        </Box>
+                        <Divider />
+                        <HoldCountButton
+                            label="Execute Build"
+                            onExecute={executeBuildsOnEmptyBranch}
+                            maxQty={MAX_BUILDS_PER_HOLD}
+                            dwellMs={HOLD_DWELL_MS}
+                            startDelayMs={HOLD_START_DELAY_MS}
+                            data-testid="bv-menu-add-build"
+                        />
+                    </>
+                ) : (
+                    /* ─── Normal build-dot mode ─── */
+                    <>
+                        {/* Build Info Card */}
+                        <Box sx={{ px: 2, pt: 1, pb: 0.5, pointerEvents: 'none' }}>
+                            <Typography variant="subtitle2" fontWeight={700}>
+                                Build {dotMenu?.buildRecord?.version}
+                            </Typography>
+                            <Typography variant="caption" color="text.secondary" display="block">
+                                {dotMenuBranch ? String(dotMenuBranch.name).replace(/\n/g, ' / ') : ''}
+                            </Typography>
+                            <Typography variant="caption" color="text.secondary" display="block">
+                                {(() => {
+                                    const ts = dotMenu && model?.builds?.[dotMenu.buildRecord?.id]?.createdAt;
+                                    return ts ? new Date(ts).toLocaleString() : '—';
+                                })()}
+                            </Typography>
+                        </Box>
+                        <Divider />
 
-                <HoldCountButton
-                    label="Execute Build"
-                    onExecute={executeBuilds}
-                    maxQty={MAX_BUILDS_PER_HOLD}
-                    dwellMs={HOLD_DWELL_MS}
-                    startDelayMs={HOLD_START_DELAY_MS}
-                    data-testid="bv-menu-add-build"
-                />
+                        <HoldCountButton
+                            label="Execute Build"
+                            onExecute={executeBuilds}
+                            maxQty={MAX_BUILDS_PER_HOLD}
+                            dwellMs={HOLD_DWELL_MS}
+                            startDelayMs={HOLD_START_DELAY_MS}
+                            data-testid="bv-menu-add-build"
+                        />
 
-                {/* Production Ready — two-state toggle (req #2737). Off = not
-                    production ready (default); On = production ready. */}
-                <MenuItem onClick={handleToggleApproved} data-testid="bv-menu-approve">
-                    <FormControlLabel
-                        sx={{ m: 0, pointerEvents: 'none' }}
-                        control={(
-                            <Switch
-                                size="small"
-                                checked={!!dotMenu?.buildRecord?.approvedForRelease}
-                                tabIndex={-1}
-                                inputProps={{ readOnly: true, 'data-testid': 'bv-menu-approve-switch' }}
+                        {/* Production Ready — two-state toggle (req #2737). Off = not
+                            production ready (default); On = production ready. */}
+                        <MenuItem onClick={handleToggleApproved} data-testid="bv-menu-approve">
+                            <FormControlLabel
+                                sx={{ m: 0, pointerEvents: 'none' }}
+                                control={(
+                                    <Switch
+                                        size="small"
+                                        checked={!!dotMenu?.buildRecord?.approvedForRelease}
+                                        tabIndex={-1}
+                                        inputProps={{ readOnly: true, 'data-testid': 'bv-menu-approve-switch' }}
+                                    />
+                                )}
+                                label="Production Ready"
                             />
-                        )}
-                        label="Production Ready"
-                    />
-                </MenuItem>
+                        </MenuItem>
 
-                {dotMenu?.buildRecord?.approvedForRelease && (
-                    <MenuItem onClick={handlePerformReleaseEvent} data-testid="bv-menu-release-prompt">
-                        Perform release event…
-                    </MenuItem>
-                )}
-
-                <Divider />
-                <ListSubheader
-                    disableSticky
-                    sx={{
-                        bgcolor: 'transparent',
-                        lineHeight: 1.8,
-                        fontSize: '0.7rem',
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.5,
-                    }}
-                >
-                    Create branch
-                </ListSubheader>
-                {branchSubtypes.length === 0 && (
-                    <MenuItem disabled>No branches allowed here</MenuItem>
-                )}
-                {branchSubtypes.map(t => (
-                    MULTI_BRANCH_TYPES.has(t)
-                        ? (
-                            <HoldCountButton
-                                key={t}
-                                label={branchTypeLabel(t)}
-                                onExecute={(n) => handleCreateBranch(t, n)}
-                                maxQty={MAX_BRANCHES_PER_HOLD}
-                                dwellMs={HOLD_DWELL_MS}
-                                startDelayMs={HOLD_START_DELAY_MS}
-                                data-testid={`bv-menu-branch-${t}`}
-                            />
-                        )
-                        : (
-                            <MenuItem
-                                key={t}
-                                onClick={() => handleCreateBranch(t)}
-                                data-testid={`bv-menu-branch-${t}`}
-                            >
-                                {branchTypeLabel(t)}
+                        {dotMenu?.buildRecord?.approvedForRelease && (
+                            <MenuItem onClick={handlePerformReleaseEvent} data-testid="bv-menu-release-prompt">
+                                Perform release event…
                             </MenuItem>
-                        )
-                ))}
+                        )}
+
+                        <Divider />
+                        <ListSubheader
+                            disableSticky
+                            sx={{
+                                bgcolor: 'transparent',
+                                lineHeight: 1.8,
+                                fontSize: '0.7rem',
+                                textTransform: 'uppercase',
+                                letterSpacing: 0.5,
+                            }}
+                        >
+                            Create branch
+                        </ListSubheader>
+                        {branchSubtypes.length === 0 && (
+                            <MenuItem disabled>No branches allowed here</MenuItem>
+                        )}
+                        {branchSubtypes.map(t => (
+                            MULTI_BRANCH_TYPES.has(t)
+                                ? (
+                                    <HoldCountButton
+                                        key={t}
+                                        label={branchTypeLabel(t)}
+                                        onExecute={(n) => handleCreateBranch(t, n)}
+                                        maxQty={MAX_BRANCHES_PER_HOLD}
+                                        dwellMs={HOLD_DWELL_MS}
+                                        startDelayMs={HOLD_START_DELAY_MS}
+                                        data-testid={`bv-menu-branch-${t}`}
+                                    />
+                                )
+                                : (
+                                    <MenuItem
+                                        key={t}
+                                        onClick={() => handleCreateBranch(t)}
+                                        data-testid={`bv-menu-branch-${t}`}
+                                    >
+                                        {branchTypeLabel(t)}
+                                    </MenuItem>
+                                )
+                        ))}
+
+                        {/* Delete build — destructive, at the bottom (req #2742).
+                            Gated: last build, no child branch parented off it. */}
+                        {dotMenu && dotMenuBranch && dotMenu.buildRecord && canDeleteBuild({
+                            branch: dotMenuBranch,
+                            buildId: dotMenu.buildRecord.id,
+                            branches: model?.branches || [],
+                        }) && (
+                            <>
+                                <Divider />
+                                <MenuItem
+                                    onClick={handleDeleteBuild}
+                                    data-testid="bv-menu-delete-build"
+                                    sx={{ color: 'error.main' }}
+                                >
+                                    Delete build…
+                                </MenuItem>
+                            </>
+                        )}
+                    </>
+                )}
             </Popover>
 
             <Dialog
@@ -872,6 +1236,21 @@ const BuildVisualizerPage = () => {
                     )}
                 </DialogContent>
                 <DialogActions>
+                    {/* Delete — destructive, left-aligned (req #2742).
+                        Gated: not main and no child branches. */}
+                    {branchEditorBranch && canDeleteBranch({
+                        branch: branchEditorBranch,
+                        branches: model?.branches || [],
+                    }) && (
+                        <Button
+                            color="error"
+                            onClick={handleDeleteBranch}
+                            sx={{ mr: 'auto' }}
+                            data-testid="bv-branch-delete"
+                        >
+                            Delete
+                        </Button>
+                    )}
                     <Button onClick={closeBranchEditor}>Cancel</Button>
                     <Button
                         onClick={confirmBranchEditor}
@@ -880,6 +1259,157 @@ const BuildVisualizerPage = () => {
                         data-testid="bv-branch-save"
                     >
                         Save
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            {/* ─── Sprint branch-number prompt (req #2742) ─── */}
+            <Dialog
+                open={!!sampleBranchNumPrompt}
+                onClose={() => setSampleBranchNumPrompt(null)}
+                data-testid="bv-sample-branchnum-prompt"
+            >
+                <DialogTitle>Sprint branch number</DialogTitle>
+                <DialogContent>
+                    <Typography variant="body2" sx={{ mb: 1 }}>
+                        A sprint branch off a release shares the release's
+                        Major.Minor.Build coordinate, so it needs its own Branch#
+                        to avoid version collisions.
+                    </Typography>
+                    <Typography variant="body2" sx={{ mb: 0.5, fontFamily: 'monospace', fontWeight: 600 }}>
+                        Version: {sampleBranchNumPrompt
+                            ? `${sampleBranchNumPrompt.frozen.major}.${sampleBranchNumPrompt.frozen.minor}.${sampleBranchNumPrompt.frozen.build}.x`
+                            : ''}
+                    </Typography>
+                    {sampleBranchNumPrompt?.used?.length > 0 && (
+                        <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                            In use: {sampleBranchNumPrompt.used.join(', ')}
+                        </Typography>
+                    )}
+                    <TextField
+                        label="First Branch#"
+                        type="number"
+                        autoFocus
+                        fullWidth
+                        margin="dense"
+                        value={sbnValue}
+                        onChange={(e) => setSbnValue(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === 'Enter' && sbnValid) confirmSampleBranchNum(); }}
+                        inputProps={{
+                            min: 1,
+                            step: 1,
+                            'data-testid': 'bv-sample-branchnum-input',
+                        }}
+                        error={sbnInUse}
+                        helperText={sbnInUse
+                            ? `Branch# ${sbnParsed} is already in use on this version`
+                            : ''}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        onClick={() => setSampleBranchNumPrompt(null)}
+                        data-testid="bv-sample-branchnum-cancel"
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={confirmSampleBranchNum}
+                        disabled={!sbnValid}
+                        variant="contained"
+                        data-testid="bv-sample-branchnum-confirm"
+                    >
+                        Confirm
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            {/* ─── Delete confirmation dialog (req #2742) ───
+                 Mirrors TaskDeleteDialog: generic prompt + bordered preview
+                 box rendering the item with contextual attributes. */}
+            <Dialog
+                open={!!deleteConfirm}
+                onClose={() => setDeleteConfirm(null)}
+                data-testid="bv-delete-dialog"
+            >
+                <DialogTitle>
+                    {deleteConfirm?.kind === 'build' ? 'Delete Build' : 'Delete Branch'}
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText data-testid="bv-delete-message">
+                        {deleteConfirm?.kind === 'build'
+                            ? 'Do you want to permanently delete this build?'
+                            : 'Do you want to permanently delete this branch?'}
+                    </DialogContentText>
+                    {deleteConfirm && (
+                        <Box
+                            data-testid="bv-delete-preview"
+                            sx={{
+                                mt: 2,
+                                mx: 2,
+                                p: 1.5,
+                                border: '1px solid',
+                                borderColor: 'divider',
+                                borderRadius: 1,
+                                bgcolor: 'background.paper',
+                            }}
+                        >
+                            {deleteConfirm.kind === 'build' ? (
+                                <>
+                                    <Typography
+                                        variant="body2"
+                                        sx={{ fontFamily: 'monospace', fontWeight: 700 }}
+                                    >
+                                        {deleteConfirm.version}
+                                    </Typography>
+                                    <Typography variant="body2" color="text.secondary">
+                                        {deleteConfirm.branchName}
+                                    </Typography>
+                                    {deleteConfirm.approvedForRelease && (
+                                        <Typography variant="body2" color="text.secondary">
+                                            Production ready
+                                        </Typography>
+                                    )}
+                                    {deleteConfirm.releaseEventCount > 0 && (
+                                        <Typography variant="body2" color="text.secondary">
+                                            {`${deleteConfirm.releaseEventCount} customer release event${deleteConfirm.releaseEventCount === 1 ? '' : 's'}`}
+                                        </Typography>
+                                    )}
+                                </>
+                            ) : (
+                                <>
+                                    <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                                        {deleteConfirm.branchName}
+                                    </Typography>
+                                    <Typography variant="body2" color="text.secondary">
+                                        {deleteConfirm.typeLabel}
+                                    </Typography>
+                                    <Typography variant="body2" color="text.secondary">
+                                        {`Deletes ${deleteConfirm.buildCount} build${deleteConfirm.buildCount === 1 ? '' : 's'}`}
+                                        {deleteConfirm.releaseEventCount > 0
+                                            ? ` and ${deleteConfirm.releaseEventCount} release event${deleteConfirm.releaseEventCount === 1 ? '' : 's'}`
+                                            : ''}
+                                    </Typography>
+                                </>
+                            )}
+                        </Box>
+                    )}
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        onClick={() => setDeleteConfirm(null)}
+                        data-testid="bv-delete-cancel"
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        color="error"
+                        variant="contained"
+                        autoFocus
+                        onClick={confirmDelete}
+                        data-testid="bv-delete-confirm-button"
+                    >
+                        Delete
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/src/BuildVisualizer/__tests__/branchEngine.test.js
+++ b/src/BuildVisualizer/__tests__/branchEngine.test.js
@@ -4,6 +4,7 @@ import {
     allowedChildTypes,
     canCreate,
     creationGate,
+    needsBranchNumberPrompt,
     GATE_PROCEED,
 } from '../branchEngine';
 
@@ -180,6 +181,47 @@ describe('creationGate — no gates currently defined', () => {
 
     it('GATE_PROCEED export equals "proceed"', () => {
         expect(GATE_PROCEED).toBe('proceed');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// needsBranchNumberPrompt — §4.4 Branch# collision gate (req #2742)
+// ---------------------------------------------------------------------------
+describe('needsBranchNumberPrompt', () => {
+    it('true for sample-release child + release parent', () => {
+        expect(needsBranchNumberPrompt({ childType: 'sample-release', parentBranchType: 'release' })).toBe(true);
+    });
+
+    it('false for sample-release child + main parent', () => {
+        expect(needsBranchNumberPrompt({ childType: 'sample-release', parentBranchType: 'main' })).toBe(false);
+    });
+
+    it('false for release child + release parent (release has distinct create path)', () => {
+        expect(needsBranchNumberPrompt({ childType: 'release', parentBranchType: 'release' })).toBe(false);
+    });
+
+    it('false for hotfix child + release parent', () => {
+        expect(needsBranchNumberPrompt({ childType: 'hotfix', parentBranchType: 'release' })).toBe(false);
+    });
+
+    it('false for csr child + release parent', () => {
+        expect(needsBranchNumberPrompt({ childType: 'csr', parentBranchType: 'release' })).toBe(false);
+    });
+
+    it('false for development child + release parent', () => {
+        expect(needsBranchNumberPrompt({ childType: 'development', parentBranchType: 'release' })).toBe(false);
+    });
+
+    it('false for bootleg child + release parent', () => {
+        expect(needsBranchNumberPrompt({ childType: 'bootleg', parentBranchType: 'release' })).toBe(false);
+    });
+
+    it('false for sample-release child + sample-release parent (not allowed but still false)', () => {
+        expect(needsBranchNumberPrompt({ childType: 'sample-release', parentBranchType: 'sample-release' })).toBe(false);
+    });
+
+    it('false for sample-release child + hotfix parent', () => {
+        expect(needsBranchNumberPrompt({ childType: 'sample-release', parentBranchType: 'hotfix' })).toBe(false);
     });
 });
 

--- a/src/BuildVisualizer/__tests__/d3LayoutEngine.test.js
+++ b/src/BuildVisualizer/__tests__/d3LayoutEngine.test.js
@@ -36,7 +36,7 @@ function makeModel({ mainBuilds = 5, subBranches = [], releaseEvents = {}, relea
 
     for (const sub of subBranches) {
         const subBuildIds = [];
-        for (let i = 0; i < (sub.buildCount || 1); i++) {
+        for (let i = 0; i < (sub.buildCount ?? 1); i++) {
             const bid = `${sub.id}-b${i + 1}`;
             subBuildIds.push(bid);
             builds[bid] = {
@@ -459,7 +459,91 @@ describe('main path', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 10. MAIN ENDPOINT LABELS
+// 10. EMPTY BRANCHES — emptyAnchors, label, connector (req #2742)
+// ---------------------------------------------------------------------------
+describe('empty branches', () => {
+    it('a branch with zero builds emits an emptyAnchors entry at parentX + colW', () => {
+        const model = makeModel({
+            mainBuilds: 5,
+            subBranches: [
+                { id: 'dev-empty', type: 'development', parentBuildId: 'm3', buildCount: 0, name: 'Empty Dev' },
+            ],
+        });
+
+        const layout = computeLayout(model);
+        expect(layout.emptyAnchors).toHaveLength(1);
+        const anchor = layout.emptyAnchors[0];
+        expect(anchor.branchId).toBe('dev-empty');
+        // x should be at parentX + colW (first-build slot)
+        const parentBuildRecord = layout.builds.find(b => b.id === 'm3');
+        expect(anchor.x).toBe(parentBuildRecord.x + DEFAULT_OPTS.colW);
+        // y should match the branch's assigned Y
+        const branchRecord = layout.branches.find(b => b.id === 'dev-empty');
+        expect(anchor.y).toBe(branchRecord.y);
+    });
+
+    it('a named empty branch gets a non-null labelX', () => {
+        const model = makeModel({
+            mainBuilds: 3,
+            subBranches: [
+                { id: 'dev-empty', type: 'development', parentBuildId: 'm2', buildCount: 0, name: 'Empty Dev' },
+            ],
+        });
+
+        const layout = computeLayout(model);
+        const branchRecord = layout.branches.find(b => b.id === 'dev-empty');
+        expect(branchRecord.labelX).not.toBeNull();
+        expect(branchRecord.labelY).not.toBeNull();
+    });
+
+    it('an empty branch connector has hasArrow: true and lineD reaching the first-build slot', () => {
+        const model = makeModel({
+            mainBuilds: 5,
+            subBranches: [
+                { id: 'hf-empty', type: 'hotfix', parentBuildId: 'm2', buildCount: 0, name: 'Empty HF' },
+            ],
+        });
+
+        const layout = computeLayout(model);
+        const conn = layout.connectors.find(c => c.branchId === 'hf-empty');
+        expect(conn).toBeTruthy();
+        expect(conn.hasArrow).toBe(true);
+        // lineD should contain a segment extending past the parent X
+        expect(conn.lineD).toMatch(/^M .* L .*/);
+    });
+
+    it('a branch with builds does NOT emit an emptyAnchors entry', () => {
+        const model = makeModel({
+            mainBuilds: 3,
+            subBranches: [
+                { id: 'dev1', type: 'development', parentBuildId: 'm1', buildCount: 2 },
+            ],
+        });
+
+        const layout = computeLayout(model);
+        expect(layout.emptyAnchors).toHaveLength(0);
+    });
+
+    it('empty anchor x is included in canvas width calculation', () => {
+        // Main has 2 builds. Empty branch off m2 → anchor at m2.x + colW.
+        // That anchor extends past main's last build and should widen the canvas.
+        const model = makeModel({
+            mainBuilds: 2,
+            subBranches: [
+                { id: 'dev-empty', type: 'development', parentBuildId: 'm2', buildCount: 0, name: 'Empty' },
+            ],
+        });
+
+        const layoutWithEmpty = computeLayout(model);
+        const layoutNoEmpty = computeLayout(makeModel({ mainBuilds: 2 }));
+
+        // The empty anchor extends past main's tail, so width should be >=
+        expect(layoutWithEmpty.width).toBeGreaterThanOrEqual(layoutNoEmpty.width);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 11. MAIN ENDPOINT LABELS
 // ---------------------------------------------------------------------------
 describe('main endpoint labels', () => {
     it('includes left label using the main branch name', () => {

--- a/src/BuildVisualizer/__tests__/deleteRules.test.js
+++ b/src/BuildVisualizer/__tests__/deleteRules.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { canDeleteBuild, canDeleteBranch } from '../deleteRules';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeBranch = (id, type, buildIds, parentBranchId = null) => ({
+    id,
+    type,
+    buildIds: buildIds || [],
+    parentBranchId,
+});
+
+// ─── canDeleteBuild ──────────────────────────────────────────────────────────
+
+describe('canDeleteBuild', () => {
+    it('returns true for the last build on a branch with siblings and no child branches', () => {
+        const branch = makeBranch('release-1', 'release', ['b1', 'b2', 'b3']);
+        const branches = [makeBranch('main', 'main', ['m1']), branch];
+        expect(canDeleteBuild({ branch, buildId: 'b3', branches })).toBe(true);
+    });
+
+    it('returns false for a middle build (not the last)', () => {
+        const branch = makeBranch('release-1', 'release', ['b1', 'b2', 'b3']);
+        const branches = [makeBranch('main', 'main', ['m1']), branch];
+        expect(canDeleteBuild({ branch, buildId: 'b2', branches })).toBe(false);
+    });
+
+    it('returns false for the first build (not the last)', () => {
+        const branch = makeBranch('release-1', 'release', ['b1', 'b2', 'b3']);
+        const branches = [makeBranch('main', 'main', ['m1']), branch];
+        expect(canDeleteBuild({ branch, buildId: 'b1', branches })).toBe(false);
+    });
+
+    it('returns true when the build is the only build on the branch and no child branch', () => {
+        const branch = makeBranch('dev-a', 'development', ['b1']);
+        const branches = [makeBranch('main', 'main', ['m1']), branch];
+        expect(canDeleteBuild({ branch, buildId: 'b1', branches })).toBe(true);
+    });
+
+    it('returns false when the build is the only build AND a child branch is parented off it', () => {
+        const branch = makeBranch('release-1', 'release', ['b1']);
+        const child = makeBranch('hotfix-1', 'hotfix', ['h1'], 'release-1');
+        child.parentBuildId = 'b1';
+        const branches = [makeBranch('main', 'main', ['m1']), branch, child];
+        expect(canDeleteBuild({ branch, buildId: 'b1', branches })).toBe(false);
+    });
+
+    it('returns false when a child branch is parented off the last build', () => {
+        const branch = makeBranch('release-1', 'release', ['b1', 'b2']);
+        const child = makeBranch('hotfix-1', 'hotfix', ['h1'], 'release-1');
+        child.parentBuildId = 'b2';
+        const branches = [makeBranch('main', 'main', ['m1']), branch, child];
+        expect(canDeleteBuild({ branch, buildId: 'b2', branches })).toBe(false);
+    });
+
+    it('returns true when a child branch is parented off a NON-last build', () => {
+        const branch = makeBranch('release-1', 'release', ['b1', 'b2', 'b3']);
+        const child = makeBranch('hotfix-1', 'hotfix', ['h1'], 'release-1');
+        child.parentBuildId = 'b1';
+        const branches = [makeBranch('main', 'main', ['m1']), branch, child];
+        // b3 is the last build; the child branches off b1, not b3
+        expect(canDeleteBuild({ branch, buildId: 'b3', branches })).toBe(true);
+    });
+
+    // ─── Null / empty guard cases ──────────────────────────────────────────
+
+    it('returns false when branch is null', () => {
+        expect(canDeleteBuild({ branch: null, buildId: 'b1', branches: [] })).toBe(false);
+    });
+
+    it('returns false when branch is undefined', () => {
+        expect(canDeleteBuild({ branch: undefined, buildId: 'b1', branches: [] })).toBe(false);
+    });
+
+    it('returns false when buildId is null', () => {
+        const branch = makeBranch('dev-a', 'development', ['b1', 'b2']);
+        expect(canDeleteBuild({ branch, buildId: null, branches: [] })).toBe(false);
+    });
+
+    it('returns false when buildId is undefined', () => {
+        const branch = makeBranch('dev-a', 'development', ['b1', 'b2']);
+        expect(canDeleteBuild({ branch, buildId: undefined, branches: [] })).toBe(false);
+    });
+
+    it('returns false when buildIds is empty', () => {
+        const branch = makeBranch('dev-a', 'development', []);
+        expect(canDeleteBuild({ branch, buildId: 'b1', branches: [] })).toBe(false);
+    });
+
+    it('returns false when buildIds is null/missing', () => {
+        const branch = { id: 'dev-a', type: 'development', buildIds: null };
+        expect(canDeleteBuild({ branch, buildId: 'b1', branches: [] })).toBe(false);
+    });
+
+    it('returns false when branches array is null', () => {
+        const branch = makeBranch('dev-a', 'development', ['b1', 'b2']);
+        expect(canDeleteBuild({ branch, buildId: 'b2', branches: null })).toBe(false);
+    });
+});
+
+// ─── canDeleteBranch ─────────────────────────────────────────────────────────
+
+describe('canDeleteBranch', () => {
+    it('returns true for a leaf sub-branch with no children', () => {
+        const mainBranch = makeBranch('main', 'main', ['m1']);
+        const leaf = makeBranch('dev-a', 'development', ['d1'], 'main');
+        const branches = [mainBranch, leaf];
+        expect(canDeleteBranch({ branch: leaf, branches })).toBe(true);
+    });
+
+    it('returns false for main branch', () => {
+        const mainBranch = makeBranch('main', 'main', ['m1']);
+        const branches = [mainBranch];
+        expect(canDeleteBranch({ branch: mainBranch, branches })).toBe(false);
+    });
+
+    it('returns false for a branch that has child branches', () => {
+        const mainBranch = makeBranch('main', 'main', ['m1']);
+        const release = makeBranch('release-1', 'release', ['r1'], 'main');
+        const hotfix = makeBranch('hotfix-1', 'hotfix', ['h1'], 'release-1');
+        const branches = [mainBranch, release, hotfix];
+        expect(canDeleteBranch({ branch: release, branches })).toBe(false);
+    });
+
+    it('returns true for a release branch with no children', () => {
+        const mainBranch = makeBranch('main', 'main', ['m1']);
+        const release = makeBranch('release-1', 'release', ['r1'], 'main');
+        const branches = [mainBranch, release];
+        expect(canDeleteBranch({ branch: release, branches })).toBe(true);
+    });
+
+    it('returns true for hotfix with no children', () => {
+        const mainBranch = makeBranch('main', 'main', ['m1']);
+        const hotfix = makeBranch('hotfix-1', 'hotfix', ['h1'], 'main');
+        const branches = [mainBranch, hotfix];
+        expect(canDeleteBranch({ branch: hotfix, branches })).toBe(true);
+    });
+
+    it('returns true for bootleg with no children', () => {
+        const mainBranch = makeBranch('main', 'main', ['m1']);
+        const bootleg = makeBranch('bootleg-1', 'bootleg', ['bl1'], 'main');
+        const branches = [mainBranch, bootleg];
+        expect(canDeleteBranch({ branch: bootleg, branches })).toBe(true);
+    });
+
+    // ─── Null / empty guard cases ──────────────────────────────────────────
+
+    it('returns false when branch is null', () => {
+        expect(canDeleteBranch({ branch: null, branches: [] })).toBe(false);
+    });
+
+    it('returns false when branch is undefined', () => {
+        expect(canDeleteBranch({ branch: undefined, branches: [] })).toBe(false);
+    });
+
+    it('returns false when branches array is null', () => {
+        const leaf = makeBranch('dev-a', 'development', ['d1'], 'main');
+        expect(canDeleteBranch({ branch: leaf, branches: null })).toBe(false);
+    });
+
+    it('returns false when branches array is undefined', () => {
+        const leaf = makeBranch('dev-a', 'development', ['d1'], 'main');
+        expect(canDeleteBranch({ branch: leaf, branches: undefined })).toBe(false);
+    });
+});

--- a/src/BuildVisualizer/__tests__/versionEngine.test.js
+++ b/src/BuildVisualizer/__tests__/versionEngine.test.js
@@ -12,6 +12,8 @@ import {
     nextBuildVersion,
     firstBuildOnNewBranchVersion,
     takesMainMm,
+    suggestFirstBranchNumber,
+    usedBranchNumbersFor,
 } from '../versionEngine';
 
 // All fixtures below are the worked examples from
@@ -130,6 +132,115 @@ describe('open state — §4.2', () => {
         expect(takesMainMm('release')).toBe(true);
         expect(takesMainMm('sample-release')).toBe(false);
         expect(takesMainMm('hotfix')).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// usedBranchNumbersFor — §4.4 Branch# collision helpers (req #2742)
+// ---------------------------------------------------------------------------
+describe('usedBranchNumbersFor', () => {
+    it('returns sorted Branch#s sharing the same M.m.B coordinate', () => {
+        const parentBuild = { major: 5, minor: 0, build: 8, branchNum: 0 };
+        const builds = {
+            m8: { major: 5, minor: 0, build: 8, branchNum: 0 },
+            r1: { major: 5, minor: 0, build: 8, branchNum: 1 },
+            r2: { major: 5, minor: 0, build: 8, branchNum: 2 },
+            r3: { major: 5, minor: 0, build: 8, branchNum: 3 },
+            m9: { major: 5, minor: 0, build: 9, branchNum: 0 }, // different B
+            m7: { major: 5, minor: 0, build: 7, branchNum: 0 }, // different B
+            other: { major: 5, minor: 1, build: 8, branchNum: 0 }, // different m
+        };
+        expect(usedBranchNumbersFor({ parentBuild, builds })).toEqual([0, 1, 2, 3]);
+    });
+
+    it('works with builds as an array', () => {
+        const parentBuild = { major: 1, minor: 0, build: 3, branchNum: 0 };
+        const builds = [
+            { major: 1, minor: 0, build: 3, branchNum: 0 },
+            { major: 1, minor: 0, build: 3, branchNum: 5 },
+        ];
+        expect(usedBranchNumbersFor({ parentBuild, builds })).toEqual([0, 5]);
+    });
+
+    it('returns empty array when no builds share the coordinate', () => {
+        const parentBuild = { major: 5, minor: 0, build: 8, branchNum: 0 };
+        const builds = {
+            m1: { major: 5, minor: 0, build: 7, branchNum: 0 },
+        };
+        expect(usedBranchNumbersFor({ parentBuild, builds })).toEqual([]);
+    });
+
+    it('returns empty array for null/undefined inputs', () => {
+        expect(usedBranchNumbersFor({ parentBuild: null, builds: {} })).toEqual([]);
+        expect(usedBranchNumbersFor({ parentBuild: { major: 1, minor: 0, build: 1, branchNum: 0 }, builds: null })).toEqual([]);
+        expect(usedBranchNumbersFor({ parentBuild: null, builds: null })).toEqual([]);
+    });
+
+    it('handles branchNumber (canonical name) as well as branchNum (model name)', () => {
+        const parentBuild = { major: 1, minor: 0, build: 1, branchNumber: 0 };
+        const builds = [
+            { major: 1, minor: 0, build: 1, branchNumber: 0 },
+            { major: 1, minor: 0, build: 1, branchNumber: 7 },
+        ];
+        expect(usedBranchNumbersFor({ parentBuild, builds })).toEqual([0, 7]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// suggestFirstBranchNumber — §4.4 Branch# collision helpers (req #2742)
+// ---------------------------------------------------------------------------
+describe('suggestFirstBranchNumber', () => {
+    it('returns max+1 over the shared M.m.B coordinate', () => {
+        const parentBuild = { major: 5, minor: 0, build: 8, branchNum: 0 };
+        const builds = {
+            m8: { major: 5, minor: 0, build: 8, branchNum: 0 },
+            r1: { major: 5, minor: 0, build: 8, branchNum: 1 },
+            r2: { major: 5, minor: 0, build: 8, branchNum: 2 },
+            r3: { major: 5, minor: 0, build: 8, branchNum: 3 },
+        };
+        expect(suggestFirstBranchNumber({ parentBuild, builds })).toBe(4);
+    });
+
+    it('ignores builds on other M.m.B coordinates', () => {
+        const parentBuild = { major: 5, minor: 0, build: 8, branchNum: 0 };
+        const builds = {
+            m8: { major: 5, minor: 0, build: 8, branchNum: 0 },
+            other: { major: 5, minor: 0, build: 7, branchNum: 100 },
+        };
+        // Only m8 shares the coordinate; max is 0, so suggestion is 1
+        expect(suggestFirstBranchNumber({ parentBuild, builds })).toBe(1);
+    });
+
+    it('falls back to parentBuild.branchNum + 1 when no builds share the coordinate', () => {
+        const parentBuild = { major: 5, minor: 0, build: 8, branchNum: 5 };
+        const builds = {};
+        expect(suggestFirstBranchNumber({ parentBuild, builds })).toBe(6);
+    });
+
+    it('falls back to 1 for null parentBuild', () => {
+        expect(suggestFirstBranchNumber({ parentBuild: null, builds: {} })).toBe(1);
+    });
+
+    it('handles the §4.5 worked example: release has builds at branchNum 0,1,2,3 → suggest 4', () => {
+        // release-1 has 3 builds: 5.0.8.1, 5.0.8.2, 5.0.8.3
+        // plus main build 5.0.8.0 shares the coordinate
+        const parentBuild = { major: 5, minor: 0, build: 8, branchNum: 3 };
+        const builds = {
+            m8:  { major: 5, minor: 0, build: 8, branchNum: 0 },
+            r1a: { major: 5, minor: 0, build: 8, branchNum: 1 },
+            r1b: { major: 5, minor: 0, build: 8, branchNum: 2 },
+            r1c: { major: 5, minor: 0, build: 8, branchNum: 3 },
+        };
+        expect(suggestFirstBranchNumber({ parentBuild, builds })).toBe(4);
+    });
+
+    it('works with an array of builds', () => {
+        const parentBuild = { major: 1, minor: 0, build: 5, branchNum: 0 };
+        const builds = [
+            { major: 1, minor: 0, build: 5, branchNum: 0 },
+            { major: 1, minor: 0, build: 5, branchNum: 10 },
+        ];
+        expect(suggestFirstBranchNumber({ parentBuild, builds })).toBe(11);
     });
 });
 

--- a/src/BuildVisualizer/__tests__/visibilityRules.test.js
+++ b/src/BuildVisualizer/__tests__/visibilityRules.test.js
@@ -1,0 +1,297 @@
+import { describe, it, expect } from 'vitest';
+import { computeHiddenBranchIds } from '../visibilityRules';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const ALL_TYPES = ['release', 'sample-release', 'hotfix', 'bootleg', 'csr', 'development'];
+
+const makeBranch = (id, type, parentBranchId = null) => ({
+    id,
+    type,
+    parentBranchId,
+});
+
+// A reusable tree for multi-level tests:
+//
+//   main
+//     ├── release-1   (release)
+//     │     ├── hotfix-1  (hotfix)
+//     │     └── bootleg-1 (bootleg)
+//     ├── release-2   (release)
+//     │     └── bootleg-2 (bootleg)
+//     ├── dev-a       (development)
+//     └── csr-1       (csr)
+//
+const TREE_BRANCHES = [
+    makeBranch('main',       'main'),
+    makeBranch('release-1',  'release',     'main'),
+    makeBranch('hotfix-1',   'hotfix',      'release-1'),
+    makeBranch('bootleg-1',  'bootleg',     'release-1'),
+    makeBranch('release-2',  'release',     'main'),
+    makeBranch('bootleg-2',  'bootleg',     'release-2'),
+    makeBranch('dev-a',      'development', 'main'),
+    makeBranch('csr-1',      'csr',         'main'),
+];
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('computeHiddenBranchIds', () => {
+    // ─── Basic type filtering ─────────────────────────────────────────────
+
+    it('hides all non-main branches when only main is selected (no selectedTypes)', () => {
+        const hidden = computeHiddenBranchIds({
+            branches: TREE_BRANCHES,
+            selectedTypes: [],
+            allTypes: ALL_TYPES,
+        });
+        // Every non-main branch is hidden because no type is selected,
+        // and no non-main branch is shown to trigger ancestor rescue.
+        expect(hidden.size).toBe(TREE_BRANCHES.length - 1); // all except main
+        expect(hidden.has('main')).toBe(false);
+    });
+
+    it('hides nothing when all types are selected', () => {
+        const hidden = computeHiddenBranchIds({
+            branches: TREE_BRANCHES,
+            selectedTypes: ALL_TYPES,
+            allTypes: ALL_TYPES,
+        });
+        expect(hidden.size).toBe(0);
+    });
+
+    // ─── Direct-off-main — no ancestors needed ────────────────────────────
+
+    it('shows only dev branches when development is selected (all off main, no rescue needed)', () => {
+        const hidden = computeHiddenBranchIds({
+            branches: TREE_BRANCHES,
+            selectedTypes: ['development'],
+            allTypes: ALL_TYPES,
+        });
+        // dev-a is shown (selected type, parent is main).
+        // All other non-main branches are hidden.
+        expect(hidden.has('dev-a')).toBe(false);
+        expect(hidden.has('release-1')).toBe(true);
+        expect(hidden.has('release-2')).toBe(true);
+        expect(hidden.has('hotfix-1')).toBe(true);
+        expect(hidden.has('bootleg-1')).toBe(true);
+        expect(hidden.has('bootleg-2')).toBe(true);
+        expect(hidden.has('csr-1')).toBe(true);
+    });
+
+    // ─── Ancestor rescue — the core bug fix ───────────────────────────────
+
+    it('un-hides a release ancestor when bootleg (off that release) is selected', () => {
+        // Select ONLY bootleg. bootleg-1 descends from release-1.
+        // release-1's type is deselected, but it must be un-hidden so
+        // bootleg-1 can render (its parent build X comes from release-1).
+        const hidden = computeHiddenBranchIds({
+            branches: TREE_BRANCHES,
+            selectedTypes: ['bootleg'],
+            allTypes: ALL_TYPES,
+        });
+        // bootleg-1 and bootleg-2 are shown.
+        expect(hidden.has('bootleg-1')).toBe(false);
+        expect(hidden.has('bootleg-2')).toBe(false);
+        // release-1 rescued by bootleg-1; release-2 rescued by bootleg-2.
+        expect(hidden.has('release-1')).toBe(false);
+        expect(hidden.has('release-2')).toBe(false);
+        // Other types stay hidden.
+        expect(hidden.has('hotfix-1')).toBe(true);
+        expect(hidden.has('dev-a')).toBe(true);
+        expect(hidden.has('csr-1')).toBe(true);
+    });
+
+    // ─── 2-deep chain ─────────────────────────────────────────────────────
+
+    it('un-hides a 2-deep ancestor chain (bootleg -> release-A -> release-B -> main)', () => {
+        // Build a chain: bootleg -> release-A -> release-B -> main
+        const branches = [
+            makeBranch('main',      'main'),
+            makeBranch('rel-B',     'release',  'main'),
+            makeBranch('rel-A',     'release',  'rel-B'),
+            makeBranch('boot-deep', 'bootleg',  'rel-A'),
+        ];
+        const hidden = computeHiddenBranchIds({
+            branches,
+            selectedTypes: ['bootleg'],
+            allTypes: ALL_TYPES,
+        });
+        // boot-deep is shown; BOTH rel-A and rel-B must be rescued.
+        expect(hidden.has('boot-deep')).toBe(false);
+        expect(hidden.has('rel-A')).toBe(false);
+        expect(hidden.has('rel-B')).toBe(false);
+    });
+
+    // ─── Two shown branches sharing one hidden ancestor ───────────────────
+
+    it('un-hides a shared ancestor once; siblings with no shown descendants stay hidden', () => {
+        // Two bootlegs off release-1; release-2 has NO shown descendant.
+        const branches = [
+            makeBranch('main',       'main'),
+            makeBranch('release-1',  'release',  'main'),
+            makeBranch('release-2',  'release',  'main'),
+            makeBranch('bootleg-x',  'bootleg',  'release-1'),
+            makeBranch('bootleg-y',  'bootleg',  'release-1'),
+        ];
+        const hidden = computeHiddenBranchIds({
+            branches,
+            selectedTypes: ['bootleg'],
+            allTypes: ALL_TYPES,
+        });
+        expect(hidden.has('bootleg-x')).toBe(false);
+        expect(hidden.has('bootleg-y')).toBe(false);
+        expect(hidden.has('release-1')).toBe(false);  // rescued
+        expect(hidden.has('release-2')).toBe(true);   // no shown descendant — stays hidden
+    });
+
+    // ─── Cycle guard ──────────────────────────────────────────────────────
+
+    it('does not infinite-loop on a cycle in parentBranchId', () => {
+        // Defensive: data should never have cycles, but the guard must
+        // prevent an infinite loop if one exists.
+        const branches = [
+            makeBranch('main', 'main'),
+            { id: 'a', type: 'release', parentBranchId: 'b' },
+            { id: 'b', type: 'release', parentBranchId: 'a' },
+            { id: 'c', type: 'bootleg', parentBranchId: 'a' },
+        ];
+        // Should terminate without throwing.
+        const hidden = computeHiddenBranchIds({
+            branches,
+            selectedTypes: ['bootleg'],
+            allTypes: ALL_TYPES,
+        });
+        // c is shown; a is rescued; b is rescued via a's parent walk.
+        expect(hidden.has('c')).toBe(false);
+        expect(hidden.has('a')).toBe(false);
+        expect(hidden.has('b')).toBe(false);
+    });
+
+    // ─── Edge cases ───────────────────────────────────────────────────────
+
+    it('returns empty set for empty branches array', () => {
+        const hidden = computeHiddenBranchIds({
+            branches: [],
+            selectedTypes: ['release'],
+            allTypes: ALL_TYPES,
+        });
+        expect(hidden.size).toBe(0);
+    });
+
+    it('returns empty set for null branches', () => {
+        const hidden = computeHiddenBranchIds({
+            branches: null,
+            selectedTypes: ['release'],
+            allTypes: ALL_TYPES,
+        });
+        expect(hidden.size).toBe(0);
+    });
+
+    it('returns empty set for undefined branches', () => {
+        const hidden = computeHiddenBranchIds({
+            branches: undefined,
+            selectedTypes: [],
+            allTypes: ALL_TYPES,
+        });
+        expect(hidden.size).toBe(0);
+    });
+
+    it('treats empty selectedTypes as "only main"', () => {
+        const branches = [
+            makeBranch('main', 'main'),
+            makeBranch('dev-a', 'development', 'main'),
+        ];
+        const hidden = computeHiddenBranchIds({
+            branches,
+            selectedTypes: [],
+            allTypes: ALL_TYPES,
+        });
+        expect(hidden.has('dev-a')).toBe(true);
+    });
+
+    it('treats null selectedTypes as "all selected" (defaults to empty -> adds main)', () => {
+        // When selectedTypes is null, the function wraps it with
+        // new Set(null) → empty set, then adds 'main'. So everything
+        // whose type is in allTypes is hidden. This matches the
+        // BuildVisualizerCanvas guard that passes `selectedTypes || BRANCH_TYPES`.
+        const branches = [
+            makeBranch('main', 'main'),
+            makeBranch('dev-a', 'development', 'main'),
+        ];
+        const hidden = computeHiddenBranchIds({
+            branches,
+            selectedTypes: null,
+            allTypes: ALL_TYPES,
+        });
+        expect(hidden.has('dev-a')).toBe(true);
+    });
+
+    // ─── Non-togglable types are never hidden ─────────────────────────────
+
+    it('never hides a branch whose type is not in allTypes', () => {
+        // A hypothetical branch type 'custom' not in allTypes.
+        const branches = [
+            makeBranch('main', 'main'),
+            makeBranch('custom-1', 'custom', 'main'),
+        ];
+        const hidden = computeHiddenBranchIds({
+            branches,
+            selectedTypes: [],
+            allTypes: ALL_TYPES,
+        });
+        // 'custom' is not in allTypes, so it's not eligible to be hidden.
+        expect(hidden.has('custom-1')).toBe(false);
+    });
+
+    // ─── Hotfix off release — same ancestor rescue pattern ────────────────
+
+    it('un-hides release ancestor when hotfix (off that release) is selected', () => {
+        const hidden = computeHiddenBranchIds({
+            branches: TREE_BRANCHES,
+            selectedTypes: ['hotfix'],
+            allTypes: ALL_TYPES,
+        });
+        expect(hidden.has('hotfix-1')).toBe(false);
+        // release-1 must be rescued because hotfix-1 descends from it.
+        expect(hidden.has('release-1')).toBe(false);
+        // release-2 has no shown descendant — stays hidden.
+        expect(hidden.has('release-2')).toBe(true);
+    });
+
+    // ─── Mixed selection — some types on, some off ────────────────────────
+
+    it('keeps deselected branches hidden when their type has no shown descendants needing rescue', () => {
+        // Select release + development. Bootleg / hotfix / csr are off.
+        const hidden = computeHiddenBranchIds({
+            branches: TREE_BRANCHES,
+            selectedTypes: ['release', 'development'],
+            allTypes: ALL_TYPES,
+        });
+        // Releases and dev are shown.
+        expect(hidden.has('release-1')).toBe(false);
+        expect(hidden.has('release-2')).toBe(false);
+        expect(hidden.has('dev-a')).toBe(false);
+        // Bootlegs, hotfix, csr are hidden — none are selected and none
+        // have shown descendants that need them.
+        expect(hidden.has('bootleg-1')).toBe(true);
+        expect(hidden.has('bootleg-2')).toBe(true);
+        expect(hidden.has('hotfix-1')).toBe(true);
+        expect(hidden.has('csr-1')).toBe(true);
+    });
+
+    // ─── Dangling parentBranchId ──────────────────────────────────────────
+
+    it('stops walking when parentBranchId references a non-existent branch', () => {
+        const branches = [
+            makeBranch('main', 'main'),
+            makeBranch('boot-1', 'bootleg', 'ghost'), // ghost doesn't exist
+        ];
+        // Should not throw.
+        const hidden = computeHiddenBranchIds({
+            branches,
+            selectedTypes: ['bootleg'],
+            allTypes: ALL_TYPES,
+        });
+        expect(hidden.has('boot-1')).toBe(false);
+    });
+});

--- a/src/BuildVisualizer/branchEngine.js
+++ b/src/BuildVisualizer/branchEngine.js
@@ -72,6 +72,23 @@ export const GATE_CONFIRM = 'confirm';
 export const GATE_BLOCK = 'block';
 
 /**
+ * §4.4 — True when creating `childType` from a parent branch of
+ * `parentBranchType` requires a user-chosen first Branch#. Today this fires
+ * ONLY for `sample-release` off a `release` parent, because both types share
+ * the same `base:1, stride:50` reserved Branch# range and the sample freezes
+ * the SAME Build# as the release — a head-on collision. Every other create
+ * path has a distinct reserved range or a distinct frozen Build#.
+ *
+ * The predicate is a simple boolean — it doesn't compute the suggestion or the
+ * used set; those live in versionEngine.js (suggestFirstBranchNumber /
+ * usedBranchNumbersFor). Keeping them separate matches the existing module
+ * boundary: branchEngine owns policy, versionEngine owns version arithmetic.
+ */
+export function needsBranchNumberPrompt({ childType, parentBranchType }) {
+    return childType === 'sample-release' && parentBranchType === 'release';
+}
+
+/**
  * Gate a (would-be) creation on the parent build's state (§4.7).
  *
  * There are currently NO creation gates. The earlier "release requires a

--- a/src/BuildVisualizer/d3LayoutEngine.js
+++ b/src/BuildVisualizer/d3LayoutEngine.js
@@ -116,7 +116,9 @@ function dotRadiusFor(type) {
 function horizontalExtentFor(branch, parentX, opts) {
     const colW = opts.colW;
     const nBuilds = (branch.buildIds || []).length;
-    const lastBuildX = nBuilds > 0 ? parentX + nBuilds * colW : parentX;
+    // Empty branches extend to the first-build slot (parentX + colW) so the
+    // arrow sits where the first build would land — matching the exemplar.
+    const lastBuildX = nBuilds > 0 ? parentX + nBuilds * colW : parentX + colW;
     const hasArrow = !branch._hasChildAtLastBuild;
     const arrowExt = hasArrow ? colW * opts.arrowExtColumns : 0;
     return { xMin: parentX, xMax: Math.max(parentX, lastBuildX) + arrowExt };
@@ -197,7 +199,7 @@ export function computeLayout(model, opts = {}) {
         return {
             branches: [], builds: [], connectors: [],
             mainPath: null, mainEndpointLabels: null,
-            strata: [],
+            strata: [], emptyAnchors: [],
             width: 800, height: 200, mainY: 0,
         };
     }
@@ -462,7 +464,10 @@ export function computeLayout(model, opts = {}) {
         const lastId = buildIds.length ? buildIds[buildIds.length - 1] : null;
         const lastPos = lastId != null ? positions[lastId] : null;
         const arrowExt = hasArrow ? o.colW * o.arrowExtColumns : 0;
-        const horizontalEndX = (lastPos ? Math.max(p3.x, lastPos.x) : p3.x) + arrowExt;
+        // Empty branches extend to the first-build slot (p3.x + colW) so the
+        // arrow sits where the first build would land.
+        const emptySlotX = !buildIds.length ? p3.x + o.colW : null;
+        const horizontalEndX = (lastPos ? Math.max(p3.x, lastPos.x) : (emptySlotX || p3.x)) + arrowExt;
 
         // Split into TWO paths:
         //   • curveD — the connector arrow from the parent build to the branch
@@ -546,7 +551,7 @@ export function computeLayout(model, opts = {}) {
         const parentPos = parentBuildId != null ? positions[parentBuildId] : null;
         const stratumId = STRATUM_BY_TYPE.get(b.type) || 'sample';
         const stratumDef = STRATA.find(s => s.id === stratumId);
-        if (!parentPos || buildIds.length === 0 || !b.name) {
+        if (!parentPos || !b.name) {
             return {
                 id: b.id, type: b.type, name: b.name || '', side: stratumDef.side,
                 y, isMain: false,
@@ -605,6 +610,26 @@ export function computeLayout(model, opts = {}) {
         };
     }).filter(Boolean);
 
+    // ─── Step 10b. Empty-branch anchors ─────────────────────────────────
+    // One per visible non-main branch with zero builds — the hover target
+    // position where the first build would sit. Used by the canvas to render
+    // an Execute-Build-only hover anchor at the arrow tip.
+    const emptyAnchors = [];
+    for (const b of visible) {
+        if ((b.buildIds || []).length > 0) continue;
+        const parentBuildId = b.parentBuildId;
+        const parentPos = parentBuildId != null ? positions[parentBuildId] : null;
+        if (!parentPos) continue;
+        const y = branchY.get(b.id);
+        if (y == null) continue;
+        emptyAnchors.push({
+            branchId: b.id,
+            x: parentPos.x + o.colW,   // first-build slot
+            y,
+            radius: dotRadiusFor(b.type),
+        });
+    }
+
     // ─── Step 11. Canvas size ──────────────────────────────────────────
     const yValues = Array.from(branchY.values());
     const lowestY = yValues.length ? Math.max(...yValues) : mainY;
@@ -612,8 +637,13 @@ export function computeLayout(model, opts = {}) {
     // a sub-branch off a late main build (e.g. a dev branch with several builds)
     // can extend past main's tail, and the <svg> viewport clips anything beyond
     // `width` (req #2741 — fixed a cut-off where added builds weren't shown).
-    const maxBuildX = buildRecords.length
-        ? Math.max(...buildRecords.map(r => r.x))
+    // Also include empty-anchor x values so the arrow isn't clipped.
+    const allXValues = [
+        ...buildRecords.map(r => r.x),
+        ...emptyAnchors.map(a => a.x),
+    ];
+    const maxBuildX = allXValues.length
+        ? Math.max(...allXValues)
         : o.leftPad + Math.max(0, mainBuildIds.length - 1) * o.colW;
     const arrowTail = o.colW * o.arrowExtColumns;
     const totalWidth = maxBuildX + arrowTail + o.rightPad + 160;
@@ -629,6 +659,7 @@ export function computeLayout(model, opts = {}) {
         mainPath,
         mainEndpointLabels,
         strata: strataBands,
+        emptyAnchors,
         width: totalWidth,
         height: totalHeight,
         mainY,

--- a/src/BuildVisualizer/deleteRules.js
+++ b/src/BuildVisualizer/deleteRules.js
@@ -1,0 +1,47 @@
+// deleteRules.js — Pure predicates for delete-affordance visibility (req #2742).
+//
+// Both predicates enforce the no-orphan invariant: a build or branch may only
+// be deleted when doing so cannot strand a child branch.
+
+/**
+ * Can the given build be deleted?
+ *
+ * True when ALL of:
+ *   1. It is the LAST build on the branch.
+ *   2. No branch is parented off this build.
+ *
+ * The sole build on a branch IS now deletable (leaves an empty branch with
+ * an arrow hover anchor for re-creating the first build). The prior ">1 build"
+ * condition was removed to enable this. The no-orphan invariant (condition 2)
+ * still prevents deletion when a child branch depends on the build.
+ *
+ * @param {{ branch: object|null, buildId: string, branches: object[] }} opts
+ * @returns {boolean}
+ */
+export function canDeleteBuild({ branch, buildId, branches }) {
+    if (!branch || !buildId) return false;
+    const ids = branch.buildIds;
+    if (!Array.isArray(ids) || ids.length === 0) return false;
+    if (ids[ids.length - 1] !== buildId) return false;
+    if (!Array.isArray(branches)) return false;
+    if (branches.some(b => b.parentBuildId === buildId)) return false;
+    return true;
+}
+
+/**
+ * Can the given branch be deleted?
+ *
+ * True when BOTH of:
+ *   1. Not main (the trunk cannot be deleted).
+ *   2. No child branches exist off this branch.
+ *
+ * @param {{ branch: object|null, branches: object[] }} opts
+ * @returns {boolean}
+ */
+export function canDeleteBranch({ branch, branches }) {
+    if (!branch) return false;
+    if (branch.type === 'main') return false;
+    if (!Array.isArray(branches)) return false;
+    if (branches.some(b => b.parentBranchId === branch.id)) return false;
+    return true;
+}

--- a/src/BuildVisualizer/versionEngine.js
+++ b/src/BuildVisualizer/versionEngine.js
@@ -179,3 +179,62 @@ export function firstBuildOnNewBranchVersion({ type, parentBuild, siblingOrd0 = 
 export function takesMainMm(branchType) {
     return branchType === 'release';
 }
+
+// ─── Branch# collision helpers (req #2742) ────────────────────────────────
+//
+// When a sample-release is created off a release parent, both types share the
+// same Branch# range (base:1, stride:50) AND the same frozen Build#, so the
+// default first Branch# (=1) collides with the release's own builds. These
+// two helpers let the UI prompt the user for a collision-free first Branch#.
+
+/**
+ * Sorted array of Branch#s already used on the same M.m.B coordinate as
+ * `parentBuild`. Useful for displaying "in use" values so the user can pick
+ * a free one.
+ *
+ * `builds` is the model's builds map (Object) or array — normalized
+ * internally. Null-safe.
+ */
+export function usedBranchNumbersFor({ parentBuild, builds }) {
+    if (!parentBuild || !builds) return [];
+    const M = num(parentBuild.major, NaN);
+    const m = num(parentBuild.minor, NaN);
+    const B = num(parentBuild.build, NaN);
+    if (!Number.isFinite(M) || !Number.isFinite(m) || !Number.isFinite(B)) return [];
+
+    const arr = Array.isArray(builds) ? builds : Object.values(builds);
+    const used = new Set();
+    for (const b of arr) {
+        if (!b) continue;
+        if (num(b.major, NaN) === M && num(b.minor, NaN) === m && num(b.build, NaN) === B) {
+            const bn = num(b.branchNum != null ? b.branchNum : b.branchNumber, NaN);
+            if (Number.isFinite(bn)) used.add(bn);
+        }
+    }
+    return [...used].sort((a, b) => a - b);
+}
+
+/**
+ * Suggest a first Branch# for a new sub-branch that shares `parentBuild`'s
+ * M.m.B coordinate. Returns `1 + max(branchNum)` over all builds on that
+ * coordinate — guaranteed collision-free.
+ *
+ * Fallback chain:
+ *   1. max+1 over the shared M.m.B coordinate.
+ *   2. parentBuild.branchNum + 1 (shouldn't be needed — the parent itself
+ *      occupies the coordinate).
+ *   3. 1 (absolute fallback).
+ */
+export function suggestFirstBranchNumber({ parentBuild, builds }) {
+    const used = usedBranchNumbersFor({ parentBuild, builds });
+    if (used.length > 0) return used[used.length - 1] + 1;
+    // Fallback — the parent itself should be in the set, but be safe.
+    if (parentBuild) {
+        const bn = num(
+            parentBuild.branchNum != null ? parentBuild.branchNum : parentBuild.branchNumber,
+            NaN,
+        );
+        if (Number.isFinite(bn)) return bn + 1;
+    }
+    return 1;
+}

--- a/src/BuildVisualizer/visibilityRules.js
+++ b/src/BuildVisualizer/visibilityRules.js
@@ -1,0 +1,72 @@
+// Pure-logic module for branch visibility / filtering (req #2742).
+//
+// Extracted from BuildVisualizerCanvas.jsx so the hidden-branch-id
+// computation is independently testable (follows the section 20
+// testability pattern from the design guide).
+//
+// The core rule: selecting a branch type auto-reveals the minimum
+// ancestor-branch chain needed to anchor each shown branch to the
+// trunk. A deselected type never hides a branch that a shown branch
+// depends on for positioning.
+
+/**
+ * Compute the set of branch IDs that should be hidden from the layout.
+ *
+ * @param {object} params
+ * @param {Array<{id: string, type: string, parentBranchId?: string|null}>} params.branches
+ *   All branches in the model (including main).
+ * @param {string[]} params.selectedTypes
+ *   Currently-on type strings from the chip rail.
+ * @param {string[]} params.allTypes
+ *   The full BRANCH_TYPES list (togglable types). Only branches whose
+ *   type is in this list are eligible to be hidden. Main and any
+ *   non-togglable type are always allowed.
+ * @returns {Set<string>} IDs of branches to hide.
+ */
+export function computeHiddenBranchIds({ branches, selectedTypes, allTypes }) {
+    if (!branches?.length) return new Set();
+
+    const allTypesSet = new Set(allTypes || []);
+    const allowedTypes = new Set(selectedTypes || []);
+    allowedTypes.add('main');
+
+    // Step 1: type-based hidden set — every branch whose type is a
+    // togglable type (in allTypes) but is NOT in the allowed set.
+    const hidden = new Set();
+    for (const b of branches) {
+        if (allTypesSet.has(b.type) && !allowedTypes.has(b.type)) {
+            hidden.add(b.id);
+        }
+    }
+
+    // Step 2: ancestor-rescue pass. For every branch that is NOT hidden,
+    // walk its parentBranchId chain toward main. Any ancestor currently
+    // in the hidden set is removed (un-hidden) so the shown branch has
+    // an unbroken visible chain to the trunk.
+    const branchById = new Map(branches.map(b => [b.id, b]));
+
+    for (const b of branches) {
+        if (hidden.has(b.id)) continue;       // this branch is hidden — skip
+        if (b.type === 'main') continue;       // main is never hidden
+
+        // Walk ancestors toward root.
+        const visited = new Set();             // cycle guard (defensive)
+        let current = b;
+        while (current?.parentBranchId) {
+            const parentId = current.parentBranchId;
+            if (visited.has(parentId)) break;  // cycle detected — stop
+            visited.add(parentId);
+
+            const parent = branchById.get(parentId);
+            if (!parent) break;                // dangling ref — stop
+            if (parent.type === 'main') break; // reached the trunk — done
+
+            // Un-hide this ancestor if it was hidden by the type filter.
+            hidden.delete(parentId);
+
+            current = parent;
+        }
+    }
+
+    return hidden;
+}

--- a/tests/tests/build-visualizer.spec.ts
+++ b/tests/tests/build-visualizer.spec.ts
@@ -24,6 +24,59 @@ test.describe('Build Visualizer — D3 React implementation (req #2720)', () => 
         await expect(trigger).toBeVisible();
     });
 
+    // ─── Delete build visibility gate (req #2742) ─────────────────────────
+    // Data setup for a full delete-build round-trip requires creating a
+    // project, branch, and multiple builds via the API — impractical in the
+    // current E2E harness (no project setup fixture). The gate test below
+    // verifies that the "Delete build..." item does NOT appear in the
+    // default dot-menu (the seed project's main branch has child branches
+    // off most builds, and deleting main's last build is blocked when a
+    // child branch exists).
+
+    test('delete-build menu item is hidden when conditions are not met', async ({ page }) => {
+        // Wait for canvas to render with at least one build dot.
+        const canvas = page.getByTestId('build-visualizer-canvas');
+        await expect(canvas).toBeVisible();
+
+        // Hover the first visible build dot to open the popover.
+        const dot = canvas.locator('.build-dot').first();
+        if (await dot.count() > 0) {
+            await dot.hover();
+            // Short wait for the hover popover to appear.
+            await page.waitForTimeout(300);
+            // The delete-build item should NOT appear on a typical first dot
+            // (either not the last build, only build, or has child branches).
+            const deleteItem = page.getByTestId('bv-menu-delete-build');
+            // Use count check — the item may not exist at all in the DOM.
+            expect(await deleteItem.count()).toBe(0);
+        }
+    });
+
+    // ─── Delete branch visibility gate (req #2742) ───────────────────────
+    // Similar limitation: opening the branch editor requires clicking a
+    // branch label, which needs a rendered non-main branch. The gate test
+    // below verifies the Delete button is NOT shown for the main branch.
+
+    test('delete-branch button is hidden for main branch', async ({ page }) => {
+        const canvas = page.getByTestId('build-visualizer-canvas');
+        await expect(canvas).toBeVisible();
+
+        // Click main's label to open the branch editor. Main's label carries
+        // data-branch-id="main" on its <text> or <g> wrapper.
+        const mainLabel = canvas.locator('[data-branch-id="main"]').first();
+        if (await mainLabel.count() > 0) {
+            await mainLabel.click();
+            // Wait for the branch editor dialog to appear.
+            const dialog = page.getByTestId('bv-branch-editor');
+            await expect(dialog).toBeVisible({ timeout: 3000 });
+            // The Delete button must NOT appear for main.
+            const deleteBtn = page.getByTestId('bv-branch-delete');
+            expect(await deleteBtn.count()).toBe(0);
+            // Close the dialog.
+            await page.keyboard.press('Escape');
+        }
+    });
+
     // Future: add tests for build-dot click menu, branch creation, etc.
     // The old iframe-based E2E tests (pattern CRUD, branch editor, natural
     // spacing) were retired with the iframe in req #2720. New E2E coverage


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-06-01T01:15:33Z
- chore: init swarm session feature/2742-build-visualizer-polish-3-1

## Files changed
```
 src/BuildVisualizer/BuildVisualizerCanvas.jsx      |  47 +-
 src/BuildVisualizer/BuildVisualizerPage.jsx        | 786 +++++++++++++++++----
 src/BuildVisualizer/__tests__/branchEngine.test.js |  42 ++
 .../__tests__/d3LayoutEngine.test.js               |  88 ++-
 src/BuildVisualizer/__tests__/deleteRules.test.js  | 165 +++++
 .../__tests__/versionEngine.test.js                | 111 +++
 .../__tests__/visibilityRules.test.js              | 297 ++++++++
 src/BuildVisualizer/branchEngine.js                |  17 +
 src/BuildVisualizer/d3LayoutEngine.js              |  43 +-
 src/BuildVisualizer/deleteRules.js                 |  47 ++
 src/BuildVisualizer/versionEngine.js               |  59 ++
 src/BuildVisualizer/visibilityRules.js             |  72 ++
 tests/tests/build-visualizer.spec.ts               |  53 ++
 13 files changed, 1683 insertions(+), 144 deletions(-)
```

## Testing
Build Visualizer Polish 3 — 5 items, 407 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)