### PR TITLE
Click on template requirement doesnt stick

### DIFF
--- a/src/SwarmView/RequirementRow.jsx
+++ b/src/SwarmView/RequirementRow.jsx
@@ -166,6 +166,54 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
         requirementDrop(node);
     }, [drag, requirementDrop]);
 
+    // req #2884 — dev-only, OPT-IN diagnostic for the intermittent template-title
+    // focus loss (root cause not yet identified; req re-opened when it reproduces).
+    // Silent by default so it never spams dev consoles. Enable in DevTools with:
+    //     window.__req2884Focus = true   (or localStorage.setItem('req2884Focus','1'))
+    // Then reproduce the focus loss and read the last [req2884] line:
+    //   • "UNMOUNTED WHILE FOCUSED" → the field REMOUNTED (reconciliation), not a steal.
+    //   • "BLURRED … activeElementAfter: X" → focus was STOLEN to element X.
+    const titleInputRef = useRef(null);
+    useEffect(() => {
+        if (!import.meta.env.DEV || !isTemplate) return;
+        const enabled = () => {
+            try {
+                return Boolean(window.__req2884Focus) || localStorage.getItem('req2884Focus') === '1';
+            } catch { return false; }
+        };
+        const el = titleInputRef.current;
+        if (!el) return;
+        const describe = (n) => {
+            if (!n) return String(n);
+            if (n === document.body) return 'document.body';
+            const testid = n.closest?.('[data-testid]')?.getAttribute('data-testid');
+            return `${n.tagName.toLowerCase()}${testid ? `[testid=${testid}]` : ''}${n.name ? `[name=${n.name}]` : ''}`;
+        };
+        const onBlur = (e) => {
+            if (!enabled()) return;
+            const related = e.relatedTarget;
+            // Defer one tick so document.activeElement settles after the blur.
+            setTimeout(() => {
+                // eslint-disable-next-line no-console
+                console.warn('[req2884] template title BLURRED', {
+                    stillInDOM: document.contains(el),
+                    relatedTarget: describe(related),
+                    activeElementAfter: describe(document.activeElement),
+                });
+            }, 0);
+        };
+        el.addEventListener('blur', onBlur);
+        return () => {
+            el.removeEventListener('blur', onBlur);
+            // If this fires while the field is focused, the field REMOUNTED (focus loss
+            // by reconciliation), not a steal.
+            if (enabled() && document.activeElement === el) {
+                // eslint-disable-next-line no-console
+                console.warn('[req2884] template title UNMOUNTED WHILE FOCUSED → remount caused the focus loss');
+            }
+        };
+    }, [isTemplate]);
+
     // Determine status for indicator
     const sessionStatus = sessionStatusMap && sessionStatusMap[requirement.id];
     const status = requirement.requirement_status;
@@ -396,6 +444,7 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
                         sx = {{...(status === 'met' && strikethroughMet && {textDecoration: 'line-through'}), ...((status === 'deferred' || status === 'wontfix') && {opacity: 0.5}),}}
                         size = 'small'
                         slotProps={{ htmlInput: { maxLength: 256 } }}
+                        inputRef={isTemplate ? titleInputRef : undefined}
                         key={`title-${requirement.id}`}
              />
 

