### PR TITLE
Swarm visualizer — phase durations & transitions in the broad pan view

### DIFF
--- a/src/CalendarFC/TimeSeriesView.jsx
+++ b/src/CalendarFC/TimeSeriesView.jsx
@@ -13,6 +13,8 @@ import {
     parseSessionRequirementId,
     clusterSessionsByStartTime,
     clusterSessionsBySwarmStart,
+    computePhaseSegments,
+    PHASE_UNCLASSIFIED_COLOR,
 } from './timeSeriesSizes';
 import './TimeSeriesView.css';
 
@@ -452,6 +454,14 @@ export const indexMaxStackByDate = (requirements, sessions, timezone, extras = {
     return out;
 };
 
+// req #2823 follow-up — Sidewalk sub-day horizontal zoom. Maps the toolbar
+// window value to the per-panel pixel-width multiplier: a day panel always holds
+// a full 24h, so to show only `n` hours in one viewport-width we render the panel
+// 24/n times as wide and let the strip scroll through it. '6h' → 4×, '12h' → 2×,
+// everything else (incl. '24h'/'36h') → 1× (unchanged). Exported for unit tests.
+export const sidewalkPanelScale = (beadWindow) =>
+    beadWindow === '6h' ? 4 : beadWindow === '12h' ? 2 : 1;
+
 // ─────────── Date helpers ─────────────────────────────────────────────────────
 const shiftDateStr = (dateStr, delta) => {
     const d = new Date(dateStr + 'T12:00:00');
@@ -856,6 +866,7 @@ const BeadRow = React.memo(({
     dataKey = DEFAULT_DATA_KEY,   // 'category' | 'coordination' — req #2382
     titlesOn = false,             // req #2556 — render req title to right of bubble
     completesOn = false,          // req #2790 — show completion-terminus badge (off by default)
+    phasesOn = false,             // req #2823 — segment duration line by phase buckets (off by default)
     crossDays = [], onChipClick, onSwarmStartClick, onUndoClick, isWeekView = false,
     sidewalkPanel = false,   // when true → top-down layout + seamless 24h panel
     hideTimeline = false,    // req #2744 — suppress the per-row time axis; a single
@@ -1470,15 +1481,60 @@ const BeadRow = React.memo(({
                         // ring at leftPct (same diameter as a regular bubble),
                         // so the line should stop at the ring's left edge.
                         const x2 = `calc(${chip.leftPct}% - ${circleDiameter / 2 + 2}px)`;
+                        // req #2823 — phase-duration segmentation. Only completed,
+                        // in-window 'normal' chips (full start→complete duration
+                        // visible, real session) are eligible: clamped lines run
+                        // off-window so their proportions would be wrong, and
+                        // in-progress phantoms are still mid-flight. When the
+                        // session is instrumented with phase time, replace the
+                        // single grey line with proportional coloured segments;
+                        // an instrumented==0 / no-data session falls through to a
+                        // single neutral-gray "unclassified" line.
+                        const phase = (phasesOn && chip.markerMode === 'normal' && !isInProgress)
+                            ? computePhaseSegments(chip.session, chip.startPct, chip.leftPct)
+                            : null;
+                        if (phase && phase.classified) {
+                            return (
+                                <g key={`line-${chip.chipKey}`}
+                                   data-testid={`ts-swarm-phases-${chip.chipKey}`}>
+                                    {phase.segments.map((seg, i) => {
+                                        const last = i === phase.segments.length - 1;
+                                        // NB: deliberately NOT `ts-swarm-line` — that
+                                        // class carries a dark-mode `stroke: …
+                                        // !important` override (TimeSeriesView.css)
+                                        // that would force every segment to one grey,
+                                        // beating the inline per-phase colour. The
+                                        // thick colour bar also needs no arrowhead —
+                                        // the bubble is its terminus (an arrow here
+                                        // would just scale up with strokeWidth=3).
+                                        return (
+                                            <line
+                                                key={seg.key}
+                                                data-testid={`ts-swarm-phase-${chip.chipKey}-${seg.key}`}
+                                                className={`ts-swarm-phase ts-swarm-phase-${seg.family}`}
+                                                x1={`${seg.x1Pct}%`}
+                                                y1={yCenter}
+                                                x2={last ? x2 : `${seg.x2Pct}%`}
+                                                y2={yCenter}
+                                                stroke={seg.color}
+                                                strokeWidth={3}
+                                            />
+                                        );
+                                    })}
+                                </g>
+                            );
+                        }
                         const stroke = isInProgress
                             ? '#43A047'
-                            : 'rgba(96,125,139,0.85)';
+                            // Phases on + this normal chip carries no usable phase
+                            // split → flat neutral gray = explicit "unknown split".
+                            : (phase ? PHASE_UNCLASSIFIED_COLOR : 'rgba(96,125,139,0.85)');
                         const strokeWidth = isInProgress ? 2 : 1.5;
                         return (
                             <line
                                 key={`line-${chip.chipKey}`}
                                 data-testid={`ts-swarm-line-${chip.chipKey}`}
-                                className={`ts-swarm-line ${isClamped ? 'ts-swarm-line-clamped' : ''} ${isInProgress ? 'ts-swarm-line-inprogress' : ''}`}
+                                className={`ts-swarm-line ${isClamped ? 'ts-swarm-line-clamped' : ''} ${isInProgress ? 'ts-swarm-line-inprogress' : ''} ${phase ? 'ts-swarm-line-unclassified' : ''}`}
                                 x1={`${chip.startPct}%`}
                                 y1={yCenter}
                                 x2={x2}
@@ -2040,7 +2096,7 @@ const SIDEWALK_EXTEND_BY = 10;
 const SIDEWALK_MAX_PANELS = 60;
 
 const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowProps }) => {
-    const { requirements, sessions, timezone, circleDiameter, spaceKey,
+    const { requirements, sessions, timezone, circleDiameter, spaceKey, beadWindow,
             swarmStarts, swarmStartSessions, swarmUndos, requirementById,
             categoryList, canonicalStartById, swarmStartIdById, swarmStartById } = rowProps;
     // Today (local) — stable per mount; drives in-progress cross-day spans + the
@@ -2062,6 +2118,19 @@ const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowPr
     // every extension (which would trash in-progress drag state).
     const datesRef = React.useRef(dates);
     const [frameWidth, setFrameWidth] = React.useState(0);
+
+    // req #2823 follow-up — sub-day horizontal zoom. A day panel still represents
+    // a full 24h (BeadRow's sidewalkPanel path is unconditionally 24h, and every
+    // chip/tick/line positions in % within the panel), but we render the panel
+    // WIDER than the viewport so the day spreads across multiple screen-widths and
+    // the strip — which already hand-scrolls horizontally — reveals only a slice at
+    // a time. panelScale = 24 / visibleHours:
+    //   '6h'  → 4× (viewport shows ~6h)   '12h' → 2× (~12h)   else → 1× (full 24h,
+    //   byte-identical to the original behaviour). panelWidth is the per-panel
+    //   pixel STRIDE the infinite-scroll / centring math runs on; frameWidth stays
+    //   the measured viewport width.
+    const panelScale = sidewalkPanelScale(beadWindow);
+    const panelWidth = frameWidth * panelScale;
 
     // Req #2798 — cross-day pass-through lines for multi-day sessions, keyed by
     // each day panel in the strip, with the 24h start-bar coordinate.
@@ -2166,32 +2235,33 @@ const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowPr
     };
 
     const indexForOffset = () => {
-        if (frameWidth === 0) return 0;
+        if (panelWidth === 0) return 0;
         const cur = datesRef.current;
-        const raw = -offsetRef.current / frameWidth;
+        const raw = -offsetRef.current / panelWidth;
         return Math.max(0, Math.min(cur.length - 1, Math.round(raw)));
     };
 
     // Infinite-scroll buffer maintenance. When the visible panel approaches
     // either edge, prepend / append SIDEWALK_EXTEND_BY days. Left extension
-    // shifts translateX by -extend*frameWidth so the visible panel stays put;
+    // shifts translateX by -extend*panelWidth so the visible panel stays put;
     // when the array overflows SIDEWALK_MAX_PANELS, we prune the opposite end
-    // (with a matching +removed*frameWidth shift if pruning the left side).
+    // (with a matching +removed*panelWidth shift if pruning the left side).
+    // panelWidth is the zoom-aware per-panel stride (frameWidth × scale).
     //
     // datesRef is updated synchronously so a follow-up call within the same
     // frame doesn't see the pre-extension array and re-extend.
     const maybeExtend = () => {
-        if (frameWidth === 0) return;
+        if (panelWidth === 0) return;
         const cur = datesRef.current;
         if (!cur || cur.length === 0) return;
-        const raw = -offsetRef.current / frameWidth;
+        const raw = -offsetRef.current / panelWidth;
         const idx = Math.round(raw);
         const distLeft  = idx;
         const distRight = cur.length - 1 - idx;
 
         if (distLeft <= SIDEWALK_BUFFER_THRESHOLD) {
             // Extend left, then shift translateX so the visible panel stays put.
-            applyOffset(offsetRef.current - SIDEWALK_EXTEND_BY * frameWidth);
+            applyOffset(offsetRef.current - SIDEWALK_EXTEND_BY * panelWidth);
             let next = extendDates(cur, 'left', SIDEWALK_EXTEND_BY);
             const pruned = pruneDates(next, SIDEWALK_MAX_PANELS, 'right');
             next = pruned.dates;
@@ -2205,7 +2275,7 @@ const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowPr
             // by `removedCount`; compensate translateX so the visible panel
             // stays put.
             if (pruned.removedCount > 0) {
-                applyOffset(offsetRef.current + pruned.removedCount * frameWidth);
+                applyOffset(offsetRef.current + pruned.removedCount * panelWidth);
             }
             datesRef.current = next;
             setDates(next);
@@ -2239,7 +2309,7 @@ const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowPr
     // chevrons), rebuild the strip around the new centerDate so the Sidewalk
     // stays coherent with the rest of the calendar state.
     React.useEffect(() => {
-        if (frameWidth === 0) return;
+        if (panelWidth === 0) return;
         if (centerDate === lastReported.current) return;
         // Parent drove the change (e.g. a chevron click). Cancel any pending
         // debounced scroll report so a stale scroll date doesn't fire after
@@ -2257,23 +2327,30 @@ const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowPr
             datesRef.current = rebuilt;
             setDates(rebuilt);
             lastReported.current = centerDate;
-            requestAnimationFrame(() => applyOffset(-rebuilt.indexOf(centerDate) * frameWidth));
+            requestAnimationFrame(() => applyOffset(-rebuilt.indexOf(centerDate) * panelWidth));
             return;
         }
         lastReported.current = centerDate;
-        animateTo(-idx * frameWidth);
+        animateTo(-idx * panelWidth);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [centerDate, frameWidth]);
+    }, [centerDate, panelWidth]);
 
-    // Initial placement on mount — put centerDate at index-of.
+    // Initial placement on mount AND re-snap on zoom change — put the focused
+    // panel's left edge at the viewport left. Depending on panelWidth means a
+    // zoom toggle (which changes the per-panel stride) re-centres the same day
+    // instead of leaving the strip parked at a stale pixel offset.
     React.useEffect(() => {
-        if (frameWidth === 0) return;
-        const idx = datesRef.current.indexOf(centerDate);
-        if (idx >= 0) applyOffset(-idx * frameWidth);
+        if (panelWidth === 0) return;
+        const cur = datesRef.current;
+        const idx = cur.indexOf(lastReported.current) >= 0
+            ? cur.indexOf(lastReported.current)
+            : cur.indexOf(centerDate);
+        if (idx >= 0) applyOffset(-idx * panelWidth);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [frameWidth]);
+    }, [panelWidth]);
 
-    // Drag + momentum. Bind once per frameWidth — `dates.length` is read via
+    // Drag + momentum. Bind once per panelWidth (the zoom-aware stride) —
+    // `dates.length` is read via
     // `datesRef` inside maybeExtend so we can extend the strip without
     // re-binding (which would lose in-progress drag state). onMove uses
     // delta-from-last instead of cumulative-from-startOffset because
@@ -2372,15 +2449,17 @@ const Sidewalk = ({ centerDate, onCenterDateChange, requirementsByDate, ...rowPr
             frame.removeEventListener('wheel', onWheel);
             stopAnim();
         };
+    // Re-bind on panelWidth (not just frameWidth) so the drag/wheel handlers
+    // capture a maybeExtend closure that uses the current zoom's stride.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [frameWidth]);
+    }, [panelWidth]);
 
     return (
         <Box className="ts-sidewalk" data-testid="ts-sidewalk" ref={frameRef}>
             <Box className="ts-sidewalk-inner" ref={innerRef}>
                 {dates.map(d => (
                     <Box key={d} className="ts-sidewalk-panel" data-date={d}
-                         style={{ width: frameWidth || '100%', flex: `0 0 ${frameWidth || 1}px` }}>
+                         style={{ width: panelWidth || '100%', flex: `0 0 ${panelWidth || 1}px` }}>
                         {/* Per-day slice (req #2800) — overrides the full
                             `requirements` carried in rowProps so unchanged/empty
                             panels keep a stable prop reference and BeadRow's memo
@@ -2985,6 +3064,7 @@ const TimeSeriesView = ({
     dataKey = DEFAULT_DATA_KEY,      // 'category' | 'coordination' — req #2382
     titlesOn = false,                // req #2556 — render req title to right of bubble
     completesOn = false,             // req #2790 — show completion-terminus badge (off by default)
+    phasesOn = false,                // req #2823 — segment duration line by phase buckets (off by default)
     isWeekView = false,
     categoryList = [],
     onChipClick,
@@ -3201,6 +3281,7 @@ const TimeSeriesView = ({
             titlesOn={titlesOn}
 
             completesOn={completesOn}
+            phasesOn={phasesOn}
             tooltipFontSize={tooltipFontSize}
             circleDiameter={circleDiameter}
             spaceKey={spaceKey}
@@ -3244,6 +3325,7 @@ const TimeSeriesView = ({
                     titlesOn={titlesOn}
 
                     completesOn={completesOn}
+                    phasesOn={phasesOn}
                     tooltipFontSize={tooltipFontSize}
                     circleDiameter={circleDiameter}
                     spaceKey={spaceKey}
@@ -3277,6 +3359,7 @@ const TimeSeriesView = ({
                     titlesOn={titlesOn}
 
                     completesOn={completesOn}
+                    phasesOn={phasesOn}
                     tooltipFontSize={tooltipFontSize}
                     circleDiameter={circleDiameter}
                     spaceKey={spaceKey}

--- a/src/CalendarFC/__tests__/timeSeriesHelpers.test.js
+++ b/src/CalendarFC/__tests__/timeSeriesHelpers.test.js
@@ -15,6 +15,7 @@ import {
     assignSwarmLanes,
     buildCrossDayGhosts,
     buildCrossDayMap,
+    sidewalkPanelScale,
 } from '../TimeSeriesView';
 import { getSpaceMultiplier } from '../timeSeriesSizes';
 
@@ -953,5 +954,28 @@ describe('buildCrossDayGhosts (req #2747)', () => {
         const ghosts = buildCrossDayGhosts(
             [{ sessionId: 9, role: 'middle', groupKey: 'g', completedAt: 't' }]);
         expect(ghosts[0].id).toBeNull();
+    });
+});
+
+// req #2823 follow-up — Sidewalk sub-day horizontal zoom multiplier.
+describe('sidewalkPanelScale', () => {
+    it('maps 6h → 4× and 12h → 2×', () => {
+        expect(sidewalkPanelScale('6h')).toBe(4);
+        expect(sidewalkPanelScale('12h')).toBe(2);
+    });
+
+    it('is 1× (unchanged) for 24h, 36h, and any other value', () => {
+        expect(sidewalkPanelScale('24h')).toBe(1);
+        expect(sidewalkPanelScale('36h')).toBe(1);
+        expect(sidewalkPanelScale(undefined)).toBe(1);
+        expect(sidewalkPanelScale(null)).toBe(1);
+        expect(sidewalkPanelScale('bogus')).toBe(1);
+    });
+
+    it('panelWidth = frameWidth × scale preserves 24h pixel stride', () => {
+        const frameWidth = 900;
+        expect(frameWidth * sidewalkPanelScale('24h')).toBe(900);
+        expect(frameWidth * sidewalkPanelScale('12h')).toBe(1800);
+        expect(frameWidth * sidewalkPanelScale('6h')).toBe(3600);
     });
 });

--- a/src/CalendarFC/__tests__/timeSeriesSizes.test.js
+++ b/src/CalendarFC/__tests__/timeSeriesSizes.test.js
@@ -10,6 +10,7 @@ import {
     SWARM_CLUSTER_WINDOW_MS, clusterSessionsByStartTime, clusterSessionsBySwarmStart,
     DATA_KEYS, DEFAULT_DATA_KEY, COORDINATION_COLORS,
     COORDINATION_FALLBACK_COLOR, getCoordinationColor,
+    PHASE_SEGMENTS, PHASE_UNCLASSIFIED_COLOR, computePhaseSegments,
 } from '../timeSeriesSizes';
 
 describe('Font size option A/B/C/D', () => {
@@ -1160,5 +1161,96 @@ describe('isHiddenSwarmStatus (phantom-chip skip filter, req #2650)', () => {
         // act when a real "do not phantom this" case appears.
         expect(isHiddenSwarmStatus('queued')).toBe(false);
         expect(isHiddenSwarmStatus('blocked')).toBe(false);
+    });
+});
+
+// req #2823 — phase-duration segmentation of the swarm duration line.
+describe('PHASE_SEGMENTS config', () => {
+    it('lists the agentic block before the human block', () => {
+        const families = PHASE_SEGMENTS.map(p => p.family);
+        const firstHuman = families.indexOf('human');
+        const lastAgentic = families.lastIndexOf('agentic');
+        expect(firstHuman).toBeGreaterThan(lastAgentic);
+    });
+
+    it('covers exactly the seven session phase buckets', () => {
+        expect(PHASE_SEGMENTS.map(p => p.key)).toEqual([
+            'starting_secs', 'planning_secs', 'implementing_secs', 'completion_secs',
+            'waiting_secs', 'review_secs', 'paused_secs',
+        ]);
+    });
+
+    it('gives every phase a distinct hex colour, none equal to unclassified gray', () => {
+        const colors = PHASE_SEGMENTS.map(p => p.color);
+        expect(new Set(colors).size).toBe(colors.length);
+        expect(colors).not.toContain(PHASE_UNCLASSIFIED_COLOR);
+        for (const c of colors) expect(c).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    });
+});
+
+describe('computePhaseSegments (req #2823)', () => {
+    const instrumented = {
+        instrumented: 1,
+        starting_secs: 10, planning_secs: 0, implementing_secs: 60,
+        completion_secs: 0, waiting_secs: 0, review_secs: 30, paused_secs: 0,
+    };
+
+    it('returns unclassified when session is null', () => {
+        expect(computePhaseSegments(null, 0, 100)).toEqual({ classified: false, segments: [] });
+    });
+
+    it('returns unclassified when startPct/endPct missing', () => {
+        expect(computePhaseSegments(instrumented, null, 100).classified).toBe(false);
+        expect(computePhaseSegments(instrumented, 0, null).classified).toBe(false);
+    });
+
+    it('returns unclassified for a legacy (instrumented=0) session', () => {
+        const legacy = { instrumented: 0, legacy_secs: 500, implementing_secs: 0 };
+        expect(computePhaseSegments(legacy, 0, 100)).toEqual({ classified: false, segments: [] });
+    });
+
+    it('returns unclassified when every bucket is zero', () => {
+        const empty = { instrumented: 1, starting_secs: 0, implementing_secs: 0, review_secs: 0 };
+        expect(computePhaseSegments(empty, 0, 100).classified).toBe(false);
+    });
+
+    it('accepts instrumented as 1, true, or "1"', () => {
+        for (const v of [1, true, '1']) {
+            expect(computePhaseSegments({ ...instrumented, instrumented: v }, 0, 100).classified).toBe(true);
+        }
+    });
+
+    it('emits one segment per NON-ZERO bucket, in PHASE_SEGMENTS order', () => {
+        const { classified, segments } = computePhaseSegments(instrumented, 0, 100);
+        expect(classified).toBe(true);
+        expect(segments.map(s => s.key)).toEqual([
+            'starting_secs', 'implementing_secs', 'review_secs',
+        ]);
+    });
+
+    it('splits the span proportionally to each bucket', () => {
+        // 10 / 60 / 30 of 100 total → widths 10 / 60 / 30 across [0,100].
+        const { segments } = computePhaseSegments(instrumented, 0, 100);
+        expect(segments[0].x1Pct).toBeCloseTo(0);
+        expect(segments[0].x2Pct).toBeCloseTo(10);
+        expect(segments[1].x1Pct).toBeCloseTo(10);
+        expect(segments[1].x2Pct).toBeCloseTo(70);
+        expect(segments[2].x1Pct).toBeCloseTo(70);
+        expect(segments[2].x2Pct).toBeCloseTo(100);
+    });
+
+    it('respects a non-zero start offset and pins the last segment to endPct', () => {
+        const { segments } = computePhaseSegments(instrumented, 20, 80);
+        expect(segments[0].x1Pct).toBeCloseTo(20);
+        expect(segments[segments.length - 1].x2Pct).toBe(80);
+    });
+
+    it('carries family + color through onto each segment', () => {
+        const { segments } = computePhaseSegments(instrumented, 0, 100);
+        const impl = segments.find(s => s.key === 'implementing_secs');
+        expect(impl.family).toBe('agentic');
+        expect(impl.color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+        const review = segments.find(s => s.key === 'review_secs');
+        expect(review.family).toBe('human');
     });
 });

--- a/src/CalendarFC/timeSeriesSizes.js
+++ b/src/CalendarFC/timeSeriesSizes.js
@@ -113,6 +113,79 @@ export function getCoordinationColor(coordinationType) {
     return COORDINATION_COLORS[coordinationType] || COORDINATION_FALLBACK_COLOR;
 }
 
+// ── Session phase-duration segmentation (req #2823) ─────────────────────────────
+// req #2332 records per-phase second-buckets on every instrumented swarm_session.
+// The broad visualizer's "Phases" overlay segments each completed session's
+// start→complete duration line proportionally so you can see at a glance where
+// time went and which side of the agentic/human divide it fell on.
+//
+//   agentic = Claude working autonomously — starting (machine setup), planning,
+//             implementing, completion. Cool hues (blue-grey → indigo → blue → teal).
+//   human   = waiting on the user — waiting (discuss idle), review, paused.
+//             Warm hues (amber → orange → brown).
+//
+// Order: the agentic block first, then the human block, so the two families read
+// as two contiguous colour runs and the divide is a single boundary. These are
+// AGGREGATE buckets, not a literal timeline, so family-grouping (clearest "where
+// did time go" read) is preferred over reconstructing lifecycle order.
+export const PHASE_SEGMENTS = [
+    { key: 'starting_secs',     label: 'Starting',     family: 'agentic', color: '#90A4AE' }, // blue-grey
+    { key: 'planning_secs',     label: 'Planning',     family: 'agentic', color: '#5C6BC0' }, // indigo
+    { key: 'implementing_secs', label: 'Implementing', family: 'agentic', color: '#1E88E5' }, // blue
+    { key: 'completion_secs',   label: 'Completion',   family: 'agentic', color: '#26A69A' }, // teal
+    { key: 'waiting_secs',      label: 'Waiting',      family: 'human',   color: '#FFB300' }, // amber
+    { key: 'review_secs',       label: 'Review',       family: 'human',   color: '#FB8C00' }, // orange
+    { key: 'paused_secs',       label: 'Paused',       family: 'human',   color: '#8D6E63' }, // brown
+];
+
+// Pre-instrumentation (instrumented=0) and no-phase-data sessions render a single
+// neutral-gray segment — an explicit "unknown split", never mistaken for a phase.
+export const PHASE_UNCLASSIFIED_COLOR = '#9E9E9E';
+
+// `instrumented` arrives from the JSON API as 1/0, true/false, or "1"/"0".
+const isInstrumented = (v) => v === 1 || v === true || v === '1';
+
+// Split the [startPct, endPct] duration span into proportional phase segments.
+// Returns:
+//   { classified: false, segments: [] }  — session missing, not instrumented, or
+//                                           zero total phase time → caller draws a
+//                                           single neutral-gray unclassified line.
+//   { classified: true, segments: [...] } — one entry per NON-ZERO bucket, in
+//                                           PHASE_SEGMENTS order, each
+//                                           { key, label, family, color, secs,
+//                                             x1Pct, x2Pct } spanning its slice.
+// The final segment's x2Pct is pinned exactly to endPct to absorb float drift.
+// Pure + exported for unit-test coverage.
+export function computePhaseSegments(session, startPct, endPct) {
+    if (session == null || startPct == null || endPct == null) {
+        return { classified: false, segments: [] };
+    }
+    if (!isInstrumented(session.instrumented)) {
+        return { classified: false, segments: [] };
+    }
+    const buckets = PHASE_SEGMENTS.map((p) => {
+        const v = Number(session[p.key]);
+        return { ...p, secs: Number.isFinite(v) && v > 0 ? v : 0 };
+    });
+    const total = buckets.reduce((sum, b) => sum + b.secs, 0);
+    if (total <= 0) return { classified: false, segments: [] };
+
+    const span = endPct - startPct;
+    const segments = [];
+    let cursor = startPct;
+    for (const b of buckets) {
+        if (b.secs <= 0) continue;
+        const x1Pct = cursor;
+        cursor += span * (b.secs / total);
+        segments.push({
+            key: b.key, label: b.label, family: b.family, color: b.color,
+            secs: b.secs, x1Pct, x2Pct: cursor,
+        });
+    }
+    if (segments.length) segments[segments.length - 1].x2Pct = endPct;
+    return { classified: true, segments };
+}
+
 // ── Swarm start-time clustering (req #2341) ─────────────────────────────────────
 // Sessions whose started_at fall within this window are treated as a single swarm
 // and share one canonical start X so their vertical start-bars line up.

--- a/src/SwarmView/SwarmVisualizerView.jsx
+++ b/src/SwarmView/SwarmVisualizerView.jsx
@@ -10,7 +10,42 @@ import {
     useAllSwarmCompletes, useAllSwarmCompleteSessions,
 } from '../hooks/useDataQueries';
 import { localDateStr } from '../utils/dateFormat';
+import { PHASE_SEGMENTS, PHASE_UNCLASSIFIED_COLOR } from '../CalendarFC/timeSeriesSizes';
 import TimeSeriesView from '../CalendarFC/TimeSeriesView';
+import Box from '@mui/material/Box';
+
+// req #2823 — compact legend for the "Phases" overlay. Maps PHASE_SEGMENTS to
+// swatches grouped by agentic / human family, plus the neutral-gray
+// "Unclassified" swatch for legacy (instrumented=0) sessions. Rendered only when
+// the Phases toggle is on, so the default view stays uncluttered.
+const PhaseSwatch = ({ color, label }) => (
+    <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+        <Box component="span" sx={{
+            width: 14, height: 6, borderRadius: '3px',
+            backgroundColor: color, flexShrink: 0,
+        }} />
+        <span>{label}</span>
+    </Box>
+);
+
+const PhaseLegend = () => {
+    const agentic = PHASE_SEGMENTS.filter(p => p.family === 'agentic');
+    const human   = PHASE_SEGMENTS.filter(p => p.family === 'human');
+    return (
+        <Box data-testid="ts-phase-legend"
+             sx={{
+                 display: 'flex', flexWrap: 'wrap', alignItems: 'center',
+                 gap: 1.5, rowGap: 0.5, px: 1, py: 0.5, mb: 0.5,
+                 fontSize: '0.75rem', color: 'text.secondary',
+             }}>
+            <Box component="span" sx={{ fontWeight: 600 }}>Agentic:</Box>
+            {agentic.map(p => <PhaseSwatch key={p.key} color={p.color} label={p.label} />)}
+            <Box component="span" sx={{ fontWeight: 600, ml: 1 }}>Human:</Box>
+            {human.map(p => <PhaseSwatch key={p.key} color={p.color} label={p.label} />)}
+            <PhaseSwatch color={PHASE_UNCLASSIFIED_COLOR} label="Unclassified" />
+        </Box>
+    );
+};
 
 // Shift a YYYY-MM-DD string by N days using local calendar parts, so east-of-UTC
 // timezones don't roll the result backward.
@@ -43,6 +78,7 @@ const SwarmVisualizerView = () => {
     const dataKey     = useSwarmVisualizerStore(s => s.dataKey);
     const titlesOn    = useSwarmVisualizerStore(s => s.titlesOn);
     const completesOn = useSwarmVisualizerStore(s => s.completesOn);
+    const phasesOn    = useSwarmVisualizerStore(s => s.phasesOn);
     const setCurrentDate = useSwarmVisualizerStore(s => s.setCurrentDate);
 
     const isWeekView = viewType === 'week';
@@ -186,6 +222,7 @@ const SwarmVisualizerView = () => {
     // component now renders only the time-series content.
     return (
         <div>
+            {phasesOn && <PhaseLegend />}
             <TimeSeriesView
                 requirements={requirements}
                 allRequirements={allRequirements}
@@ -203,6 +240,7 @@ const SwarmVisualizerView = () => {
                 dataKey={dataKey}
                 titlesOn={titlesOn}
                 completesOn={completesOn}
+                phasesOn={phasesOn}
                 isWeekView={isWeekView}
                 categoryList={categoryList}
                 onChipClick={onChipClick}

--- a/src/SwarmView/VisualizerToolbar.jsx
+++ b/src/SwarmView/VisualizerToolbar.jsx
@@ -47,6 +47,7 @@ const VisualizerToolbar = () => {
     const dataKey     = useSwarmVisualizerStore(s => s.dataKey);
     const titlesOn    = useSwarmVisualizerStore(s => s.titlesOn);
     const completesOn = useSwarmVisualizerStore(s => s.completesOn);
+    const phasesOn    = useSwarmVisualizerStore(s => s.phasesOn);
     const setViewType    = useSwarmVisualizerStore(s => s.setViewType);
     const setCurrentDate = useSwarmVisualizerStore(s => s.setCurrentDate);
     const setBeadWindow  = useSwarmVisualizerStore(s => s.setBeadWindow);
@@ -55,6 +56,7 @@ const VisualizerToolbar = () => {
     const setDataKey     = useSwarmVisualizerStore(s => s.setDataKey);
     const setTitlesOn    = useSwarmVisualizerStore(s => s.setTitlesOn);
     const setCompletesOn = useSwarmVisualizerStore(s => s.setCompletesOn);
+    const setPhasesOn    = useSwarmVisualizerStore(s => s.setPhasesOn);
 
     const isWeekView = viewType === 'week';
     const todayStr = useMemo(() => localDateStr(), []);
@@ -106,10 +108,22 @@ const VisualizerToolbar = () => {
         setCompletesOn(!completesOn);
     }, [completesOn, setCompletesOn]);
 
+    const handlePhasesClick = useCallback(() => {
+        setPhasesOn(!phasesOn);
+    }, [phasesOn, setPhasesOn]);
+
     // Auto-off sidewalk/elevator when the active layout stops applying.
     React.useEffect(() => {
         if (isWeekView && sidewalkOn) setSidewalkOn(false);
     }, [isWeekView, sidewalkOn, setSidewalkOn]);
+    // The 6h/12h sub-day zooms only exist in Sidewalk (req #2823 follow-up). If
+    // Sidewalk turns off while one is selected, fall back to 24h so the non-
+    // sidewalk render paths never see a sub-day window.
+    React.useEffect(() => {
+        if (!sidewalkOn && (beadWindow === '6h' || beadWindow === '12h')) {
+            setBeadWindow('24h');
+        }
+    }, [sidewalkOn, beadWindow, setBeadWindow]);
     React.useEffect(() => {
         if (!isWeekView && elevatorOn) setElevatorOn(false);
     }, [isWeekView, elevatorOn, setElevatorOn]);
@@ -129,6 +143,24 @@ const VisualizerToolbar = () => {
             </Button>
             <ToggleButtonGroup size="small" sx={{ ml: 0.5 }}
                                data-testid="timeseries-group">
+                {/* 6h / 12h sub-day zooms — Sidewalk-only (req #2823 follow-up).
+                    They widen each day panel so the strip scrolls through a slice
+                    of the day, spreading chips + phase segments out. Disabled
+                    outside Sidewalk, where a sub-day window would clip the day. */}
+                <ToggleButton value="6h" className="cal-toggle-btn"
+                              selected={beadWindow === '6h' && sidewalkOn}
+                              disabled={!sidewalkOn}
+                              onChange={() => setBeadWindow('6h')}
+                              data-testid="timeseries-window-6h">
+                    6h
+                </ToggleButton>
+                <ToggleButton value="12h" className="cal-toggle-btn"
+                              selected={beadWindow === '12h' && sidewalkOn}
+                              disabled={!sidewalkOn}
+                              onChange={() => setBeadWindow('12h')}
+                              data-testid="timeseries-window-12h">
+                    12h
+                </ToggleButton>
                 <ToggleButton value="24h" className="cal-toggle-btn"
                               selected={beadWindow === '24h'}
                               onChange={() => setBeadWindow('24h')}
@@ -173,6 +205,12 @@ const VisualizerToolbar = () => {
                               onChange={handleCompletesClick}
                               data-testid="timeseries-completes">
                     Done
+                </ToggleButton>
+                <ToggleButton value="phases" className="cal-toggle-btn"
+                              selected={phasesOn}
+                              onChange={handlePhasesClick}
+                              data-testid="timeseries-phases">
+                    Phases
                 </ToggleButton>
             </ToggleButtonGroup>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: 0.5 }}>

--- a/src/stores/__tests__/useSwarmVisualizerStore.test.js
+++ b/src/stores/__tests__/useSwarmVisualizerStore.test.js
@@ -102,6 +102,13 @@ describe('migrateVisualizerState (req #2799, req #2806)', () => {
         expect(out.dataKey).toBe('category');
         expect(out.titlesOn).toBe(false);
         expect(out.completesOn).toBe(false);
+        // req #2823 — phasesOn (v6 → v7) back-fills to false.
+        expect(out.phasesOn).toBe(false);
+    });
+
+    it('preserves a persisted phasesOn=true (req #2823)', () => {
+        const out = migrateVisualizerState({ phasesOn: true });
+        expect(out.phasesOn).toBe(true);
     });
 
     it('normalizes an unknown dataKey to category', () => {

--- a/src/stores/useSwarmVisualizerStore.js
+++ b/src/stores/useSwarmVisualizerStore.js
@@ -31,6 +31,9 @@ export const migrateVisualizerState = (persisted) => {
         titlesOn: rest.titlesOn ?? false,
         // v3 → v4: req #2790 completesOn (off by default).
         completesOn: rest.completesOn ?? false,
+        // v6 → v7: req #2823 phasesOn (off by default) — segment the duration
+        // line by session phase-duration buckets.
+        phasesOn: rest.phasesOn ?? false,
     };
 };
 
@@ -45,6 +48,7 @@ export const useSwarmVisualizerStore = create(
             dataKey: 'category',         // 'category' | 'coordination' — req #2382
             titlesOn: false,             // show requirement title to right of bubble — req #2556
             completesOn: false,          // show completion-terminus badge — req #2790 (off by default)
+            phasesOn: false,             // segment duration line by session phase buckets — req #2823 (off by default)
 
             setViewType: (viewType) => set({ viewType }),
             setCurrentDate: (currentDate) => set({ currentDate }),
@@ -55,6 +59,7 @@ export const useSwarmVisualizerStore = create(
                 set({ dataKey: key === 'coordination' ? 'coordination' : 'category' }),
             setTitlesOn: (on) => set({ titlesOn: !!on }),
             setCompletesOn: (on) => set({ completesOn: !!on }),
+            setPhasesOn: (on) => set({ phasesOn: !!on }),
         }),
         {
             name: 'darwin_swarm_visualizer',
@@ -63,7 +68,8 @@ export const useSwarmVisualizerStore = create(
             // version forces migrate to run once for existing users so a stale
             // date OR a persisted vizKey already in localStorage is stripped on
             // first load.
-            version: 6,
+            // v6 → v7 (req #2823): phasesOn added; migrate back-fills it to false.
+            version: 7,
             // Never write currentDate (req #2799) — it stays a today-default each load.
             partialize: persistPartialize,
             migrate: migrateVisualizerState,


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2823-swarm-visualizer-phase-durations-1
- wip(Darwin): 2026-06-13T05:56:47Z
- chore: init swarm session feature/2823-swarm-visualizer-phase-durations-1

## Files changed
```
 src/CalendarFC/TimeSeriesView.jsx                  | 129 +++++++++++++++++----
 src/CalendarFC/__tests__/timeSeriesHelpers.test.js |  24 ++++
 src/CalendarFC/__tests__/timeSeriesSizes.test.js   |  92 +++++++++++++++
 src/CalendarFC/timeSeriesSizes.js                  |  73 ++++++++++++
 src/SwarmView/SwarmVisualizerView.jsx              |  38 ++++++
 src/SwarmView/VisualizerToolbar.jsx                |  38 ++++++
 .../__tests__/useSwarmVisualizerStore.test.js      |   7 ++
 src/stores/useSwarmVisualizerStore.js              |   8 +-
 8 files changed, 385 insertions(+), 24 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)