### PR TITLE
Complete req #2827 sweep: SwarmSessionDetail DELETE + exportService read still pinned to darwinOpsUri

### DIFF
--- a/src/NavBar/ProfileContent.jsx
+++ b/src/NavBar/ProfileContent.jsx
@@ -25,7 +25,7 @@ import PersonAddOutlined from '@mui/icons-material/PersonAddOutlined';
 const ProfileContent = ({ onClose }) => {
 
     const { idToken, profile, setProfile } = useContext(AuthContext);
-    const { darwinUri, darwinOpsUri } = useContext(AppContext);
+    const { darwinUri } = useContext(AppContext);
     const { themeMode, setThemeMode } = useContext(ThemeContext);
     const showError = useSnackBarStore(s => s.showError);
     const navigate = useNavigate();
@@ -152,7 +152,7 @@ const ProfileContent = ({ onClose }) => {
     const handleExport = async (selectedApps) => {
         setExporting(true);
         try {
-            const data = await fetchExportData(darwinUri, darwinOpsUri, profile.userName, idToken, profile, selectedApps);
+            const data = await fetchExportData(darwinUri, profile.userName, idToken, profile, selectedApps);
             const date = new Date().toISOString().slice(0, 10);
             downloadJson(data, `darwin-export-${date}.json`);
         } catch (err) {

--- a/src/SwarmView/detail/SwarmSessionDetail.jsx
+++ b/src/SwarmView/detail/SwarmSessionDetail.jsx
@@ -35,7 +35,7 @@ const SwarmSessionDetail = () => {
     const location = useLocation();
 
     const { idToken, profile } = useContext(AuthContext);
-    const { darwinOpsUri } = useContext(AppContext);
+    const { darwinUri } = useContext(AppContext);
     const queryClient = useQueryClient();
     const showError = useSnackBarStore(s => s.showError);
 
@@ -92,8 +92,10 @@ const SwarmSessionDetail = () => {
 
     const sessionDelete = useConfirmDialog({
         onConfirm: ({ sessionId }) => {
-            // Req #2697 — operational tables live exclusively in `darwin`.
-            const uri = `${darwinOpsUri}/swarm_sessions`;
+            // Req #2837 — read/write swarm_sessions via `darwinUri` so the dev UI
+            // (darwin_dev) deletes the row it actually shows; prod no-op
+            // (darwinUri === darwinOpsUri). Completes the req #2827/#2834 sweep.
+            const uri = `${darwinUri}/swarm_sessions`;
             call_rest_api(uri, 'DELETE', { id: sessionId }, idToken)
                 .then(result => {
                     if (result.httpStatus.httpStatus === 200) {

--- a/src/services/__tests__/exportService.test.js
+++ b/src/services/__tests__/exportService.test.js
@@ -8,10 +8,10 @@ vi.mock('../../RestApi/RestApi', () => ({
 
 import call_rest_api from '../../RestApi/RestApi';
 
-// Distinct URIs so the test surface catches any regression that reverts an
-// ops-table read to `darwinUri` (req #2697).
-const DARWIN_URI     = 'https://api.example.com/darwin_dev';
-const DARWIN_OPS_URI = 'https://api.example.com/darwin';
+// Dev-mode base URL (darwin_dev). Req #2837 — every table, including the
+// operational `swarm_sessions`, now reads through this single dev/prod-split URI;
+// the export service no longer takes a separate ops URI.
+const DARWIN_URI = 'https://api.example.com/darwin_dev';
 const ID_TOKEN = 'mock-token';
 const PROFILE = {
     name: 'Test User',
@@ -47,7 +47,7 @@ beforeEach(() => {
 describe('fetchExportData', () => {
     it('returns v2.0 with selectedApps metadata', async () => {
         mockApi({});
-        const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, {
+        const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, {
             tasks: false, maps: false, swarm: false,
         });
         expect(result.exportVersion).toBe('2.0');
@@ -57,7 +57,7 @@ describe('fetchExportData', () => {
 
     it('exports profile with all fields', async () => {
         mockApi({});
-        const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, {
+        const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, {
             tasks: false, maps: false, swarm: false,
         });
         expect(result.profile).toEqual({
@@ -75,7 +75,7 @@ describe('fetchExportData', () => {
 
     it('omits app keys when not selected', async () => {
         mockApi({});
-        const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, {
+        const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, {
             tasks: false, maps: false, swarm: false,
         });
         expect(result.domains).toBeUndefined();
@@ -96,7 +96,7 @@ describe('fetchExportData', () => {
                 '/recurring_tasks': [{ id: 200, description: 'RT1', recurrence: 'daily', anchor_date: '2026-01-01', area_fk: 10, priority: 0, accumulate: 0, insert_position: 'bottom', active: 1, last_generated: null, create_ts: 't', update_ts: null }],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
 
             expect(result.domains).toHaveLength(1);
             expect(result.domains[0].areas).toHaveLength(1);
@@ -124,14 +124,14 @@ describe('fetchExportData', () => {
                 '/recurring_tasks': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.domains[0].areas[0].tasks[0].description).toBe('T1');
             expect(result.domains[1].areas[0].tasks[0].description).toBe('T2');
         });
 
         it('handles 404 (empty tables) gracefully', async () => {
             mockApi({}); // All tables return 404
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.domains).toEqual([]);
             expect(result.recurringTasks).toEqual([]);
         });
@@ -152,7 +152,7 @@ describe('fetchExportData', () => {
                 '/map_run_partners': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
 
             expect(result.mapRoutes).toHaveLength(1);
             expect(result.mapRoutes[0].runs).toHaveLength(1);
@@ -170,7 +170,7 @@ describe('fetchExportData', () => {
                 '/map_run_partners': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.unassignedRuns[0].coordinates).toBeUndefined();
             // No coordinate API calls should have been made
             const coordCalls = call_rest_api.mock.calls.filter(c => c[0].includes('map_coordinates'));
@@ -190,7 +190,7 @@ describe('fetchExportData', () => {
                 '/map_run_partners': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, {
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, {
                 ...SELECTED, mapsGps: true,
             });
 
@@ -209,7 +209,7 @@ describe('fetchExportData', () => {
                 '/map_run_partners': [{ map_run_fk: 10, map_partner_fk: 1, create_ts: 't' }],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.mapViews).toHaveLength(1);
             expect(result.mapPartners).toHaveLength(1);
             expect(result.mapRunPartners).toHaveLength(1);
@@ -228,7 +228,7 @@ describe('fetchExportData', () => {
                 '/categories': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.requirements[0].requirement_status).toBe('authoring');
             expect(result.requirements[0].coordination_type).toBe('implemented');
             expect(result.requirements[0].deferred_at).toBe('2026-03-01');
@@ -236,10 +236,10 @@ describe('fetchExportData', () => {
             expect(result.requirements[0].category_fk).toBe(10);
         });
 
-        // Req #2697 regression guard — swarm_sessions is an operational table,
-        // must be fetched from darwinOpsUri (production `darwin`), never from
-        // darwinUri (which honors the dev/prod USER-data split).
-        it('reads swarm_sessions from darwinOpsUri (production darwin) not darwinUri', async () => {
+        // Req #2837 regression guard — swarm_sessions now follows the dev/prod
+        // split like every other table (completing the req #2827/#2834 sweep), so
+        // the dev export reads it from darwinUri (darwin_dev), NOT a pinned ops URI.
+        it('reads swarm_sessions from darwinUri (dev/prod split) not a pinned ops URI', async () => {
             mockApi({
                 '/requirements': [],
                 '/swarm_sessions': [],
@@ -247,12 +247,12 @@ describe('fetchExportData', () => {
                 '/categories': [],
             });
 
-            await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
 
             const sessionCall = call_rest_api.mock.calls.find(c => c[0].includes('swarm_sessions'));
             expect(sessionCall).toBeDefined();
-            expect(sessionCall[0]).toContain(DARWIN_OPS_URI);
-            expect(sessionCall[0]).not.toContain('darwin_dev');
+            expect(sessionCall[0]).toContain(DARWIN_URI);
+            expect(sessionCall[0]).toContain('darwin_dev');
         });
 
         it('exports swarm session with review status transparently', async () => {
@@ -263,7 +263,7 @@ describe('fetchExportData', () => {
                 '/categories': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.swarmSessions[0].swarm_status).toBe('review');
         });
 
@@ -275,7 +275,7 @@ describe('fetchExportData', () => {
                 '/categories': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.requirements[0].coordination_type).toBeNull();
         });
 
@@ -287,7 +287,7 @@ describe('fetchExportData', () => {
                 '/categories': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             const s = result.swarmSessions[0];
             expect(s.completed_at).toBe('t2');
             expect(s.start_summary).toBe('Started work');
@@ -316,7 +316,7 @@ describe('fetchExportData', () => {
                 '/categories': [{ id: 1, category_name: 'Cat1', project_fk: 1, sort_order: 1, sort_mode: 'hand', color: '#ff0000', closed: 0, create_ts: 't', update_ts: null }],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.projects[0].project_name).toBe('Proj1');
             expect(result.projects[0].closed).toBe(0);
             expect(result.categories[0].category_name).toBe('Cat1');
@@ -348,7 +348,7 @@ describe('fetchExportData', () => {
                 }],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, SELECTED);
             expect(result.features).toHaveLength(1);
             expect(result.features[0].feature_status).toBe('active');
             expect(result.features[0].description).toContain('Given');
@@ -384,7 +384,7 @@ describe('fetchExportData', () => {
                 '/categories': [],
             });
 
-            const result = await fetchExportData(DARWIN_URI, DARWIN_OPS_URI, 'user-123', ID_TOKEN, PROFILE, {
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, {
                 tasks: true, maps: true, swarm: true,
             });
 

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -2,14 +2,15 @@ import call_rest_api from '../RestApi/RestApi';
 
 /**
  * Fetch all user data for selected apps and assemble into nested hierarchy.
- * @param {string} darwinUri - API base URL (USER-data tables; dev-mode = darwin_dev)
- * @param {string} darwinOpsUri - API base URL for operational tables (always darwin per req #2697)
+ * @param {string} darwinUri - API base URL (dev-mode = darwin_dev, prod = darwin).
+ *   Used for every table including the operational ones (req #2837 — swarm_sessions
+ *   now honors the dev/prod split, completing the req #2827/#2834 sweep).
  * @param {string} userName - Cognito username (creator_fk filter)
  * @param {string} idToken - Auth token
  * @param {object} profile - User profile object
  * @param {object} selectedApps - { tasks: boolean, maps: boolean, swarm: boolean }
  */
-export async function fetchExportData(darwinUri, darwinOpsUri, userName, idToken, profile, selectedApps) {
+export async function fetchExportData(darwinUri, userName, idToken, profile, selectedApps) {
     // Lambda-Rest returns 404 when a table has no rows — treat as empty array, not error.
     const safeGet = async (url) => {
         try {
@@ -219,8 +220,9 @@ export async function fetchExportData(darwinUri, darwinOpsUri, userName, idToken
         const [requirements, swarmSessions, projects, categories,
                features, testCases, testPlans] = await Promise.all([
             safeGet(`${darwinUri}/requirements`),
-            // Req #2697 — `swarm_sessions` is an operational table; always read from `darwin`.
-            safeGet(`${darwinOpsUri}/swarm_sessions`),
+            // Req #2837 — `swarm_sessions` now follows the dev/prod split like every
+            // other table, so the dev export reads the seeded `darwin_dev` rows.
+            safeGet(`${darwinUri}/swarm_sessions`),
             safeGet(`${darwinUri}/projects`),
             safeGet(`${darwinUri}/categories`),
             safeGet(`${darwinUri}/features`),


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-06-13T07:21:58Z
- chore: init swarm session feature/2837-complete-req-2827-sweep-1

## Files changed
```
 src/NavBar/ProfileContent.jsx                |  4 +-
 src/SwarmView/detail/SwarmSessionDetail.jsx  |  8 ++--
 src/services/__tests__/exportService.test.js | 56 ++++++++++++++--------------
 src/services/exportService.js                | 12 +++---
 4 files changed, 42 insertions(+), 38 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)