### PR TITLE
swarm visualizer likes May dates

### DIFF
--- a/src/SwarmView/VisualizerToolbar.jsx
+++ b/src/SwarmView/VisualizerToolbar.jsx
@@ -197,7 +197,7 @@ const VisualizerToolbar = () => {
                 <IconButton onClick={handlePrev} size="small" data-testid="visualizer-prev">
                     <ChevronLeftIcon />
                 </IconButton>
-                <Typography sx={{
+                <Typography data-testid="visualizer-date-title" sx={{
                     fontFamily: "'Roboto',sans-serif", fontSize: '1em', fontWeight: 500,
                     textAlign: 'center', minWidth: 170, whiteSpace: 'nowrap',
                 }}>

--- a/src/stores/__tests__/useSwarmVisualizerStore.test.js
+++ b/src/stores/__tests__/useSwarmVisualizerStore.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+    persistPartialize,
+    migrateVisualizerState,
+} from '../useSwarmVisualizerStore';
+
+// req #2799 — `currentDate` is navigation state, not a saved preference. It must
+// never round-trip through localStorage, so a stale date (e.g. a late-May day the
+// elevator scrolled to) can never reload instead of today. These tests lock the
+// two pure helpers that enforce that contract.
+
+describe('persistPartialize (req #2799)', () => {
+    it('drops currentDate from the persisted slice', () => {
+        const out = persistPartialize({
+            viewType: 'week',
+            currentDate: '2026-05-22',
+            vizKey: 'swarm',
+            beadWindow: '24h',
+            sidewalkOn: false,
+            elevatorOn: true,
+            dataKey: 'coordination',
+            titlesOn: true,
+            completesOn: false,
+        });
+        expect(out).not.toHaveProperty('currentDate');
+    });
+
+    it('keeps every real UI preference', () => {
+        const out = persistPartialize({
+            viewType: 'week',
+            currentDate: '2026-05-22',
+            vizKey: 'swarm',
+            beadWindow: '36h',
+            sidewalkOn: true,
+            elevatorOn: true,
+            dataKey: 'coordination',
+            titlesOn: true,
+            completesOn: true,
+        });
+        expect(out).toEqual({
+            viewType: 'week',
+            vizKey: 'swarm',
+            beadWindow: '36h',
+            sidewalkOn: true,
+            elevatorOn: true,
+            dataKey: 'coordination',
+            titlesOn: true,
+            completesOn: true,
+        });
+    });
+
+    it('does not mutate the input state', () => {
+        const input = { viewType: 'day', currentDate: '2026-05-25', vizKey: 'bead' };
+        persistPartialize(input);
+        expect(input.currentDate).toBe('2026-05-25');
+    });
+});
+
+describe('migrateVisualizerState (req #2799)', () => {
+    it('strips a stale persisted currentDate (the late-May affinity)', () => {
+        const out = migrateVisualizerState({
+            viewType: 'week',
+            currentDate: '2026-05-23',
+            vizKey: 'bead',
+            beadWindow: '24h',
+            sidewalkOn: false,
+            elevatorOn: true,
+            dataKey: 'category',
+        });
+        expect(out).not.toHaveProperty('currentDate');
+    });
+
+    it('preserves preferences carried by an old (v2) blob', () => {
+        const out = migrateVisualizerState({
+            viewType: 'week',
+            currentDate: '2026-05-22',
+            vizKey: 'swarm',
+            beadWindow: '24h',
+            sidewalkOn: false,
+            elevatorOn: true,
+            dataKey: 'coordination',
+        });
+        expect(out.viewType).toBe('week');
+        expect(out.vizKey).toBe('swarm');
+        expect(out.elevatorOn).toBe(true);
+        expect(out.dataKey).toBe('coordination');
+    });
+
+    it('back-fills fields added after the persisted version', () => {
+        // A v1 blob predating elevatorOn/dataKey/titlesOn/completesOn.
+        const out = migrateVisualizerState({
+            viewType: 'day',
+            currentDate: '2026-05-25',
+            vizKey: 'bead',
+            beadWindow: '24h',
+            sidewalkOn: false,
+        });
+        expect(out.elevatorOn).toBe(false);
+        expect(out.dataKey).toBe('category');
+        expect(out.titlesOn).toBe(false);
+        expect(out.completesOn).toBe(false);
+    });
+
+    it('normalizes an unknown dataKey to category', () => {
+        const out = migrateVisualizerState({ dataKey: 'bogus' });
+        expect(out.dataKey).toBe('category');
+    });
+
+    it('tolerates null/undefined persisted state', () => {
+        expect(() => migrateVisualizerState(null)).not.toThrow();
+        expect(() => migrateVisualizerState(undefined)).not.toThrow();
+        const out = migrateVisualizerState(null);
+        expect(out).not.toHaveProperty('currentDate');
+        expect(out.dataKey).toBe('category');
+    });
+});

--- a/src/stores/useSwarmVisualizerStore.js
+++ b/src/stores/useSwarmVisualizerStore.js
@@ -2,11 +2,41 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { localDateStr } from '../utils/dateFormat';
 
+// `currentDate` is NAVIGATION state, not a saved preference (req #2799). It must
+// reset to today on every fresh page load. Persisting it was the source of the
+// "late-May affinity": the elevator/sidewalk/chevrons call setCurrentDate as they
+// scroll, which wrote whatever date the strip landed on (e.g. a dense late-May
+// day) to localStorage, and the next page load rehydrated that stale date instead
+// of today. partialize drops it from what gets written; migrate strips any date a
+// pre-#2799 build already persisted so existing users also reset to today.
+// Exported for unit-test coverage.
+export const persistPartialize = (state) => {
+    const { currentDate, ...rest } = state;
+    return rest;
+};
+
+// Forward-migrate persisted state to the current schema. Always strips
+// `currentDate` (req #2799) and back-fills the fields added since v1 with their
+// defaults so an old blob upgrades cleanly. Exported for unit-test coverage.
+export const migrateVisualizerState = (persisted) => {
+    const { currentDate, ...rest } = persisted || {};   // drop stale persisted date (req #2799)
+    return {
+        ...rest,
+        // v1 → v2: req #2383 elevatorOn, req #2382 dataKey.
+        elevatorOn: rest.elevatorOn ?? false,
+        dataKey: rest.dataKey === 'coordination' ? 'coordination' : 'category',
+        // v2 → v3: req #2556 titlesOn.
+        titlesOn: rest.titlesOn ?? false,
+        // v3 → v4: req #2790 completesOn (off by default).
+        completesOn: rest.completesOn ?? false,
+    };
+};
+
 export const useSwarmVisualizerStore = create(
     persist(
         (set) => ({
             viewType: 'day',             // 'day' | 'week'
-            currentDate: localDateStr(), // YYYY-MM-DD
+            currentDate: localDateStr(), // YYYY-MM-DD — navigation state, NOT persisted (req #2799)
             vizKey: 'bead',              // 'bead' | 'swarm'
             beadWindow: '24h',           // '24h' | '36h'
             sidewalkOn: false,           // horizontal 21-day strip (day view)
@@ -28,17 +58,13 @@ export const useSwarmVisualizerStore = create(
         }),
         {
             name: 'darwin_swarm_visualizer',
-            version: 4,
-            migrate: (persisted, version) => ({
-                ...persisted,
-                // v1 → v2: req #2383 elevatorOn, req #2382 dataKey.
-                elevatorOn: persisted.elevatorOn ?? false,
-                dataKey: persisted.dataKey === 'coordination' ? 'coordination' : 'category',
-                // v2 → v3: req #2556 titlesOn.
-                titlesOn: persisted.titlesOn ?? false,
-                // v3 → v4: req #2790 completesOn (off by default).
-                completesOn: persisted.completesOn ?? false,
-            }),
+            // v4 → v5 (req #2799): currentDate no longer persisted. Bumping the
+            // version forces migrate to run once for existing users so a stale
+            // date already in localStorage is stripped on first load.
+            version: 5,
+            // Never write currentDate (req #2799) — it stays a today-default each load.
+            partialize: persistPartialize,
+            migrate: migrateVisualizerState,
         }
     )
 );

--- a/tests/tests/swarm-visualizer.spec.ts
+++ b/tests/tests/swarm-visualizer.spec.ts
@@ -260,4 +260,55 @@ test.describe('Swarm Visualizer — Bead / Swarm / Sidewalk toolbar on /swarm', 
         expect(bg).not.toBe('rgba(0, 0, 0, 0)');
         expect(bg).not.toBe('transparent');
     });
+
+    // req #2799 — `currentDate` is navigation state, not a saved preference. A
+    // pre-#2799 build persisted it, so a stale date (the elevator scrolled to a
+    // dense late-May day, or a chevron jump) would reload instead of today — the
+    // "late-May affinity." The store now drops currentDate from persistence and
+    // strips any already-persisted date on migrate, so every fresh load is today.
+    test('TS-12: a stale persisted currentDate does not survive a reload — resets to today (req #2799)', async ({ page }) => {
+        await page.goto('/swarm');
+        // Seed a returning user's localStorage: a stale late-May date under a
+        // pre-#2799 schema version, exactly the reported reproduction.
+        await page.evaluate(() => {
+            localStorage.setItem('darwin_swarm_visualizer', JSON.stringify({
+                state: {
+                    viewType: 'day',
+                    currentDate: '2026-05-22',
+                    vizKey: 'bead',
+                    beadWindow: '24h',
+                    sidewalkOn: false,
+                    elevatorOn: false,
+                    dataKey: 'category',
+                },
+                version: 4,
+            }));
+            localStorage.setItem('darwin-swarm-view', 'visualizer');
+        });
+        await page.reload();
+
+        const title = page.getByTestId('visualizer-date-title');
+        await expect(title).toBeVisible({ timeout: 10000 });
+
+        // Compute today's title with the SAME logic the toolbar uses (localDateStr
+        // + formatDayTitle, browser locale, pinned UTC) — the view must show today,
+        // not the seeded May 22.
+        const expectedToday = await page.evaluate(() => {
+            const now = new Date();
+            const y = now.getFullYear();
+            const m = String(now.getMonth() + 1).padStart(2, '0');
+            const day = String(now.getDate()).padStart(2, '0');
+            const d = new Date(`${y}-${m}-${day}T12:00:00`);
+            return d.toLocaleDateString(undefined, {
+                weekday: 'short', year: 'numeric', month: 'short', day: 'numeric',
+            });
+        });
+        await expect(title).toHaveText(expectedToday);
+
+        // And the rewritten blob must no longer carry currentDate (partialize),
+        // so it can never re-seed a stale date on the next load.
+        const persisted = await page.evaluate(() =>
+            JSON.parse(localStorage.getItem('darwin_swarm_visualizer') || '{}'));
+        expect(persisted.state).not.toHaveProperty('currentDate');
+    });
 });


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-06-09T17:24:07Z
- chore: init swarm session feature/2799-swarm-visualizer-likes-may-dates-1

## Files changed
```
 src/SwarmView/VisualizerToolbar.jsx                |   2 +-
 .../__tests__/useSwarmVisualizerStore.test.js      | 116 +++++++++++++++++++++
 src/stores/useSwarmVisualizerStore.js              |  50 ++++++---
 tests/tests/swarm-visualizer.spec.ts               |  51 +++++++++
 4 files changed, 206 insertions(+), 13 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)