### PR TITLE
Build Visualizer Polish

### DIFF
--- a/src/BuildVisualizer/BuildVisualizerCanvas.jsx
+++ b/src/BuildVisualizer/BuildVisualizerCanvas.jsx
@@ -90,10 +90,13 @@ function ReleaseTooltipContent({ build, branchName }) {
     const details = build.releaseDetails?.length
         ? build.releaseDetails
         : (build.releaseCustomers || []).map(name => ({ name, date: null }));
+    // Every release event on a build shares one type (derived from the branch
+    // type — req #2772). Surface it in the header.
+    const releaseType = details.find(d => d.releaseType)?.releaseType;
     return (
         <Box sx={{ py: 0.25 }}>
             <Typography variant="caption" sx={{ fontWeight: 700, display: 'block' }}>
-                Released — Build {build.version}
+                {releaseType ? `${releaseType} release` : 'Released'} — Build {build.version}
             </Typography>
             {branchName ? (
                 <Typography variant="caption" sx={{ display: 'block', opacity: 0.8 }}>

--- a/src/BuildVisualizer/BuildVisualizerPage.jsx
+++ b/src/BuildVisualizer/BuildVisualizerPage.jsx
@@ -56,6 +56,7 @@ import {
     isThemeVariant,
 } from './themeVariants';
 import { canDeleteBuild, canDeleteBranch } from './deleteRules';
+import { readinessLabelFor } from './readinessRules';
 import { formatBranchLocation } from './buildLocation';
 import ThemeContext from '../Theme/ThemeContext';
 import AppContext from '../Context/AppContext';
@@ -70,9 +71,10 @@ const MAX_BRANCHES_PER_HOLD = 5;
 // Common hold-to-count timing for BOTH builds and branches (req #2741): one
 // start delay + one dwell, only the cap differs. Derived from the prior branch
 // cadence — start delay 2× the old 200 ms (the wait before the count leaves 1),
-// dwell = the old branch dwell (2× builds = 450) made 25% longer.
-const HOLD_START_DELAY_MS = 400;        // 2× the prior 200 ms
-const HOLD_DWELL_MS = 450 * 1.25;       // 562.5 ms — 25% longer than the old branch dwell
+// dwell = the inter-increment step, decreased ~33% from the prior 562.5 ms so the
+// count ramps faster while the start-delay offset is unchanged.
+const HOLD_START_DELAY_MS = 400;        // 2× the prior 200 ms (offset before count leaves 1)
+const HOLD_DWELL_MS = 375;              // ~33% faster than the prior 562.5 ms (= 562.5 × ⅔)
 // Only these branch types support hold-to-make-multiple; others are single.
 const MULTI_BRANCH_TYPES = new Set(['hotfix', 'bootleg', 'development']);
 
@@ -1046,8 +1048,9 @@ const BuildVisualizerPage = () => {
                             data-testid="bv-menu-add-build"
                         />
 
-                        {/* Production Ready — two-state toggle (req #2737). Off = not
-                            production ready (default); On = production ready. */}
+                        {/* Readiness — two-state toggle (req #2737). Off = not ready
+                            (default); On = ready. The label varies by branch type
+                            (req #2772): Production / Sample / Debug / Hot Fix Ready. */}
                         <MenuItem onClick={handleToggleApproved} data-testid="bv-menu-approve">
                             <FormControlLabel
                                 sx={{ m: 0, pointerEvents: 'none' }}
@@ -1059,7 +1062,7 @@ const BuildVisualizerPage = () => {
                                         inputProps={{ readOnly: true, 'data-testid': 'bv-menu-approve-switch' }}
                                     />
                                 )}
-                                label="Production Ready"
+                                label={readinessLabelFor(dotMenu?.buildRecord?.branchType)}
                             />
                         </MenuItem>
 

--- a/src/BuildVisualizer/HoldCountButton.jsx
+++ b/src/BuildVisualizer/HoldCountButton.jsx
@@ -19,7 +19,7 @@ export default function HoldCountButton({
     label,
     onExecute,
     maxQty = 14,
-    dwellMs = 562.5,
+    dwellMs = 375,
     startDelayMs = 400,
     'data-testid': testId,
 }) {

--- a/src/BuildVisualizer/__tests__/d3LayoutEngine.test.js
+++ b/src/BuildVisualizer/__tests__/d3LayoutEngine.test.js
@@ -285,6 +285,80 @@ describe('labelY — top-track raise for release events', () => {
 });
 
 // ---------------------------------------------------------------------------
+// 4b. RELEASE CLEARANCE (req #2772) — a release-bearing row reserves extra
+//     vertical room ABOVE it so its star row + raised label don't collide with
+//     the version labels of the row directly above. Applied only to the gap
+//     above the release-bearing row; release-free layouts are unchanged.
+// ---------------------------------------------------------------------------
+describe('release clearance — extra room above a release-bearing row', () => {
+    // Two CSR branches off the SAME parent build overlap horizontally, so they
+    // land on different lanes of the CSR stratum (lane 0 = inner/lower, lane 1
+    // = outer/upper). cs1 is first in model order → lane 0 (nearest main).
+    const twoCsr = (releaseEvents = {}) => computeLayout(makeModel({
+        mainBuilds: 4,
+        subBranches: [
+            { id: 'cs1', type: 'csr', parentBuildId: 'm1', buildCount: 3 },
+            { id: 'cs2', type: 'csr', parentBuildId: 'm1', buildCount: 3 },
+        ],
+        releaseEvents,
+    }));
+    const gapBetween = (layout) => {
+        const cs1 = layout.branches.find(b => b.id === 'cs1');
+        const cs2 = layout.branches.find(b => b.id === 'cs2');
+        return Math.abs(cs1.y - cs2.y);
+    };
+
+    it('release-free: adjacent same-stratum lanes are exactly laneGap apart', () => {
+        expect(gapBetween(twoCsr())).toBe(DEFAULT_OPTS.laneGap);
+    });
+
+    it('release on the INNER lane widens the gap above it by releaseClearance', () => {
+        // cs1 (lane 0, lower) bears the release → clearance is inserted between
+        // it and cs2 (the lane directly above).
+        const gap = gapBetween(twoCsr({ 'cs1-b1': ['Acme'] }));
+        expect(gap).toBe(DEFAULT_OPTS.laneGap + DEFAULT_OPTS.releaseClearance);
+    });
+
+    it('release on the OUTER lane does NOT widen the inter-lane gap', () => {
+        // cs2 (lane 1, upper) bears the release → clearance goes above cs2
+        // (toward the stratum/canvas above), not between the two CSR lanes.
+        const gap = gapBetween(twoCsr({ 'cs2-b1': ['Acme'] }));
+        expect(gap).toBe(DEFAULT_OPTS.laneGap);
+    });
+
+    it('release-free absolute Y matches the documented formula (no upward shift)', () => {
+        // One 1-lane above stratum (bootleg) + main. The prior engine placed the
+        // topmost lane at canvasPadTop + laneGap and main a sideGap below the
+        // band — locking this guards against the rows-walk shifting everything up.
+        const { canvasPadTop, laneGap, sideGap } = DEFAULT_OPTS;
+        const layout = computeLayout(makeModel({
+            mainBuilds: 3,
+            subBranches: [{ id: 'bl1', type: 'bootleg', parentBuildId: 'm1', buildCount: 1 }],
+        }));
+        const bootleg = layout.branches.find(b => b.id === 'bl1');
+        expect(bootleg.y).toBe(canvasPadTop + laneGap);          // 40 + 70 = 110
+        expect(layout.mainY).toBe(canvasPadTop + laneGap + sideGap); // 110 + 70 = 180
+    });
+
+    it('a release on a dev branch pushes it further below main', () => {
+        const plain = computeLayout(makeModel({
+            mainBuilds: 3,
+            subBranches: [{ id: 'dev1', type: 'development', parentBuildId: 'm1', buildCount: 2 }],
+        }));
+        const withRel = computeLayout(makeModel({
+            mainBuilds: 3,
+            subBranches: [{ id: 'dev1', type: 'development', parentBuildId: 'm1', buildCount: 2 }],
+            releaseEvents: { 'dev1-b1': ['Acme'] },
+        }));
+        const devPlain = plain.branches.find(b => b.id === 'dev1');
+        const devRel = withRel.branches.find(b => b.id === 'dev1');
+        // main stays put; the dev lane drops by releaseClearance to clear main's
+        // version labels with its star row.
+        expect(devRel.y - devPlain.y).toBe(DEFAULT_OPTS.releaseClearance);
+    });
+});
+
+// ---------------------------------------------------------------------------
 // 5. BUILD RECORDS — branchType and releaseDetails carried through
 // ---------------------------------------------------------------------------
 describe('build records — branchType and releaseDetails', () => {

--- a/src/BuildVisualizer/__tests__/holdCountFormula.test.js
+++ b/src/BuildVisualizer/__tests__/holdCountFormula.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { holdCount } from '../holdCountFormula';
 
-// Default timing from HoldCountButton: startDelayMs=400, dwellMs=562.5
+// Default timing from HoldCountButton: startDelayMs=400, dwellMs=375
 const START = 400;
-const DWELL = 562.5;
+const DWELL = 375;
 const MAX = 14;
 
 describe('holdCount — quick click', () => {

--- a/src/BuildVisualizer/__tests__/readinessRules.test.js
+++ b/src/BuildVisualizer/__tests__/readinessRules.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+    readinessFor,
+    readinessLabelFor,
+    releaseTypeFor,
+    READINESS_BY_TYPE,
+    DEFAULT_READINESS,
+} from '../readinessRules';
+
+// req #2772 mapping:
+//   Production Ready / Production : main, release, csr
+//   Sample Ready     / Sample     : development, sample-release
+//   Debug Ready      / Debug      : bootleg
+//   Hot Fix Ready    / Hot Fix    : hotfix
+
+describe('readinessRules — branch-type → label + release type', () => {
+    const cases = [
+        ['main',           'Production Ready', 'Production'],
+        ['release',        'Production Ready', 'Production'],
+        ['csr',            'Production Ready', 'Production'],
+        ['development',    'Sample Ready',     'Sample'],
+        ['sample-release', 'Sample Ready',     'Sample'],
+        ['bootleg',        'Debug Ready',      'Debug'],
+        ['hotfix',         'Hot Fix Ready',    'Hot Fix'],
+    ];
+
+    it.each(cases)('%s → label "%s", releaseType "%s"', (type, label, releaseType) => {
+        expect(readinessLabelFor(type)).toBe(label);
+        expect(releaseTypeFor(type)).toBe(releaseType);
+        expect(readinessFor(type)).toEqual({ label, releaseType });
+    });
+
+    it('covers every REGISTRY branch type exactly once', () => {
+        // All 7 Build Visualizer branch types must be mapped — no gaps.
+        const mapped = Object.keys(READINESS_BY_TYPE).sort();
+        expect(mapped).toEqual(
+            ['bootleg', 'csr', 'development', 'hotfix', 'main', 'release', 'sample-release'],
+        );
+    });
+
+    it('hotfix is its OWN release type, NOT Production (req #2772 correction)', () => {
+        expect(releaseTypeFor('hotfix')).toBe('Hot Fix');
+        expect(releaseTypeFor('hotfix')).not.toBe('Production');
+    });
+
+    it('falls back to Production Ready for an unknown branch type', () => {
+        expect(readinessFor('does-not-exist')).toEqual(DEFAULT_READINESS);
+        expect(readinessLabelFor(undefined)).toBe('Production Ready');
+        expect(releaseTypeFor(null)).toBe('Production');
+    });
+});

--- a/src/BuildVisualizer/d3LayoutEngine.js
+++ b/src/BuildVisualizer/d3LayoutEngine.js
@@ -79,6 +79,16 @@ export const DEFAULT_OPTS = {
     sideGap: 70,
     // Gap between adjacent lanes within a stratum.
     laneGap: 70,
+    // Extra vertical room reserved ABOVE any row (lane / main / dev lane) whose
+    // builds carry a customer release event. Such a row renders a star glyph
+    // row at dot.y − 22 and raises its name label to dot.y − 34 (vs the normal
+    // dot.y − 16) — both extend higher than a release-free row, so without this
+    // reservation the version labels of the row directly above collide with the
+    // stars + raised label (req #2772). Sized as the star-row height (~14) plus
+    // the label-raise delta (34 − 16 = 18) ≈ 30 px; applied only to the gap
+    // directly above a release-bearing row, so release-free layouts are
+    // unchanged and no global whitespace is added.
+    releaseClearance: 30,
     // Gap between adjacent strata (e.g. between Hot Fix's farthest lane and
     // Bootleg's closest-to-main lane). Bumped to 70 (= laneGap) so the
     // staggered far-lane version labels of an upper stratum's bottom lane
@@ -302,74 +312,83 @@ export function computeLayout(model, opts = {}) {
     // Within the Dev stratum (below main), lane 0 is INNERMOST = TOP of
     // band; lane N-1 is OUTERMOST = BOTTOM.
 
-    // Compute Y of the bottom of each above stratum (i.e. lane 0).
     const ABOVE_STRATA = STRATA.filter(s => s.side === 'above');
     const DEV_STRATA = STRATA.filter(s => s.side === 'below');
 
+    // A branch "bears a release" when any of its builds carries a customer
+    // release event. Such a branch renders a star row ABOVE its dots and a
+    // raised name label, so the row directly above it must reserve extra
+    // clearance (req #2772 — see DEFAULT_OPTS.releaseClearance).
+    const branchBearsRelease = (b) =>
+        (b.buildIds || []).some(bid => (releaseEvents[bid]?.length || 0) > 0);
+    const laneBearsRelease = (stratumId, lane) =>
+        (branchesByStratum.get(stratumId) || []).some(
+            b => (laneByBranch.get(b.id) || 0) === lane && branchBearsRelease(b)
+        );
+    const mainBearsRelease = branchBearsRelease(main);
+
+    // Build the ordered list of horizontal rows, top-to-bottom, then walk it
+    // ONCE accumulating Y. Each row carries the base gap that precedes it and a
+    // flag for whether it needs release clearance ABOVE it. This replaces the
+    // prior uniform `lane * laneGap` spacing so a release-bearing row ANYWHERE
+    // (any above stratum/lane, main, or a dev lane) widens only the single gap
+    // directly above it — release-free layouts are byte-for-byte unchanged.
+    const keyOf = (sid, lane) => `${sid}:${lane}`;
+    const aboveNonEmpty = ABOVE_STRATA.filter(s => (laneCountByStratum.get(s.id) || 0) > 0);
+    const devNonEmpty = DEV_STRATA.filter(s => (laneCountByStratum.get(s.id) || 0) > 0);
+    const gapFor = (stratum, fallback) => (stratum.gapAfter != null ? stratum.gapAfter : fallback);
+    const rows = [];
+    // Above strata top-to-bottom: farthest stratum first; within a stratum the
+    // OUTERMOST lane (highest index) is highest on canvas, lane 0 nearest main.
+    aboveNonEmpty.forEach((s, si) => {
+        const lanes = laneCountByStratum.get(s.id);
+        for (let lane = lanes - 1; lane >= 0; lane--) {
+            // The very first (topmost) row sits a full laneGap below canvasPadTop
+            // — the prior engine bottom-aligned the topmost stratum's band there,
+            // so this reproduces the old absolute Y exactly for release-free
+            // layouts (and leaves headroom for that lane's label/stars).
+            const gapAbove = lane === lanes - 1
+                ? (si === 0 ? o.laneGap : gapFor(aboveNonEmpty[si - 1], o.stratumGap))
+                : o.laneGap;
+            rows.push({ key: keyOf(s.id, lane), gapAbove, bearsRelease: laneBearsRelease(s.id, lane) });
+        }
+    });
+    // Main — a sideGap below the closest above stratum (and a sideGap below
+    // canvasPadTop when there are no above strata, matching the prior layout).
+    rows.push({ main: true, gapAbove: o.sideGap, bearsRelease: mainBearsRelease });
+    // Dev strata top-to-bottom: lane 0 (nearest main) first, growing downward.
+    devNonEmpty.forEach((s, di) => {
+        const lanes = laneCountByStratum.get(s.id);
+        for (let lane = 0; lane < lanes; lane++) {
+            const gapAbove = lane === 0
+                ? (di === 0 ? o.sideGap : gapFor(devNonEmpty[di - 1], o.stratumGap))
+                : o.laneGap;
+            rows.push({ key: keyOf(s.id, lane), gapAbove, bearsRelease: laneBearsRelease(s.id, lane) });
+        }
+    });
+
+    // Single top-to-bottom walk assigning Y to every row. The release clearance
+    // is added to the gap ABOVE each release-bearing row (including the very
+    // first row, so its stars/label don't clip the top of the canvas).
+    const laneY = new Map();
     let mainY = o.canvasPadTop;
-    // Cumulative height of all above strata + stratum gaps + sideGap from
-    // the topmost above stratum to mainY.
-    for (let i = 0; i < ABOVE_STRATA.length; i++) {
-        const stratum = ABOVE_STRATA[i];
-        const lanes = laneCountByStratum.get(stratum.id) || 0;
-        if (lanes > 0) {
-            mainY += lanes * o.laneGap;
-            // Stratum-gap between adjacent non-empty above strata.
-            // Use per-stratum gapAfter when defined (e.g. release→sample
-            // gets a larger gap for visual differentiation).
-            const nextNonEmpty = ABOVE_STRATA
-                .slice(i + 1)
-                .find(s => (laneCountByStratum.get(s.id) || 0) > 0);
-            if (nextNonEmpty) {
-                mainY += (stratum.gapAfter != null ? stratum.gapAfter : o.stratumGap);
-            }
-        }
-    }
-    // Add sideGap between the closest above stratum (Sample) and main.
-    mainY += o.sideGap;
-
-    // Re-walk to assign each above stratum's lane-0 Y (innermost, near main).
-    // Outermost lanes (higher index) sit FURTHER from main = HIGHER in SVG.
-    const stratumLane0Y = new Map();
     {
-        let cursor = mainY - o.sideGap; // sample lane 0 sits here
-        for (let i = ABOVE_STRATA.length - 1; i >= 0; i--) {
-            const stratum = ABOVE_STRATA[i];
-            const lanes = laneCountByStratum.get(stratum.id) || 0;
-            if (lanes === 0) { stratumLane0Y.set(stratum.id, cursor); continue; }
-            stratumLane0Y.set(stratum.id, cursor);
-            // Reserve room for this stratum's lanes; cursor moves UP by
-            // (lanes-1) × laneGap (lanes occupy from cursor up to
-            // cursor - (lanes-1)*laneGap), then gap to the next stratum.
-            cursor -= (lanes - 1) * o.laneGap;
-            // If there's a non-empty stratum above this one, apply the
-            // per-stratum gapAfter from that stratum (it sits above us, so
-            // its gapAfter is the gap between IT and us). Walk upward to
-            // find it, then read its gapAfter.
-            const nextAbove = ABOVE_STRATA
-                .slice(0, i)
-                .reverse()
-                .find(s => (laneCountByStratum.get(s.id) || 0) > 0);
-            if (nextAbove) {
-                cursor -= (nextAbove.gapAfter != null ? nextAbove.gapAfter : o.stratumGap);
-            }
+        let cursor = o.canvasPadTop;
+        for (const row of rows) {
+            cursor += row.gapAbove + (row.bearsRelease ? o.releaseClearance : 0);
+            if (row.main) mainY = cursor;
+            else laneY.set(row.key, cursor);
         }
     }
-    // Dev: lane 0 sits at mainY + sideGap, growing DOWN by laneGap per lane.
-    if (DEV_STRATA.length) {
-        stratumLane0Y.set(DEV_STRATA[0].id, mainY + o.sideGap);
-    }
 
-    // Map each branch to its Y.
+    // Map each branch to its row Y.
     const branchY = new Map([[main.id, mainY]]);
     for (const b of visible) {
         const stratumId = STRATUM_BY_TYPE.get(b.type) || 'sample';
-        const stratumDef = STRATA.find(s => s.id === stratumId);
         const lane = laneByBranch.get(b.id) || 0;
-        const lane0Y = stratumLane0Y.get(stratumId);
-        if (lane0Y == null) continue;
-        const direction = stratumDef.side === 'above' ? -1 : 1;
-        branchY.set(b.id, lane0Y + lane * o.laneGap * direction);
+        const y = laneY.get(keyOf(stratumId, lane));
+        if (y == null) continue;
+        branchY.set(b.id, y);
     }
 
     // Update build Y values now that branch Y is known.
@@ -594,11 +613,16 @@ export function computeLayout(model, opts = {}) {
     const strataBands = ABOVE_STRATA.concat(DEV_STRATA).map(s => {
         const lanes = laneCountByStratum.get(s.id) || 0;
         if (lanes === 0) return null;
-        const lane0Y = stratumLane0Y.get(s.id);
-        const direction = s.side === 'above' ? -1 : 1;
-        const lastLaneY = lane0Y + (lanes - 1) * o.laneGap * direction;
-        const yTop = Math.min(lane0Y, lastLaneY) - o.laneGap * 0.5;
-        const yBottom = Math.max(lane0Y, lastLaneY) + o.laneGap * 0.5;
+        // Read each lane's actual Y (lane spacing is no longer uniform once a
+        // release-bearing lane has reserved extra clearance — req #2772).
+        const laneYs = [];
+        for (let lane = 0; lane < lanes; lane++) {
+            const y = laneY.get(keyOf(s.id, lane));
+            if (y != null) laneYs.push(y);
+        }
+        if (!laneYs.length) return null;
+        const yTop = Math.min(...laneYs) - o.laneGap * 0.5;
+        const yBottom = Math.max(...laneYs) + o.laneGap * 0.5;
         return {
             id: s.id,
             label: s.label,

--- a/src/BuildVisualizer/readinessRules.js
+++ b/src/BuildVisualizer/readinessRules.js
@@ -1,0 +1,54 @@
+// req #2772 — Build Visualizer readiness / release-type rules.
+//
+// The build-dot "ready" toggle is a single boolean on the build
+// (`approved_for_release`), but its DISPLAYED label and the TYPE of release
+// event it later produces both vary by the build's branch type. This module is
+// the single source of truth for that mapping — components import it; no inline
+// branch-type → label switches live anywhere else (mirrors starColors.js,
+// deleteRules.js, etc.).
+//
+// Mapping (req #2772, user-specified):
+//
+//   | Toggle label      | Release type | Branch types                      |
+//   |-------------------|--------------|-----------------------------------|
+//   | Production Ready  | Production   | main, release, csr                |
+//   | Sample Ready      | Sample       | development, sample-release       |
+//   | Debug Ready       | Debug        | bootleg                           |
+//   | Hot Fix Ready     | Hot Fix      | hotfix                            |
+//
+// `releaseType` is the value RECORDED on a customer release event (the data
+// model for persisting it is owned by data-architect — req #2772 part B).
+// `label` is the toggle's switch label in the build-dot menu.
+
+export const READINESS_BY_TYPE = {
+    main:             { releaseType: 'Production', label: 'Production Ready' },
+    release:          { releaseType: 'Production', label: 'Production Ready' },
+    csr:              { releaseType: 'Production', label: 'Production Ready' },
+    'sample-release': { releaseType: 'Sample',     label: 'Sample Ready' },
+    development:      { releaseType: 'Sample',     label: 'Sample Ready' },
+    bootleg:          { releaseType: 'Debug',      label: 'Debug Ready' },
+    hotfix:           { releaseType: 'Hot Fix',    label: 'Hot Fix Ready' },
+};
+
+// Fallback for an unrecognized branch type — treat as Production (the most
+// conservative "this ships" reading), matching the historical single label.
+export const DEFAULT_READINESS = { releaseType: 'Production', label: 'Production Ready' };
+
+/**
+ * Resolve the readiness label + release type for a branch type.
+ * @param {string} branchType — one of the REGISTRY keys.
+ * @returns {{releaseType: string, label: string}}
+ */
+export function readinessFor(branchType) {
+    return READINESS_BY_TYPE[branchType] || DEFAULT_READINESS;
+}
+
+/** The toggle label shown in the build-dot menu for a branch type. */
+export function readinessLabelFor(branchType) {
+    return readinessFor(branchType).label;
+}
+
+/** The release-event type recorded for a release shipped off a branch type. */
+export function releaseTypeFor(branchType) {
+    return readinessFor(branchType).releaseType;
+}

--- a/src/BuildVisualizer/useBuildVisualizerData.js
+++ b/src/BuildVisualizer/useBuildVisualizerData.js
@@ -18,6 +18,7 @@ import { useQuery } from '@tanstack/react-query';
 import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
 import { fetchEntity } from '../hooks/factory/createEntityQueries';
+import { releaseTypeFor } from './readinessRules';
 
 function csv(ids) {
     return ids.map(n => Number(n)).filter(Number.isFinite).join(',');
@@ -199,12 +200,23 @@ export function useBuildVisualizerData(projectId) {
             const name = customerNameById.get(Number(row.customer_fk));
             if (!name) continue;
             const extId = buildRow.external_id;
+            // Release type (Production / Sample / Debug / Hot Fix) is DERIVED
+            // from the build's branch type — a deterministic classification, not
+            // stored data, so a mapping change applies retroactively (req #2772;
+            // data-architect: derive, don't persist). Resolve the effective type
+            // the same way the branch model does (trunk → 'main').
+            const branchRow = branchBySqlId.get(Number(buildRow.branch_fk));
+            const effType = branchRow
+                ? (Number(branchRow.id) === trunkSqlId ? 'main' : (branchRow.branch_type || 'development'))
+                : 'development';
+            const releaseType = releaseTypeFor(effType);
             if (!releaseEvents[extId]) releaseEvents[extId] = [];
             releaseEvents[extId].push(name);
             if (!releaseEventDetails[extId]) releaseEventDetails[extId] = [];
             releaseEventDetails[extId].push({
                 name,
                 date: row.release_date || row.create_ts || null,
+                releaseType,
             });
         }
 


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-06-02T02:52:22Z
- chore: init swarm session feature/2772-build-visualizer-polish-1

## Files changed
```
 src/BuildVisualizer/BuildVisualizerCanvas.jsx      |   5 +-
 src/BuildVisualizer/BuildVisualizerPage.jsx        |  15 ++-
 src/BuildVisualizer/HoldCountButton.jsx            |   2 +-
 .../__tests__/d3LayoutEngine.test.js               |  74 +++++++++++
 .../__tests__/holdCountFormula.test.js             |   4 +-
 .../__tests__/readinessRules.test.js               |  51 ++++++++
 src/BuildVisualizer/d3LayoutEngine.js              | 144 ++++++++++++---------
 src/BuildVisualizer/readinessRules.js              |  54 ++++++++
 src/BuildVisualizer/useBuildVisualizerData.js      |  12 ++
 9 files changed, 291 insertions(+), 70 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)