### PR TITLE
req #2875

### DIFF
--- a/standalone/stubAppContext.js
+++ b/standalone/stubAppContext.js
@@ -1,11 +1,15 @@
 // Standalone stub for ../Context/AppContext (req #2743).
-// Aliased in by vite.standalone.js. The BuildVisualizer subtree consumes only
-// `darwinUri` from this context; the value is a placeholder root the
+// Aliased in by vite.standalone.js. The BuildVisualizer subtree reads
+// `darwinBuildVizUri` from this context (req #2760 dev/prod split — the Build
+// Visualizer is pinned to darwin_dev); the value is a placeholder root the
 // standaloneApi adapter ignores (it routes by table name, not host).
+// `darwinBuildVizUri` MUST be truthy or the data hooks' `enabled` gate stays
+// false and nothing seeds.
 import { createContext } from 'react';
 
 const AppContext = createContext({
     darwinUri: 'local',
+    darwinBuildVizUri: 'local',
     setDarwinUri: () => {},
     database: 'standalone',
     darwinOpsUri: 'local',


### PR DESCRIPTION
## Summary
- Standalone Build Visualizer loads no data — stub missing darwinBuildVizUri (req #2875)
- chore: init swarm session feature/2875-standalone-build-visualizer-loads-1

## Files changed
```
 standalone/stubAppContext.js | 8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)