### PR TITLE
Regression: sessions page is broken

### DIFF
--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -90,7 +90,7 @@ const RequirementDetail = () => {
     const backLabel = fromCalendar ? 'Back to Calendar' : 'Back to Roadmap';
     const { idToken, profile } = useContext(AuthContext);
     const timezone = profile?.timezone;
-    const { darwinUri, darwinOpsUri } = useContext(AppContext);
+    const { darwinUri } = useContext(AppContext);
 
     const [requirement, setRequirement] = useState(isNew ? {
         id: null,
@@ -199,8 +199,14 @@ const RequirementDetail = () => {
                     ? ''
                     : `&requirement_status=(${siblingStatuses.join(',')})`;
                 const [sessionsResult, siblingsResult, categoryResult] = await Promise.all([
-                    // Req #2697 — `swarm_sessions` is an operational table; always read from `darwin`.
-                    call_rest_api(`${darwinOpsUri}/swarm_sessions?source_ref=requirement:${p.id}`, 'GET', '', idToken).catch(() => null),
+                    // Req #2834 — read swarm_sessions through `darwinUri` (the dev/prod split),
+                    // matching req #2827's migration of the factory ops hooks. The req #2697
+                    // pin to production `darwin` is gone: in production `darwinUri === darwinOpsUri`
+                    // (= `…/darwin`) so this is a no-op there, while in dev mode the linked-sessions
+                    // read now hits `darwin_dev` — the same schema SessionsView/useSessions reads —
+                    // so a dev-seeded session is visible here too (without this, dev showed the
+                    // list from darwin_dev but linked sessions from production darwin).
+                    call_rest_api(`${darwinUri}/swarm_sessions?source_ref=requirement:${p.id}`, 'GET', '', idToken).catch(() => null),
                     call_rest_api(`${darwinUri}/requirements?category_fk=${p.category_fk}&fields=id,requirement_status,completed_at,deferred_at,started_at${siblingFilter}`, 'GET', '', idToken).catch(() => null),
                     call_rest_api(`${darwinUri}/categories?id=${p.category_fk}&fields=id,sort_mode`, 'GET', '', idToken).catch(() => null),
                 ]);
@@ -224,7 +230,7 @@ const RequirementDetail = () => {
         };
 
         fetchData();
-    }, [id, idToken, darwinUri, darwinOpsUri, siblingStatuses.join()]);
+    }, [id, idToken, darwinUri, siblingStatuses.join()]);
 
     const saveField = (field, value) => {
         if (isNew) return;  // draft — nothing is saved until category is picked

--- a/src/hooks/__tests__/createEntityQueriesOpsUrl.test.js
+++ b/src/hooks/__tests__/createEntityQueriesOpsUrl.test.js
@@ -124,6 +124,30 @@ describe('createEntityQueries — wired devops blocks follow dev/prod split (req
         expect(url).toContain(`${TEST_DARWIN_URI}/swarm_sessions`);
     });
 
