### PR TITLE
visualizer default to MId- May

### DIFF
--- a/src/SwarmView/KonvaSwarmCanvas.jsx
+++ b/src/SwarmView/KonvaSwarmCanvas.jsx
@@ -42,6 +42,7 @@ import { laneParityFor } from '../CalendarFC/swarmGeometry';
 import {
     dateRange, semanticLevel,
     buildModelContext, buildDayModel, phaseBarSegments,
+    recenterDecision,
 } from './konvaSwarmModel';
 import '../CalendarFC/swarmVisualizer.css';
 
@@ -186,6 +187,7 @@ const KonvaSwarmCanvas = ({
     const zoomRef = useRef(null);
     const downRef = useRef(null);
     const draggingRef = useRef(false);   // true while a drag-pan gesture is active (cursor → grabbing)
+    const userPannedRef = useRef(false); // true once the user has manually panned/zoomed (req #2860)
     const rowsRef = useRef([]);          // live rows for hit-testing in handlers
     const centerDateRef = useRef(null);  // date currently at the viewport center
     const prevWinRef = useRef(null);     // detects a window (36h) toggle
@@ -307,6 +309,11 @@ const KonvaSwarmCanvas = ({
             .on('zoom', (ev) => {
                 const tr = ev.transform;
                 setTransform({ x: tr.x, y: tr.y, k: tr.k });
+                // A real user gesture (drag/wheel) carries a sourceEvent; a
+                // programmatic zb.transform (our centering) does not. Latch the
+                // manual-pan flag so a later data-load relayout never yanks the
+                // hand-positioned view back to today (req #2860).
+                if (ev.sourceEvent) userPannedRef.current = true;
                 // Track the day at the viewport center so a window (36h) toggle can
                 // re-anchor on it instead of jumping to a different day.
                 const d = dateAtWorldY(rowsRef.current, (size.h / 2 - tr.y) / tr.k);
@@ -366,16 +373,32 @@ const KonvaSwarmCanvas = ({
     // width aligned to the frame, scale = kBase. Also the Today/"view reset" action
     // (resetTick bump) re-runs this even when the date is unchanged, snapping zoom
     // back to mid and the window back to full-width-centered-on-today (req feedback).
-    const lastCenterRef = useRef(null);
+    //
+    // req #2860 — the recenter must also re-fire when an async data-load relayout
+    // shifts the selected day's world-Y (its row top moves once the dense rows grow
+    // from their empty-data ROW_MIN), so the view follows today instead of staying
+    // pinned to the stale pre-data world-Y (which fell over the mid/late-May data
+    // mass). recenterDecision() encodes "recenter on navigation OR on a geometry
+    // shift the user hasn't overridden by manually panning". Refs hold the last
+    // navigation key and the last centered world-Y.
+    const lastNavKeyRef = useRef(null);
+    const lastCenterYRef = useRef(null);
     useEffect(() => {
         const el = containerRef.current;
         const zb = zoomRef.current;
         if (!el || !zb || size.w === 0 || !rows.length) return;
-        const key = `${selectedDate}|${rangeStart}|${rangeEnd}|${size.w}x${size.h}|${resetTick}`;
-        if (lastCenterRef.current === key) return;
-        lastCenterRef.current = key;
-        centerDateRef.current = selectedDate;
+        const navKey = `${selectedDate}|${rangeStart}|${rangeEnd}|${size.w}x${size.h}|${resetTick}`;
         const cy = rowTopFor(selectedDate);
+        const { recenter, clearPan } = recenterDecision({
+            navKey, lastNavKey: lastNavKeyRef.current,
+            centerY: cy, lastCenterY: lastCenterYRef.current,
+            userPanned: userPannedRef.current,
+        });
+        if (!recenter) return;
+        if (clearPan) userPannedRef.current = false;  // explicit navigation releases the manual-pan lock
+        lastNavKeyRef.current = navKey;
+        lastCenterYRef.current = cy;
+        centerDateRef.current = selectedDate;
         const ty = size.h / 2 - cy * kBase;
         select(el).call(zb.transform, zoomIdentity.translate(0, ty).scale(kBase));
     }, [selectedDate, rangeStart, rangeEnd, size.w, size.h, rows, kBase, rowTopFor, resetTick]);

--- a/src/SwarmView/__tests__/konvaSwarmModel.test.js
+++ b/src/SwarmView/__tests__/konvaSwarmModel.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
     DAY_HOURS, hoursFromRowMidnight, xPct36, xPctWin, semanticLevel,
     shiftDayStr, dayDelta, dateRange, isWeekend,
-    buildModelContext, buildDayModel,
+    buildModelContext, buildDayModel, recenterDecision,
 } from '../konvaSwarmModel';
 
 const TZ = 'UTC';
@@ -123,6 +123,55 @@ describe('day-string helpers', () => {
         expect(isWeekend('2026-06-13')).toBe(true);  // Saturday
         expect(isWeekend('2026-06-14')).toBe(true);  // Sunday
         expect(isWeekend('2026-06-12')).toBe(false); // Friday
+    });
+});
+
+describe('recenterDecision — stale-transform / mid-May affinity (req #2860)', () => {
+    const NAV = 'today|s|e|800x600|0';
+
+    it('recenters on the first run (no prior nav key)', () => {
+        // Mount: lastNavKey null → navChanged → recenter, and clearPan latches.
+        expect(recenterDecision({
+            navKey: NAV, lastNavKey: null,
+            centerY: 100, lastCenterY: null, userPanned: false,
+        })).toEqual({ recenter: true, clearPan: true });
+    });
+
+    it('recenters when an async data-load relayout shifts the selected day', () => {
+        // SAME navigation (cold-cache first center already happened at cy=100),
+        // data arrives → dense rows grow → today's row moves to cy=4000. The user
+        // has not panned → follow today instead of staying pinned to the stale Y.
+        // This is the exact bug: without this branch the view kept the cy=100
+        // transform, which post-relayout fell over the mid-May cluster.
+        expect(recenterDecision({
+            navKey: NAV, lastNavKey: NAV,
+            centerY: 4000, lastCenterY: 100, userPanned: false,
+        })).toEqual({ recenter: true, clearPan: false });
+    });
+
+    it('does NOT recenter on a geometry shift after the user has manually panned', () => {
+        // refetchOnWindowFocus brings new data (cy moves) but the user dragged the
+        // canvas — respect their position, do not yank back to today.
+        expect(recenterDecision({
+            navKey: NAV, lastNavKey: NAV,
+            centerY: 4000, lastCenterY: 100, userPanned: true,
+        })).toEqual({ recenter: false, clearPan: false });
+    });
+
+    it('does NOT recenter when neither navigation nor geometry changed', () => {
+        expect(recenterDecision({
+            navKey: NAV, lastNavKey: NAV,
+            centerY: 4000, lastCenterY: 4000, userPanned: false,
+        })).toEqual({ recenter: false, clearPan: false });
+    });
+
+    it('an explicit navigation always recenters and clears the pan lock', () => {
+        // User presses Today/Prev/Next (or resizes) after panning → navChanged
+        // wins regardless of userPanned, and clearPan releases the lock.
+        expect(recenterDecision({
+            navKey: 'today|s|e|800x600|1', lastNavKey: NAV,
+            centerY: 4000, lastCenterY: 4000, userPanned: true,
+        })).toEqual({ recenter: true, clearPan: true });
     });
 });
 

--- a/src/SwarmView/konvaSwarmModel.js
+++ b/src/SwarmView/konvaSwarmModel.js
@@ -127,6 +127,41 @@ export function isWeekend(dateStr) {
     return dow === 0 || dow === 6;
 }
 
+// ── Canvas re-centering decision (req #2860) ────────────────────────────────
+// The Konva canvas centers the viewport vertically on the selected day. That
+// transform is computed in an effect, but it must NOT be computed only once: on
+// a hard reset the effect first fires while the data is still empty (every row a
+// uniform ROW_MIN), centers today against that flat layout, and then the async
+// data arrives — the dense rows grow, every row below shifts down, and today's
+// row lands at a NEW world-Y. The original guard keyed only on
+// navigation (selectedDate|range|size|resetTick), so it never recomputed after
+// that relayout and the view stayed pinned to the stale world-Y, which fell over
+// the densest data mass (historically the mid/late-May swarm cluster) — the
+// "visualizer defaults to May 20/21" affinity.
+//
+// This pure helper decides, on each effect run, whether to re-issue the
+// centering transform:
+//   • `navChanged`     — selectedDate / range / size / resetTick changed: an
+//                        explicit navigation (mount, Prev/Next/Today, resize).
+//                        Always recenter, and clear the manual-pan lock.
+//   • `geometryShifted`— the selected day's world-Y center moved (an async
+//                        data-load relayout). Recenter ONLY if the user has not
+//                        manually panned, so a background refetch
+//                        (refetchOnWindowFocus) can't yank a hand-positioned view
+//                        back to today.
+// `navKey`/`lastNavKey` are the navigation-intent strings; `centerY`/`lastCenterY`
+// are rowTopFor(selectedDate) now vs. at the last centering.
+export function recenterDecision({
+    navKey, lastNavKey, centerY, lastCenterY, userPanned,
+} = {}) {
+    const navChanged = navKey !== lastNavKey;
+    const geometryShifted = centerY !== lastCenterY;
+    return {
+        recenter: navChanged || (geometryShifted && !userPanned),
+        clearPan: navChanged,
+    };
+}
+
 // ── Shared-context precompute ───────────────────────────────────────────────
 // Build the cross-data maps once for the whole visible window so each per-day
 // build is cheap. `dates` is the full visible date list (the cross-day map needs


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2860-visualizer-default-to-mid-may-1
- wip(Darwin): 2026-06-14T07:33:02Z
- chore: init swarm session feature/2860-visualizer-default-to-mid-may-1

## Files changed
```
 src/SwarmView/KonvaSwarmCanvas.jsx              | 33 +++++++++++++---
 src/SwarmView/__tests__/konvaSwarmModel.test.js | 51 ++++++++++++++++++++++++-
 src/SwarmView/konvaSwarmModel.js                | 35 +++++++++++++++++
 3 files changed, 113 insertions(+), 6 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)