### PR TITLE
req #2827

### DIFF
--- a/src/hooks/__tests__/createEntityQueriesOpsUrl.test.js
+++ b/src/hooks/__tests__/createEntityQueriesOpsUrl.test.js
@@ -1,14 +1,18 @@
-// Req #2697 — regression guard for the operational-table URL routing.
+// Req #2697 / #2827 — URL routing guard for the entity-queries factory.
 //
-// Pre-#2697: a dev-mode build pointing AppContext.database at `darwin_dev`
-// caused every operational-table read (`dev_servers`, `swarm_sessions`,
-// `swarm_starts`, `swarm_start_sessions`) to silently return 0 rows because
-// the MCP daemon writes them exclusively to the production `darwin` schema.
-//
-// The fix: `ops: true` in the entity config makes the factory pick
+// Req #2697 introduced an `ops: true` flag: it makes the factory pick
 // `darwinOpsUri` (always `/darwin`) from AppContext instead of `darwinUri`
-// (which honors the dev/prod split). These tests assert the actual REST URL
-// every factory hook builds depending on the `ops` flag.
+// (which honors the dev/prod split). The first describe block below still
+// exercises that flag directly — it remains a generic factory capability.
+//
+// Req #2827 REMOVED `ops: true` from the four original ops tables
+// (`dev_servers`, `swarm_sessions`, `swarm_starts`, `swarm_start_sessions`):
+// pinning their reads to production `darwin` defeated dev/prod separation for
+// TESTING (you could not seed viewable test data without polluting
+// production). They now route through `darwinUri` like every other ops block.
+// The "wired devops blocks" describe at the bottom locks in that new behavior:
+// in a dev-mode build (darwinUri ends in `/darwin_dev`) those reads hit
+// `darwin_dev`, not production.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -102,37 +106,35 @@ describe('createEntityQueries — default (ops:false) still uses darwinUri', () 
     });
 });
 
