### PR TITLE
Branch Stoplight Function in L1-L3

### DIFF
--- a/src/BuildVisualizer/BuildVisualizerControls.jsx
+++ b/src/BuildVisualizer/BuildVisualizerControls.jsx
@@ -10,6 +10,7 @@ import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Box from '@mui/material/Box';
+import Tooltip from '@mui/material/Tooltip';
 import CheckIcon from '@mui/icons-material/Check';
 import BuildPatternMenu from './BuildPatternMenu';
 import MergeRulesDialog from './MergeRulesDialog';
@@ -22,6 +23,15 @@ import {
     themeVariantAccent,
     themeVariantBorder,
 } from './themeVariants';
+
+// Branch-type "stoplight" (req #2897) — as the semantic level (L1/L2/L3) hides
+// whole branch types, each SELECTED chip carries a red/amber/green dot reporting
+// what the current viewport actually shows for that type. See typeVisibility.js.
+const STOPLIGHT = {
+    shown:   { color: '#43a047', text: 'fully shown at this zoom level' },
+    partial: { color: '#fbc02d', text: 'partially shown — some hidden at this zoom level' },
+    hidden:  { color: '#e53935', text: 'hidden at this zoom level' },
+};
 
 // Dedicated horizontal control row above the build viewer (req #2616). One row
 // only — a single horizontal control row above the build visualizer canvas.
