### PR TITLE
Eradicate bead feature

### DIFF
--- a/src/CalendarFC/TimeSeriesView.jsx
+++ b/src/CalendarFC/TimeSeriesView.jsx
@@ -6,7 +6,7 @@ import { toLocaleDateString, getTimeOfDayFraction, formatCardDateTime, formatHM1
 import {
     DEFAULT_FONT_SIZE,
     getFontSize, getCircleSize, formatCoordination, getCoordinationColor,
-    DEFAULT_VIZ, DEFAULT_DATA_KEY,
+    DEFAULT_DATA_KEY,
     DEFAULT_SPACE, getSpaceMultiplier,
     DEFAULT_ZOOM, getZoomHours, ZOOM_HOURS,
     indexSessionsByRequirement,
@@ -17,36 +17,33 @@ import {
 import './TimeSeriesView.css';
 
 // ─────────── Chip-count helpers (used by Sidewalk height precomputation) ─────
-// Bucket chips by their tz-local date string. Bead mode: one chip per same-day
-// requirement. Swarm mode: one chip per (requirement, session) pair, or a
-// single bare-requirement chip when a requirement has no linked session.
+// Bucket chips by their tz-local date string: one chip per (requirement, session)
+// pair, or a single bare-requirement chip when a requirement has no linked
+// session.
 //
 // Single pass over `requirements` and `sessions` so the Sidewalk parent can
 // size 21 panels without 21 × O(R+S) work (was the 100-200ms stall on scroll
 // that made the strip feel frozen — req #2334 follow-up). Callers that want a
 // specific date's count can use `countChipsForDate`, which just delegates here.
 // Exported for unit-test coverage.
-export const indexChipsByDate = (requirements, sessions, timezone, vizKey) => {
+export const indexChipsByDate = (requirements, sessions, timezone) => {
     const map = new Map();
     if (!Array.isArray(requirements)) return map;
-    const sessionsByReq = vizKey === 'swarm' ? indexSessionsByRequirement(sessions) : null;
+    const sessionsByReq = indexSessionsByRequirement(sessions);
     for (const r of requirements) {
         if (!r?.completed_at) continue;
         const d = toLocaleDateString(r.completed_at, timezone);
         if (!d) continue;
-        let n = 1;
-        if (vizKey === 'swarm') {
-            const linked = sessionsByReq.get(String(r.id)) || [];
-            n = linked.length > 0 ? linked.length : 1;
-        }
+        const linked = sessionsByReq.get(String(r.id)) || [];
+        const n = linked.length > 0 ? linked.length : 1;
         map.set(d, (map.get(d) || 0) + n);
     }
     return map;
 };
 
-export const countChipsForDate = (requirements, sessions, date, timezone, vizKey) => {
+export const countChipsForDate = (requirements, sessions, date, timezone) => {
     if (!date) return 0;
-    return indexChipsByDate(requirements, sessions, timezone, vizKey).get(date) || 0;
+    return indexChipsByDate(requirements, sessions, timezone).get(date) || 0;
 };
 
 // Stable empty array (req #2800) — the per-day fallback for Sidewalk/Elevator
@@ -77,16 +74,6 @@ export const bucketByDate = (requirements, timezone) => {
     return map;
 };
 
-// ─────────── Cluster-stack layout (Bead mode) ─────────────────────────────────
-// Chips sorted by leftPct. If a chip is within minGapPct of the previous chip,
-// it extends the stack upward; otherwise a new stack begins at row 0.
-//
-// `topDown` reverses the walk direction (descending leftPct). Sidewalk mode uses
-// this so the latest chip in a cluster gets row 0 — the row rendered closest to
-// the wire (which is at the TOP of a sidewalk panel). Cluster-gap detection uses
-// |Δ leftPct| so the direction of traversal doesn't change what counts as a
-// cluster. Exported for unit-test coverage.
-const MAX_ROWS = 24;
 // req #2805 — rendered pixel height of a `.ts-bead-label` title (CSS line-height
 // 16px + 1px padding top/bottom). Kept in sync with TimeSeriesView.css so the
 // Week-stack row-spacing buffer reserves exactly enough room for a title.
@@ -95,32 +82,6 @@ const TITLE_LABEL_HEIGHT = 18;
 // a day with no cross-day entries passes the SAME reference every parent render
 // instead of a fresh `[]` literal, which would defeat BeadRow's React.memo.
 const EMPTY_CROSS_DAYS = [];
-export const assignRows = (chips, minGapPct, topDown = false) => {
-    const sorted = [...chips].sort((a, b) =>
-        topDown ? b.leftPct - a.leftPct : a.leftPct - b.leftPct
-    );
-    const out = [];
-    let stackRow = -1;
-    let lastPct = null;
-    for (const chip of sorted) {
-        const isCluster = lastPct !== null
-            && Math.abs(chip.leftPct - lastPct) < minGapPct;
-        if (isCluster) {
-            const nextRow = stackRow + 1;
-            if (nextRow < MAX_ROWS) {
-                out.push({ ...chip, row: nextRow });
-                stackRow = nextRow;
-            } else {
-                out.push({ ...chip, row: MAX_ROWS - 1 });
-            }
-        } else {
-            out.push({ ...chip, row: 0 });
-            stackRow = 0;
-        }
-        lastPct = chip.leftPct;
-    }
-    return out;
-};
 
 // ─────────── Vertical start-bar x-position (Swarm mode) ─────────────────────
 // Returns the SVG x-coordinate string for the vertical start tick, or null
@@ -237,12 +198,10 @@ export const computePhantomPlacement = (startPct, nowPct) => {
 //
 // Math invariants (per memo comment above): startPct from swarm_start.started_at,
 // leftPct from undo.undone_at, markerMode resolves normal/clamped/left exactly
-// like a completed chip. Returns [] when vizKey != 'swarm' or no undos in
-// window.
+// like a completed chip. Returns [] when no undos in window.
 //
 // Exported for unit-test coverage.
 export const buildUndoneChips = ({
-    vizKey,
     swarmUndos,
     swarmStarts,
     xPctFn,
@@ -255,7 +214,6 @@ export const buildUndoneChips = ({
     closeThresholdPct = 1.5,
     formatHHMM = formatHM12,
 }) => {
-    if (vizKey !== 'swarm') return [];
     if (!Array.isArray(swarmUndos) || swarmUndos.length === 0) return [];
 
     const startById = new Map();
@@ -371,9 +329,9 @@ export const assignSwarmLanes = (chips, topDown = false) => {
 // requirement's end-day `completed_at`, so assignSwarmLanes seats it contiguously
 // with its cluster-mates. The original `crossDay` entry rides along so the SVG
 // renderer can read role/pct/card after the lane is resolved. Returns [] for
-// non-swarm or empty input. Exported for unit-test coverage of the field mapping.
-export const buildCrossDayGhosts = (crossDays, vizKey) => {
-    if (vizKey !== 'swarm' || !Array.isArray(crossDays) || crossDays.length === 0) return [];
+// empty input. Exported for unit-test coverage of the field mapping.
+export const buildCrossDayGhosts = (crossDays) => {
+    if (!Array.isArray(crossDays) || crossDays.length === 0) return [];
     return crossDays.map((cd, i) => ({
         chipKey: `xdghost-${cd.sessionId}-${cd.role}-${i}`,
         id: cd.card?.id ?? null,
@@ -458,65 +416,38 @@ export const indexSwarmExtraChipsByDate = ({
 // ─────────── Max-stack-row index (Elevator per-day sizing) ───────────────────
 // Return Map<YYYY-MM-DD, maxRow> where maxRow is the row index BeadRow will
 // assign to its tallest chip on that date. Elevator uses this to size each day
-// panel to its actual rendered content instead of the swarm worst case:
+// panel to its actual rendered content instead of the worst case:
 //
-//   • Swarm: every chip (req + per-session fan-out, plus in-progress phantom
-//     and undone tombstone chips) gets its own lane via `assignSwarmLanes`, so
+//   • Every chip (req + per-session fan-out, plus in-progress phantom and undone
+//     tombstone chips) gets its own lane via `assignSwarmLanes`, so
 //     maxRow = (completedChips + extraSwarmChips)(date) - 1. The `extras` arg
 //     supplies the swarm-start / undo data needed to count the phantom/undone
-//     lanes (req #2797); omit it (4-arg call) and only completed chips count,
+//     lanes (req #2797); omit it (3-arg call) and only completed chips count,
 //     preserving the original behavior for non-Elevator callers + unit tests.
-//   • Bead:  chips cluster-stack via `assignRows` with minGapPct=1.2 on leftPct.
-//     leftPct in a 24h sidewalk panel = time-of-day fraction × 100, so we can
-//     reproduce the placement here without going through positionFor.
 //
-// A 39-req day in bead mode that's spread across the day might only stack to
-// row 3 or 4, not row 38 — this is what makes the per-day heights differ
-// between bead and swarm for the same dataset (req #2383 follow-up).
 // Exported for unit-test coverage.
-export const indexMaxStackByDate = (requirements, sessions, timezone, vizKey, extras = {}) => {
+export const indexMaxStackByDate = (requirements, sessions, timezone, extras = {}) => {
     const out = new Map();
     if (!Array.isArray(requirements)) return out;
 
-    if (vizKey === 'swarm') {
-        const totals = new Map(indexChipsByDate(requirements, sessions, timezone, vizKey));
-        const extraByDate = indexSwarmExtraChipsByDate({ ...extras, sessions, timezone });
-        for (const [date, n] of extraByDate) {
+    const totals = new Map(indexChipsByDate(requirements, sessions, timezone));
+    const extraByDate = indexSwarmExtraChipsByDate({ ...extras, sessions, timezone });
+    for (const [date, n] of extraByDate) {
+        totals.set(date, (totals.get(date) || 0) + n);
+    }
+    // Req #2798 — cross-day pass-through "ghost" lanes also occupy a row in
+    // the swarm lane stack (BeadRow folds them into assignSwarmLanes). The
+    // Elevator/Sidewalk pass a Map<date, ghostCount> so start/interim days
+    // size for the dashed lines and their bubbles don't clip. Absent →
+    // no-op (preserves the original 3/4-arg behavior + unit tests).
+    const xdCounts = extras.crossDayCountByDate;
+    if (xdCounts instanceof Map) {
+        for (const [date, n] of xdCounts) {
             totals.set(date, (totals.get(date) || 0) + n);
         }
-        // Req #2798 — cross-day pass-through "ghost" lanes also occupy a row in
-        // the swarm lane stack (BeadRow folds them into assignSwarmLanes). The
-        // Elevator/Sidewalk pass a Map<date, ghostCount> so start/interim days
-        // size for the dashed lines and their bubbles don't clip. Absent →
-        // no-op (preserves the original 4/5-arg behavior + unit tests).
-        const xdCounts = extras.crossDayCountByDate;
-        if (xdCounts instanceof Map) {
-            for (const [date, n] of xdCounts) {
-                totals.set(date, (totals.get(date) || 0) + n);
-            }
-        }
-        for (const [date, n] of totals) {
-            out.set(date, Math.max(0, n - 1));
-        }
-        return out;
     }
-
-    // Bead: bucket leftPcts by date, then run assignRows per date.
-    const leftPctsByDate = new Map();
-    for (const r of requirements) {
-        if (!r?.completed_at) continue;
-        const d = toLocaleDateString(r.completed_at, timezone);
-        if (!d) continue;
-        const frac = getTimeOfDayFraction(r.completed_at, timezone);
-        if (frac === null || frac === undefined) continue;
-        if (!leftPctsByDate.has(d)) leftPctsByDate.set(d, []);
-        leftPctsByDate.get(d).push(frac * 100);
-    }
-    for (const [date, leftPcts] of leftPctsByDate) {
-        const chips = leftPcts.map(p => ({ leftPct: p }));
-        const placed = assignRows(chips, 1.2);
-        const maxRow = placed.length ? Math.max(...placed.map(c => c.row)) : 0;
-        out.set(date, maxRow);
+    for (const [date, n] of totals) {
+        out.set(date, Math.max(0, n - 1));
     }
     return out;
 };
@@ -905,7 +836,7 @@ const DayLabels = ({ labels, timezone, inlineCount = null }) => (
 // data per req #2777), only the 1–2 panels whose props actually change re-render.
 const BeadRow = React.memo(({
     requirements, sessions, categoryList, selectedDate, timezone,
-    beadWindow, vizKey, tooltipFontSize, circleDiameter, spaceKey = 1,
+    beadWindow, tooltipFontSize, circleDiameter, spaceKey = 1,
     zoomKey = DEFAULT_ZOOM,
     dataKey = DEFAULT_DATA_KEY,   // 'category' | 'coordination' — req #2382
     titlesOn = false,             // req #2556 — render req title to right of bubble
@@ -1015,9 +946,9 @@ const BeadRow = React.memo(({
         return out;
     }, [requirements, categoryList, selectedDate, timezone, xPctFn, dataKey]);
 
-    // Bead: one chip per requirement. Swarm: one chip per (req, session) pair;
-    // requirements with zero sessions get a lone chip with markerMode='left' —
-    // rendered as a short vertical bar immediately left of the met bubble.
+    // One chip per (requirement, session) pair; requirements with zero sessions
+    // get a lone chip with markerMode='left' — rendered as a short vertical bar
+    // immediately left of the met bubble.
     //
     // markerMode values:
     //   'normal'  — session fully inside window; horizontal line + vertical tick at started_at
@@ -1031,7 +962,6 @@ const BeadRow = React.memo(({
     // chips (which force 'normal' even at tiny gaps) still skip the arrow.
     const ARROW_OMIT_THRESHOLD_PCT = 2.5;
     const drawChips = useMemo(() => {
-        if (vizKey !== 'swarm') return windowChips;
         const out = [];
         for (const chip of windowChips) {
             const sess = sessionsByReq.get(String(chip.id)) || [];
@@ -1095,7 +1025,7 @@ const BeadRow = React.memo(({
             }
         }
         return out;
-    }, [vizKey, windowChips, sessionsByReq, xPctFn, timezone, selectedDate,
+    }, [windowChips, sessionsByReq, xPctFn, timezone, selectedDate,
         canonicalStartById, clusterSizeById, swarmStartIdById, swarmStartById,
         swarmCompleteBySession]);
 
@@ -1123,7 +1053,6 @@ const BeadRow = React.memo(({
     // sort by the swarm_start.started_at (used as the surrogate completed_at)
     // so they interleave with completed chips in time order.
     const phantomChips = useMemo(() => {
-        if (vizKey !== 'swarm') return [];
         if (!Array.isArray(swarmStarts) || swarmStarts.length === 0) return [];
         if (!Array.isArray(sessions)) return [];
 
@@ -1196,7 +1125,7 @@ const BeadRow = React.memo(({
             }
         }
         return out;
-    }, [vizKey, swarmStarts, swarmStartSessions, sessions, xPctFn, timezone,
+    }, [swarmStarts, swarmStartSessions, sessions, xPctFn, timezone,
         selectedDate, nowPct, requirementById, categoryList, dataKey]);
 
     // Undone session chips (req #2719). One chip per `swarm_undos` row —
@@ -1219,15 +1148,15 @@ const BeadRow = React.memo(({
     // formula `drawChips` uses for completed chips.
     const undoneChips = useMemo(
         () => buildUndoneChips({
-            vizKey, swarmUndos, swarmStarts, xPctFn, timezone, selectedDate,
+            swarmUndos, swarmStarts, xPctFn, timezone, selectedDate,
             requirementById, categoryList,
             closeThresholdPct: CLOSE_THRESHOLD_PCT,
         }),
-        [vizKey, swarmUndos, swarmStarts, xPctFn, timezone, selectedDate,
+        [swarmUndos, swarmStarts, xPctFn, timezone, selectedDate,
          requirementById, categoryList],
     );
 
-    // Placement: cluster-stack for Bead, swarm-lane for Swarm.
+    // Placement: every chip gets its own swarm lane.
     //
     // In every top-anchored layout (Day / Sidewalk / Elevator) the wire is at
     // the TOP of the panel, so row 0 — the row rendered closest to the wire —
@@ -1242,11 +1171,12 @@ const BeadRow = React.memo(({
     // renders for them); their assigned row drives the cross-day line Y via
     // `crossDayPlaced` below. See buildCrossDayGhosts (module scope) for the
     // field mapping + rationale (req #2747).
-    const crossDayGhosts = buildCrossDayGhosts(crossDays, vizKey);
+    const crossDayGhosts = buildCrossDayGhosts(crossDays);
 
-    const placedAll = vizKey === 'swarm'
-        ? assignSwarmLanes(crossDayGhosts.length ? [...allSwarmChips, ...crossDayGhosts] : allSwarmChips, topDown)
-        : assignRows(drawChips, 1.2, topDown);
+    const placedAll = assignSwarmLanes(
+        crossDayGhosts.length ? [...allSwarmChips, ...crossDayGhosts] : allSwarmChips,
+        topDown,
+    );
     const placed = crossDayGhosts.length
         ? placedAll.filter(c => !c.isCrossDayGhost)
         : placedAll;
@@ -1353,10 +1283,11 @@ const BeadRow = React.memo(({
                 where a single shared axis renders at the top of the view. */}
             {!hideTimeline && <BeadTimeline ticks={ticks} />}
 
-            {vizKey === 'swarm' && (
-                <svg className="ts-swarm-lines" data-testid="ts-swarm-lines"
-                     aria-hidden="true" preserveAspectRatio="none"
-                     width="100%" height="100%">
+            {/* Swarm duration lines + start bars (req #2806 — the only render
+                mode now that the bead necklace is gone). */}
+            <svg className="ts-swarm-lines" data-testid="ts-swarm-lines"
+                 aria-hidden="true" preserveAspectRatio="none"
+                 width="100%" height="100%">
                     <defs>
                         <marker id={`ts-swarm-arrow-${selectedDate}`} viewBox="0 0 10 10"
                                 refX="9" refY="5" markerWidth="7" markerHeight="7"
@@ -1610,8 +1541,7 @@ const BeadRow = React.memo(({
                             </g>
                         );
                     })}
-                </svg>
-            )}
+            </svg>
 
             {/* Swarm-start anchor hover targets — invisible HTML boxes overlay
                 each SVG anchor circle. Hover shows a "Swarm-Start #N" datacard:
@@ -1621,7 +1551,7 @@ const BeadRow = React.memo(({
                 The hover is needed because the SVG layer has pointer-events:
                 none (lines and circles are decorative); this overlay restores
                 hover affordance for the anchor specifically. Req #2504. */}
-            {vizKey === 'swarm' && placed.map(chip => {
+            {placed.map(chip => {
                 // Phantom-clamped (req #2649) — no SVG anchor was rendered for
                 // this chip, so there's nothing to overlay a hover target on.
                 if (chip.startClamped === true) return null;
@@ -2090,7 +2020,7 @@ const SIDEWALK_EXTEND_BY = 10;
 const SIDEWALK_MAX_PANELS = 60;
 
 const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowProps }) => {
-    const { requirements, sessions, timezone, vizKey, circleDiameter, spaceKey,
+    const { requirements, sessions, timezone, circleDiameter, spaceKey,
             swarmStarts, swarmStartSessions, swarmUndos, requirementById,
             categoryList, canonicalStartById, swarmStartIdById, swarmStartById } = rowProps;
     // Today (local) — stable per mount; drives in-progress cross-day spans + the
@@ -2116,14 +2046,13 @@ const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowPr
     // Req #2798 — cross-day pass-through lines for multi-day sessions, keyed by
     // each day panel in the strip, with the 24h start-bar coordinate.
     const crossDayMap = useMemo(() => {
-        if (vizKey !== 'swarm') return new Map();
         return buildCrossDayMap(dates, {
             requirements, sessions, swarmStarts, swarmStartSessions,
             requirementById, categoryList,
             canonicalStartById, swarmStartIdById, swarmStartById,
             timezone, startXPct: bead24hXPct, today: todayStr,
         });
-    }, [vizKey, dates, requirements, sessions, swarmStarts, swarmStartSessions,
+    }, [dates, requirements, sessions, swarmStarts, swarmStartSessions,
         requirementById, categoryList, canonicalStartById, swarmStartIdById,
         swarmStartById, timezone, todayStr]);
 
@@ -2132,9 +2061,9 @@ const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowPr
     // height formula (sidewalk branch: chromeOffset=80, bubbleOffset=20).
     // Single-pass bucket via indexChipsByDate so 21-day strips stay O(R+S+D)
     // instead of O(D × (R+S)) — matters during scroll, when requirements
-    // refetches churn this memo. Swarm mode also folds in the phantom/undone
-    // (req #2797) and cross-day pass-through (req #2798) lanes so a busy day's
-    // dashed lines don't clip below the uniform height; bead mode is unchanged.
+    // refetches churn this memo. Also folds in the phantom/undone (req #2797)
+    // and cross-day pass-through (req #2798) lanes so a busy day's dashed lines
+    // don't clip below the uniform height.
     const sidewalkHeight = useMemo(() => {
         const BASE_HEIGHT   = 400;
         const bubbleOffset  = 20;
@@ -2142,19 +2071,16 @@ const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowPr
         const dateClearance = Math.ceil(circleDiameter / 2) + 4;
         const spaceMul      = getSpaceMultiplier(spaceKey);
         const rowSpacing    = Math.max(16, Math.round((circleDiameter + 4) * spaceMul));
-        const chipsByDate   = indexChipsByDate(requirements, sessions, timezone, vizKey);
-        const extraByDate   = vizKey === 'swarm'
-            ? indexSwarmExtraChipsByDate({
-                swarmStarts, swarmStartSessions, swarmUndos, requirementById,
-                sessions, timezone, today: todayStr,
-              })
-            : null;
+        const chipsByDate   = indexChipsByDate(requirements, sessions, timezone);
+        const extraByDate   = indexSwarmExtraChipsByDate({
+            swarmStarts, swarmStartSessions, swarmUndos, requirementById,
+            sessions, timezone, today: todayStr,
+        });
         let maxChips = 0;
         for (const d of dates) {
-            let n = chipsByDate.get(d) || 0;
-            if (vizKey === 'swarm') {
-                n += (extraByDate.get(d) || 0) + (crossDayMap.get(d)?.length || 0);
-            }
+            const n = (chipsByDate.get(d) || 0)
+                + (extraByDate.get(d) || 0)
+                + (crossDayMap.get(d)?.length || 0);
             if (n > maxChips) maxChips = n;
         }
         const maxStackRow = Math.max(0, maxChips - 1);
@@ -2162,7 +2088,7 @@ const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowPr
             BASE_HEIGHT,
             maxStackRow * rowSpacing + bubbleOffset + circleDiameter + chromeOffset + dateClearance,
         );
-    }, [dates, requirements, sessions, timezone, vizKey, circleDiameter, spaceKey,
+    }, [dates, requirements, sessions, timezone, circleDiameter, spaceKey,
         crossDayMap, swarmStarts, swarmStartSessions, swarmUndos, requirementById, todayStr]);
 
     // Measure frame width; re-measure on resize. `layoutEffect` so initial paint has a width.
@@ -2537,7 +2463,7 @@ const Elevator = ({ centerDate, onCenterDateChange, sharedTicks, requirementsByD
     // below. The swarm extras are a read-only destructure (rowProps is still spread
     // to each BeadRow, so naming them here does NOT remove them from the spread);
     // they feed per-day phantom/undone lane counts into the panel sizing (req #2797).
-    const { requirements, sessions, timezone, vizKey, circleDiameter, spaceKey,
+    const { requirements, sessions, timezone, circleDiameter, spaceKey,
             swarmStarts, swarmStartSessions, swarmUndos, requirementById,
             categoryList, canonicalStartById, swarmStartIdById, swarmStartById } = rowProps;
     const frameRef = React.useRef(null);
@@ -2567,10 +2493,8 @@ const Elevator = ({ centerDate, onCenterDateChange, sharedTicks, requirementsByD
     const datesRef = React.useRef(dates);
     const [frameHeight, setFrameHeight] = React.useState(0);
 
-    // Per-date max stack row — reproduces BeadRow's placement for the active
-    // vizKey: bead uses cluster-stack (many chips collapse to a handful of rows
-    // when spread across the day), swarm uses one-lane-per-chip (maxRow =
-    // chips − 1). For swarm the chip count must include the in-progress phantom
+    // Per-date max stack row — reproduces BeadRow's placement: one-lane-per-chip
+    // (maxRow = chips − 1). The chip count must include the in-progress phantom
     // and undone tombstone lanes BeadRow also stacks, or a panel carrying them
     // is too short and its bottom bubbles bleed into the next day's header
     // (req #2797) — hence the swarm-extras passed through. Lifted to its own
@@ -2582,14 +2506,13 @@ const Elevator = ({ centerDate, onCenterDateChange, sharedTicks, requirementsByD
     // handed to each BeadRow below; the per-date ghost counts feed panel sizing
     // so start/interim dashed lines don't clip their day's bubbles.
     const crossDayMap = useMemo(() => {
-        if (vizKey !== 'swarm') return new Map();
         return buildCrossDayMap(dates, {
             requirements, sessions, swarmStarts, swarmStartSessions,
             requirementById, categoryList,
             canonicalStartById, swarmStartIdById, swarmStartById,
             timezone, startXPct: bead24hXPct, today: todayStr,
         });
-    }, [vizKey, dates, requirements, sessions, swarmStarts, swarmStartSessions,
+    }, [dates, requirements, sessions, swarmStarts, swarmStartSessions,
         requirementById, categoryList, canonicalStartById, swarmStartIdById,
         swarmStartById, timezone, todayStr]);
     const crossDayCountByDate = useMemo(() => {
@@ -2599,11 +2522,11 @@ const Elevator = ({ centerDate, onCenterDateChange, sharedTicks, requirementsByD
     }, [crossDayMap]);
 
     const maxRowByDate = useMemo(
-        () => indexMaxStackByDate(requirements, sessions, timezone, vizKey, {
+        () => indexMaxStackByDate(requirements, sessions, timezone, {
             swarmStarts, swarmStartSessions, swarmUndos, requirementById, today: todayStr,
             crossDayCountByDate,
         }),
-        [requirements, sessions, timezone, vizKey, swarmStarts, swarmStartSessions,
+        [requirements, sessions, timezone, swarmStarts, swarmStartSessions,
          swarmUndos, requirementById, todayStr, crossDayCountByDate],
     );
 
@@ -3037,7 +2960,6 @@ const TimeSeriesView = ({
     selectedDate,
     timezone,
     beadWindow = '24h',
-    vizKey = DEFAULT_VIZ,
     sidewalkOn = false,
     elevatorOn = false,
     dataKey = DEFAULT_DATA_KEY,      // 'category' | 'coordination' — req #2382
@@ -3057,9 +2979,7 @@ const TimeSeriesView = ({
     const fontSizeKey  = DEFAULT_FONT_SIZE;
     const spaceKey     = DEFAULT_SPACE;
     const zoomKey      = DEFAULT_ZOOM;
-    const circleSizeKey = (sidewalkOn || elevatorOn)
-        ? 1                                              // 21-day strips always use size 1
-        : (isWeekView ? 1 : (vizKey === 'swarm' ? 1 : 3));
+    const circleSizeKey = 1;   // swarm visualizer uses size 1 across every layout
     const tooltipFontSize = getFontSize(fontSizeKey);
     const circleDiameter  = getCircleSize(circleSizeKey);
 
@@ -3175,14 +3095,14 @@ const TimeSeriesView = ({
     // iterated only `requirements` (completed-only), so its in-progress branch
     // was dead and open multi-day sessions never drew a pass-through line.
     const crossDayMap = useMemo(() => {
-        if (!isWeekView || vizKey !== 'swarm' || !rowDates.length) return new Map();
+        if (!isWeekView || !rowDates.length) return new Map();
         return buildCrossDayMap(rowDates, {
             requirements, sessions, swarmStarts, swarmStartSessions,
             requirementById, categoryList,
             canonicalStartById, swarmStartIdById, swarmStartById,
             timezone, startXPct: bead36hXPct, today: todayStr,
         });
-    }, [isWeekView, vizKey, rowDates, requirements, sessions, swarmStarts,
+    }, [isWeekView, rowDates, requirements, sessions, swarmStarts,
         swarmStartSessions, requirementById, categoryList,
         canonicalStartById, swarmStartIdById, swarmStartById, timezone, todayStr]);
 
@@ -3257,7 +3177,6 @@ const TimeSeriesView = ({
             selectedDate={d}
             timezone={timezone}
             beadWindow={beadWindow}
-            vizKey={vizKey}
             dataKey={dataKey}
             titlesOn={titlesOn}
 
@@ -3301,7 +3220,6 @@ const TimeSeriesView = ({
                     sessions={sessions}
                     timezone={timezone}
                     beadWindow={beadWindow}
-                    vizKey={vizKey}
                     dataKey={dataKey}
                     titlesOn={titlesOn}
 
@@ -3335,7 +3253,6 @@ const TimeSeriesView = ({
                     sessions={sessions}
                     timezone={timezone}
                     beadWindow={beadWindow}
-                    vizKey={vizKey}
                     dataKey={dataKey}
                     titlesOn={titlesOn}
 

--- a/src/CalendarFC/__tests__/timeSeriesHelpers.test.js
+++ b/src/CalendarFC/__tests__/timeSeriesHelpers.test.js
@@ -178,9 +178,9 @@ describe('countChipsForDate (Sidewalk uniform-height precomputation)', () => {
     const OTHER = '2026-04-18';
 
     it('returns 0 for empty / invalid input', () => {
-        expect(countChipsForDate([], [], DAY, TZ, 'swarm')).toBe(0);
-        expect(countChipsForDate(null, [], DAY, TZ, 'swarm')).toBe(0);
-        expect(countChipsForDate([{ id: 1, completed_at: `${DAY} 12:00:00` }], [], null, TZ, 'bead'))
+        expect(countChipsForDate([], [], DAY, TZ)).toBe(0);
+        expect(countChipsForDate(null, [], DAY, TZ)).toBe(0);
+        expect(countChipsForDate([{ id: 1, completed_at: `${DAY} 12:00:00` }], [], null, TZ))
             .toBe(0);
     });
 
@@ -189,7 +189,7 @@ describe('countChipsForDate (Sidewalk uniform-height precomputation)', () => {
             { id: 1, completed_at: null },
             { id: 2, completed_at: `${DAY} 10:00:00` },
         ];
-        expect(countChipsForDate(reqs, [], DAY, TZ, 'bead')).toBe(1);
+        expect(countChipsForDate(reqs, [], DAY, TZ)).toBe(1);
     });
 
     it('filters out requirements whose completed_at lands on a different day', () => {
@@ -198,24 +198,11 @@ describe('countChipsForDate (Sidewalk uniform-height precomputation)', () => {
             { id: 2, completed_at: `${OTHER} 09:00:00` },
             { id: 3, completed_at: `${DAY} 23:00:00` },
         ];
-        expect(countChipsForDate(reqs, [], DAY, TZ, 'bead')).toBe(2);
-        expect(countChipsForDate(reqs, [], OTHER, TZ, 'bead')).toBe(1);
+        expect(countChipsForDate(reqs, [], DAY, TZ)).toBe(2);
+        expect(countChipsForDate(reqs, [], OTHER, TZ)).toBe(1);
     });
 
-    it('bead mode: one chip per same-day requirement (sessions ignored)', () => {
-        const reqs = [
-            { id: 1, completed_at: `${DAY} 09:00:00` },
-            { id: 2, completed_at: `${DAY} 10:00:00` },
-            { id: 3, completed_at: `${DAY} 11:00:00` },
-        ];
-        const sessions = [
-            { id: 10, source_ref: 'requirement:1', started_at: `${DAY} 08:00:00` },
-            { id: 11, source_ref: 'requirement:1', started_at: `${DAY} 08:30:00` },
-        ];
-        expect(countChipsForDate(reqs, sessions, DAY, TZ, 'bead')).toBe(3);
-    });
-
-    it('swarm mode: one chip per (requirement, session) pair', () => {
+    it('one chip per (requirement, session) pair', () => {
         const reqs = [
             { id: 1, completed_at: `${DAY} 09:00:00` },
             { id: 2, completed_at: `${DAY} 10:00:00` },
@@ -226,10 +213,10 @@ describe('countChipsForDate (Sidewalk uniform-height precomputation)', () => {
             { id: 20, source_ref: 'requirement:2', started_at: `${DAY} 09:30:00` },
         ];
         // req 1 has 2 sessions + req 2 has 1 session → 3 chips
-        expect(countChipsForDate(reqs, sessions, DAY, TZ, 'swarm')).toBe(3);
+        expect(countChipsForDate(reqs, sessions, DAY, TZ)).toBe(3);
     });
 
-    it('swarm mode: bare-requirement fallback when no linked session', () => {
+    it('bare-requirement fallback when no linked session', () => {
         const reqs = [
             { id: 1, completed_at: `${DAY} 09:00:00` },   // no sessions
             { id: 2, completed_at: `${DAY} 10:00:00` },   // 2 sessions
@@ -239,10 +226,10 @@ describe('countChipsForDate (Sidewalk uniform-height precomputation)', () => {
             { id: 21, source_ref: 'requirement:2', started_at: `${DAY} 09:15:00` },
         ];
         // req 1 = 1 bare chip, req 2 = 2 session chips → 3 chips
-        expect(countChipsForDate(reqs, sessions, DAY, TZ, 'swarm')).toBe(3);
+        expect(countChipsForDate(reqs, sessions, DAY, TZ)).toBe(3);
     });
 
-    it('swarm mode: sessions whose requirement falls on a different day do not count', () => {
+    it('sessions whose requirement falls on a different day do not count', () => {
         const reqs = [
             { id: 1, completed_at: `${OTHER} 09:00:00` },
         ];
@@ -250,7 +237,7 @@ describe('countChipsForDate (Sidewalk uniform-height precomputation)', () => {
             { id: 10, source_ref: 'requirement:1', started_at: `${DAY} 08:00:00` },
             { id: 11, source_ref: 'requirement:1', started_at: `${DAY} 08:30:00` },
         ];
-        expect(countChipsForDate(reqs, sessions, DAY, TZ, 'swarm')).toBe(0);
+        expect(countChipsForDate(reqs, sessions, DAY, TZ)).toBe(0);
     });
 });
 
@@ -260,24 +247,24 @@ describe('indexChipsByDate (Sidewalk single-pass bucket)', () => {
     const D2 = '2026-04-18';
 
     it('returns empty Map for invalid / empty input', () => {
-        expect(indexChipsByDate(null, [], TZ, 'swarm').size).toBe(0);
-        expect(indexChipsByDate([], [], TZ, 'bead').size).toBe(0);
+        expect(indexChipsByDate(null, [], TZ).size).toBe(0);
+        expect(indexChipsByDate([], [], TZ).size).toBe(0);
     });
 
-    it('bead mode: one count per same-day requirement, grouped by date', () => {
+    it('bare requirements (no sessions) count one chip per same-day requirement', () => {
         const reqs = [
             { id: 1, completed_at: `${D1} 09:00:00` },
             { id: 2, completed_at: `${D1} 10:00:00` },
             { id: 3, completed_at: `${D2} 11:00:00` },
             { id: 4, completed_at: null },
         ];
-        const map = indexChipsByDate(reqs, [], TZ, 'bead');
+        const map = indexChipsByDate(reqs, [], TZ);
         expect(map.get(D1)).toBe(2);
         expect(map.get(D2)).toBe(1);
         expect(map.size).toBe(2);
     });
 
-    it('swarm mode: sessions bucket under their requirement\'s completed_at date', () => {
+    it('sessions bucket under their requirement\'s completed_at date', () => {
         const reqs = [
             { id: 1, completed_at: `${D1} 09:00:00` },    // 2 sessions
             { id: 2, completed_at: `${D2} 10:00:00` },    // 0 sessions → bare-req fallback
@@ -286,7 +273,7 @@ describe('indexChipsByDate (Sidewalk single-pass bucket)', () => {
             { id: 10, source_ref: 'requirement:1', started_at: `${D1} 08:00:00` },
             { id: 11, source_ref: 'requirement:1', started_at: `${D1} 08:30:00` },
         ];
-        const map = indexChipsByDate(reqs, sessions, TZ, 'swarm');
+        const map = indexChipsByDate(reqs, sessions, TZ);
         expect(map.get(D1)).toBe(2);    // 2 (req,session) chips on D1
         expect(map.get(D2)).toBe(1);    // 1 bare-req chip on D2
     });
@@ -302,11 +289,9 @@ describe('indexChipsByDate (Sidewalk single-pass bucket)', () => {
             { id: 11, source_ref: 'requirement:2', started_at: `${D1} 09:00:00` },
             { id: 12, source_ref: 'requirement:3', started_at: `${D2} 10:00:00` },
         ];
-        for (const vizKey of ['bead', 'swarm']) {
-            const map = indexChipsByDate(reqs, sessions, TZ, vizKey);
-            for (const d of [D1, D2]) {
-                expect(map.get(d) || 0).toBe(countChipsForDate(reqs, sessions, d, TZ, vizKey));
-            }
+        const map = indexChipsByDate(reqs, sessions, TZ);
+        for (const d of [D1, D2]) {
+            expect(map.get(d) || 0).toBe(countChipsForDate(reqs, sessions, d, TZ));
         }
     });
 });
@@ -317,11 +302,11 @@ describe('indexMaxStackByDate (Elevator per-panel sizing)', () => {
     const D2 = '2026-04-18';
 
     it('returns empty Map for invalid / empty input', () => {
-        expect(indexMaxStackByDate(null, [], TZ, 'bead').size).toBe(0);
-        expect(indexMaxStackByDate([], [], TZ, 'swarm').size).toBe(0);
+        expect(indexMaxStackByDate(null, [], TZ).size).toBe(0);
+        expect(indexMaxStackByDate([], [], TZ).size).toBe(0);
     });
 
-    it('swarm mode: maxRow = chips − 1 per date (one lane per chip)', () => {
+    it('maxRow = chips − 1 per date (one lane per chip)', () => {
         const reqs = [
             { id: 1, completed_at: `${D1} 09:00:00` },
             { id: 2, completed_at: `${D1} 10:00:00` },
@@ -332,59 +317,33 @@ describe('indexMaxStackByDate (Elevator per-panel sizing)', () => {
             { id: 11, source_ref: 'requirement:1', started_at: `${D1} 08:30:00` },
             { id: 12, source_ref: 'requirement:2', started_at: `${D1} 09:30:00` },
         ];
-        const map = indexMaxStackByDate(reqs, sessions, TZ, 'swarm');
+        const map = indexMaxStackByDate(reqs, sessions, TZ);
         expect(map.get(D1)).toBe(2);    // 3 chips → rows 0,1,2 → maxRow 2
         expect(map.get(D2)).toBe(0);    // 1 bare-req chip → row 0
     });
 
-    it('bead mode: well-separated chips collapse to row 0 (no stacking)', () => {
-        const reqs = [
-            { id: 1, completed_at: `${D1} 00:00:00` },   // leftPct ≈ 0
-            { id: 2, completed_at: `${D1} 08:00:00` },   // ≈ 33.3
-            { id: 3, completed_at: `${D1} 16:00:00` },   // ≈ 66.6
-            { id: 4, completed_at: `${D1} 23:00:00` },   // ≈ 95.8
-        ];
-        const map = indexMaxStackByDate(reqs, [], TZ, 'bead');
-        expect(map.get(D1)).toBe(0);
-    });
-
-    it('bead mode: chips within minGapPct cluster and stack', () => {
-        // Same-minute requirements → identical leftPct → guaranteed to cluster.
-        const reqs = [
-            { id: 1, completed_at: `${D1} 09:00:00` },
-            { id: 2, completed_at: `${D1} 09:00:01` },
-            { id: 3, completed_at: `${D1} 09:00:02` },
-        ];
-        const map = indexMaxStackByDate(reqs, [], TZ, 'bead');
-        expect(map.get(D1)).toBe(2);    // 3 clustered chips → rows 0,1,2
-    });
-
-    it('bead mode vs swarm mode: bead can be much shorter than swarm for the same data', () => {
-        // 10 requirements spread evenly through the day — bead clusters them
-        // into row 0 only; swarm gives each its own lane.
+    it('gives each of 10 same-day requirements its own lane', () => {
         const reqs = Array.from({ length: 10 }, (_, i) => ({
             id: i + 1,
             completed_at: `${D1} ${String(2 + i * 2).padStart(2, '0')}:00:00`,
         }));
-        const beadMap = indexMaxStackByDate(reqs, [], TZ, 'bead');
-        const swarmMap = indexMaxStackByDate(reqs, [], TZ, 'swarm');
-        expect(beadMap.get(D1)).toBeLessThan(swarmMap.get(D1));
-        expect(swarmMap.get(D1)).toBe(9);   // 10 chips → rows 0..9
+        const map = indexMaxStackByDate(reqs, [], TZ);
+        expect(map.get(D1)).toBe(9);   // 10 chips → rows 0..9
     });
 
-    it('bead mode: ignores requirements with null completed_at', () => {
+    it('ignores requirements with null completed_at', () => {
         const reqs = [
             { id: 1, completed_at: `${D1} 09:00:00` },
             { id: 2, completed_at: null },
             { id: 3, completed_at: undefined },
         ];
-        const map = indexMaxStackByDate(reqs, [], TZ, 'bead');
+        const map = indexMaxStackByDate(reqs, [], TZ);
         expect(map.get(D1)).toBe(0);
         expect(map.size).toBe(1);
     });
 
-    // req #2797 — swarm panels also stack in-progress phantom + undone chips.
-    it('swarm mode: counts in-progress phantom lanes on the start-day panel', () => {
+    // req #2797 — panels also stack in-progress phantom + undone chips.
+    it('counts in-progress phantom lanes on the start-day panel', () => {
         // One completed req on D1 (1 chip) + one in-progress session whose
         // swarm-start fired on D1 (1 phantom). Stack should be 2 chips → maxRow 1,
         // not 0 as the completed-only count would give.
@@ -400,9 +359,9 @@ describe('indexMaxStackByDate (Elevator per-panel sizing)', () => {
             requirementById: new Map([['2', { id: 2 }]]),
             today: D2,   // today differs from D1 so the start-day branch is exercised
         };
-        const withExtras = indexMaxStackByDate(reqs, sessions, TZ, 'swarm', extras);
+        const withExtras = indexMaxStackByDate(reqs, sessions, TZ, extras);
         expect(withExtras.get(D1)).toBe(1);   // completed(1) + phantom(1) = 2 → maxRow 1
-        const withoutExtras = indexMaxStackByDate(reqs, sessions, TZ, 'swarm');
+        const withoutExtras = indexMaxStackByDate(reqs, sessions, TZ);
         expect(withoutExtras.get(D1)).toBe(0);   // backward-compat: completed-only
     });
 
@@ -419,7 +378,7 @@ describe('indexMaxStackByDate (Elevator per-panel sizing)', () => {
             requirementById: new Map([['2', { id: 2 }]]),
             today: D2,
         };
-        const map = indexMaxStackByDate(reqs, sessions, TZ, 'swarm', extras);
+        const map = indexMaxStackByDate(reqs, sessions, TZ, extras);
         expect(map.get(D1)).toBe(0);   // 1 phantom → maxRow 0
         expect(map.get(D2)).toBe(0);   // 1 clamped phantom on today → maxRow 0
     });
@@ -442,7 +401,7 @@ describe('indexMaxStackByDate (Elevator per-panel sizing)', () => {
         };
         // req 1 has 2 linked sessions (92,93) → 2 completed chips → maxRow 1.
         // No phantom added: 91 is paused (hidden), 92's req is completed.
-        const map = indexMaxStackByDate(reqs, sessions, TZ, 'swarm', extras);
+        const map = indexMaxStackByDate(reqs, sessions, TZ, extras);
         expect(map.get(D1)).toBe(1);
     });
 
@@ -456,7 +415,7 @@ describe('indexMaxStackByDate (Elevator per-panel sizing)', () => {
             ],
             today: D2,
         };
-        const map = indexMaxStackByDate(reqs, [], TZ, 'swarm', extras);
+        const map = indexMaxStackByDate(reqs, [], TZ, extras);
         expect(map.get(D1)).toBe(2);   // completed(1) + undone(2) = 3 → maxRow 2
         expect(map.get(D2)).toBe(0);   // undone(1) only → maxRow 0
     });
@@ -470,23 +429,16 @@ describe('indexMaxStackByDate — cross-day ghost lanes (req #2798)', () => {
     it('folds crossDayCountByDate additively into swarm totals', () => {
         const reqs = [{ id: 1, completed_at: `${D1} 09:00:00` }];   // 1 completed chip on D1
         const extras = { crossDayCountByDate: new Map([[D1, 2], [D2, 1]]) };
-        const map = indexMaxStackByDate(reqs, [], TZ, 'swarm', extras);
+        const map = indexMaxStackByDate(reqs, [], TZ, extras);
         expect(map.get(D1)).toBe(2);   // completed(1) + xd(2) = 3 → maxRow 2
         expect(map.get(D2)).toBe(0);   // xd(1) only = 1 → maxRow 0
     });
 
     it('is a no-op when crossDayCountByDate is absent (backward compat)', () => {
         const reqs = [{ id: 1, completed_at: `${D1} 09:00:00` }];
-        const map = indexMaxStackByDate(reqs, [], TZ, 'swarm', {});
+        const map = indexMaxStackByDate(reqs, [], TZ, {});
         expect(map.get(D1)).toBe(0);
         expect(map.has(D2)).toBe(false);
-    });
-
-    it('ignores crossDayCountByDate in bead mode', () => {
-        const reqs = [{ id: 1, completed_at: `${D1} 09:00:00` }];
-        const extras = { crossDayCountByDate: new Map([[D1, 5]]) };
-        const map = indexMaxStackByDate(reqs, [], TZ, 'bead', extras);
-        expect(map.get(D1)).toBe(0);   // bead clusters; cross-day extra not applied
     });
 });
 
@@ -961,18 +913,14 @@ describe('buildCrossDayGhosts (req #2747)', () => {
           completedAt: '2026-05-29T10:00:00Z', card: { id: 2716 } },
     ];
 
-    it('returns [] when vizKey is not swarm', () => {
-        expect(buildCrossDayGhosts(sampleCrossDays, 'bead')).toEqual([]);
-    });
-
     it('returns [] for empty / non-array input', () => {
-        expect(buildCrossDayGhosts([], 'swarm')).toEqual([]);
-        expect(buildCrossDayGhosts(undefined, 'swarm')).toEqual([]);
-        expect(buildCrossDayGhosts(null, 'swarm')).toEqual([]);
+        expect(buildCrossDayGhosts([])).toEqual([]);
+        expect(buildCrossDayGhosts(undefined)).toEqual([]);
+        expect(buildCrossDayGhosts(null)).toEqual([]);
     });
 
     it('maps each entry to a ghost carrying groupKey, end-day completed_at, and the original crossDay', () => {
-        const ghosts = buildCrossDayGhosts(sampleCrossDays, 'swarm');
+        const ghosts = buildCrossDayGhosts(sampleCrossDays);
         expect(ghosts).toHaveLength(2);
         expect(ghosts[0]).toEqual({
             chipKey: 'xdghost-4-middle-0',
@@ -992,7 +940,7 @@ describe('buildCrossDayGhosts (req #2747)', () => {
     it('feeds assignSwarmLanes so ghosts get distinct rows from same-day chips', () => {
         const sameDay = [{ chipKey: '2708-s1', groupKey: '2026-05-27T08:00:00Z',
                            completed_at: '2026-05-28T10:00:00Z' }];
-        const ghosts = buildCrossDayGhosts(sampleCrossDays, 'swarm');
+        const ghosts = buildCrossDayGhosts(sampleCrossDays);
         const placed = assignSwarmLanes([...sameDay, ...ghosts]);
         const rows = placed.map(c => c.row);
         expect(new Set(rows).size).toBe(rows.length);   // every occupant a unique lane
@@ -1003,7 +951,7 @@ describe('buildCrossDayGhosts (req #2747)', () => {
 
     it('handles a null card without throwing (id falls back to null)', () => {
         const ghosts = buildCrossDayGhosts(
-            [{ sessionId: 9, role: 'middle', groupKey: 'g', completedAt: 't' }], 'swarm');
+            [{ sessionId: 9, role: 'middle', groupKey: 'g', completedAt: 't' }]);
         expect(ghosts[0].id).toBeNull();
     });
 });

--- a/src/CalendarFC/__tests__/timeSeriesSizes.test.js
+++ b/src/CalendarFC/__tests__/timeSeriesSizes.test.js
@@ -5,7 +5,6 @@ import {
     getFontSize, getCircleSize,
     COORDINATION_LABELS, formatCoordination,
     parseSessionRequirementId, indexSessionsByRequirement,
-    VIZ_KEYS, DEFAULT_VIZ,
     SPACE_KEYS, DEFAULT_SPACE, SPACE_MULTIPLIERS, getSpaceMultiplier,
     ZOOM_KEYS, DEFAULT_ZOOM, ZOOM_HOURS, getZoomHours,
     SWARM_CLUSTER_WINDOW_MS, clusterSessionsByStartTime, clusterSessionsBySwarmStart,
@@ -174,13 +173,6 @@ describe('indexSessionsByRequirement', () => {
             mk(3, 'requirement:5', '2026-04-17 11:00:00'),
         ]);
         expect(idx.get('5').map(s => s.id)).toEqual([2, 3, 1]);
-    });
-});
-
-describe('Visualization option keys', () => {
-    it('exposes bead and swarm, bead is default', () => {
-        expect(VIZ_KEYS).toEqual(['bead', 'swarm']);
-        expect(DEFAULT_VIZ).toBe('bead');
     });
 });
 
@@ -390,7 +382,7 @@ describe('clusterSessionsByStartTime', () => {
 // Row 0 = earliest met = bottom; higher rows = later met = top.
 // topDown=true reverses the order so the latest gets row 0 (Sidewalk mode —
 // wire sits at the top of the panel, so row 0 renders closest to it). ──────────
-import { assignSwarmLanes, assignRows, weekDates, centeredDateRange, swarmStartBarX, positionFor, computePhantomPlacement, isHiddenSwarmStatus, coordinationRingColor } from '../TimeSeriesView';
+import { assignSwarmLanes, weekDates, centeredDateRange, swarmStartBarX, positionFor, computePhantomPlacement, isHiddenSwarmStatus, coordinationRingColor } from '../TimeSeriesView';
 
 // ─── clusterSessionsByStartTime — MySQL-format parsing (req #2398) ─────────────
 // Regression guard: before the fix, clusterSessionsByStartTime parsed
@@ -798,101 +790,6 @@ describe('assignSwarmLanes (Swarm Visualizer lane order)', () => {
             const out = assignSwarmLanes(input);
             expect(out.map(c => c.chipKey)).toEqual(['lone2', 'lone1', 'a2', 'a1']);
         });
-    });
-});
-
-// ─── assignRows: bead-mode cluster stack. Chips close in leftPct stack at
-// rows 0, 1, 2…; otherwise a new stack begins at row 0. topDown=true reverses
-// the walk direction so in a cluster the latest (highest leftPct) lands at
-// row 0 (closest to the wire in Sidewalk's top-anchored layout). ───────────────
-describe('assignRows (Bead cluster-stack)', () => {
-    const mk = (id, leftPct) => ({ id, leftPct });
-    const MIN_GAP = 1.2;
-
-    it('returns empty array for empty input', () => {
-        expect(assignRows([], MIN_GAP)).toEqual([]);
-    });
-
-    it('single chip → row 0, single-stack', () => {
-        expect(assignRows([mk('a', 50)], MIN_GAP)).toEqual([
-            expect.objectContaining({ id: 'a', row: 0 }),
-        ]);
-    });
-
-    it('chips far apart each start a fresh row-0 stack', () => {
-        const out = assignRows([mk('a', 10), mk('b', 40), mk('c', 70)], MIN_GAP);
-        expect(out.map(c => [c.id, c.row])).toEqual([
-            ['a', 0], ['b', 0], ['c', 0],
-        ]);
-    });
-
-    it('chips closer than minGapPct stack upward — first-in-cluster at row 0', () => {
-        // Default (topDown=false): ascending leftPct walk.
-        const out = assignRows(
-            [mk('a', 50), mk('b', 50.5), mk('c', 51.0), mk('d', 80)],
-            MIN_GAP,
-        );
-        expect(out.find(c => c.id === 'a').row).toBe(0);
-        expect(out.find(c => c.id === 'b').row).toBe(1);
-        expect(out.find(c => c.id === 'c').row).toBe(2);
-        expect(out.find(c => c.id === 'd').row).toBe(0); // new stack, far from c
-    });
-
-    it('topDown=true reverses the walk — latest-in-cluster at row 0', () => {
-        // Same input as above; topDown sorts descending by leftPct.
-        const out = assignRows(
-            [mk('a', 50), mk('b', 50.5), mk('c', 51.0), mk('d', 80)],
-            MIN_GAP,
-            true,
-        );
-        // d (80) is its own stack at row 0.
-        // Within the 50..51 cluster, c (51.0) is now first in the descending
-        // walk so gets row 0, then b (50.5) row 1, then a (50) row 2.
-        expect(out.find(c => c.id === 'd').row).toBe(0);
-        expect(out.find(c => c.id === 'c').row).toBe(0);
-        expect(out.find(c => c.id === 'b').row).toBe(1);
-        expect(out.find(c => c.id === 'a').row).toBe(2);
-    });
-
-    it('topDown cluster-gap detection uses |Δ leftPct| — cluster survives reversal', () => {
-        // A cluster that would be detected ascending MUST also be detected
-        // descending. Use gaps just under MIN_GAP (=1.2): [60, 61, 62].
-        const ascending = assignRows(
-            [mk('a', 60), mk('b', 61), mk('c', 62)],
-            MIN_GAP,
-        );
-        const descending = assignRows(
-            [mk('a', 60), mk('b', 61), mk('c', 62)],
-            MIN_GAP,
-            true,
-        );
-        // Ascending: a=0, b=1, c=2  (a starts stack, b/c extend).
-        // Descending: c=0, b=1, a=2 (c starts stack, b/a extend).
-        expect(ascending.find(c => c.id === 'a').row).toBe(0);
-        expect(ascending.find(c => c.id === 'c').row).toBe(2);
-        expect(descending.find(c => c.id === 'c').row).toBe(0);
-        expect(descending.find(c => c.id === 'a').row).toBe(2);
-    });
-
-    it('clamps stacks at MAX_ROWS (24) — 25+ clustered chips land at row 23', () => {
-        const chips = Array.from({ length: 26 }, (_, i) =>
-            mk(`r${i}`, 50 + i * 0.1)  // gaps of 0.1 well under 1.2 threshold
-        );
-        const out = assignRows(chips, MIN_GAP);
-        const maxRow = Math.max(...out.map(c => c.row));
-        expect(maxRow).toBe(23);
-    });
-
-    it('clamp at MAX_ROWS still applies when topDown=true', () => {
-        // Same oversize cluster, descending walk — the clamp is direction-
-        // independent but worth a regression guard so Sidewalk doesn't grow
-        // a 25-row panel by accident.
-        const chips = Array.from({ length: 26 }, (_, i) =>
-            mk(`r${i}`, 50 + i * 0.1)
-        );
-        const out = assignRows(chips, MIN_GAP, true);
-        const maxRow = Math.max(...out.map(c => c.row));
-        expect(maxRow).toBe(23);
     });
 });
 

--- a/src/CalendarFC/__tests__/undoneChips.test.js
+++ b/src/CalendarFC/__tests__/undoneChips.test.js
@@ -48,7 +48,6 @@ const requirementById = new Map([[String(baseRequirement.id), baseRequirement]])
 const categoryList = [{ id: 1186, category_name: 'Topology', color: '#470486' }];
 
 const callArgs = (overrides = {}) => ({
-    vizKey: 'swarm',
     swarmUndos: [baseUndo],
     swarmStarts: [baseSwarmStart],
     xPctFn: inWindowXPct,
@@ -62,10 +61,6 @@ const callArgs = (overrides = {}) => ({
 });
 
 describe('buildUndoneChips', () => {
-    it('returns [] when vizKey is not "swarm"', () => {
-        expect(buildUndoneChips(callArgs({ vizKey: 'bead' }))).toEqual([]);
-    });
-
     it('returns [] for empty/missing undos', () => {
         expect(buildUndoneChips(callArgs({ swarmUndos: [] }))).toEqual([]);
         expect(buildUndoneChips(callArgs({ swarmUndos: null }))).toEqual([]);

--- a/src/CalendarFC/timeSeriesSizes.js
+++ b/src/CalendarFC/timeSeriesSizes.js
@@ -93,11 +93,6 @@ export function getZoomHours(zoomKey, beadWindow) {
     return row[beadWindow] || row['24h'];
 }
 
-// Visualization mode — Bead Necklace (default) or Swarm Visualizer.
-export const VIZ_KEYS = ['bead', 'swarm'];
-export const VIZ_LABELS = { bead: 'Bead', swarm: 'Swarm' };
-export const DEFAULT_VIZ = 'bead';
-
 // Time Series data-selection mode (req #2382).
 // 'category'    — chip color from requirement.category_fk → category.color (default / unchanged).
 // 'coordination' — chip color from requirement.coordination_type (red/orange/yellow/green).

--- a/src/SwarmView/SwarmVisualizerView.jsx
+++ b/src/SwarmView/SwarmVisualizerView.jsx
@@ -37,7 +37,6 @@ const SwarmVisualizerView = () => {
 
     const viewType    = useSwarmVisualizerStore(s => s.viewType);
     const currentDate = useSwarmVisualizerStore(s => s.currentDate);
-    const vizKey      = useSwarmVisualizerStore(s => s.vizKey);
     const beadWindow  = useSwarmVisualizerStore(s => s.beadWindow);
     const sidewalkOn  = useSwarmVisualizerStore(s => s.sidewalkOn);
     const elevatorOn  = useSwarmVisualizerStore(s => s.elevatorOn);
@@ -199,7 +198,6 @@ const SwarmVisualizerView = () => {
                 selectedDate={currentDate}
                 timezone={profile?.timezone}
                 beadWindow={beadWindow}
-                vizKey={vizKey}
                 sidewalkOn={sidewalkOn}
                 elevatorOn={elevatorOn}
                 dataKey={dataKey}

--- a/src/SwarmView/VisualizerToolbar.jsx
+++ b/src/SwarmView/VisualizerToolbar.jsx
@@ -41,7 +41,6 @@ const formatWeekTitle = (dateStr) => {
 const VisualizerToolbar = () => {
     const viewType    = useSwarmVisualizerStore(s => s.viewType);
     const currentDate = useSwarmVisualizerStore(s => s.currentDate);
-    const vizKey      = useSwarmVisualizerStore(s => s.vizKey);
     const beadWindow  = useSwarmVisualizerStore(s => s.beadWindow);
     const sidewalkOn  = useSwarmVisualizerStore(s => s.sidewalkOn);
     const elevatorOn  = useSwarmVisualizerStore(s => s.elevatorOn);
@@ -50,7 +49,6 @@ const VisualizerToolbar = () => {
     const completesOn = useSwarmVisualizerStore(s => s.completesOn);
     const setViewType    = useSwarmVisualizerStore(s => s.setViewType);
     const setCurrentDate = useSwarmVisualizerStore(s => s.setCurrentDate);
-    const setVizKey      = useSwarmVisualizerStore(s => s.setVizKey);
     const setBeadWindow  = useSwarmVisualizerStore(s => s.setBeadWindow);
     const setSidewalkOn  = useSwarmVisualizerStore(s => s.setSidewalkOn);
     const setElevatorOn  = useSwarmVisualizerStore(s => s.setElevatorOn);
@@ -76,10 +74,6 @@ const VisualizerToolbar = () => {
         if (!next) return;
         setViewType(next);
     }, [setViewType]);
-
-    const handleVizClick = useCallback((viz) => {
-        setVizKey(viz);
-    }, [setVizKey]);
 
     const handleSidewalkClick = useCallback(() => {
         const next = !sidewalkOn;
@@ -135,18 +129,6 @@ const VisualizerToolbar = () => {
             </Button>
             <ToggleButtonGroup size="small" sx={{ ml: 0.5 }}
                                data-testid="timeseries-group">
-                <ToggleButton value="bead" className="cal-toggle-btn"
-                              selected={vizKey === 'bead'}
-                              onChange={() => handleVizClick('bead')}
-                              data-testid="timeseries-viz-bead">
-                    Bead
-                </ToggleButton>
-                <ToggleButton value="swarm" className="cal-toggle-btn"
-                              selected={vizKey === 'swarm'}
-                              onChange={() => handleVizClick('swarm')}
-                              data-testid="timeseries-viz-swarm">
-                    Swarm
-                </ToggleButton>
                 <ToggleButton value="24h" className="cal-toggle-btn"
                               selected={beadWindow === '24h'}
                               onChange={() => setBeadWindow('24h')}

--- a/src/stores/__tests__/useSwarmVisualizerStore.test.js
+++ b/src/stores/__tests__/useSwarmVisualizerStore.test.js
@@ -14,7 +14,6 @@ describe('persistPartialize (req #2799)', () => {
         const out = persistPartialize({
             viewType: 'week',
             currentDate: '2026-05-22',
-            vizKey: 'swarm',
             beadWindow: '24h',
             sidewalkOn: false,
             elevatorOn: true,
@@ -29,7 +28,6 @@ describe('persistPartialize (req #2799)', () => {
         const out = persistPartialize({
             viewType: 'week',
             currentDate: '2026-05-22',
-            vizKey: 'swarm',
             beadWindow: '36h',
             sidewalkOn: true,
             elevatorOn: true,
@@ -39,7 +37,6 @@ describe('persistPartialize (req #2799)', () => {
         });
         expect(out).toEqual({
             viewType: 'week',
-            vizKey: 'swarm',
             beadWindow: '36h',
             sidewalkOn: true,
             elevatorOn: true,
@@ -50,18 +47,17 @@ describe('persistPartialize (req #2799)', () => {
     });
 
     it('does not mutate the input state', () => {
-        const input = { viewType: 'day', currentDate: '2026-05-25', vizKey: 'bead' };
+        const input = { viewType: 'day', currentDate: '2026-05-25' };
         persistPartialize(input);
         expect(input.currentDate).toBe('2026-05-25');
     });
 });
 
-describe('migrateVisualizerState (req #2799)', () => {
+describe('migrateVisualizerState (req #2799, req #2806)', () => {
     it('strips a stale persisted currentDate (the late-May affinity)', () => {
         const out = migrateVisualizerState({
             viewType: 'week',
             currentDate: '2026-05-23',
-            vizKey: 'bead',
             beadWindow: '24h',
             sidewalkOn: false,
             elevatorOn: true,
@@ -70,18 +66,26 @@ describe('migrateVisualizerState (req #2799)', () => {
         expect(out).not.toHaveProperty('currentDate');
     });
 
+    it('strips a persisted vizKey (bead/swarm mode removed, req #2806)', () => {
+        const out = migrateVisualizerState({
+            viewType: 'week',
+            currentDate: '2026-05-23',
+            vizKey: 'bead',
+            beadWindow: '24h',
+        });
+        expect(out).not.toHaveProperty('vizKey');
+    });
+
     it('preserves preferences carried by an old (v2) blob', () => {
         const out = migrateVisualizerState({
             viewType: 'week',
             currentDate: '2026-05-22',
-            vizKey: 'swarm',
             beadWindow: '24h',
             sidewalkOn: false,
             elevatorOn: true,
             dataKey: 'coordination',
         });
         expect(out.viewType).toBe('week');
-        expect(out.vizKey).toBe('swarm');
         expect(out.elevatorOn).toBe(true);
         expect(out.dataKey).toBe('coordination');
     });
@@ -91,7 +95,6 @@ describe('migrateVisualizerState (req #2799)', () => {
         const out = migrateVisualizerState({
             viewType: 'day',
             currentDate: '2026-05-25',
-            vizKey: 'bead',
             beadWindow: '24h',
             sidewalkOn: false,
         });

--- a/src/stores/useSwarmVisualizerStore.js
+++ b/src/stores/useSwarmVisualizerStore.js
@@ -19,7 +19,9 @@ export const persistPartialize = (state) => {
 // `currentDate` (req #2799) and back-fills the fields added since v1 with their
 // defaults so an old blob upgrades cleanly. Exported for unit-test coverage.
 export const migrateVisualizerState = (persisted) => {
-    const { currentDate, ...rest } = persisted || {};   // drop stale persisted date (req #2799)
+    // drop stale persisted date (req #2799); drop the removed vizKey (req #2806 —
+    // the bead/swarm mode selector is gone, swarm is the only visualization).
+    const { currentDate, vizKey, ...rest } = persisted || {};
     return {
         ...rest,
         // v1 → v2: req #2383 elevatorOn, req #2382 dataKey.
@@ -37,7 +39,6 @@ export const useSwarmVisualizerStore = create(
         (set) => ({
             viewType: 'day',             // 'day' | 'week'
             currentDate: localDateStr(), // YYYY-MM-DD — navigation state, NOT persisted (req #2799)
-            vizKey: 'bead',              // 'bead' | 'swarm'
             beadWindow: '24h',           // '24h' | '36h'
             sidewalkOn: false,           // horizontal 21-day strip (day view)
             elevatorOn: false,           // vertical 21-day strip (week view) — req #2383
@@ -47,7 +48,6 @@ export const useSwarmVisualizerStore = create(
 
             setViewType: (viewType) => set({ viewType }),
             setCurrentDate: (currentDate) => set({ currentDate }),
-            setVizKey: (vizKey) => set({ vizKey }),
             setBeadWindow: (beadWindow) => set({ beadWindow }),
             setSidewalkOn: (on) => set({ sidewalkOn: !!on }),
             setElevatorOn: (on) => set({ elevatorOn: !!on }),
@@ -58,10 +58,12 @@ export const useSwarmVisualizerStore = create(
         }),
         {
             name: 'darwin_swarm_visualizer',
-            // v4 → v5 (req #2799): currentDate no longer persisted. Bumping the
+            // v4 → v5 (req #2799): currentDate no longer persisted.
+            // v5 → v6 (req #2806): vizKey (bead/swarm mode) removed. Bumping the
             // version forces migrate to run once for existing users so a stale
-            // date already in localStorage is stripped on first load.
-            version: 5,
+            // date OR a persisted vizKey already in localStorage is stripped on
+            // first load.
+            version: 6,
             // Never write currentDate (req #2799) — it stays a today-default each load.
             partialize: persistPartialize,
             migrate: migrateVisualizerState,

--- a/tests/tests/swarm-visualizer.spec.ts
+++ b/tests/tests/swarm-visualizer.spec.ts
@@ -15,7 +15,6 @@ async function seedVisualizerState(
             state: {
                 viewType: v,
                 currentDate: d,
-                vizKey: 'bead',
                 beadWindow: '24h',
                 sidewalkOn: false,
                 elevatorOn: false,
@@ -37,7 +36,7 @@ async function seedVisualizerState(
 // this only removes host-timezone nondeterminism from the test.)
 test.use({ timezoneId: 'UTC' });
 
-test.describe('Swarm Visualizer — Bead / Swarm / Sidewalk toolbar on /swarm', () => {
+test.describe('Swarm Visualizer — Sidewalk toolbar on /swarm', () => {
     let idToken: string;
     let testProjectId: string;
     let testCategoryId: string;
@@ -122,7 +121,7 @@ test.describe('Swarm Visualizer — Bead / Swarm / Sidewalk toolbar on /swarm', 
         expect(countA).not.toBe(countB);
     });
 
-    test('TS-04: Bead click → requirement detail', async ({ page }) => {
+    test('TS-04: chip click → requirement detail', async ({ page }) => {
         await page.goto('/swarm');
         await seedVisualizerState(page, testDate);
         await page.reload();
@@ -141,11 +140,11 @@ test.describe('Swarm Visualizer — Bead / Swarm / Sidewalk toolbar on /swarm', 
 
         await page.getByTestId('view-toggle-cards').click();
         await expect(page.getByTestId('time-series-view')).toHaveCount(0);
-        await expect(page.getByTestId('timeseries-viz-bead')).toHaveCount(0);
+        await expect(page.getByTestId('timeseries-group')).toHaveCount(0);
 
         await page.getByTestId('view-toggle-visualizer').click();
         await expect(page.getByTestId('time-series-view')).toBeVisible({ timeout: 5000 });
-        await expect(page.getByTestId('timeseries-viz-bead')).toBeVisible();
+        await expect(page.getByTestId('timeseries-group')).toBeVisible();
     });
 
     test('TS-06: Sidewalk button — disabled in Week view, enabled in Day view', async ({ page }) => {
@@ -167,7 +166,6 @@ test.describe('Swarm Visualizer — Bead / Swarm / Sidewalk toolbar on /swarm', 
         await page.goto('/swarm');
         await seedVisualizerState(page, testDate);
         await page.reload();
-        await page.getByTestId('timeseries-viz-swarm').click();
         await expect(page.getByTestId('ts-bead')).toBeVisible({ timeout: 10000 });
 
         const id = createdRequirementIds[0];


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-06-10T23:52:04Z
- chore: init swarm session feature/2806-eradicate-bead-feature-1

## Files changed
```
 src/CalendarFC/TimeSeriesView.jsx                  | 239 +++++++--------------
 src/CalendarFC/__tests__/timeSeriesHelpers.test.js | 142 ++++--------
 src/CalendarFC/__tests__/timeSeriesSizes.test.js   | 105 +--------
 src/CalendarFC/__tests__/undoneChips.test.js       |   5 -
 src/CalendarFC/timeSeriesSizes.js                  |   5 -
 src/SwarmView/SwarmVisualizerView.jsx              |   2 -
 src/SwarmView/VisualizerToolbar.jsx                |  18 --
 .../__tests__/useSwarmVisualizerStore.test.js      |  21 +-
 src/stores/useSwarmVisualizerStore.js              |  14 +-
 tests/tests/swarm-visualizer.spec.ts               |  10 +-
 10 files changed, 148 insertions(+), 413 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)