### PR TITLE
Sessions display selector re-order

### DIFF
--- a/src/stores/useShowClosedStore.js
+++ b/src/stores/useShowClosedStore.js
@@ -1,7 +1,8 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-export const ALL_SESSION_STATUSES = ['starting', 'active', 'review', 'paused', 'completing', 'completed'];
+// req #2810: 'paused' moved to the end of the selector order (was after 'review').
+export const ALL_SESSION_STATUSES = ['starting', 'active', 'review', 'completing', 'completed', 'paused'];
 export const DEFAULT_SESSION_STATUSES = ['starting', 'active', 'review', 'completing'];
 
 // req #2784 reordered filter chips to met-before-deferred; req #2783 appends wontfix last.


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-06-11T23:22:42Z
- chore: init swarm session feature/2810-sessions-display-selector-re-order-1

## Files changed
```
 src/stores/useShowClosedStore.js | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)