### PR TITLE
Closes zoom shows phase key

### DIFF
--- a/src/SwarmView/KonvaSwarmCanvas.jsx
+++ b/src/SwarmView/KonvaSwarmCanvas.jsx
@@ -167,7 +167,7 @@ const KonvaSwarmCanvas = ({
     titlesOn = false, completesOn = false, phasesOn = false,
     costOn = false, devServersOn = true, wide36 = true, resetTick = 0,
     onChipClick, onSwarmStartClick, onUndoClick, onCompleteClick,
-    onExtendPast,
+    onExtendPast, onLevelChange,
 }) => {
     const theme = useTheme();
     const dark = theme.palette.mode === 'dark';
@@ -230,6 +230,16 @@ const KonvaSwarmCanvas = ({
     const kBase = size.w > 0 ? size.w / WORLD_W : 0.7;
     const curK = transform ? transform.k : kBase;
     const level = semanticLevel(kBase > 0 ? curK / kBase : 1);
+
+    // Surface the current semantic zoom level to the parent (req #2880) so it can
+    // force the phase key visible at the `in` level — where phase segments draw
+    // regardless of the Phases toggle (see `usePhases` below).
+    const onLevelChangeRef = useRef(onLevelChange);
+    onLevelChangeRef.current = onLevelChange;
+    useEffect(() => {
+        onLevelChangeRef.current?.(level);
+    }, [level]);
+
     const win = wide36 ? WIN36 : WIN24;
     const winSpan = win.end - win.start;
     const hourToPct = (h) => ((h - win.start) / winSpan) * 100;

--- a/src/SwarmView/SwarmVisualizerView.jsx
+++ b/src/SwarmView/SwarmVisualizerView.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo, useCallback, Suspense, lazy } from 'react';
+import React, { useContext, useMemo, useCallback, useState, Suspense, lazy } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import AuthContext from '../Context/AuthContext';
@@ -22,6 +22,13 @@ import Box from '@mui/material/Box';
 // swatches grouped by agentic / human family, plus the neutral-gray
 // "Unclassified" swatch for legacy (instrumented=0) sessions. Rendered only when
 // the Phases toggle is on, so the default view stays uncluttered.
+// req #2880 — the phase key follows the same rule the canvas uses to draw phase
+// SEGMENTS (`usePhases = phasesOn || level === 'in'`): the Phases toggle controls
+// it at the out/mid levels, but the deepest ('in') zoom always shows phases, so
+// the key is forced visible there regardless of the toggle.
+export const shouldShowPhaseLegend = ({ phasesOn, zoomLevel }) =>
+    !!phasesOn || zoomLevel === 'in';
+
 const PhaseSwatch = ({ color, label }) => (
     <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
         <Box component="span" sx={{
@@ -88,6 +95,11 @@ const SwarmVisualizerView = () => {
     // oldest loaded day.
     const pastExtraDays = useSwarmVisualizerStore(s => s.pastExtraDays);
     const extendPast    = useSwarmVisualizerStore(s => s.extendPast);
+
+    // Current semantic zoom level reported by the canvas (req #2880). At the `in`
+    // level phase segments draw regardless of the Phases toggle, so the phase key
+    // must follow suit — show it whenever phasesOn OR we're zoomed all the way in.
+    const [zoomLevel, setZoomLevel] = useState('mid');
 
     // Konva canvas fetch window (req #2841) — a wide, week-quantized range so the
     // user can pan freely across ~7 weeks of past + the rest of this week without
@@ -218,7 +230,7 @@ const SwarmVisualizerView = () => {
     // component now renders only the Konva canvas content (req #2844).
     return (
         <div>
-            {phasesOn && <PhaseLegend />}
+            {shouldShowPhaseLegend({ phasesOn, zoomLevel }) && <PhaseLegend />}
             <Suspense fallback={<Box sx={{ height: 'calc(100vh - 150px)', minHeight: 480 }} />}>
             <KonvaSwarmCanvas
                 requirements={requirements}
@@ -248,6 +260,7 @@ const SwarmVisualizerView = () => {
                 onUndoClick={onUndoClick}
                 onCompleteClick={onCompleteClick}
                 onExtendPast={onExtendPast}
+                onLevelChange={setZoomLevel}
             />
             </Suspense>
         </div>

--- a/src/SwarmView/__tests__/phaseLegendVisibility.test.js
+++ b/src/SwarmView/__tests__/phaseLegendVisibility.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowPhaseLegend } from '../SwarmVisualizerView';
+
+// req #2880 — the phase key (PhaseLegend) is gated by shouldShowPhaseLegend. The
+// Phases toggle drives it at the out/mid zoom levels; the deepest `in` zoom always
+// draws phase segments, so the key must always show there regardless of the toggle.
+describe('shouldShowPhaseLegend', () => {
+    it('shows the key whenever the Phases toggle is on, at any zoom level', () => {
+        for (const zoomLevel of ['out', 'mid', 'in']) {
+            expect(shouldShowPhaseLegend({ phasesOn: true, zoomLevel })).toBe(true);
+        }
+    });
+
+    it('forces the key visible at the `in` level even when the toggle is off', () => {
+        expect(shouldShowPhaseLegend({ phasesOn: false, zoomLevel: 'in' })).toBe(true);
+    });
+
+    it('hides the key at out/mid levels when the toggle is off', () => {
+        expect(shouldShowPhaseLegend({ phasesOn: false, zoomLevel: 'out' })).toBe(false);
+        expect(shouldShowPhaseLegend({ phasesOn: false, zoomLevel: 'mid' })).toBe(false);
+    });
+
+    it('coerces a falsy phasesOn (undefined) without throwing', () => {
+        expect(shouldShowPhaseLegend({ phasesOn: undefined, zoomLevel: 'mid' })).toBe(false);
+        expect(shouldShowPhaseLegend({ phasesOn: undefined, zoomLevel: 'in' })).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2880-closes-zoom-shows-phase-key-1
- wip(Darwin): 2026-06-16T06:40:59Z
- chore: init swarm session feature/2880-closes-zoom-shows-phase-key-1

## Files changed
```
 src/SwarmView/KonvaSwarmCanvas.jsx                 | 12 +++++++++-
 src/SwarmView/SwarmVisualizerView.jsx              | 17 ++++++++++++--
 .../__tests__/phaseLegendVisibility.test.js        | 27 ++++++++++++++++++++++
 3 files changed, 53 insertions(+), 3 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)