### PR TITLE
swarm trend data not honor Timezone

### DIFF
--- a/src/utils/__tests__/aggregateRequirementTrends.test.js
+++ b/src/utils/__tests__/aggregateRequirementTrends.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { aggregateRequirementTrends, getISOWeek } from '../aggregateRequirementTrends';
 
 const cats = [
@@ -7,6 +7,14 @@ const cats = [
 ];
 
 const req = (completed_at, category_fk = 1) => ({ completed_at, category_fk });
+
+// Pin the timezone so local-day bucketing (req #2822) is deterministic across
+// machines/CI. America/Los_Angeles is behind UTC — exactly the case that exposed
+// the bug, where an evening-local close reads as the next day in UTC. Node honors
+// a runtime TZ change for subsequent Date operations.
+const ORIGINAL_TZ = process.env.TZ;
+beforeAll(() => { process.env.TZ = 'America/Los_Angeles'; });
+afterAll(() => { process.env.TZ = ORIGINAL_TZ; });
 
 describe('aggregateRequirementTrends', () => {
     it('returns empty data for no rows', () => {
@@ -29,16 +37,46 @@ describe('aggregateRequirementTrends', () => {
     });
 
     it('buckets by day with gap-fill between first and last', () => {
+        // All times are UTC; under the pinned LA zone they stay on the same
+        // calendar day (morning/afternoon local), so the day buckets are stable.
         const rows = [
-            req('2026-06-10T10:00:00', 1),
-            req('2026-06-10T23:00:00', 1),
-            req('2026-06-12T01:00:00', 1),
+            req('2026-06-10T18:00:00', 1), // Jun 10 11:00 PDT
+            req('2026-06-11T06:00:00', 1), // Jun 10 23:00 PDT -> still Jun 10
+            req('2026-06-12T15:00:00', 1), // Jun 12 08:00 PDT
         ];
         const out = aggregateRequirementTrends(rows, cats, { timeframe: 'day' });
         // Jun 10, 11 (gap), 12
         expect(out.data.map(d => d.key)).toEqual(['2026-06-10', '2026-06-11', '2026-06-12']);
         expect(out.data.map(d => d.total)).toEqual([2, 0, 1]);
         expect(out.data[0].label).toBe('Jun 10');
+    });
+
+    it('buckets an evening-local close on the local day, not the next UTC day (req #2822)', () => {
+        // Stored UTC. In America/Los_Angeles this is Jun 11 18:00 PDT — still
+        // Jun 11 locally even though the UTC calendar date is already Jun 12.
+        // The pre-fix code sliced the UTC date string and wrongly reported Jun 12
+        // ("closed tomorrow"); local-day bucketing must land it on Jun 11.
+        const rows = [req('2026-06-12T01:00:00', 1)];
+        const out = aggregateRequirementTrends(rows, cats, { timeframe: 'day' });
+        expect(out.data.map(d => d.key)).toEqual(['2026-06-11']);
+        expect(out.data[0].label).toBe('Jun 11');
+        expect(out.data[0].total).toBe(1);
+    });
+
+    it('buckets a late-night close on the local day for a viewer ahead of UTC (req #2822)', () => {
+        // Asia/Karachi is UTC+5. "2026-06-11T22:00:00" UTC is Jun 12 03:00 local,
+        // so it must bucket on Jun 12 — the symmetric case to a behind-UTC viewer.
+        const saved = process.env.TZ;
+        process.env.TZ = 'Asia/Karachi';
+        try {
+            const rows = [req('2026-06-11T22:00:00', 1)];
+            const out = aggregateRequirementTrends(rows, cats, { timeframe: 'day' });
+            expect(out.data.map(d => d.key)).toEqual(['2026-06-12']);
+            expect(out.data[0].label).toBe('Jun 12');
+            expect(out.data[0].total).toBe(1);
+        } finally {
+            process.env.TZ = saved;
+        }
     });
 
     it('buckets by month', () => {

--- a/src/utils/aggregateRequirementTrends.js
+++ b/src/utils/aggregateRequirementTrends.js
@@ -50,18 +50,36 @@ const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
 const DAY_MS = 86400000;
 
 /**
- * Parse the YYYY-MM-DD portion of a timestamp into a UTC Date. Requirement
- * timestamps are stored without a trailing 'Z'; we only ever need calendar-day
- * resolution, so we read the date components directly and avoid local-timezone
- * drift (a "2026-06-11T23:15" close should land on Jun 11 regardless of the
- * viewer's offset).
+ * Resolve a stored timestamp (or a YYYY-MM-DD bucket key) to the Date whose
+ * UTC fields equal the VIEWER'S LOCAL calendar day (req #2822).
+ *
+ * Requirement timestamps are stored in UTC — RDS runs with
+ * `@@global.time_zone = @@session.time_zone = UTC` and `completed_at` is stamped
+ * via `NOW()` — but serialized without a trailing 'Z'. Bucketing on the raw UTC
+ * calendar date drifts a late-evening-local close onto the next, future day for
+ * any viewer behind UTC: a "2026-06-12T01:00" UTC close is really Jun 11 evening
+ * in US-Pacific, but the UTC date reads Jun 12 ("closed tomorrow"). So we parse
+ * the UTC instant and read the LOCAL Y/M/D, then re-encode them as a UTC midnight
+ * so the downstream getUTC* / Date.UTC bucket math stays simple and unchanged.
+ *
+ * A bare date-only string (length <= 10) carries no time-of-day, so it is taken
+ * as that calendar day verbatim with no timezone shift — this path also serves
+ * the YYYY-MM-DD bucket keys fed back in by fillGaps() / bucketEndMs().
  */
-function toUTCDate(ts) {
+function toBucketDate(ts) {
     if (!ts) return null;
-    const datePart = String(ts).slice(0, 10); // "YYYY-MM-DD"
-    const [y, m, d] = datePart.split('-').map(Number);
-    if (!y || !m || !d) return null;
-    return new Date(Date.UTC(y, m - 1, d));
+    const s = String(ts);
+    if (s.length <= 10) {
+        const [y, m, d] = s.slice(0, 10).split('-').map(Number);
+        if (!y || !m || !d) return null;
+        return new Date(Date.UTC(y, m - 1, d));
+    }
+    // Full timestamp: ensure it's read as a UTC instant (append 'Z' when the
+    // stored value carries no timezone designator), then bucket by the local day.
+    const hasTz = /[zZ]$|[+-]\d\d:?\d\d$/.test(s);
+    const instant = new Date(hasTz ? s : s + 'Z');
+    if (Number.isNaN(instant.getTime())) return null;
+    return new Date(Date.UTC(instant.getFullYear(), instant.getMonth(), instant.getDate()));
 }
 
 /** ISO 8601 week number; Monday is day 1, week 1 contains the first Thursday. */
@@ -134,8 +152,8 @@ function fillGaps(keys, timeframe) {
 
     switch (timeframe) {
         case 'day': {
-            const start = toUTCDate(first);
-            const end = toUTCDate(last);
+            const start = toBucketDate(first);
+            const end = toBucketDate(last);
             for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
                 all.push(bucketKey(d, 'day'));
             }
@@ -175,7 +193,7 @@ function fillGaps(keys, timeframe) {
 function bucketEndMs(key, timeframe) {
     switch (timeframe) {
         case 'day': {
-            const d = toUTCDate(key);
+            const d = toBucketDate(key);
             return d.getTime() + DAY_MS;
         }
         case 'month': {
@@ -224,7 +242,7 @@ export function aggregateRequirementTrends(rows, categoryMetas, options = {}) {
     const catTotals = new Map();
 
     for (const r of closed) {
-        const d = toUTCDate(r.completed_at);
+        const d = toBucketDate(r.completed_at);
         if (!d) continue;
         const key = bucketKey(d, timeframe);
         let b = buckets.get(key);


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2822-swarm-trend-data-not-honor-timezone
- wip(Darwin): 2026-06-12T18:45:45Z
- chore: init swarm session feature/2822-swarm-trend-data-not-honor-timezone

## Files changed
```
 .../__tests__/aggregateRequirementTrends.test.js   | 46 ++++++++++++++++++++--
 src/utils/aggregateRequirementTrends.js            | 46 +++++++++++++++-------
 2 files changed, 74 insertions(+), 18 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)