### PR TITLE
visualizer default to May 20, 2026

### DIFF
--- a/src/SwarmView/KonvaSwarmCanvas.jsx
+++ b/src/SwarmView/KonvaSwarmCanvas.jsx
@@ -376,7 +376,14 @@ const KonvaSwarmCanvas = ({
         select(el).call(zb.transform, zoomIdentity.translate(tx, size.h / 2 - cy * k).scale(k));
     }, [win, rows, size.w, size.h, worldH, kBase, selectedDate, transform]);
 
-    const t = transform || { x: 0, y: size.h / 2 - worldH / 2, k: kBase };
+    // Until the centering effect installs the real transform, fall back to a view
+    // centered on the SELECTED day's row (today on a fresh load) — NOT worldH/2.
+    // worldH/2 is the pixel-height midpoint of the fetched world, and because row
+    // height scales with session count that midpoint lands on the densest data
+    // mass (historically the mid/late-May swarm cluster), which is the source of
+    // the "visualizer defaults to May 20/21" affinity (req #2856). rowTopFor falls
+    // back to worldH/2 itself only when the selected row isn't present.
+    const t = transform || { x: 0, y: size.h / 2 - rowTopFor(selectedDate) * kBase, k: kBase };
     const inv = t.k > 0 ? 1 / t.k : 1;
 
     const visibleRows = useMemo(() => {

--- a/src/SwarmView/VisualizerToolbar.jsx
+++ b/src/SwarmView/VisualizerToolbar.jsx
@@ -138,7 +138,7 @@ const VisualizerToolbar = () => {
                               onChange={handleCostClick}
                               data-testid="timeseries-cost"
                               title="Size beads by token cost">
-                    Cost
+                    Tokens
                 </ToggleButton>
             </ToggleButtonGroup>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: 0.5 }}>

--- a/src/stores/__tests__/useSwarmVisualizerStore.test.js
+++ b/src/stores/__tests__/useSwarmVisualizerStore.test.js
@@ -119,12 +119,13 @@ describe('migrateVisualizerState (req #2799, req #2806, req #2844)', () => {
             dataKey: 'category',
         });
         expect(out.dataKey).toBe('category');
-        expect(out.titlesOn).toBe(false);
+        // req #2856 — titlesOn now defaults ON.
+        expect(out.titlesOn).toBe(true);
         expect(out.completesOn).toBe(false);
         // req #2823 — phasesOn back-fills to false.
         expect(out.phasesOn).toBe(false);
-        // req #2841 — konvaWide back-fills to true (36h mid zoom).
-        expect(out.konvaWide).toBe(true);
+        // req #2856 — konvaWide now back-fills to false (24h default window).
+        expect(out.konvaWide).toBe(false);
     });
 
     it('preserves a persisted phasesOn=true (req #2823)', () => {
@@ -148,6 +149,7 @@ describe('migrateVisualizerState (req #2799, req #2806, req #2844)', () => {
         const out = migrateVisualizerState(null);
         expect(out).not.toHaveProperty('currentDate');
         expect(out.dataKey).toBe('category');
-        expect(out.konvaWide).toBe(true);
+        // req #2856 — konvaWide defaults to false (24h).
+        expect(out.konvaWide).toBe(false);
     });
 });