+    // Req #2834 — the sessions LIST query must project a `fields=` whitelist that
+    // EXCLUDES the four heavy TEXT columns. Without this, the unfiltered all-rows
+    // response grew past AWS Lambda's 6 MB synchronous response limit (~6.06 MB at
+    // 668 rows) → the Lambda failed → API Gateway 502 → the /swarm/sessions page
+    // hung on an infinite spinner. This guards against silently dropping the
+    // projection and reintroducing the regression.
+    it('sessions.useAll projects fields and EXCLUDES the heavy TEXT columns (req #2834)', async () => {
+        const { sessions } = await import('../factory/devopsQueries');
+        sessions.useAll('alice');
+        const url = callRestApiMock.mock.calls[0][0];
+        const fieldsMatch = /[?&]fields=([^&]+)/.exec(url);
+        expect(fieldsMatch).not.toBeNull();
+        // Match whole CSV tokens, not substrings — 'plan' is a substring of the KEPT
+        // column 'planning_secs', so a naive url.includes('plan') would false-positive.
+        const projected = fieldsMatch[1].split(',');
+        for (const heavy of ['telemetry', 'plan', 'start_summary', 'complete_summary']) {
+            expect(projected).not.toContain(heavy);
+        }
+        // Sanity: the projection still includes the columns the list/cards/visualizer render.
+        for (const kept of ['swarm_status', 'source_ref', 'title', 'implementing_secs']) {
+            expect(projected).toContain(kept);
+        }
+    });
+
     it('swarmStarts.useAll reads from darwinUri (darwin_dev in dev mode)', async () => {
         const { swarmStarts } = await import('../factory/devopsQueries');
         swarmStarts.useAll('alice');

--- a/src/hooks/factory/devopsQueries.js
+++ b/src/hooks/factory/devopsQueries.js
@@ -44,9 +44,29 @@ export const devServers = createEntityQueries({
 // swarm_sessions
 // Hooks: useSessions (all) + useSession (legacy: sessionId-only, no creator in
 // cache key — SwarmSessionDetail.jsx invalidates with sessionKeys.byId(id)).
+//
+// Req #2834 — the list query (useSessions) projects every column EXCEPT the four
+// heavy TEXT fields (`telemetry`, `plan`, `start_summary`, `complete_summary`).
+// Those four are only read by the detail view (useSession/byId, which does NOT
+// apply defaultFields — it still fetches the full single row) and by
+// exportService.js (which fetches swarm_sessions directly, not via this hook).
+// Without this projection the unfiltered all-rows fetch grew past AWS Lambda's
+// 6 MB synchronous response limit (~6.06 MB at 668 rows) → the Lambda failed →
+// API Gateway returned 502 Bad Gateway (surfacing as a CORS error) → the
+// sessions page / visualizer hung on an infinite spinner. The projection drops
+// the response to ~0.56 MB. `fieldsInKey` stays false so the cache key
+// (`['swarm_sessions', creator]`) and every existing invalidation are unchanged.
 // ---------------------------------------------------------------------------
+const SWARM_SESSION_DEFAULT_FIELDS =
+    'id,branch,task_name,source_type,source_ref,title,pr_url,swarm_status,' +
+    'worktree_path,started_at,completed_at,last_transition_at,' +
+    'starting_secs,waiting_secs,planning_secs,implementing_secs,review_secs,' +
+    'completion_secs,paused_secs,legacy_secs,instrumented,pre_pause_status,' +
+    'creator_fk,create_ts,update_ts';
+
 export const sessions = createEntityQueries({
     entity: 'swarm_sessions',
+    defaultFields: SWARM_SESSION_DEFAULT_FIELDS,
     byIdCreatorScoped: false,
 });
 

--- a/tests/helpers/api.ts
+++ b/tests/helpers/api.ts
@@ -7,22 +7,20 @@ const TEST_DATABASE = process.env.TEST_DATABASE || 'darwin_dev';
 const API_BASE = 'https://k5j0ftr527.execute-api.us-west-1.amazonaws.com/eng';
 const DARWIN_API = `${API_BASE}/${TEST_DATABASE}`;
 
-// Req #2697 — operational tables live exclusively in the production `darwin`
-// schema. The app reads/writes them via `darwinOpsUri` (always `…/darwin`),
-// regardless of the active dev database. So E2E seeds/reads of these tables MUST
-// target `darwin` too: when TEST_DATABASE=darwin_dev, content tables (requirements,
-// projects, domains, …) go to darwin_dev but ops tables must still go to darwin, or
-// the UI (which reads ops from darwin) never sees the seeded rows — e.g. a seeded
-// swarm_session shows up as "Session not found." This mirrors the app's
-// darwinUri / darwinOpsUri split. Keep in sync with the `ops: true` entities in
-// src/hooks/factory/devopsQueries.js.
-const OPS_API = `${API_BASE}/darwin`;
-const OPS_TABLES = new Set(['swarm_sessions', 'dev_servers', 'swarm_starts', 'swarm_start_sessions']);
-
-/** Resolve the API base for a table (ops tables → production `darwin`). */
-function apiBaseFor(tableWithQuery: string): string {
-  const table = tableWithQuery.split('?')[0];
-  return OPS_TABLES.has(table) ? OPS_API : DARWIN_API;
+// Req #2827 (2026-06-12) — the operational tables (`swarm_sessions`, `dev_servers`,
+// `swarm_starts`, `swarm_start_sessions`) no longer carry the req #2697 `ops: true`
+// pin in src/hooks/factory/devopsQueries.js. Every ops block now routes through the
+// default `darwinUri` (the dev/prod split): in dev mode the UI reads ops tables from
+// `darwin_dev`, in production from `darwin`. So E2E seeds/reads of ops tables MUST
+// follow the SAME split — i.e. go to `${API_BASE}/${TEST_DATABASE}` like every content
+// table — or the dev-mode UI (reading darwin_dev) never sees a row seeded into
+// production darwin, and the sessions DataGrid renders "No rows" (req #2834).
+//
+// Previously (req #2697) these tables were pinned to production `darwin`; that pin is
+// gone, so there is no longer a per-table override. `apiBaseFor` now resolves every
+// table to the active TEST_DATABASE base.
+function apiBaseFor(_tableWithQuery: string): string {
+  return DARWIN_API;
 }
 
 /** Extract the idToken from the browser context cookies. */

--- a/tests/tests/swarm.spec.ts
+++ b/tests/tests/swarm.spec.ts
@@ -160,7 +160,10 @@ test.describe('Swarm View', () => {
   test('SWM-16: /swarm/session/:id renders SwarmSessionDetail', async ({ page }) => {
     await page.goto(`/swarm/session/${testSessionId}`);
     await expect(page.getByTestId('swarm-session-detail')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByTestId('chip-swarm-status')).toContainText('active');
+    // The chip renders the swarm_status DISPLAY label, not the raw value: per req #2332
+    // the `active` status is shown as "Implementing" (swarmStatusLabel in
+    // src/SwarmView/swarmStatusChipProps.js). The session is seeded with swarm_status:'active'.
+    await expect(page.getByTestId('chip-swarm-status')).toContainText('Implementing');
   });
 
   test('SWM-17: Session detail shows status chip with correct color', async ({ page }) => {


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-06-13T04:21:09Z
- chore: init swarm session feature/2834-regression-sessions-page-is-broken-1

## Files changed
```
 src/SwarmView/detail/RequirementDetail.jsx         | 14 +++++++---
 .../__tests__/createEntityQueriesOpsUrl.test.js    | 24 +++++++++++++++++
 src/hooks/factory/devopsQueries.js                 | 20 +++++++++++++++
 tests/helpers/api.ts                               | 30 ++++++++++------------
 tests/tests/swarm.spec.ts                          |  5 +++-
 5 files changed, 72 insertions(+), 21 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)