### PR TITLE
Represent branch location

### DIFF
--- a/src/BuildVisualizer/BuildVisualizerPage.jsx
+++ b/src/BuildVisualizer/BuildVisualizerPage.jsx
@@ -35,6 +35,7 @@ import {
     nextBuildVersion,
     firstBuildOnNewBranchVersion,
     fromModelBuild,
+    formatVersion,
     toBuildRow,
     isOpenMm,
     openMm,
@@ -55,6 +56,7 @@ import {
     isThemeVariant,
 } from './themeVariants';
 import { canDeleteBuild, canDeleteBranch } from './deleteRules';
+import { formatBranchLocation } from './buildLocation';
 import ThemeContext from '../Theme/ThemeContext';
 import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
@@ -106,7 +108,20 @@ const writeStoredDarkVariant = (variant) => {
 const BuildVisualizerPage = () => {
     const lib = useBuildPatterns();
     const projectId = lib.activePattern?.projectId || null;
+    // Active project's display name — used to compose the branch-location
+    // string shown on build/branch click (req #2753).
+    const projectName = lib.activePattern?.name || '';
     const { isLoading: dataLoading, error: dataError, model } = useBuildVisualizerData(projectId);
+
+    // Version of a branch's FIRST build (req #2753). The branch-location string
+    // identifies the branch, so it is the same for the branch and every build
+    // on it — always the first build's M.m.B.b. Empty when the branch has no
+    // builds yet. `buildIds` is ordered by position (see useBuildVisualizerData).
+    const branchFirstBuildVersion = useCallback((branch) => {
+        const firstId = branch?.buildIds?.[0];
+        const firstBuild = firstId ? model?.builds?.[firstId] : null;
+        return firstBuild ? formatVersion(fromModelBuild(firstBuild)) : '';
+    }, [model]);
 
     const { darwinUri } = useContext(AppContext);
     const { idToken, profile } = useContext(AuthContext);
@@ -1003,6 +1018,22 @@ const BuildVisualizerPage = () => {
                                     return ts ? new Date(ts).toLocaleString() : '—';
                                 })()}
                             </Typography>
+                            {/* Branch location (req #2753) — informational, not a link.
+                                Identifies the branch: project / branch name /
+                                version of the branch's first build. */}
+                            <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                display="block"
+                                sx={{ mt: 0.5, wordBreak: 'break-all' }}
+                                data-testid="bv-build-location"
+                            >
+                                {formatBranchLocation(
+                                    projectName,
+                                    dotMenuBranch?.name,
+                                    branchFirstBuildVersion(dotMenuBranch),
+                                )}
+                            </Typography>
                         </Box>
                         <Divider />
 
@@ -1231,6 +1262,23 @@ const BuildVisualizerPage = () => {
                             )}
                             <Typography variant="caption" color="text.secondary" display="block">
                                 Builds: {branchEditorBranch.buildIds?.length || 0}
+                            </Typography>
+                            {/* Branch location (req #2753) — informational, not a link.
+                                Same shape as the build menu: project / branch name /
+                                version of the branch's first build (omitted when the
+                                branch has no builds yet). */}
+                            <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                display="block"
+                                sx={{ mt: 0.5, wordBreak: 'break-all' }}
+                                data-testid="bv-branch-location"
+                            >
+                                {formatBranchLocation(
+                                    projectName,
+                                    branchEditorBranch.name,
+                                    branchFirstBuildVersion(branchEditorBranch),
+                                )}
                             </Typography>
                         </Box>
                     )}