-describe('createEntityQueries — wired devops blocks route correctly', () => {
+describe('createEntityQueries — wired devops blocks follow dev/prod split (req #2827)', () => {
     // Imported here so vi.mock declarations above are in effect.
-    it('devServers.useAll hits the production darwin schema', async () => {
+    // Req #2827 removed ops:true from these four blocks — a dev-mode build
+    // (darwinUri == /darwin_dev) now reads them from darwin_dev, never prod.
+    it('devServers.useAll reads from darwinUri (darwin_dev in dev mode)', async () => {
         const { devServers } = await import('../factory/devopsQueries');
         devServers.useAll('alice');
         const url = callRestApiMock.mock.calls[0][0];
-        expect(url).toContain(`${TEST_DARWIN_OPS_URI}/dev_servers`);
-        expect(url).not.toContain('darwin_dev');
+        expect(url).toContain(`${TEST_DARWIN_URI}/dev_servers`);
     });
 
-    it('sessions.useAll hits the production darwin schema', async () => {
+    it('sessions.useAll reads from darwinUri (darwin_dev in dev mode)', async () => {
         const { sessions } = await import('../factory/devopsQueries');
         sessions.useAll('alice');
         const url = callRestApiMock.mock.calls[0][0];
-        expect(url).toContain(`${TEST_DARWIN_OPS_URI}/swarm_sessions`);
-        expect(url).not.toContain('darwin_dev');
+        expect(url).toContain(`${TEST_DARWIN_URI}/swarm_sessions`);
     });
 
-    it('swarmStarts.useAll hits the production darwin schema', async () => {
+    it('swarmStarts.useAll reads from darwinUri (darwin_dev in dev mode)', async () => {
         const { swarmStarts } = await import('../factory/devopsQueries');
         swarmStarts.useAll('alice');
         const url = callRestApiMock.mock.calls[0][0];
-        expect(url).toContain(`${TEST_DARWIN_OPS_URI}/swarm_starts`);
-        expect(url).not.toContain('darwin_dev');
+        expect(url).toContain(`${TEST_DARWIN_URI}/swarm_starts`);
     });
 
-    it('swarmStartSessions.useAll hits the production darwin schema', async () => {
+    it('swarmStartSessions.useAll reads from darwinUri (darwin_dev in dev mode)', async () => {
         const { swarmStartSessions } = await import('../factory/devopsQueries');
         swarmStartSessions.useAll('alice');
         const url = callRestApiMock.mock.calls[0][0];
-        expect(url).toContain(`${TEST_DARWIN_OPS_URI}/swarm_start_sessions`);
-        expect(url).not.toContain('darwin_dev');
+        expect(url).toContain(`${TEST_DARWIN_URI}/swarm_start_sessions`);
     });
 });

--- a/src/hooks/__tests__/devopsQueriesParity.test.js
+++ b/src/hooks/__tests__/devopsQueriesParity.test.js
@@ -64,9 +64,9 @@ describe('swarmStartSessionKeys parity', () => {
 
 // Req #2719 — swarm_undos key + hook shape matches the existing devops factory
 // outputs (swarmStarts pattern, fields-in-key, defaultSort:undone_at).
-// Intentionally NOT ops:true (departure from req #2697 — see devopsQueries.js
-// comment): swarm_undos is a new feature whose data lives in darwin_dev during
-// development and only graduates to production on /swarm-complete merge.
+// Routes through darwinUri (dev/prod split) — as do all ops blocks since
+// req #2827 dropped the req #2697 `ops: true` pin from the four original
+// ops tables. See devopsQueries.js comment.
 describe('swarmUndoKeys parity', () => {
     it('all(creator) → ["swarm_undos", creator]', () => {
         expect(swarmUndoKeys.all('alice')).toEqual(['swarm_undos', 'alice']);

--- a/src/hooks/factory/devopsQueries.js
+++ b/src/hooks/factory/devopsQueries.js
@@ -6,13 +6,22 @@
 // preserved byte-for-byte by the factory output; parity is locked down by
 // __tests__/devopsQueriesParity.test.js.
 //
-// Req #2697 — `ops: true` on every block here. These four tables live
-// exclusively in the production `darwin` schema (the MCP daemon's
-// `DB_NAME=darwin` is hard-wired). The factory routes their reads through
-// `darwinOpsUri` instead of `darwinUri` so dev-mode builds (where
-// `darwinUri` ends in `/darwin_dev` per req #2683) still see real rows.
-// A future devops table that genuinely IS per-database (e.g. recurring_tasks)
-// would omit `ops` and inherit the default `darwinUri` routing.
+// Req #2827 — every block here routes through the default `darwinUri`
+// (dev/prod split per req #2683). The four original ops tables (`dev_servers`,
+// `swarm_sessions`, `swarm_starts`, `swarm_start_sessions`) previously carried
+// `ops: true` (req #2697) to pin their reads to production `darwin` so a
+// dev-mode build still saw the daemon's live rows. That pin defeated dev/prod
+// separation for TESTING — you could not seed viewable test data without
+// polluting production. Removing it lets all six ops tables follow the same
+// rule the newer two (swarm_undos, swarm_completes) already did: dev reads
+// seeded fixtures from `darwin_dev`, production reads `darwin` unchanged
+// (in prod `darwinUri === /darwin`, so production behavior is identical).
+//
+// ACCEPTED CONSEQUENCE: the dev server no longer shows live production ops —
+// the daemon still writes real ops to production for the production app; dev
+// shows seeded test data. The `ops` flag remains a generic capability of
+// createEntityQueries (and `darwinOpsUri` stays defined in AppContext for the
+// JWT call) — it is simply no longer used by any block here.
 
 import { createEntityQueries } from './createEntityQueries';
 
@@ -23,7 +32,6 @@ import { createEntityQueries } from './createEntityQueries';
 // ---------------------------------------------------------------------------
 export const devServers = createEntityQueries({
     entity: 'dev_servers',
-    ops: true,
     foreignKeys: [
         // `keyParam: 'sessionId'` preserves the legacy `devServerKeys.bySession(id)`
         // cache-key shape `['dev_servers', { sessionId }]`. New devops entities
@@ -39,7 +47,6 @@ export const devServers = createEntityQueries({
 // ---------------------------------------------------------------------------
 export const sessions = createEntityQueries({
     entity: 'swarm_sessions',
-    ops: true,
     byIdCreatorScoped: false,
 });
 
@@ -55,7 +62,6 @@ const SWARM_START_DEFAULT_FIELDS =
 
 export const swarmStarts = createEntityQueries({
     entity: 'swarm_starts',
-    ops: true,
     defaultFields: SWARM_START_DEFAULT_FIELDS,
     fieldsInKey: true,
     defaultSort: 'started_at:desc',
@@ -67,7 +73,6 @@ export const swarmStarts = createEntityQueries({
 // ---------------------------------------------------------------------------
 export const swarmStartSessions = createEntityQueries({
     entity: 'swarm_start_sessions',
-    ops: true,
     defaultFields: 'swarm_start_fk,session_fk',
 });
 
@@ -76,14 +81,10 @@ export const swarmStartSessions = createEntityQueries({
 // Hooks: useAllSwarmUndos (fields-in-key, sort undone_at:desc) +
 // useSwarmUndoById (creator-scoped key).
 //
-// Intentionally NOT ops:true (departure from req #2697's pattern for the four
-// pre-existing swarm tables). swarm_undos is a brand-new data type whose data
-// has no reason to live exclusively in the production `darwin` schema during
-// development — routing through the default `darwinUri` lets dev-mode builds
-// read seeded fixtures from `darwin_dev`. The broader question of whether
-// req #2697's ops-routing rule should apply to every operational table by
-// default is a separate design conversation the data-architect should groom
-// (filed for follow-up per user direction 2026-05-28).
+// Routes through the default `darwinUri` (dev/prod split) so dev-mode builds
+// read seeded fixtures from `darwin_dev`. This was the first ops table to drop
+// the req #2697 `ops: true` pin; req #2827 brought the four original ops tables
+// into line, so every ops block now follows this same dev/prod-split rule.
 // ---------------------------------------------------------------------------
 const SWARM_UNDO_DEFAULT_FIELDS =
     'id,session_fk,swarm_start_fk_at_undo,req_id_at_undo,' +
@@ -101,10 +102,9 @@ export const swarmUndos = createEntityQueries({
 // Hooks: useAllSwarmCompletes (fields-in-key, sort completed_at:desc) +
 // useSwarmCompleteById (creator-scoped key).
 //
-// Intentionally NOT ops:true — same rationale as swarm_undos above: a brand-new
-// data type whose rows should be readable from `darwin_dev` in dev-mode builds
-// (the prod `darwin` table lands at /swarm-complete time). Routing through the
-// default `darwinUri` lets dev-mode read seeded fixtures from `darwin_dev`.
+// Routes through the default `darwinUri` (dev/prod split) — same rule as every
+// ops block here after req #2827. Dev-mode reads seeded fixtures from
+// `darwin_dev`; the prod `darwin` rows land at /swarm-complete time.
 // ---------------------------------------------------------------------------
 const SWARM_COMPLETE_DEFAULT_FIELDS =
     'id,skill_name,coordination_type,status,session_count,' +


### PR DESCRIPTION
## Summary
- Ops tables follow dev/prod DB split (resolve req #2697 ops-routing follow-up) (req #2827)
- chore: init swarm session feature/2827-ops-tables-follow-devprod-db-split-1

## Files changed
```
 .../__tests__/createEntityQueriesOpsUrl.test.js    | 46 +++++++++++-----------
 src/hooks/__tests__/devopsQueriesParity.test.js    |  6 +--
 src/hooks/factory/devopsQueries.js                 | 46 +++++++++++-----------
 3 files changed, 50 insertions(+), 48 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)