@@ -36,6 +46,7 @@ const BuildVisualizerControls = ({
     lib,
     selectedTypes,
     onToggleType,
+    typeVisibility,
     staggerOn,
     onToggleStagger,
     onResetView,
@@ -118,13 +129,35 @@ const BuildVisualizerControls = ({
                             {BRANCH_TYPES.map(type => {
                                 const selected = selectedTypes.includes(type);
                                 const chipProps = branchTypeChipProps(type);
-                                return (
+                                // Stoplight — only meaningful for selected types with
+                                // branches present ('none'/'off' → no dot).
+                                const status = selected ? typeVisibility?.[type] : undefined;
+                                const light = STOPLIGHT[status];
+                                const chip = (
                                     <Chip
                                         key={type}
                                         label={branchTypeLabel(type)}
                                         size="small"
                                         onClick={() => onToggleType(type)}
                                         {...(selected ? chipProps : { variant: 'outlined' })}
+                                        {...(light && {
+                                            icon: (
+                                                <Box
+                                                    component="span"
+                                                    data-testid={`branch-type-stoplight-${type}`}
+                                                    data-status={status}
+                                                    sx={{
+                                                        width: 9,
+                                                        height: 9,
+                                                        ml: '7px',
+                                                        borderRadius: '50%',
+                                                        flexShrink: 0,
+                                                        bgcolor: light.color,
+                                                        boxShadow: '0 0 0 1px rgba(0,0,0,0.35)',
+                                                    }}
+                                                />
+                                            ),
+                                        })}
                                         sx={{
                                             ...(selected ? chipProps.sx : {}),
                                             ...(!selected && { opacity: 0.5 }),
@@ -133,6 +166,15 @@ const BuildVisualizerControls = ({
                                         data-testid={`branch-type-chip-${type}`}
                                     />
                                 );
+                                return light ? (
+                                    <Tooltip
+                                        key={type}
+                                        title={`${branchTypeLabel(type)}: ${light.text}`}
+                                        arrow
+                                    >
+                                        {chip}
+                                    </Tooltip>
+                                ) : chip;
                             })}
                         </Stack>
                     </>

--- a/src/BuildVisualizer/BuildVisualizerPage.jsx
+++ b/src/BuildVisualizer/BuildVisualizerPage.jsx
@@ -32,6 +32,7 @@ import HoldCountButton from './HoldCountButton';
 import { useBuildPatterns } from './useBuildPatterns';
 import { useBuildVisualizerData } from './useBuildVisualizerData';
 import { BRANCH_TYPES, branchTypeLabel } from './branchTypeChipStyles';
+import { computeTypeVisibility } from './typeVisibility';
 import { hasMergeMenu } from './mergeEngine';
 import { REGISTRY } from './d3LayoutEngine';
 import {
@@ -202,6 +203,15 @@ const BuildVisualizerPage = () => {
     // highlight the matching toolbar chip while on Auto.
     const [pinnedLevel, setPinnedLevel] = useState(null);
     const [effectiveLevel, setEffectiveLevel] = useState(2);
+
+    // Branch-type stoplight (req #2897) — per-type shown/partial/hidden/off/none
+    // at the level the canvas is currently rendering. Drives the chip-rail dots so
+    // the filter chips report what the viewport actually shows, not just the manual
+    // on/off filter. Reuses the canvas's own visibility functions (typeVisibility.js).
+    const typeVisibility = useMemo(
+        () => computeTypeVisibility({ model, level: effectiveLevel, selectedTypes }),
+        [model, effectiveLevel, selectedTypes],
+    );
 
     // Release overlay — Gold Star only (req #2741; the style picker + Chip Row
     // were removed). Toggle just shows/hides the overlay.
@@ -1090,6 +1100,7 @@ const BuildVisualizerPage = () => {
                 lib={lib}
                 selectedTypes={selectedTypes}
                 onToggleType={toggleType}
+                typeVisibility={typeVisibility}
                 staggerOn={staggerOn}
                 onToggleStagger={toggleStagger}
                 onResetView={handleResetView}

--- a/src/BuildVisualizer/__tests__/typeVisibility.test.js
+++ b/src/BuildVisualizer/__tests__/typeVisibility.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { computeTypeVisibility } from '../typeVisibility';
+import { BRANCH_TYPES } from '../branchTypeChipStyles';
+
+// Reuse the same model builder shape as semanticModel.test.js: a main trunk plus
+// sub-branches anchored to main builds, with optional release events.
+function makeModel({ mainBuilds = 8, subBranches = [], releaseEvents = {} } = {}) {
+    const builds = {};
+    const mainBuildIds = [];
+    for (let i = 0; i < mainBuilds; i++) {
+        const id = `m${i}`;
+        mainBuildIds.push(id);
+        builds[id] = { id, branchId: 'main', position: i };
+    }
+    const branches = [{
+        id: 'main', type: 'main', name: 'Main',
+        parentBuildId: null, parentBranchId: null, buildIds: mainBuildIds,
+    }];
+    for (const sub of subBranches) {
+        const ids = [];
+        for (let i = 0; i < (sub.buildCount ?? 1); i++) {
+            const bid = `${sub.id}-b${i}`;
+            ids.push(bid);
+            builds[bid] = { id: bid, branchId: sub.id, position: i };
+        }
+        branches.push({
+            id: sub.id, type: sub.type, name: sub.name || sub.id,
+            parentBuildId: sub.parentBuildId ?? 'm0',
+            parentBranchId: sub.parentBranchId ?? 'main',
+            buildIds: ids,
+        });
+    }
+    return { branches, builds, releaseEvents, releaseEventDetails: {} };
+}
+
+const allTypes = () => [...BRANCH_TYPES];
+
+describe('computeTypeVisibility — off / none', () => {
+    it('marks a deselected type as "off"', () => {
+        const model = makeModel({ subBranches: [{ id: 'dev1', type: 'development' }] });
+        const sel = allTypes().filter(t => t !== 'development');
+        const r = computeTypeVisibility({ model, level: 3, selectedTypes: sel });
+        expect(r.development).toBe('off');
+    });
+
+    it('marks a selected type with no branches present as "none"', () => {
+        const model = makeModel({ subBranches: [{ id: 'r1', type: 'release' }] });
+        const r = computeTypeVisibility({ model, level: 3, selectedTypes: allTypes() });
+        // No hotfix/bootleg/csr/development/sample-release branches exist.
+        expect(r.hotfix).toBe('none');
+        expect(r.development).toBe('none');
+        expect(r.release).toBe('shown');
+    });
+});
+
+describe('computeTypeVisibility — L3 full detail', () => {
+    it('marks every present, selected type as "shown"', () => {
+        const model = makeModel({ subBranches: [
+            { id: 'dev1', type: 'development', parentBuildId: 'm1' },
+            { id: 's1', type: 'sample-release', parentBuildId: 'm4' },
+            { id: 'r1', type: 'release', parentBuildId: 'm2' },
+        ] });
+        const r = computeTypeVisibility({ model, level: 3, selectedTypes: allTypes() });
+        expect(r.development).toBe('shown');
+        expect(r['sample-release']).toBe('shown');
+        expect(r.release).toBe('shown');
+    });
+});
+
+describe('computeTypeVisibility — L1 hides types', () => {
+    it('marks development as "hidden" (all dev branches hidden at L1)', () => {
+        const model = makeModel({ subBranches: [
+            { id: 'dev1', type: 'development', parentBuildId: 'm1' },
+            { id: 'dev2', type: 'development', parentBuildId: 'm3' },
+            { id: 's1', type: 'sample-release', parentBuildId: 'm4' },
+        ] });
+        const r = computeTypeVisibility({ model, level: 1, selectedTypes: allTypes() });
+        expect(r.development).toBe('hidden');
+    });
+
+    it('marks sample-release "partial" when the level hides some but not all', () => {
+        // sOld is a completed, not-latest, undelivered sample → hidden at L1.
+        // sNew is the latest sample → stays shown. Mixed → partial.
+        const model = makeModel({ mainBuilds: 8, subBranches: [
+            { id: 'sOld', type: 'sample-release', parentBuildId: 'm2' },
+            { id: 'sNew', type: 'sample-release', parentBuildId: 'm6' },
+        ] });
+        const r = computeTypeVisibility({ model, level: 1, selectedTypes: allTypes() });
+        expect(r['sample-release']).toBe('partial');
+    });
+
+    it('marks sample-release "shown" when the only sample is the latest', () => {
+        const model = makeModel({ mainBuilds: 8, subBranches: [
+            { id: 'sNew', type: 'sample-release', parentBuildId: 'm6' },
+        ] });
+        const r = computeTypeVisibility({ model, level: 1, selectedTypes: allTypes() });
+        expect(r['sample-release']).toBe('shown');
+    });
+
+    it('keeps a delivered non-latest sample "shown" (delivered stays at L1)', () => {
+        const model = makeModel({
+            mainBuilds: 8,
+            subBranches: [
+                { id: 'sOld', type: 'sample-release', parentBuildId: 'm2', buildCount: 2 },
+                { id: 'sNew', type: 'sample-release', parentBuildId: 'm6' },
+            ],
+            releaseEvents: { 'sOld-b1': ['AcmeCorp'] },
+        });
+        const r = computeTypeVisibility({ model, level: 1, selectedTypes: allTypes() });
+        expect(r['sample-release']).toBe('shown');
+    });
+
+    it('leaves release "shown" at L1 (release type not hidden by the level)', () => {
+        const model = makeModel({ mainBuilds: 8, subBranches: [
+            { id: 'r1', type: 'release', parentBuildId: 'm2' },
+            { id: 'sNew', type: 'sample-release', parentBuildId: 'm6' },
+        ] });
+        const r = computeTypeVisibility({ model, level: 1, selectedTypes: allTypes() });
+        expect(r.release).toBe('shown');
+    });
+});
+
+describe('computeTypeVisibility — L2 main-trunk collapse', () => {
+    it('reports development "hidden" when the only dev branch is inside a collapsed run', () => {
+        // Two samples anchor the trunk (needed for main-trunk collapse to fire).
+        // The dev branch parents off m4, which lands inside the collapsed run
+        // between the m2 and m6 origin builds → hidden by the L2 collapse until
+        // the user expands that run (baseline view = hidden).
+        const model = makeModel({ mainBuilds: 8, subBranches: [
+            { id: 's1', type: 'sample-release', parentBuildId: 'm2' },
+            { id: 's2', type: 'sample-release', parentBuildId: 'm6' },
+            { id: 'dev1', type: 'development', parentBuildId: 'm4' },
+        ] });
+        const r = computeTypeVisibility({ model, level: 2, selectedTypes: allTypes() });
+        expect(r.development).toBe('hidden');
+        // Samples anchor the trunk and stay shown at L2.
+        expect(r['sample-release']).toBe('shown');
+    });
+
+    it('reveals the collapsed dev branch when its expand token is supplied', () => {
+        const model = makeModel({ mainBuilds: 8, subBranches: [
+            { id: 's1', type: 'sample-release', parentBuildId: 'm2' },
+            { id: 's2', type: 'sample-release', parentBuildId: 'm6' },
+            { id: 'dev1', type: 'development', parentBuildId: 'm4' },
+        ] });
+        // The collapsed run between the m2 and m6 origins is [m3, m4, m5].
+        const expandedTokens = new Set(['__gap__:main:m3:m5']);
+        const r = computeTypeVisibility({ model, level: 2, selectedTypes: allTypes(), expandedTokens });
+        expect(r.development).toBe('shown');
+    });
+});
+
+describe('computeTypeVisibility — edge cases', () => {
+    it('returns off/none only for an empty model', () => {
+        const r = computeTypeVisibility({ model: { branches: [] }, level: 1, selectedTypes: allTypes() });
+        for (const t of BRANCH_TYPES) expect(r[t]).toBe('none');
+    });
+
+    it('defaults to all selected + L3 when args omitted', () => {
+        const model = makeModel({ subBranches: [{ id: 'dev1', type: 'development' }] });
+        const r = computeTypeVisibility({ model });
+        expect(r.development).toBe('shown');
+    });
+});

--- a/src/BuildVisualizer/typeVisibility.js
+++ b/src/BuildVisualizer/typeVisibility.js
@@ -1,0 +1,82 @@
+// typeVisibility.js — per-branch-type "stoplight" state for the Build Visualizer
+// toolbar chip rail (req #2897).
+//
+// The semantic-zoom level (L1/L2/L3) hides whole branch types independently of
+// the user's chip filter: at L1 the semantic transform hides ALL development
+// branches and completed (not-latest, undelivered) sample branches. The filter
+// chips previously reflected ONLY the manual on/off filter (`selectedTypes`), so
+// a chip could read "on" while zero branches of that type actually rendered.
+//
+// This pure helper answers, for the CURRENT effective level, whether each branch
+// type is fully / partially / not shown — the chip rail renders a red/amber/green
+// stoplight dot from the result. It reuses the exact functions the canvas uses to
+// decide visibility (`computeHiddenBranchIds` for the toolbar filter, then
+// `computeSemanticModel` for the level transform), so for the level's DEFAULT
+// (as-collapsed) view the stoplight matches the canvas exactly.
+//
+// It reports the baseline visibility for the level. Callers may pass the canvas's
+// live `expandedTokens` for a precise match; when omitted (the page default) the
+// stoplight ignores user-expanded L2 collapse tokens — a dev branch buried inside
+// a collapsed main-trunk run that the user later expands reads 'hidden' here while
+// the canvas reveals it. That drift is confined to L2 after a manual expand; L1
+// (dev hidden by level rule before collapse) and L3 (no collapse) always match.
+//
+// Statuses (per type):
+//   'off'     — user has deselected the type (chip already dimmed; no dot).
+//   'none'    — the project has no branches of this type (nothing to signal).
+//   'shown'   — selected AND every branch of this type renders at this level.
+//   'partial' — selected AND the level hides SOME (not all) branches of this type.
+//   'hidden'  — selected BUT the level hides ALL branches of this type.
+//
+// Pure + exported → unit-testable in isolation.
+
+import { computeHiddenBranchIds } from './visibilityRules';
+import { computeSemanticModel } from './semanticModel';
+import { BRANCH_TYPES } from './branchTypeChipStyles';
+
+/**
+ * Compute the stoplight status for every togglable branch type.
+ *
+ * @param {object} params
+ * @param {object} params.model — {branches, builds, releaseEvents, …}
+ * @param {1|2|3} params.level — the effective semantic level being rendered.
+ * @param {string[]} params.selectedTypes — currently-on chip types.
+ * @param {Set<string>} [params.expandedTokens] — sticky expanded collapse tokens
+ *   (canvas state). Optional; defaults to none (the as-collapsed default view).
+ * @returns {Record<string, 'off'|'none'|'shown'|'partial'|'hidden'>}
+ *   Keyed by every entry in BRANCH_TYPES.
+ */
+export function computeTypeVisibility({ model, level = 3, selectedTypes, expandedTokens } = {}) {
+    const selected = Array.isArray(selectedTypes) ? selectedTypes : BRANCH_TYPES;
+    const selectedSet = new Set(selected);
+    const branches = model?.branches || [];
+
+    // Actual hidden set the canvas would render: toolbar type-filter hides unioned
+    // with the semantic-level hides. Identical inputs to KonvaBuildCanvas.
+    const baseHidden = branches.length
+        ? computeHiddenBranchIds({ branches, selectedTypes: selected, allTypes: BRANCH_TYPES })
+        : new Set();
+    const { hiddenBranchIds } = computeSemanticModel(model || { branches: [] }, {
+        level,
+        expandedTokens,
+        baseHiddenBranchIds: baseHidden,
+    });
+
+    const out = {};
+    for (const type of BRANCH_TYPES) {
+        if (!selectedSet.has(type)) { out[type] = 'off'; continue; }
+
+        const ofType = branches.filter(b => b.type === type);
+        if (ofType.length === 0) { out[type] = 'none'; continue; }
+
+        const hiddenCount = ofType.reduce(
+            (n, b) => (hiddenBranchIds.has(b.id) ? n + 1 : n), 0);
+
+        if (hiddenCount === 0) out[type] = 'shown';
+        else if (hiddenCount === ofType.length) out[type] = 'hidden';
+        else out[type] = 'partial';
+    }
+    return out;
+}
+
+export default computeTypeVisibility;


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2897-branch-stoplight-function-in-l1-l3
- wip(Darwin): 2026-07-07T08:18:51Z
- chore: init swarm session feature/2897-branch-stoplight-function-in-l1-l3

## Files changed
```
 src/BuildVisualizer/BuildVisualizerControls.jsx    |  44 +++++-
 src/BuildVisualizer/BuildVisualizerPage.jsx        |  11 ++
 .../__tests__/typeVisibility.test.js               | 164 +++++++++++++++++++++
 src/BuildVisualizer/typeVisibility.js              |  82 +++++++++++
 4 files changed, 300 insertions(+), 1 deletion(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)