### PR TITLE
add hot fix/branch builds reset view

### DIFF
--- a/src/BuildVisualizer/BuildVisualizerCanvas.jsx
+++ b/src/BuildVisualizer/BuildVisualizerCanvas.jsx
@@ -15,7 +15,7 @@ import { computeLayout } from './d3LayoutEngine';
 import { BRANCH_TYPES } from './branchTypeChipStyles';
 import { computeHiddenBranchIds } from './visibilityRules';
 import paletteFor from './d3ThemePalettes';
-import { frameView } from './frameStrategies';
+import { frameView, reflowPanDeltaY } from './frameStrategies';
 import { starColorFor } from './starColors';
 import {
     DEFAULT_DARK_VARIANT,
@@ -278,33 +278,41 @@ const BuildVisualizerCanvas = ({
         return runFrameRef.current();
     }, [resetViewNonce]);
 
-    // Keep the view STABLE across in-place layout reflows (req #2741). Hiding a
-    // branch type (e.g. Release) collapses a whole stratum, so `mainY` shrinks
-    // and EVERY branch Y shifts up. With a fixed pan the graph would visibly
-    // jump. To preserve "what the user was looking at", compensate the pan by
-    // the change in `mainY` — the trunk (and everything anchored to it) keeps
-    // its on-screen position; only the toggled branches appear/disappear.
+    // Keep the view STABLE across in-place layout reflows (req #2741, #2754).
+    // Hiding a branch type (e.g. Release) collapses a whole stratum, so `mainY`
+    // shrinks and EVERY branch Y shifts up; adding hotfix/bootleg branches or
+    // builds grows the strata/lanes and shifts EVERY branch Y down. With a fixed
+    // pan the graph would visibly jump. To preserve "what the user was looking
+    // at", compensate the pan by the change in `mainY` — the trunk (and
+    // everything anchored to it) keeps its on-screen position; only the
+    // added/toggled branches appear or disappear.
     //
-    // Gated on DATA IDENTITY (`model` reference): a filter/stagger toggle
-    // recomputes `layout` while `model` stays the same object, so we compensate;
-    // a project switch / data reload gives a NEW `model`, so we skip and let
-    // runFrame own positioning. This is strategy-agnostic — it does NOT assume
-    // the framing function is linear in `mainY`, so new FRAME_STRATEGIES stay
-    // safe. Also skipped until the project is initially framed.
+    // Gated on PROJECT IDENTITY (`projectId`), NOT the `model` reference
+    // (req #2754). An add-branch / add-build refetches (`invalidateBuildData`)
+    // and produces a BRAND-NEW `model` object while staying on the same project
+    // — the old model-reference gate treated that as a reload and skipped
+    // compensation, so the view jumped to the new branches. A real project
+    // switch changes `projectId`, where we skip and let `runFrame` reframe. The
+    // delta math lives in `reflowPanDeltaY` — strategy-agnostic, so it does NOT
+    // assume the framing function is linear in `mainY` and new FRAME_STRATEGIES
+    // stay safe. A transient empty layout (no branches) reads `mainY` as null so
+    // it is never used as a comparison point.
     const prevMainYRef = useRef(null);
-    const prevModelRef = useRef(null);
+    const prevProjectIdRef = useRef(null);
     useEffect(() => {
-        const mainY = layout?.mainY ?? null;
+        const mainY = layout?.branches?.length ? (layout.mainY ?? null) : null;
         const prevMainY = prevMainYRef.current;
-        const sameData = model != null && prevModelRef.current === model;
+        const sameProject = prevProjectIdRef.current === projectId;
         prevMainYRef.current = mainY;
-        prevModelRef.current = model;
-        if (!sameData) return;                              // project switch / reload
-        if (prevMainY == null || mainY == null) return;     // nothing to compare
-        if (lastFitProjectId.current !== projectId) return; // not yet framed
-        const delta = prevMainY - mainY;
+        prevProjectIdRef.current = projectId;
+        const delta = reflowPanDeltaY({
+            sameProject,
+            framed: lastFitProjectId.current === projectId,
+            prevMainY,
+            mainY,
+        });
         if (delta !== 0) setPan(p => ({ ...p, y: p.y + delta }));
-    }, [layout, model, projectId]);
+    }, [layout, projectId]);
 
     if (isLoading) {
         return (

--- a/src/BuildVisualizer/__tests__/frameStrategies.test.js
+++ b/src/BuildVisualizer/__tests__/frameStrategies.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { FRAME_STRATEGIES, frameView, DEFAULT_FRAME_STRATEGY } from '../frameStrategies';
+import {
+    FRAME_STRATEGIES,
+    frameView,
+    DEFAULT_FRAME_STRATEGY,
+    reflowPanDeltaY,
+} from '../frameStrategies';
 
 describe('DEFAULT_FRAME_STRATEGY', () => {
     it('is centerMain', () => {
@@ -61,5 +66,89 @@ describe('frameView', () => {
     it('falls back to centerMain for unknown strategy', () => {
         const result = frameView({ mainY: 200 }, { height: 600 }, 'nonexistent');
         expect(result).toEqual({ x: 0, y: 100 });
+    });
+});
+
+describe('reflowPanDeltaY (req #2754)', () => {
+    it('compensates a same-project reflow by the mainY change (add branch/build grows mainY → negative delta)', () => {
+        // Adding hotfix/bootleg branches grows the strata above the trunk, so
+        // mainY increases; the pan must shift UP (negative) to keep the trunk fixed.
+        const delta = reflowPanDeltaY({
+            sameProject: true,
+            framed: true,
+            prevMainY: 200,
+            mainY: 260,
+        });
+        expect(delta).toBe(-60);
+    });
+
+    it('compensates a collapse (filter toggle shrinks mainY → positive delta)', () => {
+        const delta = reflowPanDeltaY({
+            sameProject: true,
+            framed: true,
+            prevMainY: 260,
+            mainY: 200,
+        });
+        expect(delta).toBe(60);
+    });
+
+    it('returns 0 on a project switch (let runFrame reframe)', () => {
+        const delta = reflowPanDeltaY({
+            sameProject: false,
+            framed: true,
+            prevMainY: 200,
+            mainY: 500,
+        });
+        expect(delta).toBe(0);
+    });
+
+    it('returns 0 before the project is framed', () => {
+        const delta = reflowPanDeltaY({
+            sameProject: true,
+            framed: false,
+            prevMainY: 200,
+            mainY: 260,
+        });
+        expect(delta).toBe(0);
+    });
+
+    it('returns 0 when prevMainY is null (first measurable layout)', () => {
+        const delta = reflowPanDeltaY({
+            sameProject: true,
+            framed: true,
+            prevMainY: null,
+            mainY: 260,
+        });
+        expect(delta).toBe(0);
+    });
+
+    it('returns 0 when mainY is null (transient empty layout)', () => {
+        const delta = reflowPanDeltaY({
+            sameProject: true,
+            framed: true,
+            prevMainY: 200,
+            mainY: null,
+        });
+        expect(delta).toBe(0);
+    });
+
+    it('returns 0 when mainY is unchanged (no jump, no-op)', () => {
+        const delta = reflowPanDeltaY({
+            sameProject: true,
+            framed: true,
+            prevMainY: 200,
+            mainY: 200,
+        });
+        expect(delta).toBe(0);
+    });
+
+    it('treats mainY = 0 as a real value, not missing', () => {
+        const delta = reflowPanDeltaY({
+            sameProject: true,
+            framed: true,
+            prevMainY: 40,
+            mainY: 0,
+        });
+        expect(delta).toBe(40);
     });
 });

--- a/src/BuildVisualizer/frameStrategies.js
+++ b/src/BuildVisualizer/frameStrategies.js
@@ -21,3 +21,28 @@ export function frameView(layout, viewport, strategy = DEFAULT_FRAME_STRATEGY) {
     const fn = FRAME_STRATEGIES[strategy] || FRAME_STRATEGIES[DEFAULT_FRAME_STRATEGY];
     return fn(layout, viewport);
 }
+
+// ─── In-place reflow pan compensation (req #2741, generalized #2754) ─────────
+// When the graph reflows WITHIN the same project — a filter/stagger toggle
+// (req #2741) OR an add-branch / add-build data mutation (req #2754) — the
+// trunk's Y (`mainY`) moves as strata/lanes are added or collapsed. To keep
+// what the user was looking at fixed on screen, the pan's Y is shifted by the
+// change in `mainY`; X is untouched because adding content only extends the
+// graph rightward (existing X positions are stable).
+//
+// The discriminator for "preserve the view" vs "reframe" is PROJECT IDENTITY,
+// not the data/model object reference: adding a build/branch refetches and
+// produces a brand-new model object while staying on the same project, and that
+// must NOT trigger a reframe. A project switch (`sameProject === false`) is left
+// to `frameView`/`runFrame` instead, so this returns 0 there.
+//
+// Returns the Y delta to ADD to the current pan. 0 means no adjustment:
+//   - project switch (sameProject false) → runFrame reframes instead
+//   - project not yet framed (framed false) → initial framing owns the position
+//   - either mainY is null (e.g. a transient empty layout) → nothing to compare
+export function reflowPanDeltaY({ sameProject, framed, prevMainY, mainY }) {
+    if (!sameProject) return 0;
+    if (!framed) return 0;
+    if (prevMainY == null || mainY == null) return 0;
+    return prevMainY - mainY;
+}


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2754-add-hot-fixbranch-builds-reset-view-1
- wip(Darwin): 2026-06-01T10:17:22Z
- chore: init swarm session feature/2754-add-hot-fixbranch-builds-reset-view-1

## Files changed
```
 src/BuildVisualizer/BuildVisualizerCanvas.jsx      | 52 +++++++------
 .../__tests__/frameStrategies.test.js              | 91 +++++++++++++++++++++-
 src/BuildVisualizer/frameStrategies.js             | 25 ++++++
 3 files changed, 145 insertions(+), 23 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)