--- a/src/stores/useSwarmVisualizerStore.js
+++ b/src/stores/useSwarmVisualizerStore.js
@@ -38,16 +38,17 @@ export const migrateVisualizerState = (persisted) => {
         ...rest,
         // req #2382 dataKey.
         dataKey: rest.dataKey === 'coordination' ? 'coordination' : 'category',
-        // req #2556 titlesOn.
-        titlesOn: rest.titlesOn ?? false,
+        // req #2556 titlesOn — ON by default since req #2856.
+        titlesOn: rest.titlesOn ?? true,
         // req #2790 completesOn (off by default).
         completesOn: rest.completesOn ?? false,
         // req #2823 phasesOn (off by default) — segment the duration line by
         // session phase-duration buckets.
         phasesOn: rest.phasesOn ?? false,
-        // req #2841 konvaWide (ON by default) — the 36h noon-centered window for
-        // the Konva canvas's mid zoom (toggled by the 36h button).
-        konvaWide: rest.konvaWide ?? true,
+        // req #2841 konvaWide — the 36h noon-centered window for the Konva canvas's
+        // mid zoom (toggled by the 36h button). OFF by default since req #2856 (the
+        // default window is 24h).
+        konvaWide: rest.konvaWide ?? false,
         // v9 → v10: req #2846 costOn (off by default) — size each bead by its
         // session's token cost so expensive work stands out at a glance.
         costOn: rest.costOn ?? false,
@@ -59,10 +60,10 @@ export const useSwarmVisualizerStore = create(
         (set) => ({
             currentDate: localDateStr(), // YYYY-MM-DD — navigation state, NOT persisted (req #2799)
             dataKey: 'category',         // 'category' | 'coordination' — req #2382
-            titlesOn: false,             // show requirement title to right of bubble — req #2556
+            titlesOn: true,              // show requirement title to right of bubble — req #2556 (ON by default since req #2856)
             completesOn: false,          // show completion-terminus badge — req #2790 (off by default)
             phasesOn: false,             // segment duration line by session phase buckets — req #2823 (off by default)
-            konvaWide: true,             // 36h noon-centered window for the Konva canvas mid zoom — req #2841
+            konvaWide: false,            // 36h noon-centered window for the Konva canvas mid zoom — req #2841 (OFF by default = 24h since req #2856)
             costOn: false,               // size each bead by its session token cost — req #2846 (off by default)
             viewResetTick: 0,            // bumped by "Today" to reset the canvas view (req #2841) — not persisted
 
@@ -89,6 +90,11 @@ export const useSwarmVisualizerStore = create(
             //   stale fields (and any persisted currentDate) are stripped on load.
             // v10 → v11 (req #2846): costOn added; migrate back-fills it to false
             //   (bead sizing by token cost is off by default).
+            // req #2856: default UI changed (no version bump — only fresh/reset
+            //   state is affected; explicit persisted prefs still win): titlesOn
+            //   now defaults ON and konvaWide defaults OFF (24h window). The migrate
+            //   back-fills match so a blob missing either field adopts the new
+            //   default.
             version: 11,
             // Never write currentDate (req #2799) — it stays a today-default each load.
             partialize: persistPartialize,

--- a/tests/tests/swarm-visualizer.spec.ts
+++ b/tests/tests/swarm-visualizer.spec.ts
@@ -121,7 +121,9 @@ test.describe('Swarm Visualizer — Konva canvas on /swarm', () => {
         await seedVisualizerState(page, testDate);
         await page.reload();
         const wide = page.getByTestId('timeseries-window-36h');
-        // konvaWide defaults true → button selected.
+        // seedVisualizerState seeds konvaWide:true explicitly → button selected.
+        // (The fresh-install default is OFF/24h since req #2856; this test seeds the
+        // ON state on purpose so the toggle has something to flip.)
         await expect(wide).toHaveAttribute('aria-pressed', 'true', { timeout: 10000 });
         await wide.click();
         await expect(wide).toHaveAttribute('aria-pressed', 'false');


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2856-visualizer-default-to-may-20-2026-1
- wip(Darwin): 2026-06-14T06:11:52Z
- chore: init swarm session feature/2856-visualizer-default-to-may-20-2026-1

## Files changed
```
 src/SwarmView/KonvaSwarmCanvas.jsx                   |  9 ++++++++-
 src/SwarmView/VisualizerToolbar.jsx                  |  2 +-
 src/stores/__tests__/useSwarmVisualizerStore.test.js | 10 ++++++----
 src/stores/useSwarmVisualizerStore.js                | 20 +++++++++++++-------
 tests/tests/swarm-visualizer.spec.ts                 |  4 +++-
 5 files changed, 31 insertions(+), 14 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)