### PR TITLE
Build Visualizer Retain Users View

### DIFF
--- a/src/BuildVisualizer/BuildVisualizerPage.jsx
+++ b/src/BuildVisualizer/BuildVisualizerPage.jsx
@@ -31,6 +31,7 @@ import BuildVisualizerCanvas from './BuildVisualizerCanvas';
 import HoldCountButton from './HoldCountButton';
 import { useBuildPatterns } from './useBuildPatterns';
 import { useBuildVisualizerData } from './useBuildVisualizerData';
+import { shouldShowCanvasSpinner } from './canvasSpinnerGate';
 import { BRANCH_TYPES, branchTypeLabel } from './branchTypeChipStyles';
 import { hasMergeMenu } from './mergeEngine';
 import { REGISTRY } from './d3LayoutEngine';
@@ -142,7 +143,9 @@ const BuildVisualizerPage = () => {
     // Active project's display name — used to compose the branch-location
     // string shown on build/branch click (req #2753).
     const projectName = lib.activePattern?.name || '';
-    const { isLoading: dataLoading, error: dataError, model } = useBuildVisualizerData(projectId);
+    const {
+        isInitialLoad, error: dataError, model,
+    } = useBuildVisualizerData(projectId);
 
     // Version of a branch's FIRST build (req #2753). The branch-location string
     // identifies the branch, so it is the same for the branch and every build
@@ -1109,7 +1112,15 @@ const BuildVisualizerPage = () => {
             <BuildVisualizerCanvas
                 model={model}
                 projectId={projectId}
-                isLoading={dataLoading || !lib.isReady}
+                // req #2895 — only cover the canvas with the spinner on the very
+                // first load; a mid-session refetch (run a build, edit a branch)
+                // keeps the canvas mounted so its pan/zoom transform survives and
+                // the view is retained instead of re-centering.
+                isLoading={shouldShowCanvasSpinner({
+                    initialLoad: isInitialLoad,
+                    ready: lib.isReady,
+                    hasBranches: !!model?.branches?.length,
+                })}
                 error={dataError || lib.error}
                 selectedTypes={selectedTypes}
                 staggerOn={staggerOn}

--- a/src/BuildVisualizer/KonvaBuildCanvas.jsx
+++ b/src/BuildVisualizer/KonvaBuildCanvas.jsx
@@ -34,6 +34,7 @@ import { select } from 'd3-selection';
 import { zoom as d3zoom, zoomIdentity } from 'd3-zoom';
 
 import { computeLayout } from './d3LayoutEngine';
+import { interpolateLayout, easeCubicOut, layoutSignature } from './layoutMorph';
 import { computeSemanticModel, autoLevel, isGapId } from './semanticModel';
 import { computeMerges, MERGE_EVALUATE, MERGE_DAYZERO } from './mergeEngine';
 import { BRANCH_TYPES } from './branchTypeChipStyles';
@@ -107,6 +108,14 @@ const KonvaBuildCanvas = ({
     const [transform, setTransform] = useState(null);
     // Per-token expand set (sticky within a level; cleared on level switch).
     const [expandedTokens, setExpandedTokens] = useState(() => new Set());
+    // req #2895 — layout morph. `prevLayoutRef` holds the last fully-settled
+    // layout; `morphRef` holds the active tween ({from, to, dy}); `morphP` is the
+    // eased progress that drives re-renders. See the morph driver effect below.
+    const prevLayoutRef = useRef(null);
+    const morphRef = useRef(null);
+    const morphProjectRef = useRef(null);
+    const morphLevelRef = useRef(null);
+    const [morphP, setMorphP] = useState(1);
 
     useLayoutEffect(() => {
         const el = containerRef.current;
@@ -176,16 +185,34 @@ const KonvaBuildCanvas = ({
         [semantic, staggerOn, atShown, showBuildAt],
     );
 
+    // Geometry signature (req #2895) — drives the morph on GEOMETRY change, not
+    // layout object identity. A single build execution invalidates 3 queries that
+    // resolve at different times; each rebuilds `layout` as a new object, but only
+    // one actually moves anything. Keying the morph off this signature collapses
+    // that cascade into one tween (no redundant second animation).
+    const layoutSig = useMemo(() => layoutSignature(layout), [layout]);
+
+    // Morph-interpolated layout used for ALL geometry (req #2895). When settled
+    // this IS `layout` (same ref → downstream memos stay stable); during a tween
+    // it's the per-node interpolation from layoutMorph. Hoisted above `merges` so
+    // merge arrows track the morphing build dots instead of snapping to their
+    // final positions. `morphP` (state) drives the per-frame re-render; `morphRef`
+    // (ref) holds the active {from, to, dy}. See the morph driver effect below.
+    const morph = morphRef.current;
+    const renderLayout = (morph && morphP < 1)
+        ? interpolateLayout(morph.from, morph.to, morphP, morph.dy)
+        : layout;
+
     // MergeEngine (req #2603) — derive merge arrows from the ORIGINAL tree +
     // the rendered layout. Pass the original `model` (full branch types/parents/
     // buildIds, so the respin/day-zero rules read the real history) but the
-    // collapsed `layout` for positions — branch tips (last build) are never
-    // collapsed, so arrow endpoints stay correct under semantic zoom. Day-zero
-    // arrows are always in the set; the per-branch toggle gates standard arrows
-    // at draw time below.
+    // collapsed `renderLayout` for positions — branch tips (last build) are never
+    // collapsed, so arrow endpoints stay correct under semantic zoom AND follow
+    // the morph. Day-zero arrows are always in the set; the per-branch toggle
+    // gates standard arrows at draw time below.
     const merges = useMemo(
-        () => computeMerges({ model, layout, dayZeroBuildIds }),
-        [model, layout, dayZeroBuildIds],
+        () => computeMerges({ model, layout: renderLayout, dayZeroBuildIds }),
+        [model, renderLayout, dayZeroBuildIds],
     );
 
     const branchNameById = useMemo(() => {
@@ -309,9 +336,90 @@ const KonvaBuildCanvas = ({
         if (!sameProject || lastFramedProjectRef.current !== projectId) return;
         if (!el || !zb || mainY == null || prevMainY == null || mainY === prevMainY) return;
         if (!transform || size.w === 0) return;
+        // req #2895 — pin the trunk: instantly shift the transform so the new
+        // mainY renders where the old one was. This RETAINS the user's view (no
+        // drift). Smoothness of the reflow itself is handled separately by the
+        // per-node layout morph (layoutMorph.js), which glides every glyph from
+        // its old to its new position IN mainY-relative space — so with this
+        // instant pin, unchanged content sits perfectly still while changed
+        // content eases. `dyPrev` (below) reuses this same (mainY - prevMainY)
+        // delta to align the morph's "from" frame to the pinned trunk.
         const ty = transform.y - (mainY - prevMainY) * transform.k;
         select(el).call(zb.transform, zoomIdentity.translate(transform.x, ty).scale(transform.k));
     }, [layout, projectId, size.w]);
+
+    // ── Layout morph driver (req #2895) ─────────────────────────────────────────
+    // On a same-project, same-level data reflow, tween every glyph from its old
+    // position to its new one (layoutMorph.interpolateLayout) so unchanged content
+    // holds still and changed content glides. SNAP (no tween) on the first layout,
+    // a project switch, a semantic-level change, or before the view is framed —
+    // those are user-driven or first-paint and should not animate. The tween runs
+    // on requestAnimationFrame; `dy` reuses the reflow effect's (newMainY -
+    // prevMainY) so the "from" frame aligns to the just-pinned trunk.
+    //
+    // Keyed on `layoutSig` (geometry), NOT `layout` object identity: a single
+    // build/hotfix execution invalidates 3 queries (branches → builds → releases)
+    // that resolve at DIFFERENT times, each rebuilding `layout`. Two failure modes
+    // this driver must avoid, both of which look like "the animation plays several
+    // times":
+    //   1. Geometrically-IDENTICAL rebuilds — collapsed by the `layoutSig` key
+    //      (Object.is on the string → effect doesn't re-run, tween undisturbed).
+    //   2. Geometrically-DIFFERENT intermediate states (branch appears, then its
+    //      build, then the release-clearance band) — each is a real new target.
+    //      Restarting the tween from the pre-burst layout would replay it from the
+    //      start on every resolution. Instead we RE-BASE: when a new target arrives
+    //      mid-tween, `from` becomes the CURRENT interpolated on-screen positions,
+    //      so the motion CONTINUES smoothly toward the newest target as ONE glide.
+    // `size.w` is intentionally NOT a dep — a resize must not cancel an in-flight
+    // rAF (the effect cleanup runs on every dep change). `layout`/`morphP` are read
+    // via the `layoutSig` key (a sig change always coincides with a fresh render).
+    useEffect(() => {
+        const sameProject = morphProjectRef.current === projectId;
+        const sameLevel = morphLevelRef.current === level;
+        morphProjectRef.current = projectId;
+        morphLevelRef.current = level;
+
+        // Re-base: if a tween is in flight, continue from where it visually IS now
+        // (the interpolated snapshot); otherwise start from the last settled layout.
+        const inFlight = morphRef.current && morphP < 1;
+        const from = inFlight
+            ? interpolateLayout(morphRef.current.from, morphRef.current.to, morphP, morphRef.current.dy)
+            : prevLayoutRef.current;
+
+        const canMorph = from && sameProject && sameLevel
+            && layout?.branches?.length && size.w > 0
+            && lastFramedProjectRef.current === projectId;
+
+        if (!canMorph) {
+            prevLayoutRef.current = layout;
+            morphRef.current = null;
+            setMorphP(1);
+            return undefined;
+        }
+
+        // A snapshot's mainY equals its source `to.mainY` (interpolateLayout copies
+        // it), and the trunk-pin has already shifted the transform by the same
+        // delta, so `dy` keeps the re-based "from" aligned to the pinned trunk.
+        const dy = (layout.mainY || 0) - (from.mainY || 0);
+        morphRef.current = { from, to: layout, dy };
+        const DURATION = 350;
+        const start = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+        let raf = 0;
+        const tick = (now) => {
+            const t = Math.min(1, (now - start) / DURATION);
+            setMorphP(easeCubicOut(t));
+            if (t < 1) {
+                raf = requestAnimationFrame(tick);
+            } else {
+                prevLayoutRef.current = layout;
+                morphRef.current = null;
+            }
+        };
+        setMorphP(0);
+        raf = requestAnimationFrame(tick);
+        return () => { if (raf) cancelAnimationFrame(raf); };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- `layout`/`morphP`/`size.w` read via the `layoutSig` key; `size.w` deliberately not a trigger.
+    }, [layoutSig, projectId, level]);
 
     // Click resolution (d3-zoom can swallow Konva's synthetic click): on a
     // non-drag click, hit-test the topmost shape and fire 'activate'.
@@ -398,8 +506,15 @@ const KonvaBuildCanvas = ({
     }, []);
 
     // ── Render ──────────────────────────────────────────────────────────────
+    // `renderLayout` (hoisted above `merges`) is the morph-interpolated frame
+    // during a tween, else the real layout. Identity/interaction derivations
+    // (latestBuildIds, branchNameById, buildById) intentionally keep using the
+    // real `layout` — only on-screen positions tween.
     const nodes = [];
-    if (layout.branches.length) {
+    if (renderLayout.branches.length) {
+        // Rebind `layout` to the interpolated frame for the whole geometry block
+        // below (req #2895) — every position/path read here follows the morph.
+        const layout = renderLayout;
         const lineW = LINE_W * inv;
         const whispyW = 0.9 * inv;
 

--- a/src/BuildVisualizer/__tests__/canvasSpinnerGate.test.js
+++ b/src/BuildVisualizer/__tests__/canvasSpinnerGate.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowCanvasSpinner } from '../canvasSpinnerGate';
+
+// req #2895 — the full-canvas spinner must only appear on the very first load.
+// A mid-session refetch (running a build, editing a branch, toggling a display
+// option) must NOT cover the canvas, or KonvaBuildCanvas unmounts and loses its
+// pan/zoom transform, re-centering the view.
+describe('shouldShowCanvasSpinner', () => {
+    it('shows the spinner on first load: not ready, no branches yet', () => {
+        expect(shouldShowCanvasSpinner({
+            initialLoad: true, ready: false, hasBranches: false,
+        })).toBe(true);
+    });
+
+    it('shows the spinner while ready but still loading the first data', () => {
+        expect(shouldShowCanvasSpinner({
+            initialLoad: true, ready: true, hasBranches: false,
+        })).toBe(true);
+    });
+
+    it('shows the spinner when the pattern library is not ready and nothing drawn', () => {
+        expect(shouldShowCanvasSpinner({
+            initialLoad: false, ready: false, hasBranches: false,
+        })).toBe(true);
+    });
+
+    it('does NOT show the spinner during a refetch that still has branches', () => {
+        // The core regression guard: initialLoad may be false here (keepPreviousData
+        // keeps branches), but even if a signal briefly trips, an on-screen graph
+        // is never covered.
+        expect(shouldShowCanvasSpinner({
+            initialLoad: true, ready: true, hasBranches: true,
+        })).toBe(false);
+    });
+
+    it('does NOT show the spinner once loaded and ready', () => {
+        expect(shouldShowCanvasSpinner({
+            initialLoad: false, ready: true, hasBranches: true,
+        })).toBe(false);
+    });
+
+    it('never covers an already-drawn graph, even if not ready', () => {
+        expect(shouldShowCanvasSpinner({
+            initialLoad: false, ready: false, hasBranches: true,
+        })).toBe(false);
+    });
+
+    it('coerces truthy/falsy initialLoad', () => {
+        expect(shouldShowCanvasSpinner({
+            initialLoad: undefined, ready: false, hasBranches: false,
+        })).toBe(true);
+        expect(shouldShowCanvasSpinner({
+            initialLoad: 0, ready: true, hasBranches: false,
+        })).toBe(false);
+    });
+});

--- a/src/BuildVisualizer/__tests__/layoutMorph.test.js
+++ b/src/BuildVisualizer/__tests__/layoutMorph.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+    easeCubicOut, lerp, lerpPath, interpolateLayout, layoutSignature,
+} from '../layoutMorph';
+
+describe('easeCubicOut', () => {
+    it('pins the endpoints and clamps out-of-range', () => {
+        expect(easeCubicOut(0)).toBe(0);
+        expect(easeCubicOut(1)).toBe(1);
+        expect(easeCubicOut(-0.5)).toBe(0);
+        expect(easeCubicOut(2)).toBe(1);
+    });
+    it('is ahead of linear (ease-OUT) at the midpoint', () => {
+        expect(easeCubicOut(0.5)).toBeGreaterThan(0.5);
+    });
+});
+
+describe('lerp', () => {
+    it('interpolates linearly', () => {
+        expect(lerp(0, 10, 0)).toBe(0);
+        expect(lerp(0, 10, 1)).toBe(10);
+        expect(lerp(0, 10, 0.5)).toBe(5);
+    });
+});
+
+describe('lerpPath', () => {
+    it('interpolates matching M/L structure, adding dy to prev y only', () => {
+        // prev y = 0 shifted by dy=10 → 10; next y = 20; p=0.5 → 15. x untouched.
+        const out = lerpPath('M 0 0 L 5 0', 'M 0 20 L 5 20', 0.5, 10);
+        expect(out).toBe('M 0 15 L 5 15');
+    });
+    it('interpolates cubic C control points component-wise', () => {
+        const out = lerpPath('M 0 0 C 1 0 2 0 3 0', 'M 0 10 C 1 10 2 10 3 10', 0.5, 0);
+        expect(out).toBe('M 0 5 C 1 5 2 5 3 5');
+    });
+    it('snaps to next when command structure differs', () => {
+        expect(lerpPath('M 0 0 L 1 1', 'M 0 0 C 1 1 2 2 3 3', 0.5, 0))
+            .toBe('M 0 0 C 1 1 2 2 3 3');
+    });
+    it('returns next at p=1 (endpoints exact)', () => {
+        expect(lerpPath('M 0 0 L 5 0', 'M 0 20 L 5 20', 1, 10)).toBe('M 0 20 L 5 20');
+    });
+    it('handles null inputs gracefully', () => {
+        expect(lerpPath(null, 'M 0 0', 0.5)).toBe('M 0 0');
+        expect(lerpPath('M 0 0', null, 0.5)).toBe('M 0 0');
+    });
+});
+
+describe('layoutSignature', () => {
+    const base = {
+        mainY: 100, width: 800,
+        builds: [{ id: 'b1', x: 10, y: 100, radius: 5, version: '1.0.1' }],
+        branches: [{ id: 'br1', labelX: 4, labelY: 100 }],
+        strata: [], connectors: [],
+    };
+
+    it('is identical for geometrically-identical layouts that differ only in non-geometry fields', () => {
+        // A releases-query resolution rebuilds `layout` as a new object and can
+        // change non-geometry fields (dotColor, releaseCustomers) without moving
+        // anything — must produce the SAME signature so no redundant morph fires.
+        const a = base;
+        const b = {
+            ...base,
+            builds: [{ id: 'b1', x: 10, y: 100, radius: 5, version: '1.0.1', dotColor: 'green', releaseCustomers: ['ACME'] }],
+        };
+        expect(layoutSignature(a)).toBe(layoutSignature(b));
+    });
+
+    it('differs when a build moves', () => {
+        const moved = { ...base, builds: [{ ...base.builds[0], y: 130 }] };
+        expect(layoutSignature(base)).not.toBe(layoutSignature(moved));
+    });
+
+    it('differs when a build is added (build execution)', () => {
+        const added = { ...base, builds: [...base.builds, { id: 'b2', x: 40, y: 100, radius: 5 }] };
+        expect(layoutSignature(base)).not.toBe(layoutSignature(added));
+    });
+
+    it('differs when a connector path changes (reflow)', () => {
+        const a = { ...base, connectors: [{ branchId: 'br1', curveD: 'M 0 0 C 1 0 2 0 3 0', lineD: 'M 3 0 L 9 0' }] };
+        const b = { ...base, connectors: [{ branchId: 'br1', curveD: 'M 0 30 C 1 30 2 30 3 30', lineD: 'M 3 30 L 9 30' }] };
+        expect(layoutSignature(a)).not.toBe(layoutSignature(b));
+    });
+
+    it('handles null/empty', () => {
+        expect(layoutSignature(null)).toBe('');
+        expect(typeof layoutSignature({})).toBe('string');
+    });
+});
+
+describe('interpolateLayout', () => {
+    const prev = {
+        mainY: 100,
+        width: 800,
+        builds: [{ id: 'b1', x: 10, y: 100, radius: 5, version: '1.0.1' }],
+        branches: [{ id: 'br1', labelX: 4, labelY: 100, name: 'x' }],
+        strata: [],
+        connectors: [],
+    };
+    const next = {
+        mainY: 130, // trunk moved down 30 in world (a release opened a clearance band)
+        width: 800,
+        builds: [
+            { id: 'b1', x: 10, y: 130, radius: 5, version: '1.0.1', releaseCustomers: ['ACME'] },
+            { id: 'b2', x: 40, y: 130, radius: 5, version: '1.0.2' }, // new build
+        ],
+        branches: [{ id: 'br1', labelX: 4, labelY: 130, name: 'x' }],
+        strata: [],
+        connectors: [],
+    };
+
+    it('returns next unchanged when prev is null or p>=1', () => {
+        expect(interpolateLayout(null, next, 0.5, 0)).toBe(next);
+        expect(interpolateLayout(prev, next, 1, -30)).toBe(next);
+    });
+
+    it('pins the trunk: with dy = mainYdelta, a build that only moved with the trunk holds still at p=0', () => {
+        // dy = nextMainY - prevMainY = 30. At p=0 the morphed world-y should equal
+        // prevY + dy = 100 + 30 = 130 = nextY → the build never moves on screen
+        // (the instant trunk-pin already shifted the transform by the same 30).
+        const at0 = interpolateLayout(prev, next, 0, 30);
+        expect(at0.builds.find(b => b.id === 'b1').y).toBe(130);
+    });
+
+    it('carries the new release info + new nodes through from next', () => {
+        const mid = interpolateLayout(prev, next, 0.5, 30);
+        const b1 = mid.builds.find(b => b.id === 'b1');
+        expect(b1.releaseCustomers).toEqual(['ACME']); // non-geometry from next
+        expect(mid.builds.find(b => b.id === 'b2')).toBeTruthy(); // appears at final
+        expect(mid.builds.find(b => b.id === 'b2').y).toBe(130);
+    });
+
+    it('interpolates x plainly (no dy) and y with dy', () => {
+        const prevX = { ...prev, builds: [{ id: 'b1', x: 0, y: 0 }] };
+        const nextX = { ...next, mainY: 0, builds: [{ id: 'b1', x: 100, y: 50 }] };
+        const mid = interpolateLayout(prevX, nextX, 0.5, 0);
+        const b1 = mid.builds[0];
+        expect(b1.x).toBe(50); // lerp(0,100,.5)
+        expect(b1.y).toBe(25); // lerp(0,50,.5)
+    });
+});

--- a/src/BuildVisualizer/__tests__/useBuildVisualizerData.placeholder.test.js
+++ b/src/BuildVisualizer/__tests__/useBuildVisualizerData.placeholder.test.js
@@ -1,0 +1,68 @@
+import {
+    describe, it, expect, vi, beforeEach,
+} from 'vitest';
+
+// req #2895 — assert the data hook wires `placeholderData: keepPreviousData` on
+// every query. That option is what keeps the prior result on screen while a
+// key-changing refetch (e.g. running a build changes the build-id CSV embedded
+// in the releases query key) resolves — so the aggregate isLoading never spikes
+// and KonvaBuildCanvas is never unmounted / re-framed.
+//
+// The hook is exercised as a plain function: React's useMemo/useContext are
+// stubbed (no render harness in this repo) and useQuery is captured so we can
+// inspect the option objects the hook builds.
+
+const KEEP_PREV = Symbol('keepPreviousData');
+const captured = [];
+
+vi.mock('@tanstack/react-query', () => ({
+    keepPreviousData: KEEP_PREV,
+    useQuery: (opts) => {
+        captured.push(opts);
+        return {
+            data: [], isLoading: false, error: null, isSuccess: true,
+        };
+    },
+}));
+
+vi.mock('react', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        useMemo: (fn) => fn(),
+        useContext: (ctx) => ctx.__testValue,
+    };
+});
+
+// Import AFTER the mocks so the hook binds to the stubbed react/useQuery.
+const { useBuildVisualizerData } = await import('../useBuildVisualizerData');
+const AppContext = (await import('../../Context/AppContext')).default;
+const AuthContext = (await import('../../Context/AuthContext')).default;
+
+describe('useBuildVisualizerData — keepPreviousData wiring', () => {
+    beforeEach(() => {
+        captured.length = 0;
+        AppContext.__testValue = { darwinBuildVizUri: 'https://api.test' };
+        AuthContext.__testValue = { idToken: 'tok', profile: { id: 'creator-1' } };
+    });
+
+    it('passes placeholderData: keepPreviousData on every query', () => {
+        useBuildVisualizerData(42);
+        // branches, builds, releases, customers.
+        expect(captured.length).toBe(4);
+        for (const opts of captured) {
+            expect(opts.placeholderData).toBe(KEEP_PREV);
+        }
+    });
+
+    it('keys the releases query on the build-id CSV (the key that changes on a build add)', () => {
+        useBuildVisualizerData(42);
+        const releases = captured.find(o => Array.isArray(o.queryKey)
+            && o.queryKey[0] === 'bv-d3-customer-releases');
+        expect(releases).toBeTruthy();
+        // 4th key segment is the build-id CSV — it changing is exactly why
+        // keepPreviousData is required here.
+        expect(releases.queryKey).toHaveLength(4);
+        expect(releases.placeholderData).toBe(KEEP_PREV);
+    });
+});

--- a/src/BuildVisualizer/canvasSpinnerGate.js
+++ b/src/BuildVisualizer/canvasSpinnerGate.js
@@ -1,0 +1,22 @@
+// canvasSpinnerGate.js — when the Build Visualizer should show the full-canvas
+// loading spinner (req #2895).
+//
+// The spinner MUST only appear on the very first load, before there is anything
+// to draw. On any later refetch (running a build, editing a branch, toggling a
+// display option) the canvas must stay mounted so KonvaBuildCanvas keeps its
+// pan/zoom transform — swapping in a spinner unmounts it and forces a re-frame,
+// which is the "re-center on redraw" bug this requirement fixes.
+//
+// Pure predicate so it can be unit-tested without a React render harness.
+//
+//   initialLoad — hook's `isInitialLoad` (loading AND no data yet)
+//   ready       — the pattern library is ready (has an active project)
+//   hasBranches — the model already has branches to draw
+//
+// Show the spinner only when we are still loading/not-ready AND there is nothing
+// on screen yet. Once branches exist, never cover them with the spinner.
+export function shouldShowCanvasSpinner({ initialLoad, ready, hasBranches }) {
+    return (!!initialLoad || !ready) && !hasBranches;
+}
+
+export default shouldShowCanvasSpinner;

--- a/src/BuildVisualizer/layoutMorph.js
+++ b/src/BuildVisualizer/layoutMorph.js
@@ -1,0 +1,228 @@
+// layoutMorph.js — smooth "general update" tween between two Build Visualizer
+// layouts (req #2895).
+//
+// When a same-project data change reflows the diagram (add a customer release →
+// a branch reserves a star-clearance band and its rows shift; toggle Build AT;
+// hide a branch type; add a build that grows a lane), the engine emits a brand
+// new `layout` with different Y positions. Re-rendering it directly makes the
+// changed region JUMP. This module interpolates every glyph from its previous
+// position to its new one so unchanged content sits still and changed content
+// glides — the "leave everything in place that doesn't change" ask.
+//
+// ── Coordinate frame ────────────────────────────────────────────────────────
+// The morph runs in mainY-RELATIVE space, paired with the canvas's instant
+// trunk-pin (which shifts the d3-zoom transform so the new mainY renders where
+// the old one was). Callers pass `dyPrev = nextMainY - prevMainY`; every PREV
+// Y coordinate is shifted by `dyPrev` before the lerp. Net effect: at p=0 every
+// glyph sits exactly where it was on screen a moment ago; at p=1 it sits at its
+// final position; the trunk (whose relative Y is ~0 in both) never moves. X is
+// never pinned (the layout is left-anchored and X is stable across reflows), so
+// X interpolates plainly.
+//
+// Nodes are matched by stable id. A node only in `next` (e.g. a freshly added
+// release star's owning build already existed, but a brand-new build/glyph) is
+// rendered at its FINAL position. A node only in `prev` (removed) is dropped.
+// Path strings (`d`) are interpolated component-wise when the two commands
+// sequences match; on any structural mismatch that element snaps to `next` — a
+// safe, jump-free-enough fallback.
+
+// Cubic ease-out — fast start, gentle settle. Exposed for the driver + tests.
+export function easeCubicOut(t) {
+    const x = t < 0 ? 0 : t > 1 ? 1 : t;
+    const u = 1 - x;
+    return 1 - u * u * u;
+}
+
+export function lerp(a, b, p) {
+    return a + (b - a) * p;
+}
+
+// A stable string capturing EVERY coordinate the morph would interpolate. Two
+// layouts with the same signature are geometrically identical — morphing between
+// them is a visual no-op. The Build Visualizer's mutations invalidate several
+// TanStack queries (branches + builds + customer_releases) that resolve at
+// different times; each resolution rebuilds `model` → `layout` as a NEW object,
+// so several geometrically-identical layouts can arrive back-to-back. Keying the
+// morph driver off this signature (instead of layout object identity) collapses
+// that cascade into a single tween — no redundant second animation (req #2895).
+// computeLayout is deterministic, so identical geometry yields byte-identical
+// numbers → an exact string match (no float-noise rounding needed).
+export function layoutSignature(layout) {
+    if (!layout) return '';
+    const parts = [layout.mainY ?? '', layout.width ?? ''];
+    for (const b of layout.builds || []) parts.push('b', b.id, b.x, b.y, b.radius);
+    for (const br of layout.branches || []) parts.push('r', br.id, br.labelX, br.labelY);
+    for (const s of layout.strata || []) parts.push('s', s.id, s.yTop, s.yBottom);
+    for (const c of layout.connectors || []) parts.push('c', c.branchId, c.curveD, c.lineD);
+    for (const a of layout.emptyAnchors || []) parts.push('e', a.branchId, a.x, a.y);
+    for (const t of layout.collapseTokens || []) parts.push('t', t.id, t.x, t.y);
+    for (const l of layout.atBuildLoops || []) parts.push('l', l.buildId, l.x, l.y);
+    for (const g of layout.atBranchGlyphs || []) parts.push('g', g.branchId, g.x, g.y, g.namesY);
+    if (layout.mainPath) parts.push('mp', layout.mainPath.d);
+    return parts.join('|');
+}
+
+// Interpolate a numeric field present on both nodes; if either is missing fall
+// back to whichever is defined (keeps optional fields from throwing).
+function lerpField(prevNode, nextNode, key, p, dy = 0) {
+    const a = prevNode?.[key];
+    const b = nextNode?.[key];
+    if (typeof a !== 'number' || typeof b !== 'number') {
+        return typeof b === 'number' ? b : a;
+    }
+    return lerp(a + dy, b, p);
+}
+
+// Split an SVG path `d` (only M / L / C / Z — the shapes the engine emits) into
+// a sequence of { cmd, nums:[...] }. Returns null if an unexpected command is
+// seen so the caller can snap.
+function parsePath(d) {
+    if (typeof d !== 'string') return null;
+    const tokens = d.match(/[MLCZ]|-?\d+(?:\.\d+)?/gi);
+    if (!tokens) return null;
+    const out = [];
+    let i = 0;
+    while (i < tokens.length) {
+        const cmd = tokens[i];
+        if (!/[MLCZ]/i.test(cmd)) return null;
+        i += 1;
+        const nums = [];
+        while (i < tokens.length && !/[MLCZ]/i.test(tokens[i])) {
+            nums.push(Number(tokens[i]));
+            i += 1;
+        }
+        out.push({ cmd, nums });
+    }
+    return out;
+}
+
+function sameStructure(a, b) {
+    if (!a || !b || a.length !== b.length) return false;
+    for (let k = 0; k < a.length; k++) {
+        if (a[k].cmd.toUpperCase() !== b[k].cmd.toUpperCase()) return false;
+        if (a[k].nums.length !== b[k].nums.length) return false;
+    }
+    return true;
+}
+
+// Interpolate two path strings. `dy` is added to every PREV y-coordinate (odd
+// indices within each command's number list — the engine only emits absolute
+// M/L/C, so numbers are x,y pairs) before the lerp. Structural mismatch → next.
+export function lerpPath(dPrev, dNext, p, dy = 0) {
+    if (dNext == null) return dPrev;
+    if (dPrev == null) return dNext;
+    const a = parsePath(dPrev);
+    const b = parsePath(dNext);
+    if (!sameStructure(a, b)) return dNext;
+    const parts = [];
+    for (let k = 0; k < a.length; k++) {
+        const nums = [];
+        for (let n = 0; n < a[k].nums.length; n++) {
+            const isY = n % 2 === 1;
+            const av = a[k].nums[n] + (isY ? dy : 0);
+            nums.push(lerp(av, b[k].nums[n], p));
+        }
+        parts.push(nums.length ? `${a[k].cmd} ${nums.map(fmt).join(' ')}` : a[k].cmd);
+    }
+    return parts.join(' ');
+}
+
+function fmt(n) {
+    // Trim to 3 decimals to keep path strings compact without visible snapping.
+    return Number.isInteger(n) ? String(n) : n.toFixed(3);
+}
+
+// Build a Map keyed by `keyFn` over an array (missing array → empty Map).
+function indexBy(arr, keyFn) {
+    const m = new Map();
+    for (const el of arr || []) m.set(keyFn(el), el);
+    return m;
+}
+
+// Interpolate an array of nodes. Output follows `nextArr` (so new nodes appear
+// and removed ones drop); matched nodes get `mutate(prevNode, nextNode)`.
+function morphArray(prevArr, nextArr, keyFn, mutate) {
+    if (!nextArr) return nextArr;
+    const prevMap = indexBy(prevArr, keyFn);
+    return nextArr.map((nextNode) => {
+        const prevNode = prevMap.get(keyFn(nextNode));
+        return prevNode ? mutate(prevNode, nextNode) : nextNode;
+    });
+}
+
+// Interpolate a whole layout at eased progress `p` (0 → 1). `dyPrev` aligns the
+// prev frame to the pinned trunk. Non-geometry fields (colors, version text,
+// names, flags, width/height/mainY) are taken from `next`.
+export function interpolateLayout(prev, next, p, dyPrev = 0) {
+    if (!prev) return next;
+    if (p >= 1) return next;
+    const dy = dyPrev;
+
+    const build = (prevN, nextN) => ({
+        ...nextN,
+        x: lerpField(prevN, nextN, 'x', p),
+        y: lerpField(prevN, nextN, 'y', p, dy),
+        versionX: lerpField(prevN, nextN, 'versionX', p),
+        versionY: lerpField(prevN, nextN, 'versionY', p, dy),
+        radius: lerpField(prevN, nextN, 'radius', p),
+    });
+
+    return {
+        ...next,
+        strata: morphArray(prev.strata, next.strata, s => s.id, (a, b) => ({
+            ...b,
+            yTop: lerpField(a, b, 'yTop', p, dy),
+            yBottom: lerpField(a, b, 'yBottom', p, dy),
+        })),
+        mainPath: next.mainPath && prev.mainPath
+            ? { ...next.mainPath, d: lerpPath(prev.mainPath.d, next.mainPath.d, p, dy) }
+            : next.mainPath,
+        connectors: morphArray(prev.connectors, next.connectors, c => c.branchId, (a, b) => ({
+            ...b,
+            curveD: lerpPath(a.curveD, b.curveD, p, dy),
+            lineD: lerpPath(a.lineD, b.lineD, p, dy),
+        })),
+        branches: morphArray(prev.branches, next.branches, br => br.id, (a, b) => ({
+            ...b,
+            labelX: lerpField(a, b, 'labelX', p),
+            labelY: lerpField(a, b, 'labelY', p, dy),
+        })),
+        mainEndpointLabels: next.mainEndpointLabels && prev.mainEndpointLabels
+            ? {
+                ...next.mainEndpointLabels,
+                leftX: lerpField(prev.mainEndpointLabels, next.mainEndpointLabels, 'leftX', p),
+                leftY: lerpField(prev.mainEndpointLabels, next.mainEndpointLabels, 'leftY', p, dy),
+                rightX: lerpField(prev.mainEndpointLabels, next.mainEndpointLabels, 'rightX', p),
+                rightY: lerpField(prev.mainEndpointLabels, next.mainEndpointLabels, 'rightY', p, dy),
+            }
+            : next.mainEndpointLabels,
+        builds: morphArray(prev.builds, next.builds, b => b.id, build),
+        emptyAnchors: morphArray(prev.emptyAnchors, next.emptyAnchors, a => a.branchId, (a, b) => ({
+            ...b,
+            x: lerpField(a, b, 'x', p),
+            y: lerpField(a, b, 'y', p, dy),
+            radius: lerpField(a, b, 'radius', p),
+        })),
+        collapseTokens: morphArray(prev.collapseTokens, next.collapseTokens, t => t.id, (a, b) => ({
+            ...b,
+            x: lerpField(a, b, 'x', p),
+            y: lerpField(a, b, 'y', p, dy),
+        })),
+        atBuildLoops: morphArray(prev.atBuildLoops, next.atBuildLoops, l => l.buildId, (a, b) => ({
+            ...b,
+            x: lerpField(a, b, 'x', p),
+            y: lerpField(a, b, 'y', p, dy),
+            radius: lerpField(a, b, 'radius', p),
+        })),
+        atBranchGlyphs: morphArray(prev.atBranchGlyphs, next.atBranchGlyphs, g => g.branchId, (a, b) => ({
+            ...b,
+            x: lerpField(a, b, 'x', p),
+            y: lerpField(a, b, 'y', p, dy),
+            namesX: lerpField(a, b, 'namesX', p),
+            namesY: lerpField(a, b, 'namesY', p, dy),
+            namesStartY: lerpField(a, b, 'namesStartY', p, dy),
+        })),
+    };
+}
+
+export default interpolateLayout;

--- a/src/BuildVisualizer/useBuildVisualizerData.js
+++ b/src/BuildVisualizer/useBuildVisualizerData.js
@@ -13,7 +13,7 @@
 // fetch, since /customer_releases stores customer_fk only.
 
 import { useContext, useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 
 import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
@@ -32,10 +32,20 @@ export function useBuildVisualizerData(projectId) {
     const creatorFk = profile?.id || null;
     const enabled = !!idToken && !!creatorFk && !!darwinUri && !!projectId;
 
+    // req #2895 — every query carries `placeholderData: keepPreviousData` so a
+    // query-key change (below, the builds/releases keys embed CSVs of the prior
+    // level's ids) returns the PREVIOUS result during the refetch instead of
+    // undefined. Without it, adding/running a build changes `buildIdsCsv`, the
+    // releases query gets a brand-new key with no cache, `isLoading` spikes true,
+    // and the page swaps the canvas for a spinner — unmounting KonvaBuildCanvas
+    // and destroying its pan/zoom transform, which then re-frames from scratch
+    // (the "re-center on redraw" bug). Mirrors the Swarm canvas fix
+    // (SwarmVisualizerView.jsx / hooks/useDataQueries.js).
     const branchesQuery = useQuery({
         queryKey: ['bv-d3-branches', creatorFk, projectId],
         queryFn: () => fetchEntity(`${darwinUri}/branches?project_fk=${projectId}`, idToken),
         enabled,
+        placeholderData: keepPreviousData,
     });
 
     const branchRows = useMemo(
@@ -51,6 +61,7 @@ export function useBuildVisualizerData(projectId) {
             idToken,
         ),
         enabled: enabled && !!branchIdsCsv,
+        placeholderData: keepPreviousData,
     });
 
     const buildRows = useMemo(
@@ -66,12 +77,14 @@ export function useBuildVisualizerData(projectId) {
             idToken,
         ),
         enabled: enabled && !!buildIdsCsv,
+        placeholderData: keepPreviousData,
     });
 
     const customersQuery = useQuery({
         queryKey: ['bv-d3-customers', creatorFk],
         queryFn: () => fetchEntity(`${darwinUri}/customers`, idToken),
         enabled,
+        placeholderData: keepPreviousData,
     });
 
     const isLoading =
@@ -79,6 +92,13 @@ export function useBuildVisualizerData(projectId) {
         || buildsQuery.isLoading
         || releasesQuery.isLoading
         || customersQuery.isLoading;
+
+    // req #2895 — first-ever load (nothing to draw yet) vs a background refetch
+    // (branches already in hand). The page gates the full-canvas spinner on this
+    // so a mid-session refetch never unmounts KonvaBuildCanvas. With
+    // keepPreviousData above, `branchRows` stays populated through a refetch, so
+    // this only trips before the very first successful load.
+    const isInitialLoad = isLoading && !branchRows.length;
 
     const error =
         branchesQuery.error
@@ -235,6 +255,7 @@ export function useBuildVisualizerData(projectId) {
 
     return {
         isLoading,
+        isInitialLoad,
         isReady: enabled && !!branchesQuery.isSuccess,
         error,
         model,


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2895-build-visualizer-retain-users-view
- wip(Darwin): 2026-07-07T19:02:26Z
- chore: init swarm session feature/2895-build-visualizer-retain-users-view

## Files changed
```
 src/BuildVisualizer/BuildVisualizerPage.jsx        |  15 +-
 src/BuildVisualizer/KonvaBuildCanvas.jsx           | 129 +++++++++++-
 .../__tests__/canvasSpinnerGate.test.js            |  56 +++++
 src/BuildVisualizer/__tests__/layoutMorph.test.js  | 141 +++++++++++++
 .../useBuildVisualizerData.placeholder.test.js     |  68 ++++++
 src/BuildVisualizer/canvasSpinnerGate.js           |  22 ++
 src/BuildVisualizer/layoutMorph.js                 | 228 +++++++++++++++++++++
 src/BuildVisualizer/useBuildVisualizerData.js      |  23 ++-
 8 files changed, 672 insertions(+), 10 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)