### PR TITLE
Starts/Completes view selector

### DIFF
--- a/src/SwarmCompletes/SwarmCompletesPage.jsx
+++ b/src/SwarmCompletes/SwarmCompletesPage.jsx
@@ -151,6 +151,25 @@ export default function SwarmCompletesPage() {
             <Box className="app-content-view-toggle"
                  sx={{ display: 'flex', alignItems: 'center', gap: 2,
                         mt: 3, mb: 1, px: 3, flexWrap: 'wrap' }}>
+                <ToggleButtonGroup
+                    value={view}
+                    exclusive
+                    onChange={handleViewChange}
+                    size="small"
+                    sx={{ flexShrink: 0 }}
+                    data-testid="swarm-completes-view-toggle"
+                >
+                    <Tooltip title="Table View">
+                        <ToggleButton value="table" data-testid="view-toggle-table" sx={{ px: 2 }}>
+                            <TableChartIcon fontSize="small" />
+                        </ToggleButton>
+                    </Tooltip>
+                    <Tooltip title="Stats View">
+                        <ToggleButton value="stats" data-testid="view-toggle-stats" sx={{ px: 2 }}>
+                            <BarChartIcon fontSize="small" />
+                        </ToggleButton>
+                    </Tooltip>
+                </ToggleButtonGroup>
                 {view === 'table' && (
                     <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}
                            data-testid="status-filter">
@@ -183,25 +202,6 @@ export default function SwarmCompletesPage() {
                         : `${swarmCompletes.length} complete${swarmCompletes.length === 1 ? '' : 's'} in stats`}
                 </Typography>
                 <Box sx={{ flexGrow: 1 }} />
-                <ToggleButtonGroup
-                    value={view}
-                    exclusive
-                    onChange={handleViewChange}
-                    size="small"
-                    sx={{ flexShrink: 0 }}
-                    data-testid="swarm-completes-view-toggle"
-                >
-                    <Tooltip title="Table View">
-                        <ToggleButton value="table" data-testid="view-toggle-table" sx={{ px: 2 }}>
-                            <TableChartIcon fontSize="small" />
-                        </ToggleButton>
-                    </Tooltip>
-                    <Tooltip title="Stats View">
-                        <ToggleButton value="stats" data-testid="view-toggle-stats" sx={{ px: 2 }}>
-                            <BarChartIcon fontSize="small" />
-                        </ToggleButton>
-                    </Tooltip>
-                </ToggleButtonGroup>
             </Box>
             {view === 'table' && (
                 <Box className="app-content-tabpanel"

--- a/src/SwarmStarts/SwarmStartsPage.jsx
+++ b/src/SwarmStarts/SwarmStartsPage.jsx
@@ -226,12 +226,6 @@ export default function SwarmStartsPage() {
             <Box className="app-content-view-toggle"
                  sx={{ display: 'flex', alignItems: 'center', gap: 2,
                         mt: 3, mb: 1, px: 3, maxWidth: TABLE_WIDTH, flexWrap: 'wrap' }}>
-                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                    {view === 'table'
-                        ? `${swarmStarts.length} invocation${swarmStarts.length === 1 ? '' : 's'} — click a row for full summary`
-                        : `${swarmStarts.length} invocation${swarmStarts.length === 1 ? '' : 's'} in stats`}
-                </Typography>
-                <Box sx={{ flexGrow: 1 }} />
                 <ToggleButtonGroup
                     value={view}
                     exclusive
@@ -251,6 +245,12 @@ export default function SwarmStartsPage() {
                         </ToggleButton>
                     </Tooltip>
                 </ToggleButtonGroup>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                    {view === 'table'
+                        ? `${swarmStarts.length} invocation${swarmStarts.length === 1 ? '' : 's'} — click a row for full summary`
+                        : `${swarmStarts.length} invocation${swarmStarts.length === 1 ? '' : 's'} in stats`}
+                </Typography>
+                <Box sx={{ flexGrow: 1 }} />
             </Box>
             {view === 'table' && (
                 <Box className="app-content-tabpanel"


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2817-startscompletes-view-selector-1
- wip(Darwin): 2026-06-12T00:07:37Z
- chore: init swarm session feature/2817-startscompletes-view-selector-1

## Files changed
```
 src/SwarmCompletes/SwarmCompletesPage.jsx | 38 +++++++++++++++----------------
 src/SwarmStarts/SwarmStartsPage.jsx       | 12 +++++-----
 2 files changed, 25 insertions(+), 25 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Related PRs: https://github.com/BillWilliams79/DarwinAI-Config/pull/431