### PR TITLE
Visualizer doesn’t scroll on mobile

### DIFF
--- a/src/CalendarFC/TimeSeriesView.jsx
+++ b/src/CalendarFC/TimeSeriesView.jsx
@@ -2129,7 +2129,11 @@ const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowPr
             velocityRef.current = 0;
             stopAnim();
             frame.style.cursor = 'grabbing';
-            e.preventDefault();
+            // Mouse: suppress text/image drag. Touch/pen (req #2802): do NOT
+            // preventDefault — `touch-action: pan-y` (CSS) already arbitrates the
+            // gesture (horizontal → us, vertical → page), and preventing default
+            // would swallow the tap-`click` that selects a chip.
+            if (e.pointerType === 'mouse') e.preventDefault();
         };
         const onMove = (e) => {
             if (!isDown) return;
@@ -2181,15 +2185,21 @@ const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowPr
             reportCenterIfChanged();
         };
 
-        frame.addEventListener('mousedown', onDown);
-        window.addEventListener('mousemove', onMove);
-        window.addEventListener('mouseup', onUp);
+        // Pointer events (req #2802) unify mouse + touch + pen, so the strip
+        // hand-scrolls on mobile (mouse-only listeners never fired for touch).
+        // `pointercancel` ends a drag the browser reclaims (e.g. it decides the
+        // gesture is a vertical page-pan under touch-action:pan-y).
+        frame.addEventListener('pointerdown', onDown);
+        window.addEventListener('pointermove', onMove);
+        window.addEventListener('pointerup', onUp);
+        window.addEventListener('pointercancel', onUp);
         frame.addEventListener('click', onClickCapture, true);
         frame.addEventListener('wheel', onWheel, { passive: false });
         return () => {
-            frame.removeEventListener('mousedown', onDown);
-            window.removeEventListener('mousemove', onMove);
-            window.removeEventListener('mouseup', onUp);
+            frame.removeEventListener('pointerdown', onDown);
+            window.removeEventListener('pointermove', onMove);
+            window.removeEventListener('pointerup', onUp);
+            window.removeEventListener('pointercancel', onUp);
             frame.removeEventListener('click', onClickCapture, true);
             frame.removeEventListener('wheel', onWheel);
             stopAnim();
@@ -2655,7 +2665,11 @@ const Elevator = ({ centerDate, onCenterDateChange, sharedTicks, requirementsByD
             velocityRef.current = 0;
             stopAnim();
             frame.style.cursor = 'grabbing';
-            e.preventDefault();
+            // Mouse: suppress text/image drag. Touch/pen (req #2802): do NOT
+            // preventDefault — `touch-action: pan-x` (CSS) already arbitrates the
+            // gesture (vertical → us, horizontal → page), and preventing default
+            // would swallow the tap-`click` that selects a chip.
+            if (e.pointerType === 'mouse') e.preventDefault();
         };
         const onMove = (e) => {
             if (!isDown) return;
@@ -2716,15 +2730,21 @@ const Elevator = ({ centerDate, onCenterDateChange, sharedTicks, requirementsByD
             reportCenterIfChanged();
         };
 
-        frame.addEventListener('mousedown', onDown);
-        window.addEventListener('mousemove', onMove);
-        window.addEventListener('mouseup', onUp);
+        // Pointer events (req #2802) unify mouse + touch + pen, so the strip
+        // hand-scrolls on mobile (mouse-only listeners never fired for touch).
+        // `pointercancel` ends a drag the browser reclaims (e.g. it decides the
+        // gesture is a horizontal page-pan under touch-action:pan-x).
+        frame.addEventListener('pointerdown', onDown);
+        window.addEventListener('pointermove', onMove);
+        window.addEventListener('pointerup', onUp);
+        window.addEventListener('pointercancel', onUp);
         frame.addEventListener('click', onClickCapture, true);
         frame.addEventListener('wheel', onWheel, { passive: false });
         return () => {
-            frame.removeEventListener('mousedown', onDown);
-            window.removeEventListener('mousemove', onMove);
-            window.removeEventListener('mouseup', onUp);
+            frame.removeEventListener('pointerdown', onDown);
+            window.removeEventListener('pointermove', onMove);
+            window.removeEventListener('pointerup', onUp);
+            window.removeEventListener('pointercancel', onUp);
             frame.removeEventListener('click', onClickCapture, true);
             frame.removeEventListener('wheel', onWheel);
             stopAnim();

--- a/src/SwarmView/SwarmView.jsx
+++ b/src/SwarmView/SwarmView.jsx
@@ -213,7 +213,18 @@ const SwarmView = () => {
                          sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 3, mb: 1, px: 3,
                                minHeight: '72px',
                                borderBottom: 1, borderColor: 'divider',
-                               ...(view === 'table' && { maxWidth: SWARM_TABLE_WIDTH }) }}
+                               ...(view === 'table' && { maxWidth: SWARM_TABLE_WIDTH }),
+                               // Req #2802 — the visualizer's wide toolbar overflowed the
+                               // viewport on mobile, scrolling the whole page left/right.
+                               // Constrain the row to its grid track and let the toolbar
+                               // scroll within its own band instead (children keep their
+                               // natural width; the flex-grow spacer still right-aligns
+                               // settings when everything fits → no scrollbar on desktop).
+                               ...(view === 'visualizer' && {
+                                   minWidth: 0,
+                                   overflowX: 'auto',
+                                   '& > *': { flexShrink: 0 },
+                               }) }}
                          data-testid="swarm-view-toggle-row"
                     >
                         <ToggleButtonGroup


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-06-10T18:28:23Z
- chore: init swarm session feature/2802-visualizer-doesnt-scroll-on-mobile-1

## Files changed
```
 src/CalendarFC/TimeSeriesView.jsx | 48 +++++++++++++++++++++++++++------------
 src/SwarmView/SwarmView.jsx       | 13 ++++++++++-
 2 files changed, 46 insertions(+), 15 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)