### PR TITLE
Remove Build Visualizer data + schema from production darwin (dev_dev-only feature)

### DIFF
--- a/src/BuildVisualizer/BuildVisualizerPage.jsx
+++ b/src/BuildVisualizer/BuildVisualizerPage.jsx
@@ -125,7 +125,8 @@ const BuildVisualizerPage = () => {
         return firstBuild ? formatVersion(fromModelBuild(firstBuild)) : '';
     }, [model]);
 
-    const { darwinUri } = useContext(AppContext);
+    // Build Visualizer is a dev-only tool pinned to `darwin_dev` (req #2760).
+    const { darwinBuildVizUri: darwinUri } = useContext(AppContext);
     const { idToken, profile } = useContext(AuthContext);
     const queryClient = useQueryClient();
 

--- a/src/BuildVisualizer/useBuildPatterns.js
+++ b/src/BuildVisualizer/useBuildPatterns.js
@@ -56,7 +56,8 @@ function buildPatternFromProject(row) {
 }
 
 export function useBuildPatterns() {
-    const { darwinUri } = useContext(AppContext);
+    // Build Visualizer is a dev-only tool pinned to `darwin_dev` (req #2760).
+    const { darwinBuildVizUri: darwinUri } = useContext(AppContext);
     const { idToken, profile } = useContext(AuthContext);
     const creatorFk = profile?.id || null;
     const queryClient = useQueryClient();

--- a/src/BuildVisualizer/useBuildVisualizerData.js
+++ b/src/BuildVisualizer/useBuildVisualizerData.js
@@ -25,7 +25,8 @@ function csv(ids) {
 }
 
 export function useBuildVisualizerData(projectId) {
-    const { darwinUri } = useContext(AppContext);
+    // Build Visualizer is a dev-only tool pinned to `darwin_dev` (req #2760).
+    const { darwinBuildVizUri: darwinUri } = useContext(AppContext);
     const { idToken, profile } = useContext(AuthContext);
     const creatorFk = profile?.id || null;
     const enabled = !!idToken && !!creatorFk && !!darwinUri && !!projectId;

--- a/src/Context/AppContext.jsx
+++ b/src/Context/AppContext.jsx
@@ -38,6 +38,22 @@ const API_BASE = 'https://k5j0ftr527.execute-api.us-west-1.amazonaws.com/eng';
 // `darwinUri` honors. Req #2697.
 const DARWIN_OPS_URI = `${API_BASE}/darwin`;
 
+// `darwinBuildVizUri` always points at the `darwin_dev` schema regardless of
+// dev/prod build mode. The Build Visualizer is a dev-only design tool whose 5
+// tables (build_projects, branches, builds, customers, customer_releases) were
+// removed from production `darwin` and now live ONLY in `darwin_dev` (req
+// #2760). Every consumer of those tables (the /build-visualizer page hooks, and
+// the /customers + /customer-releases pages) reads/writes through this URI.
+// Pinning here means build-viz works (a) when a dev server is deliberately
+// pointed at production (`VITE_DARWIN_DATABASE=darwin`) — the proximate cause of
+// the req #2754 confusion — and (b) for the /customers and /customer-releases
+// routes, which (unlike /build-visualizer) are NOT `import.meta.env.DEV`-gated
+// in index.jsx and so remain reachable by direct URL in production (their nav
+// links are hidden): without this pin they would 500 against the now-dropped
+// production tables. Never depends on the prod/dev USER-data split `darwinUri`
+// honors.
+const DARWIN_BUILDVIZ_URI = `${API_BASE}/darwin_dev`;
+
 // Context provider for general application data, URI and color schemes
 export const AppContextProvider = ({ children }) => {
 
@@ -47,6 +63,7 @@ export const AppContextProvider = ({ children }) => {
         <AppContext.Provider value={{
             darwinUri, setDarwinUri, database,
             darwinOpsUri: DARWIN_OPS_URI,
+            darwinBuildVizUri: DARWIN_BUILDVIZ_URI,
         }} >
             {children}
         </AppContext.Provider>

--- a/src/CustomerReleases/CustomerReleasesPage.jsx
+++ b/src/CustomerReleases/CustomerReleasesPage.jsx
@@ -59,7 +59,8 @@ function buildLabel(b) {
 
 export default function CustomerReleasesPage() {
     const { idToken, profile } = useContext(AuthContext);
-    const { darwinUri } = useContext(AppContext);
+    // Customer Releases is a Build Visualizer entity, pinned to `darwin_dev` (req #2760).
+    const { darwinBuildVizUri: darwinUri } = useContext(AppContext);
     const queryClient = useQueryClient();
     const showError = useSnackBarStore(s => s.showError);
 

--- a/src/Customers/CustomersPage.jsx
+++ b/src/Customers/CustomersPage.jsx
@@ -39,7 +39,8 @@ const formatDate = (v) => v ? new Date(v).toLocaleDateString() : '';
 
 export default function CustomersPage() {
     const { idToken, profile } = useContext(AuthContext);
-    const { darwinUri } = useContext(AppContext);
+    // Customers is a Build Visualizer entity, pinned to `darwin_dev` (req #2760).
+    const { darwinBuildVizUri: darwinUri } = useContext(AppContext);
     const queryClient = useQueryClient();
     const showError = useSnackBarStore(s => s.showError);
 

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -615,7 +615,7 @@ const CUSTOMER_DEFAULT_FIELDS = 'id,customer_name,description,closed,sort_order,
 const CUSTOMER_FULL_FIELDS    = 'id,customer_name,description,creator_fk,closed,sort_order,create_ts,update_ts';
 
 export function useAllCustomers(creatorFk, { fields = CUSTOMER_DEFAULT_FIELDS, enabled = true } = {}) {
-    const { darwinUri } = useContext(AppContext);
+    const { darwinBuildVizUri: darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
     const uri = `${darwinUri}/customers?closed=0&fields=${fields}&sort=sort_order:asc`;
     const queryKey = [...customerKeys.all(creatorFk), { fields }];
@@ -627,7 +627,7 @@ export function useAllCustomers(creatorFk, { fields = CUSTOMER_DEFAULT_FIELDS, e
 }
 
 export function useCustomerById(creatorFk, id, { enabled = true } = {}) {
-    const { darwinUri } = useContext(AppContext);
+    const { darwinBuildVizUri: darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
     const uri = `${darwinUri}/customers?id=${id}&fields=${CUSTOMER_FULL_FIELDS}`;
     const queryKey = customerKeys.byId(creatorFk, id);
@@ -646,7 +646,7 @@ const BUILD_DEFAULT_FIELDS         = 'id,branch_fk,position,build_number,branch_
 const CUSTOMER_RELEASE_DEFAULT_FIELDS = 'id,customer_fk,build_fk,release_notes,creator_fk,create_ts,update_ts';
 
 export function useAllBuildProjects(creatorFk, { fields = BUILD_PROJECT_DEFAULT_FIELDS, enabled = true } = {}) {
-    const { darwinUri } = useContext(AppContext);
+    const { darwinBuildVizUri: darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
     const uri = `${darwinUri}/build_projects?fields=${fields}`;
     const queryKey = [...buildProjectKeys.all(creatorFk), { fields }];
@@ -658,7 +658,7 @@ export function useAllBuildProjects(creatorFk, { fields = BUILD_PROJECT_DEFAULT_
 }
 
 export function useAllBranches(creatorFk, { fields = BRANCH_DEFAULT_FIELDS, enabled = true } = {}) {
-    const { darwinUri } = useContext(AppContext);
+    const { darwinBuildVizUri: darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
     const uri = `${darwinUri}/branches?fields=${fields}`;
     const queryKey = [...branchKeys.all(creatorFk), { fields }];
@@ -670,7 +670,7 @@ export function useAllBranches(creatorFk, { fields = BRANCH_DEFAULT_FIELDS, enab
 }
 
 export function useAllBuilds(creatorFk, { fields = BUILD_DEFAULT_FIELDS, enabled = true } = {}) {
-    const { darwinUri } = useContext(AppContext);
+    const { darwinBuildVizUri: darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
     const uri = `${darwinUri}/builds?fields=${fields}`;
     const queryKey = [...buildKeys.all(creatorFk), { fields }];
@@ -682,7 +682,7 @@ export function useAllBuilds(creatorFk, { fields = BUILD_DEFAULT_FIELDS, enabled
 }
 
 export function useAllCustomerReleases(creatorFk, { fields = CUSTOMER_RELEASE_DEFAULT_FIELDS, enabled = true } = {}) {
-    const { darwinUri } = useContext(AppContext);
+    const { darwinBuildVizUri: darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
     const uri = `${darwinUri}/customer_releases?fields=${fields}`;
     const queryKey = [...customerReleaseKeys.all(creatorFk), { fields }];
@@ -694,7 +694,7 @@ export function useAllCustomerReleases(creatorFk, { fields = CUSTOMER_RELEASE_DE
 }
 
 export function useCustomerReleasesByBuild(creatorFk, buildId, { enabled = true } = {}) {
-    const { darwinUri } = useContext(AppContext);
+    const { darwinBuildVizUri: darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
     const uri = `${darwinUri}/customer_releases?build_fk=${buildId}&fields=${CUSTOMER_RELEASE_DEFAULT_FIELDS}`;
     const queryKey = customerReleaseKeys.byBuild(creatorFk, buildId);


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-06-07T19:29:22Z
- chore: init swarm session feature/2760-remove-build-visualizer-data-schema-1

## Files changed
```
 src/BuildVisualizer/BuildVisualizerPage.jsx   |  3 ++-
 src/BuildVisualizer/useBuildPatterns.js       |  3 ++-
 src/BuildVisualizer/useBuildVisualizerData.js |  3 ++-
 src/Context/AppContext.jsx                    | 17 +++++++++++++++++
 src/CustomerReleases/CustomerReleasesPage.jsx |  3 ++-
 src/Customers/CustomersPage.jsx               |  3 ++-
 src/hooks/useDataQueries.js                   | 14 +++++++-------
 7 files changed, 34 insertions(+), 12 deletions(-)
```

## Testing
0 tests run (deployed worker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)