### PR TITLE
Change merge scheme

### DIFF
--- a/src/BuildVisualizer/BuildVisualizerControls.jsx
+++ b/src/BuildVisualizer/BuildVisualizerControls.jsx
@@ -12,6 +12,7 @@ import ListItemText from '@mui/material/ListItemText';
 import Box from '@mui/material/Box';
 import CheckIcon from '@mui/icons-material/Check';
 import BuildPatternMenu from './BuildPatternMenu';
+import MergeRulesDialog from './MergeRulesDialog';
 import { BRANCH_TYPES, branchTypeChipProps, branchTypeLabel } from './branchTypeChipStyles';
 import {
     THEME_VARIANTS,
@@ -53,6 +54,7 @@ const BuildVisualizerControls = ({
 }) => {
     const [snack, setSnack] = useState(null);
     const [themeAnchor, setThemeAnchor] = useState(null);
+    const [mergeRulesOpen, setMergeRulesOpen] = useState(false);
     const showSnack = (severity, message) => setSnack({ severity, message });
     const closeSnack = () => setSnack(null);
 
@@ -149,6 +151,19 @@ const BuildVisualizerControls = ({
                         />
                     </>
                 )}
+
+                {/* Merge Rules reference popup (req #2877) — always available,
+                    self-contained dialog state. */}
+                <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+                <Chip
+                    label="Merge Rules"
+                    size="small"
+                    onClick={() => setMergeRulesOpen(true)}
+                    variant="outlined"
+                    sx={{ cursor: 'pointer' }}
+                    aria-haspopup="dialog"
+                    data-testid="bv-merge-rules-chip"
+                />
 
                 {onToggleShowReleases && (
                     <>
@@ -354,6 +369,11 @@ const BuildVisualizerControls = ({
                     </>
                 )}
             </Paper>
+
+            <MergeRulesDialog
+                open={mergeRulesOpen}
+                onClose={() => setMergeRulesOpen(false)}
+            />
 
             <Snackbar
                 open={!!snack}

--- a/src/BuildVisualizer/BuildVisualizerPage.jsx
+++ b/src/BuildVisualizer/BuildVisualizerPage.jsx
@@ -32,7 +32,7 @@ import HoldCountButton from './HoldCountButton';
 import { useBuildPatterns } from './useBuildPatterns';
 import { useBuildVisualizerData } from './useBuildVisualizerData';
 import { BRANCH_TYPES, branchTypeLabel } from './branchTypeChipStyles';
-import { hasMergeRules } from './mergeEngine';
+import { hasMergeMenu } from './mergeEngine';
 import { REGISTRY } from './d3LayoutEngine';
 import {
     nextBuildVersion,
@@ -1296,9 +1296,11 @@ const BuildVisualizerPage = () => {
                         {/* Per-branch merge view (req #2603). Toggles this
                             build's branch in the merge-branch set so only the
                             chosen branches' arrows render — merges are reasoned
-                            about one branch at a time, not all at once. Hidden
-                            on main (no merge rules). */}
-                        {dotMenuBranch && hasMergeRules(dotMenuBranch.type) && (
+                            about one branch at a time, not all at once. Under
+                            req #2877 the affordance is offered ONLY for dev-scheme
+                            branches (development + the bootleg/hotfix exceptions);
+                            non-dev branches no longer expose a show/hide option. */}
+                        {dotMenuBranch && hasMergeMenu(dotMenuBranch.type) && (
                             <>
                                 <Divider />
                                 <MenuItem
@@ -1563,9 +1565,10 @@ const BuildVisualizerPage = () => {
                                 )}
                             </Typography>
                             {/* Per-branch merge view (req #2603) — show this
-                                branch's required/evaluate merge arrows. Hidden on
-                                main (no merge rules). */}
-                            {hasMergeRules(branchEditorBranch.type) && (
+                                branch's required/evaluate merge arrows. Under req
+                                #2877 offered ONLY for dev-scheme branches
+                                (development + bootleg/hotfix exceptions). */}
+                            {hasMergeMenu(branchEditorBranch.type) && (
                                 <FormControlLabel
                                     sx={{ mt: 1, ml: 0 }}
                                     control={(

--- a/src/BuildVisualizer/MergeRulesDialog.jsx
+++ b/src/BuildVisualizer/MergeRulesDialog.jsx
@@ -1,0 +1,119 @@
+// req #2877 — Merge Rules reference popup.
+//
+// A read-only grid documenting the Build Visualizer's merge scheme for EVERY
+// branch type that has merge rules. Under the new model every change rides a dev
+// branch: the "Merges From" column says whether a type merges via the NAMED
+// branch itself (the dev-scheme branches — Development plus the Hot Fix / Bootleg
+// exceptions) or via a dev branch taken off it (Release, Sprint/Sample, CSR).
+// The grid is derived straight from MERGE_RULES via `mergeRulesGridRows()` so it
+// can never drift from the engine.
+//
+// Each rule is tagged MANDATORY (required merge, solid arrow in the diagram) or
+// EVALUATE (consider before merging, dashed arrow). The chip colors mirror the
+// diagram: both kinds use the same blue, distinguished filled vs outlined the
+// same way the arrows are solid vs dashed.
+
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Table from '@mui/material/Table';
+import TableHead from '@mui/material/TableHead';
+import TableBody from '@mui/material/TableBody';
+import TableRow from '@mui/material/TableRow';
+import TableCell from '@mui/material/TableCell';
+import Chip from '@mui/material/Chip';
+import Typography from '@mui/material/Typography';
+import { mergeRulesGridRows, MERGE_REQUIRED } from './mergeEngine';
+import { branchTypeLabel, branchTypeChipProps } from './branchTypeChipStyles';
+
+// Blue used for both merge-arrow kinds in the diagram (d3ThemePalettes `merge`).
+const MERGE_BLUE = '#2563eb';
+
+const kindChipSx = (kind) =>
+    kind === MERGE_REQUIRED
+        ? { bgcolor: MERGE_BLUE, color: '#fff', fontWeight: 600 }
+        : { color: MERGE_BLUE, borderColor: MERGE_BLUE, borderStyle: 'dashed' };
+
+const MergeRulesDialog = ({ open, onClose }) => {
+    const rows = mergeRulesGridRows();
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            maxWidth="sm"
+            fullWidth
+            data-testid="bv-merge-rules-dialog"
+        >
+            <DialogTitle>Merge Rules</DialogTitle>
+            <DialogContent dividers>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                    Every change rides a dev branch. <strong>Merges From</strong> shows whether a
+                    branch type merges via the named branch itself (the dev branches — Development,
+                    Hot Fix, Bootleg) or via a dev branch taken off it. <strong>Mandatory</strong>{' '}
+                    merges are required (solid arrow); <strong>Evaluate</strong> merges require
+                    consideration before merging (dashed arrow).
+                </Typography>
+                <Table size="small" data-testid="bv-merge-rules-grid">
+                    <TableHead>
+                        <TableRow>
+                            <TableCell sx={{ fontWeight: 700 }}>Branch</TableCell>
+                            <TableCell sx={{ fontWeight: 700 }}>Merges From</TableCell>
+                            <TableCell sx={{ fontWeight: 700 }}>Merge destination</TableCell>
+                            <TableCell sx={{ fontWeight: 700 }}>Requirement</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {rows.map(row => (
+                            row.rules.map((rule, i) => (
+                                <TableRow
+                                    key={`${row.type}-${i}`}
+                                    data-testid={`bv-merge-rule-${row.type}`}
+                                >
+                                    {i === 0 && (
+                                        <TableCell
+                                            rowSpan={row.rules.length}
+                                            sx={{ verticalAlign: 'top' }}
+                                        >
+                                            <Chip
+                                                size="small"
+                                                label={branchTypeLabel(row.type)}
+                                                {...branchTypeChipProps(row.type)}
+                                            />
+                                        </TableCell>
+                                    )}
+                                    {i === 0 && (
+                                        <TableCell
+                                            rowSpan={row.rules.length}
+                                            sx={{ verticalAlign: 'top' }}
+                                        >
+                                            {row.mergesFrom}
+                                        </TableCell>
+                                    )}
+                                    <TableCell>{rule.dest}</TableCell>
+                                    <TableCell>
+                                        <Chip
+                                            size="small"
+                                            label={rule.kindLabel}
+                                            variant={rule.kind === MERGE_REQUIRED ? 'filled' : 'outlined'}
+                                            sx={kindChipSx(rule.kind)}
+                                            data-testid={`bv-merge-kind-${rule.kind}`}
+                                        />
+                                    </TableCell>
+                                </TableRow>
+                            ))
+                        ))}
+                    </TableBody>
+                </Table>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} data-testid="bv-merge-rules-close">
+                    Close
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default MergeRulesDialog;

--- a/src/BuildVisualizer/__tests__/mergeEngine.test.js
+++ b/src/BuildVisualizer/__tests__/mergeEngine.test.js
@@ -4,6 +4,8 @@ import {
     computeMerges,
     mergePath,
     hasMergeRules,
+    hasMergeMenu,
+    mergeRulesGridRows,
     MERGE_RULES,
     MERGE_REQUIRED,
     MERGE_EVALUATE,
@@ -60,6 +62,7 @@ function fixture() {
             { id: 'release-1',  type: 'release',        parentBuildId: 'main-b2',      parentBranchId: 'main',      nBuilds: 2 },
             { id: 'sample-1',   type: 'sample-release', parentBuildId: 'main-b1',      parentBranchId: 'main',      nBuilds: 1 },
             { id: 'dev-1',      type: 'development',     parentBuildId: 'main-b3',      parentBranchId: 'main',      nBuilds: 1 },
+            { id: 'dev-rel',    type: 'development',     parentBuildId: 'release-1-b2', parentBranchId: 'release-1', nBuilds: 1 },
             { id: 'csr-1',      type: 'csr',            parentBuildId: 'release-1-b1', parentBranchId: 'release-1', nBuilds: 1 },
             { id: 'csr-2',      type: 'csr',            parentBuildId: 'release-1-b2', parentBranchId: 'release-1', nBuilds: 1 },
             { id: 'hotfix-1',   type: 'hotfix',         parentBuildId: 'release-1-b2', parentBranchId: 'release-1', nBuilds: 1 },
@@ -92,6 +95,61 @@ describe('mergeEngine — rule table', () => {
         }
         expect(hasMergeRules('nope')).toBe(false);
     });
+
+    // req #2877 — the menu affordance narrows to the dev-branch scheme only.
+    it('hasMergeMenu is true only for dev-scheme branches (development/hotfix/bootleg)', () => {
+        for (const t of ['development', 'hotfix', 'bootleg']) {
+            expect(hasMergeMenu(t)).toBe(true);
+        }
+        for (const t of ['main', 'sample-release', 'release', 'csr', 'nope']) {
+            expect(hasMergeMenu(t)).toBe(false);
+        }
+    });
+
+    it('mergeRulesGridRows covers ALL branch types with merge rules, in display order', () => {
+        const rows = mergeRulesGridRows();
+        // Every branch type that has rules (main excluded), toolbar order.
+        expect(rows.map(r => r.type)).toEqual(
+            ['release', 'sample-release', 'hotfix', 'bootleg', 'csr', 'development']
+        );
+        // Row arity matches the underlying rule count.
+        for (const row of rows) {
+            expect(row.rules.length).toBe(MERGE_RULES[row.type].length);
+        }
+    });
+
+    it('mergeRulesGridRows tags mergesFrom: named-branch for dev-scheme, dev-branch otherwise', () => {
+        const rows = mergeRulesGridRows();
+        const byType = Object.fromEntries(rows.map(r => [r.type, r.mergesFrom]));
+        // Dev branches (development + bootleg/hotfix exceptions) merge from the named branch.
+        for (const t of ['development', 'hotfix', 'bootleg']) {
+            expect(byType[t]).toBe('Via named branch');
+        }
+        // Non-dev types merge via a dev branch taken off them.
+        for (const t of ['release', 'sample-release', 'csr']) {
+            expect(byType[t]).toBe('Via dev branch');
+        }
+    });
+
+    it('mergeRulesGridRows derives readable rules straight from MERGE_RULES', () => {
+        const rows = mergeRulesGridRows();
+        // Development → inherits its origin branch's rules (e.g. → main); the
+        // merge back to its own origin is assumed and not shown.
+        const dev = rows.find(r => r.type === 'development');
+        expect(dev.rules).toEqual([
+            { dest: 'Per origin-branch rules (e.g. → main)', kind: MERGE_REQUIRED, kindLabel: 'Mandatory' },
+        ]);
+        // Hot Fix → Mandatory main + two Evaluate merges (origin release + its CSRs).
+        const hotfix = rows.find(r => r.type === 'hotfix');
+        expect(hotfix.rules[0]).toEqual({ dest: 'main', kind: MERGE_REQUIRED, kindLabel: 'Mandatory' });
+        expect(hotfix.rules.filter(r => r.kind === MERGE_EVALUATE).map(r => r.kindLabel))
+            .toEqual(['Evaluate', 'Evaluate']);
+        // Sprint/Sample → single Mandatory merge to main.
+        const sample = rows.find(r => r.type === 'sample-release');
+        expect(sample.rules).toEqual([
+            { dest: 'main', kind: MERGE_REQUIRED, kindLabel: 'Mandatory' },
+        ]);
+    });
 });
 
 describe('mergeEngine — standard merges', () => {
@@ -108,8 +166,16 @@ describe('mergeEngine — standard merges', () => {
         expect(has(merges, MERGE_REQUIRED, 'release-1', 'main')).toBe(true);
     });
 
-    it('dev merges to its origin (parent) branch (required)', () => {
-        expect(has(merges, MERGE_REQUIRED, 'dev-1', 'main')).toBe(true);
+    // req #2877 — a dev branch inherits its scheme origin's rules; the merge back
+    // to its own origin is assumed and never drawn.
+    it('dev off main shows NO merge (merge to main is the assumed origin merge)', () => {
+        expect(merges.some(m => m.source === 'dev-1')).toBe(false);
+    });
+
+    it('dev off a release follows release rules → main (required), not back to the release', () => {
+        expect(has(merges, MERGE_REQUIRED, 'dev-rel', 'main')).toBe(true);
+        // The implicit merge back to its origin (release-1) is assumed, not drawn.
+        expect(merges.some(m => m.source === 'dev-rel' && m.dest === 'release-1')).toBe(false);
     });
 
     it('csr / hotfix / bootleg merge to main (required) + origin release + its CSRs (evaluate)', () => {
@@ -141,6 +207,45 @@ describe('mergeEngine — standard merges', () => {
     it('emits unique merge ids (deduped)', () => {
         const ids = merges.map(m => m.id);
         expect(new Set(ids).size).toBe(ids.length);
+    });
+});
+
+// req #2877 — a development branch INHERITS its scheme origin's rules (nearest
+// non-development ancestor). These cases lock the deeper inheritance paths.
+describe('mergeEngine — dev-branch scheme inheritance', () => {
+    it('dev off a dev off a release resolves to the release scheme → main', () => {
+        const model = makeModel({
+            mainBuilds: 3,
+            branchSpecs: [
+                { id: 'release-1', type: 'release',     parentBuildId: 'main-b2',      parentBranchId: 'main',      nBuilds: 2 },
+                { id: 'dev-outer', type: 'development', parentBuildId: 'release-1-b1', parentBranchId: 'release-1', nBuilds: 1 },
+                { id: 'dev-inner', type: 'development', parentBuildId: 'dev-outer-b1', parentBranchId: 'dev-outer', nBuilds: 1 },
+            ],
+        });
+        const merges = computeMerges({ model, layout: layoutOf(model) });
+        // Both dev branches follow release rules → main; neither merges to its own origin.
+        expect(has(merges, MERGE_REQUIRED, 'dev-inner', 'main')).toBe(true);
+        expect(merges.some(m => m.source === 'dev-inner' && m.dest === 'dev-outer')).toBe(false);
+        expect(has(merges, MERGE_REQUIRED, 'dev-outer', 'main')).toBe(true);
+        expect(merges.some(m => m.source === 'dev-outer' && m.dest === 'release-1')).toBe(false);
+    });
+
+    it('dev off a hotfix inherits the release scheme (main + origin release + its CSRs)', () => {
+        const model = makeModel({
+            mainBuilds: 3,
+            branchSpecs: [
+                { id: 'release-1', type: 'release',     parentBuildId: 'main-b2',      parentBranchId: 'main',      nBuilds: 2 },
+                { id: 'csr-1',     type: 'csr',         parentBuildId: 'release-1-b1', parentBranchId: 'release-1', nBuilds: 1 },
+                { id: 'hotfix-1',  type: 'hotfix',      parentBuildId: 'release-1-b2', parentBranchId: 'release-1', nBuilds: 1 },
+                { id: 'dev-hf',    type: 'development', parentBuildId: 'hotfix-1-b1',  parentBranchId: 'hotfix-1',  nBuilds: 1 },
+            ],
+        });
+        const merges = computeMerges({ model, layout: layoutOf(model) });
+        expect(has(merges, MERGE_REQUIRED, 'dev-hf', 'main')).toBe(true);          // required → main
+        expect(has(merges, MERGE_EVALUATE, 'dev-hf', 'release-1')).toBe(true);     // evaluate → origin release
+        expect(has(merges, MERGE_EVALUATE, 'dev-hf', 'csr-1')).toBe(true);         // evaluate → CSR on that release
+        // Never an arrow back to its own origin (the hotfix).
+        expect(merges.some(m => m.source === 'dev-hf' && m.dest === 'hotfix-1')).toBe(false);
     });
 });
 

--- a/src/BuildVisualizer/d3LayoutEngine.js
+++ b/src/BuildVisualizer/d3LayoutEngine.js
@@ -119,9 +119,11 @@ export const DEFAULT_OPTS = {
     // Length of the tail line + arrow past the last build dot, in colW units.
     // UNIFORM across every branch — main, sub-branches, and empty branches all
     // use this one value so the follow-on piece is identical everywhere (req
-    // #2603 follow-up). Matches main's historical 0.9 (main is the reference the
-    // user calibrates against); the main trunk path reads the same constant.
-    arrowExtColumns: 0.9,
+    // #2603 follow-up). Shortened to 0.6 (req #2877) so the tail chunk + arrow
+    // consume ~60% of a column instead of nearly a full one — at 0.9 it read as
+    // a continuation into the next build slot. The main trunk path reads the
+    // same constant, so the trunk shortens in lockstep.
+    arrowExtColumns: 0.6,
     versionCloseOffset: 12,
     versionLaneGap: 12,
     versionLanes: true,

--- a/src/BuildVisualizer/mergeEngine.js
+++ b/src/BuildVisualizer/mergeEngine.js
@@ -15,7 +15,11 @@
 //        • release        → main                              (required, solid)
 //                         → hotfix/CSR children of a RELEASED build that has a
 //                           later build beyond it on the branch (evaluate, dashed)
-//        • development    → its origin (parent) branch        (required, solid)
+//        • development    → INHERITS its scheme origin's rules (req #2877):
+//                           a dev off a release follows release rules (→ main),
+//                           a dev off a sprint follows sprint rules, etc. The
+//                           merge back to its own origin is ASSUMED, never drawn;
+//                           a dev off main therefore shows nothing.
 //        • csr / hotfix / bootleg (the "release scheme"):
 //                         → main                              (required, solid)
 //                         → its origin release branch         (evaluate, dashed)
@@ -76,17 +80,83 @@ export const MERGE_RULES = {
         { target: 'main',              kind: MERGE_REQUIRED },
         { target: 'respin-hotfix-csr', kind: MERGE_EVALUATE },
     ],
-    development:      [{ target: 'origin', kind: MERGE_REQUIRED }],
+    // req #2877 follow-up — a DEV branch no longer merges to its origin (that
+    // merge is ASSUMED and never drawn). Instead it INHERITS the rules of its
+    // scheme origin (nearest non-development ancestor): a dev off a release
+    // follows release rules (→ main), a dev off a sprint follows sprint rules,
+    // and so forth. The engine expands `origin-scheme` per-branch in
+    // `effectiveRules`; this marker entry keeps `hasMergeRules`/`hasMergeMenu`
+    // true and gives the reference grid a row.
+    development:      [{ target: 'origin-scheme', kind: MERGE_REQUIRED }],
     csr:              RELEASE_SCHEME,
     hotfix:           RELEASE_SCHEME,
     bootleg:          RELEASE_SCHEME,
 };
 
-// Whether a branch type has any standard merge rules — i.e. whether a
-// per-branch "show merges" affordance is meaningful for it. `main` (no rules)
-// returns false so the toggle is hidden on the trunk.
+// Whether a branch type has any standard merge rules — i.e. whether the engine
+// derives merge arrows for it. `main` (no rules) returns false. NOTE: this is
+// the ENGINE predicate (does it produce arrows?), distinct from `hasMergeMenu`
+// below (does the UI offer the show/hide affordance?).
 export function hasMergeRules(type) {
     return (MERGE_RULES[type] || []).length > 0;
+}
+
+// req #2877 — branch types that retain the per-branch "show merges" UI
+// affordance. Under the new merge scheme, merge requirements originate ONLY
+// from DEV branches, reasoned against their origin branch. `bootleg` and
+// `hotfix` are special kinds of dev branch, so they keep the affordance; every
+// non-dev type (sample-release, release, csr) loses the menu option. This gates
+// only the UI — MERGE_RULES is unchanged, so the engine still derives the same
+// arrows for whatever branches the user has toggled on.
+export const MERGE_MENU_TYPES = new Set(['development', 'hotfix', 'bootleg']);
+export function hasMergeMenu(type) {
+    return MERGE_MENU_TYPES.has(type);
+}
+
+// req #2877 — merge-rules REFERENCE GRID (the "Merge Rules" popup). Human
+// labels for each merge kind and target token, plus `mergeRulesGridRows()`
+// which derives display rows STRAIGHT from MERGE_RULES (single source of truth).
+// The grid documents the rule set for EVERY branch type that has merge rules —
+// it is purely a reference of the scheme, independent of WHEN any merge is
+// actually required (that is a separate part of the process).
+export const MERGE_KIND_LABELS = {
+    [MERGE_REQUIRED]: 'Mandatory',
+    [MERGE_EVALUATE]: 'Evaluate',
+};
+
+const MERGE_TARGET_LABELS = {
+    main:                 'main',
+    origin:               'Origin (parent) branch',
+    'origin-scheme':      'Per origin-branch rules (e.g. → main)',
+    release:              'Origin release branch',
+    'release-csrs':       'Every CSR on the origin release',
+    'respin-hotfix-csr':  "Re-spun release's hot fix / CSR children",
+};
+
+// req #2877 — "Merges From": HOW a branch type's merges reach the tree. Under
+// the new scheme every change rides a dev branch. Dev-scheme branches
+// (development + the bootleg/hotfix exceptions, == MERGE_MENU_TYPES) ARE dev
+// branches, so they merge from the NAMED branch itself; every other type's
+// merge happens via a dev branch taken off it, following that type's rules.
+export const MERGES_FROM_NAMED = 'Via named branch';
+export const MERGES_FROM_DEV   = 'Via dev branch';
+
+// All branch types that carry merge rules, in toolbar display order (main has
+// none and is omitted).
+const MERGE_GRID_ORDER = ['release', 'sample-release', 'hotfix', 'bootleg', 'csr', 'development'];
+
+export function mergeRulesGridRows() {
+    return MERGE_GRID_ORDER
+        .filter(type => hasMergeRules(type))
+        .map(type => ({
+            type,
+            mergesFrom: hasMergeMenu(type) ? MERGES_FROM_NAMED : MERGES_FROM_DEV,
+            rules: (MERGE_RULES[type] || []).map(r => ({
+                dest: MERGE_TARGET_LABELS[r.target] || r.target,
+                kind: r.kind,
+                kindLabel: MERGE_KIND_LABELS[r.kind] || r.kind,
+            })),
+        }));
 }
 
 // Vertical offset of the merge's horizontal run BELOW the source branch line.
@@ -125,6 +195,23 @@ export function mergePath(x0, y0, x1, y1) {
         + `C ${x0 + dirX * cornerW * 0.6} ${y0}, ${xLaneStart - dirX * cornerW * 0.6} ${yLane}, ${xLaneStart} ${yLane} `
         + `L ${xTurn} ${yLane} `
         + `C ${xTurn + dirX * approachW * 0.6} ${yLane}, ${x1} ${y1 - dirApproach * vc}, ${x1} ${y1}`;
+}
+
+// req #2877 — a development branch's "scheme origin": the nearest ancestor that
+// is NOT itself a development branch (so a dev off a dev off a release resolves
+// to the release). Returns the branch object, or null when there is no non-dev
+// ancestor. Cycle-guarded. The dev branch inherits THIS branch's merge rules.
+function nonDevAncestor(branchId, branchById) {
+    const seen = new Set();
+    let cur = branchById.get(branchId);
+    while (cur && cur.parentBranchId && !seen.has(cur.parentBranchId)) {
+        seen.add(cur.parentBranchId);
+        const parent = branchById.get(cur.parentBranchId);
+        if (!parent) return null;
+        if (parent.type !== 'development') return parent;
+        cur = parent;
+    }
+    return null;
 }
 
 // Walk the parentBranchId chain to the first ancestor branch of `type`.
@@ -188,6 +275,21 @@ export function computeMerges({ model, layout, dayZeroBuildIds } = {}) {
     const associatedReleaseFor = (branch) => {
         const anc = ancestorOfType(branch.id, 'release', branchById);
         return (anc && hasTip(anc)) ? anc : null;
+    };
+
+    // req #2877 — the effective merge rules for a branch. Non-development types
+    // use their MERGE_RULES entry verbatim. A development branch INHERITS its
+    // scheme origin's rules (dev off release → release rules → main); its
+    // implicit merge back to its own origin is assumed and never drawn, so a dev
+    // off main (scheme origin main, no rules) yields nothing. The inherited
+    // rules' targets are resolved relative to the dev branch itself, which works
+    // because every target ('main', 'release', 'release-csrs', 'respin-…') keys
+    // off main or an ancestor walk — none of which re-selects the dev's origin.
+    const effectiveRules = (branch) => {
+        if (branch.type !== 'development') return MERGE_RULES[branch.type] || [];
+        const origin = nonDevAncestor(branch.id, branchById);
+        if (!origin || origin.type === 'main') return [];
+        return MERGE_RULES[origin.type] || [];
     };
 
     const resolveTargets = (branch, token) => {
@@ -263,8 +365,8 @@ export function computeMerges({ model, layout, dayZeroBuildIds } = {}) {
     // ── Standard merges — one source branch at a time ──────────────────────
     for (const branch of branches) {
         if (!hasTip(branch.id)) continue;                 // invisible or empty
-        const rules = MERGE_RULES[branch.type];
-        if (!rules || !rules.length) continue;            // main / unknown → none
+        const rules = effectiveRules(branch);             // dev → inherited scheme
+        if (!rules || !rules.length) continue;            // main / dev-off-main → none
         const sourceX = lastBuildXById.get(branch.id);    // origin branch tip
         const sourceY = branchYById.get(branch.id);
         for (const rule of rules) {


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2877-change-merge-scheme-1
- wip(Darwin): 2026-06-16T07:17:57Z
- chore: init swarm session feature/2877-change-merge-scheme-1

## Files changed
```
 src/BuildVisualizer/BuildVisualizerControls.jsx   |  20 ++++
 src/BuildVisualizer/BuildVisualizerPage.jsx       |  17 ++--
 src/BuildVisualizer/MergeRulesDialog.jsx          | 119 ++++++++++++++++++++++
 src/BuildVisualizer/__tests__/mergeEngine.test.js | 109 +++++++++++++++++++-
 src/BuildVisualizer/d3LayoutEngine.js             |   8 +-
 src/BuildVisualizer/mergeEngine.js                | 116 +++++++++++++++++++--
 6 files changed, 370 insertions(+), 19 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)