--- a/src/BuildVisualizer/__tests__/buildLocation.test.js
+++ b/src/BuildVisualizer/__tests__/buildLocation.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { formatBranchLocation } from '../buildLocation';
+
+describe('formatBranchLocation — req #2753', () => {
+    it('composes host/project/branch/version with no scheme', () => {
+        expect(formatBranchLocation('Darwin', 'main', '1.0.3.0'))
+            .toBe('jira.microchip.com/Darwin/main/1.0.3.0');
+    });
+
+    it('includes the branch name for non-main branches', () => {
+        expect(formatBranchLocation('My App', 'hotfix-1', '2.5.1.1000'))
+            .toBe('jira.microchip.com/My App/hotfix-1/2.5.1.1000');
+    });
+
+    it('omits the version segment when version is empty (branch with no builds)', () => {
+        expect(formatBranchLocation('Darwin', 'main', ''))
+            .toBe('jira.microchip.com/Darwin/main');
+    });
+
+    it('omits the version segment when version is null/undefined', () => {
+        expect(formatBranchLocation('Darwin', 'main', null)).toBe('jira.microchip.com/Darwin/main');
+        expect(formatBranchLocation('Darwin', 'main', undefined)).toBe('jira.microchip.com/Darwin/main');
+    });
+
+    it('falls back to "project" when the project name is empty', () => {
+        expect(formatBranchLocation('', 'main', '1.0.1.0')).toBe('jira.microchip.com/project/main/1.0.1.0');
+        expect(formatBranchLocation(null, 'main', '1.0.1.0')).toBe('jira.microchip.com/project/main/1.0.1.0');
+    });
+
+    it('falls back to "branch" when the branch name is empty', () => {
+        expect(formatBranchLocation('Darwin', '', '1.0.1.0')).toBe('jira.microchip.com/Darwin/branch/1.0.1.0');
+        expect(formatBranchLocation('Darwin', null, '1.0.1.0')).toBe('jira.microchip.com/Darwin/branch/1.0.1.0');
+    });
+
+    it('flattens embedded newlines and collapses whitespace in branch names', () => {
+        expect(formatBranchLocation('Darwin', 'release\n1.0', '1.0.1.0'))
+            .toBe('jira.microchip.com/Darwin/release 1.0/1.0.1.0');
+    });
+
+    it('trims surrounding whitespace on all segments', () => {
+        expect(formatBranchLocation('  Darwin  ', '  main  ', '  1.0.1.0  '))
+            .toBe('jira.microchip.com/Darwin/main/1.0.1.0');
+    });
+});

--- a/src/BuildVisualizer/buildLocation.js
+++ b/src/BuildVisualizer/buildLocation.js
@@ -1,0 +1,33 @@
+// req #2753 — Branch location string shown when a build or branch is clicked.
+//
+// The location is purely informational (NOT a link): the user copies it into a
+// browser. Per the requirement, no scheme is included — the bare host/path is
+// enough info. Shape:
+//
+//   jira.microchip.com/{Build-project-name}/{branch name}/{version of first build}
+//
+// The location identifies the BRANCH, so it is the same string for the branch
+// itself and for every build on it: the version segment is always the version
+// of the branch's FIRST build (not the clicked build). The branch name segment
+// is always present, including for `main`.
+//
+// Branch names in this app can carry embedded newlines (multi-line labels), so
+// each segment is flattened to single-line and trimmed before composing.
+
+function clean(value) {
+    return (value ?? '')
+        .toString()
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+// Compose the branch-location string from project name, branch name, and the
+// version of the branch's first build. `version` may be empty (e.g. a branch
+// with no builds yet); in that case the trailing version segment is omitted.
+export function formatBranchLocation(projectName, branchName, version) {
+    const project = clean(projectName) || 'project';
+    const branch = clean(branchName) || 'branch';
+    const ver = clean(version);
+    const base = `jira.microchip.com/${project}/${branch}`;
+    return ver ? `${base}/${ver}` : base;
+}


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2753-represent-branch-location-1
- wip(Darwin): 2026-06-01T10:20:47Z
- chore: init swarm session feature/2753-represent-branch-location-1

## Files changed
```
 src/BuildVisualizer/BuildVisualizerPage.jsx        | 48 ++++++++++++++++++++++
 .../__tests__/buildLocation.test.js                | 44 ++++++++++++++++++++
 src/BuildVisualizer/buildLocation.js               | 33 +++++++++++++++
 3 files changed, 125 insertions(+)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)