--- a/src/SwarmView/__tests__/CategoryCard.templatefocus.test.jsx
+++ b/src/SwarmView/__tests__/CategoryCard.templatefocus.test.jsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+//
+// Req #2884 reproduction harness — does a background-refetch re-seed of
+// `requirementsArray` steal focus from the template title field in the card view?
+// Mounts the REAL CategoryCard, focuses the template <textarea>, then simulates a
+// background refetch returning new `serverRequirements` (the refetchOnWindowFocus
+// path) and asserts whether focus survives.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DndProvider } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
+
+// Controllable query data. useRequirements returns the current module-level array
+// (a new reference per re-seed); useSessions stays a stable empty list.
+let reqData = [{ id: 10, title: 'Existing req', requirement_status: 'authoring', category_fk: 5, sort_order: 0 }];
+const EMPTY_SESSIONS = [];
+vi.mock('../../hooks/useDataQueries', () => ({
+    useRequirements: () => ({ data: reqData }),
+    useSessions: () => ({ data: EMPTY_SESSIONS }),
+}));
+
+vi.mock('../../RestApi/RestApi', () => ({ default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })) }));
+
+import CategoryCard from '../CategoryCard';
+import AuthContext from '../../Context/AuthContext';
+import AppContext from '../../Context/AppContext';
+
+const CATEGORY = { id: 5, category_name: 'Test Cat', project_fk: 1, sort_mode: 'process', color: null };
+const noop = () => {};
+
+let bumpHarness;
+function Harness() {
+    const [, setTick] = useState(0);
+    bumpHarness = () => setTick((t) => t + 1);
+    return (
+        <CategoryCard
+            category={CATEGORY}
+            categoryIndex={0}
+            projectId={1}
+            categoryChange={noop}
+            categoryKeyDown={noop}
+            categoryOnBlur={noop}
+            clickCardClosed={noop}
+            clickCardDelete={noop}
+            moveCard={noop}
+            persistCategoryOrder={noop}
+            removeCategory={noop}
+            isTemplate={false}
+            showClosed={false}
+        />
+    );
+}
+
+let roots = [];
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
+                            <Harness />
+                        </DndProvider>
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    return { container };
+}
+
+function templateTextarea(container) {
+    return container.querySelector('[data-testid="requirement-template"] textarea:not([aria-hidden="true"])');
+}
+
+describe('CategoryCard template title keeps focus across a background re-seed (req #2884)', () => {
+    beforeEach(() => {
+        reqData = [{ id: 10, title: 'Existing req', requirement_status: 'authoring', category_fk: 5, sort_order: 0 }];
+        roots = [];
+    });
+    afterEach(() => {
+        act(() => { roots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+    });
+
+    it('keeps focus on the template title when serverRequirements refetches', async () => {
+        const { container } = mount();
+
+        const ta = templateTextarea(container);
+        expect(ta).not.toBeNull();
+
+        // User clicks into the template title field.
+        await act(async () => { ta.focus(); });
+        expect(document.activeElement).toBe(ta);
+
+        // Background refetch lands: a NEW requirement appears, shifting the template's
+        // index (1 → 2). This is the decisive case for index-vs-key reconciliation.
+        await act(async () => {
+            reqData = [
+                { id: 10, title: 'Existing req', requirement_status: 'authoring', category_fk: 5, sort_order: 0 },
+                { id: 11, title: 'Brand new req', requirement_status: 'authoring', category_fk: 5, sort_order: 1 },
+            ];
+            bumpHarness();
+        });
+        await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+        // The template field must still be focused.
+        const taAfter = templateTextarea(container);
+        expect(taAfter).not.toBeNull();
+        expect(document.activeElement).toBe(taAfter);
+    });
+});

--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -119,6 +119,18 @@ const RequirementDetail = () => {
     const descriptionInputRef = useRef(null);
     const [focusDescriptionPending, setFocusDescriptionPending] = useState(false);
 
+    // Req #2884: the Category <Select> is gated behind the categories query
+    // (`allCategories ? <Select autoFocus={categoryUnset}/> : —`). On a cold load
+    // it mounts only once `useAllCategories` resolves, and `autoFocus` fires at
+    // that (late) mount — yanking focus away from the Title/Description field the
+    // user already clicked into. Track whether the user has focused an editable
+    // field first; if so, the late-mounting select must NOT auto-focus. The flag
+    // is a ref because `autoFocus` is consulted only at the select's mount render
+    // (driven by the query resolving), so the ref value at that moment is exactly
+    // the signal we need — and we don't want to trigger an extra re-render.
+    const userInteractedRef = useRef(false);
+    const markUserInteracted = () => { userInteractedRef.current = true; };
+
     const showError = useSnackBarStore(s => s.showError);
     const requirementStatusFilter = useShowClosedStore(s => s.requirementStatusFilter);
 
@@ -439,6 +451,7 @@ const RequirementDetail = () => {
                     onChange={(e) => setRequirement(prev => ({ ...prev, title: e.target.value }))}
                     onBlur={handleTitleBlur}
                     onKeyDown={handleTitleKeyDown}
+                    onFocus={markUserInteracted}  // req #2884 — block late select autofocus steal
                     fullWidth
                     autoComplete="off"
                     slotProps={{
@@ -594,7 +607,10 @@ const RequirementDetail = () => {
                         // "new" case) focus the category select, not description. The user
                         // presses ArrowDown to open the list, picks a category, and then
                         // lands in description (which autofocuses once a category is set).
-                        autoFocus={categoryUnset}
+                        // Req #2884: suppress this if the user already focused a field — the
+                        // select mounts late (after the categories query resolves) and would
+                        // otherwise steal focus from the field being typed in.
+                        autoFocus={categoryUnset && !userInteractedRef.current}
                         value={requirement.category_fk || ''}
                         onChange={handleCategoryChange}
                         displayEmpty
@@ -642,11 +658,12 @@ const RequirementDetail = () => {
                     value={requirement.description || ''}
                     onChange={(e) => setRequirement(prev => ({ ...prev, description: e.target.value }))}
                     onBlur={handleDescriptionBlur}
+                    onFocus={markUserInteracted}  // req #2884 — block late select autofocus steal
                     fullWidth
                     multiline
                     minRows={3}
                     autoComplete="off"
-                    autoFocus={!categoryUnset}
+                    autoFocus={!categoryUnset && !userInteractedRef.current}
                     inputRef={descriptionInputRef}
                     size="small"
                     data-testid="requirement-description"

--- a/src/SwarmView/detail/__tests__/RequirementDetail.autofocus.test.jsx
+++ b/src/SwarmView/detail/__tests__/RequirementDetail.autofocus.test.jsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+//
+// Req #2884 — "Click on template requirement doesn't stick".
+//
+// Root cause: on the new-requirement page (`/swarm/requirement/new`, `isNew`)
+// the Category <Select> is gated behind the categories query
+// (`allCategories ? <Select autoFocus={categoryUnset}/> : —`). On a cold load it
+// mounts only once `useAllCategories` resolves, and `autoFocus` fires at that
+// (late) mount — stealing focus from the Title/Description field the user already
+// clicked into. The fix suppresses the select's auto-focus once the user has
+// focused an editable field (`userInteractedRef`).
+//
+// This test mounts the REAL RequirementDetail and drives the genuine query race
+// (loading → success) so a regression that removes the guard fails here.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// Router hooks: render in "new" mode with a prefilled title (the aggregator flow).
+vi.mock('react-router-dom', () => ({
+    useParams: () => ({ id: 'new' }),
+    useNavigate: () => () => {},
+    useLocation: () => ({ state: { title: 'A new requirement' } }),
+}));
+
+// Control the categories query timing through the shared fetchEntity. Resolution
+// is deferred until the test calls `releaseCategories()` so we can interleave a
+// user focus BEFORE the <Select> mounts — exactly the reported race. The release
+// is idempotent (resolves any pending fetch AND short-circuits future calls) so a
+// background refetch can't leave a dangling unresolved promise.
+let categoriesData = null;          // null = still "loading"
+let pendingResolvers = [];
+function releaseCategories(data) {
+    categoriesData = data;
+    pendingResolvers.forEach((r) => r(data));
+    pendingResolvers = [];
+}
+vi.mock('../../../hooks/factory/createEntityQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        fetchEntity: vi.fn(() => {
+            if (categoriesData !== null) return Promise.resolve(categoriesData);
+            return new Promise((resolve) => { pendingResolvers.push(resolve); });
+        }),
+    };
+});
+
+// call_rest_api is never hit on the isNew path, but stub it defensively.
+vi.mock('../../../RestApi/RestApi', () => ({ default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })) }));
+
+import RequirementDetail from '../RequirementDetail';
+import AuthContext from '../../../Context/AuthContext';
+import AppContext from '../../../Context/AppContext';
+
+let mountedRoots = [];
+
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0, refetchOnWindowFocus: false } },
+    });
+    const root = createRoot(container);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <RequirementDetail />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    mountedRoots.push(root);
+    return { container, root };
+}
+
+function titleInput(container) {
+    return container.querySelector('[data-testid="requirement-title"] input');
+}
+function categorySelectButton(container) {
+    return container.querySelector('[data-testid="requirement-category-select"]');
+}
+
+async function flush() {
+    // Let the resolved query propagate and React commit the re-render. Several
+    // microtask cycles plus a macrotask keeps this deterministic even when the
+    // file runs alongside the rest of the suite (react-query settles the query,
+    // then React flushes the mount that renders the <Select>).
+    await act(async () => {
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+        await new Promise((r) => setTimeout(r, 0));
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+    });
+}
+
+describe('RequirementDetail new-mode category autofocus (req #2884)', () => {
+    beforeEach(() => { categoriesData = null; pendingResolvers = []; mountedRoots = []; });
+    afterEach(() => {
+        act(() => { mountedRoots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+    });
+
+    it('does NOT steal focus from the Title field when categories resolve late', async () => {
+        const { container } = mount();
+
+        // Categories still loading → the Select is not mounted yet.
+        expect(categorySelectButton(container)).toBeNull();
+
+        // User clicks into the Title field and starts typing.
+        const input = titleInput(container);
+        expect(input).not.toBeNull();
+        await act(async () => { input.focus(); });
+        expect(document.activeElement).toBe(input);
+
+        // Categories resolve AFTER the click → the Select mounts late.
+        await act(async () => { releaseCategories([{ id: 1, category_name: 'Personal' }]); });
+        await flush();
+
+        // The late-mounting Select must NOT have yanked focus away from the Title.
+        expect(categorySelectButton(container)).not.toBeNull();
+        expect(document.activeElement).toBe(input);
+    });
+
+    it('DOES focus the Category select when the user has not interacted (intended req #2815 behavior)', async () => {
+        const { container } = mount();
+
+        // No user interaction. Categories resolve → Select mounts and autofocuses.
+        await act(async () => { releaseCategories([{ id: 1, category_name: 'Personal' }]); });
+        await flush();
+
+        const selectBtn = categorySelectButton(container);
+        expect(selectBtn).not.toBeNull();
+        // Focus left the title (the select grabbed it). Assert focus is NOT on the
+        // title input — the select's own focused node is an implementation detail
+        // of MUI, so we assert the absence of the steal-regression instead.
+        expect(document.activeElement).not.toBe(titleInput(container));
+    });
+});


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2884-click-on-template-requirement-1
- wip(Darwin): 2026-06-16T07:42:10Z
- chore: init swarm session feature/2884-click-on-template-requirement-1

## Files changed
```
 src/SwarmView/RequirementRow.jsx                   |  49 +++++++
 .../__tests__/CategoryCard.templatefocus.test.jsx  | 125 ++++++++++++++++++
 src/SwarmView/detail/RequirementDetail.jsx         |  21 ++-
 .../__tests__/RequirementDetail.autofocus.test.jsx | 146 +++++++++++++++++++++
 4 files changed, 339 insertions(+), 2 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)