### PR TITLE
Visualzer runs out of data on Apr 24

### DIFF
--- a/src/SwarmView/KonvaSwarmCanvas.jsx
+++ b/src/SwarmView/KonvaSwarmCanvas.jsx
@@ -161,6 +161,7 @@ const KonvaSwarmCanvas = ({
     titlesOn = false, completesOn = false, phasesOn = false,
     costOn = false, devServersOn = true, wide36 = true, resetTick = 0,
     onChipClick, onSwarmStartClick, onUndoClick, onCompleteClick,
+    onExtendPast,
 }) => {
     const theme = useTheme();
     const dark = theme.palette.mode === 'dark';
@@ -189,6 +190,16 @@ const KonvaSwarmCanvas = ({
     const rowsRef = useRef([]);          // live rows for hit-testing in handlers
     const centerDateRef = useRef(null);  // date currently at the viewport center
     const prevWinRef = useRef(null);     // detects a window (36h) toggle
+    // req #2859 — scroll-up auto-extend bookkeeping. onExtendPastRef/rangeStartRef
+    // keep the d3-zoom handler (which closes over a stale render) reading the live
+    // callback + current fetch boundary; extendFiredForRef guards so we fire the
+    // extension at most once per loaded boundary (rangeStart), not on every wheel
+    // tick while the next window is in flight.
+    const onExtendPastRef = useRef(onExtendPast);
+    const rangeStartRef = useRef(rangeStart);
+    const extendFiredForRef = useRef(null);
+    onExtendPastRef.current = onExtendPast;
+    rangeStartRef.current = rangeStart;
     const [size, setSize] = useState({ w: 0, h: 0 });
     const [transform, setTransform] = useState(null);
     const [tooltip, setTooltip] = useState(null);
@@ -242,11 +253,33 @@ const KonvaSwarmCanvas = ({
             out.push({ date, top, height, model, parity: laneParityFor(date) });
             top += height;
         }
+        // req #2859 — re-anchor the world-Y origin on the NEWEST in-window day so a
+        // backward fetch-window extension (scroll-up auto-extend) never shifts the
+        // rows the user is looking at. Prepending older days — or those older days
+        // growing as their async data lands — increases every accumulated `top`,
+        // including the anchor's, by the same amount; subtracting the anchor's top
+        // cancels that out for every existing row (older rows just take more
+        // negative Y), so the viewport stays put and the canvas doesn't jump. The
+        // newest day is always present and is untouched by a past-edge extension,
+        // making it the stable reference (today can leave the window on deep nav).
+        if (out.length) {
+            const anchor = out[out.length - 1].top;
+            if (anchor) for (const r of out) r.top -= anchor;
+        }
         return out;
     }, [dates, ctx, dataKey]);
 
     rowsRef.current = rows;
-    const worldH = rows.length ? rows[rows.length - 1].top + rows[rows.length - 1].height : 0;
+    // World vertical extent. After the newest-day re-anchor (req #2859) the first
+    // row's top is negative and the last row's bottom is its own height, so the
+    // world spans [rows[0].top, rows[last].bottom]; `worldMidY` is its true center.
+    // The "center on worldMidY" branches below are fallbacks for when a target
+    // date isn't found in the window (effectively unreachable, since selectedDate /
+    // centerDateRef are always in-window) — computing the real midpoint keeps them
+    // correct rather than collapsing onto the bottom row.
+    const worldTop = rows.length ? rows[0].top : 0;
+    const worldBot = rows.length ? rows[rows.length - 1].top + rows[rows.length - 1].height : 0;
+    const worldMidY = (worldTop + worldBot) / 2;
 
     // Cost-sizing normalization (req #2846). The most-expensive session in the
     // FETCHED window (not just the visible rows) is the reference, so a bead's
@@ -279,8 +312,8 @@ const KonvaSwarmCanvas = ({
 
     const rowTopFor = useCallback((date) => {
         const r = rows.find(rr => rr.date === date);
-        return r ? r.top + r.height / 2 : worldH / 2;
-    }, [rows, worldH]);
+        return r ? r.top + r.height / 2 : worldMidY;
+    }, [rows, worldMidY]);
 
     // Active dev servers keyed by session id (req #2857). The table holds only
     // currently-claimed servers, so a row's presence == active. If a session
@@ -311,6 +344,29 @@ const KonvaSwarmCanvas = ({
                 // re-anchor on it instead of jumping to a different day.
                 const d = dateAtWorldY(rowsRef.current, (size.h / 2 - tr.y) / tr.k);
                 if (d) centerDateRef.current = d;
+                // req #2859 — scroll-up auto-extend. When a DRAG-PAN brings the
+                // viewport's top edge within one screenful of the oldest loaded
+                // day, ask the view to widen the fetch window backward so panning
+                // up never dead-ends. Gated to drag gestures (sourceEvent present
+                // and not a wheel) so neither wheel zoom-out — which would race the
+                // cap with a burst of refetches — nor the programmatic centering
+                // transforms ever trigger it. Pre-fetching a screen early means the
+                // new (older) rows are usually populated before they scroll into
+                // view. Fire once per loaded boundary: the guard re-arms only when
+                // rangeStart actually changes (new data settled), so an in-flight
+                // refetch isn't spammed.
+                const isDragPan = ev.sourceEvent && ev.sourceEvent.type !== 'wheel';
+                const rws = rowsRef.current;
+                if (isDragPan && rws.length && onExtendPastRef.current && tr.k > 0) {
+                    const yTopWorld = (-tr.y) / tr.k;
+                    const topEdge = rws[0].top;
+                    const screenWorld = size.h / tr.k;
+                    if (yTopWorld <= topEdge + screenWorld &&
+                        extendFiredForRef.current !== rangeStartRef.current) {
+                        extendFiredForRef.current = rangeStartRef.current;
+                        onExtendPastRef.current();
+                    }
+                }
             })
             // Drag-pan cursor: closed-hand 'grabbing' while a pointer drag is in
             // flight, restored to the open-hand 'grab' on release (req #2853). Wheel
@@ -371,7 +427,14 @@ const KonvaSwarmCanvas = ({
         const el = containerRef.current;
         const zb = zoomRef.current;
         if (!el || !zb || size.w === 0 || !rows.length) return;
-        const key = `${selectedDate}|${rangeStart}|${rangeEnd}|${size.w}x${size.h}|${resetTick}`;
+        // req #2859 — key on rangeEnd, NOT rangeStart, so a scroll-up auto-extend
+        // (which moves only the PAST edge) does not re-center the view back onto
+        // the selected day. Toolbar Prev/Next/Today shifts Monday → rangeEnd moves
+        // too, so genuine navigation still re-centers; same-week date tweaks leave
+        // both edges unchanged and need no re-center. The newest-day layout anchor
+        // keeps existing rows fixed across an extension, so skipping re-center here
+        // leaves the user exactly where they were panning.
+        const key = `${selectedDate}|${rangeEnd}|${size.w}x${size.h}|${resetTick}`;
         if (lastCenterRef.current === key) return;
         lastCenterRef.current = key;
         centerDateRef.current = selectedDate;
@@ -392,19 +455,20 @@ const KonvaSwarmCanvas = ({
         if (!el || !zb || size.w === 0 || !rows.length) return;
         const anchor = centerDateRef.current || selectedDate;
         const r = rows.find(rr => rr.date === anchor);
-        const cy = r ? r.top + r.height / 2 : worldH / 2;
+        const cy = r ? r.top + r.height / 2 : worldMidY;
         const k = transform ? transform.k : kBase;
         const tx = transform ? transform.x : 0;
         select(el).call(zb.transform, zoomIdentity.translate(tx, size.h / 2 - cy * k).scale(k));
-    }, [win, rows, size.w, size.h, worldH, kBase, selectedDate, transform]);
+    }, [win, rows, size.w, size.h, worldMidY, kBase, selectedDate, transform]);
 
     // Until the centering effect installs the real transform, fall back to a view
-    // centered on the SELECTED day's row (today on a fresh load) — NOT worldH/2.
-    // worldH/2 is the pixel-height midpoint of the fetched world, and because row
-    // height scales with session count that midpoint lands on the densest data
-    // mass (historically the mid/late-May swarm cluster), which is the source of
-    // the "visualizer defaults to May 20/21" affinity (req #2856). rowTopFor falls
-    // back to worldH/2 itself only when the selected row isn't present.
+    // centered on the SELECTED day's row (today on a fresh load) — NOT the world
+    // midpoint. The world midpoint is the vertical center of the fetched world, and
+    // because row height scales with session count that midpoint lands on the
+    // densest data mass (historically the mid/late-May swarm cluster), which is the
+    // source of the "visualizer defaults to May 20/21" affinity (req #2856).
+    // rowTopFor falls back to worldMidY itself only when the selected row isn't
+    // present.
     const t = transform || { x: 0, y: size.h / 2 - rowTopFor(selectedDate) * kBase, k: kBase };
     const inv = t.k > 0 ? 1 / t.k : 1;
 

--- a/src/SwarmView/SwarmVisualizerView.jsx
+++ b/src/SwarmView/SwarmVisualizerView.jsx
@@ -83,16 +83,31 @@ const SwarmVisualizerView = () => {
     const costOn      = useSwarmVisualizerStore(s => s.costOn);
     const devServersOn = useSwarmVisualizerStore(s => s.devServersOn);
     const viewResetTick = useSwarmVisualizerStore(s => s.viewResetTick);
+    // Scroll-up auto-extend (req #2859) — how many extra days of history the
+    // canvas has asked for, plus the action it calls when the user pans near the
+    // oldest loaded day.
+    const pastExtraDays = useSwarmVisualizerStore(s => s.pastExtraDays);
+    const extendPast    = useSwarmVisualizerStore(s => s.extendPast);
 
     // Konva canvas fetch window (req #2841) — a wide, week-quantized range so the
     // user can pan freely across ~7 weeks of past + the rest of this week without
     // a refetch. Quantizing to Monday(currentDate) means the query key only
     // changes when toolbar Prev/Next/Today crosses a week boundary, which
     // keepPreviousData masks; free canvas pan never moves the window.
+    //
+    // req #2859 — `pastExtraDays` widens the window's PAST edge further back as the
+    // user pans up near the oldest loaded day, so scrolling up never dead-ends.
+    // The future edge (and Monday quantization) is unchanged, so a backward
+    // extension only prepends older days; keepPreviousData masks the refetch.
     const fetchRange = useMemo(() => {
         const monday = mondayOf(currentDate);
-        return { start: shiftDay(monday, -45), end: shiftDay(monday, 13) };
-    }, [currentDate]);
+        return { start: shiftDay(monday, -45 - pastExtraDays), end: shiftDay(monday, 13) };
+    }, [currentDate, pastExtraDays]);
+
+    // How many days to fetch per scroll-up extension (req #2859). A multiple of 7
+    // keeps the past edge Monday-aligned like the base window, so the per-day
+    // grid stays phase-stable across extensions.
+    const onExtendPast = useCallback(() => extendPast(28), [extendPast]);
 
     const fetchStart = fetchRange.start + 'T00:00:00';
     const fetchEnd   = fetchRange.end   + 'T23:59:59';
@@ -230,6 +245,7 @@ const SwarmVisualizerView = () => {
                 onSwarmStartClick={onSwarmStartClick}
                 onUndoClick={onUndoClick}
                 onCompleteClick={onCompleteClick}
+                onExtendPast={onExtendPast}
             />
             </Suspense>
         </div>

--- a/src/stores/__tests__/useSwarmVisualizerStore.test.js
+++ b/src/stores/__tests__/useSwarmVisualizerStore.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
     persistPartialize,
     migrateVisualizerState,
+    nextPastExtraDays,
+    MAX_PAST_EXTRA_DAYS,
 } from '../useSwarmVisualizerStore';
 
 // req #2799 — `currentDate` is navigation state, not a saved preference. It must
@@ -63,6 +65,36 @@ describe('persistPartialize (req #2799)', () => {
     it('persists devServersOn (req #2857)', () => {
         const out = persistPartialize({ currentDate: '2026-06-13', devServersOn: false });
         expect(out.devServersOn).toBe(false);
+    });
+
+    it('drops the transient pastExtraDays scroll-up counter (req #2859)', () => {
+        const out = persistPartialize({
+            currentDate: '2026-06-13', pastExtraDays: 84, dataKey: 'category',
+        });
+        expect(out).not.toHaveProperty('pastExtraDays');
+        expect(out.dataKey).toBe('category');
+    });
+});
+
+describe('nextPastExtraDays — scroll-up auto-extend reducer (req #2859)', () => {
+    it('adds positive deltas', () => {
+        expect(nextPastExtraDays(0, 28)).toBe(28);
+        expect(nextPastExtraDays(28, 28)).toBe(56);
+    });
+
+    it('ignores non-positive deltas', () => {
+        expect(nextPastExtraDays(28, 0)).toBe(28);
+        expect(nextPastExtraDays(28, -10)).toBe(28);
+    });
+
+    it('treats a null/undefined current as 0', () => {
+        expect(nextPastExtraDays(undefined, 28)).toBe(28);
+        expect(nextPastExtraDays(null, 14)).toBe(14);
+    });
+
+    it('clamps at MAX_PAST_EXTRA_DAYS', () => {
+        expect(nextPastExtraDays(MAX_PAST_EXTRA_DAYS, 28)).toBe(MAX_PAST_EXTRA_DAYS);
+        expect(nextPastExtraDays(MAX_PAST_EXTRA_DAYS - 10, 28)).toBe(MAX_PAST_EXTRA_DAYS);
     });
 });
 

--- a/src/stores/useSwarmVisualizerStore.js
+++ b/src/stores/useSwarmVisualizerStore.js
@@ -2,6 +2,18 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { localDateStr } from '../utils/dateFormat';
 
+// Cap on how far the scroll-up auto-extend (req #2859) will widen the fetch
+// window backward. ~2 years comfortably predates any Darwin swarm data, so the
+// canvas can scroll up to the project's origin while a hard ceiling prevents a
+// runaway fetch window if a pan gesture somehow keeps triggering.
+export const MAX_PAST_EXTRA_DAYS = 730;
+
+// Pure reducer for the scroll-up extension counter (req #2859): add `days` of
+// history (ignoring non-positive deltas), clamped to [0, MAX_PAST_EXTRA_DAYS].
+// Exported for unit-test coverage.
+export const nextPastExtraDays = (current, days) =>
+    Math.min(MAX_PAST_EXTRA_DAYS, (current || 0) + (days > 0 ? days : 0));
+
 // `currentDate` is NAVIGATION state, not a saved preference (req #2799). It must
 // reset to today on every fresh page load. Persisting it was the source of the
 // "late-May affinity": navigation calls setCurrentDate as the canvas pans, which
@@ -11,8 +23,9 @@ import { localDateStr } from '../utils/dateFormat';
 // users also reset to today. Exported for unit-test coverage.
 export const persistPartialize = (state) => {
     // currentDate is navigation state (req #2799); viewResetTick is a transient
-    // "Today/view-reset" signal — neither is a saved preference.
-    const { currentDate, viewResetTick, ...rest } = state;
+    // "Today/view-reset" signal; pastExtraDays is the transient scroll-up
+    // extension counter (req #2859) — none are saved preferences.
+    const { currentDate, viewResetTick, pastExtraDays, ...rest } = state;
     return rest;
 };
 
@@ -70,8 +83,12 @@ export const useSwarmVisualizerStore = create(
             costOn: false,               // size each bead by its session token cost — req #2846 (off by default)
             devServersOn: true,          // overlay active dev-server port pill on beads — req #2857 (on by default)
             viewResetTick: 0,            // bumped by "Today" to reset the canvas view (req #2841) — not persisted
+            pastExtraDays: 0,            // extra days of history fetched by scroll-up auto-extend — req #2859 (transient, NOT persisted)
 
-            setCurrentDate: (currentDate) => set({ currentDate }),
+            // Date navigation (Prev/Next/toolbar) starts a fresh window, so the
+            // scroll-up extension resets to 0 (req #2859) — otherwise an old
+            // extension would keep an over-wide fetch range after jumping weeks.
+            setCurrentDate: (currentDate) => set({ currentDate, pastExtraDays: 0 }),
             setDataKey: (key) =>
                 set({ dataKey: key === 'coordination' ? 'coordination' : 'category' }),
             setTitlesOn: (on) => set({ titlesOn: !!on }),
@@ -80,7 +97,15 @@ export const useSwarmVisualizerStore = create(
             setKonvaWide: (on) => set({ konvaWide: !!on }),
             setCostOn: (on) => set({ costOn: !!on }),
             setDevServersOn: (on) => set({ devServersOn: !!on }),
-            resetView: () => set((s) => ({ viewResetTick: s.viewResetTick + 1 })),
+            // Scroll-up auto-extend (req #2859) — widen the fetch window backward
+            // by `days`, clamped to [0, MAX_PAST_EXTRA_DAYS]. Called by the canvas
+            // when the user pans near the oldest loaded day.
+            extendPast: (days) => set((s) => ({
+                pastExtraDays: nextPastExtraDays(s.pastExtraDays, days),
+            })),
+            // "Today" / view reset also returns to a fresh, un-extended window
+            // (req #2859) so the canvas snaps back to the default ~8-week range.
+            resetView: () => set((s) => ({ viewResetTick: s.viewResetTick + 1, pastExtraDays: 0 })),
         }),
         {
             name: 'darwin_swarm_visualizer',


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-06-14T07:46:43Z
- wip(Darwin): 2026-06-14T07:43:48Z
- chore: init swarm session feature/2859-visualzer-runs-out-of-data-on-apr-1

## Files changed
```
 src/SwarmView/KonvaSwarmCanvas.jsx                 | 90 +++++++++++++++++++---
 src/SwarmView/SwarmVisualizerView.jsx              | 20 ++++-
 .../__tests__/useSwarmVisualizerStore.test.js      | 32 ++++++++
 src/stores/useSwarmVisualizerStore.js              | 33 +++++++-
 4 files changed, 157 insertions(+), 18 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)