### PR TITLE
undo not showing start

### DIFF
--- a/src/CalendarFC/__tests__/undoneChips.test.js
+++ b/src/CalendarFC/__tests__/undoneChips.test.js
@@ -149,6 +149,50 @@ describe('buildUndoneChips', () => {
         expect(chips[0].coordination_type).toBe('planned');
     });
 
+    // req #2905 — two-calendar-day window between undo and its swarm-start.
+    describe('two-calendar-day start window (req #2905)', () => {
+        // xPctFn ignores tz/date; returns a number so nothing is dropped and
+        // startPct is computable. timezone 'UTC' makes calendar-day math obvious.
+        const xp = (ts) => (ts === 'OFF_WINDOW' ? null
+            : ts.includes('T10:00') ? 50 : 10);
+        const windowArgs = (undoneAt, startedAt) => callArgs({
+            timezone: 'UTC',
+            xPctFn: xp,
+            swarmUndos: [{ ...baseUndo, undone_at: undoneAt }],
+            swarmStarts: [{ ...baseSwarmStart, started_at: startedAt }],
+        });
+
+        it('keeps the relationship when start is the SAME calendar day', () => {
+            const c = buildUndoneChips(
+                windowArgs('2026-05-27T10:00:00Z', '2026-05-27T02:00:00Z'))[0];
+            expect(c.startOutOfWindow).toBe(false);
+            expect(c.swarmStart).not.toBeNull();
+            expect(c.swarmStartId).toBe(60);
+            expect(c.startPct).toBe(10);
+        });
+
+        it('keeps the relationship when start is the calendar day BEFORE', () => {
+            const c = buildUndoneChips(
+                windowArgs('2026-05-27T10:00:00Z', '2026-05-26T22:00:00Z'))[0];
+            expect(c.startOutOfWindow).toBe(false);
+            expect(c.swarmStart).not.toBeNull();
+            expect(c.startPct).toBe(10);
+        });
+
+        it('detaches the start when it is 2+ calendar days before the undo', () => {
+            const c = buildUndoneChips(
+                windowArgs('2026-05-27T10:00:00Z', '2026-05-25T22:00:00Z'))[0];
+            expect(c.startOutOfWindow).toBe(true);
+            expect(c.swarmStart).toBeNull();
+            expect(c.swarmStartId).toBeNull();
+            expect(c.startPct).toBeNull();
+            expect(c.startClamped).toBe(false);
+            // Tombstone itself still renders at its own undone_at position.
+            expect(c.isUndone).toBe(true);
+            expect(c.leftPct).toBe(50);
+        });
+    });
+
     it('produces multiple chips ordered by input', () => {
         const a = { ...baseUndo, id: 13, swarm_start_fk_at_undo: 67,
                     undone_at: '2026-05-27T10:15:00Z' };

--- a/src/CalendarFC/swarmGeometry.js
+++ b/src/CalendarFC/swarmGeometry.js
@@ -93,9 +93,31 @@ export const buildUndoneChips = ({
         const leftPct = xPctFn(undo.undone_at, timezone, selectedDate);
         if (leftPct === null) continue;
 
-        const ss = undo.swarm_start_fk_at_undo != null
+        const rawSs = undo.swarm_start_fk_at_undo != null
             ? startById.get(String(undo.swarm_start_fk_at_undo))
             : null;
+
+        // req #2905 — detach the tombstone from its swarm-start when the start is
+        // more than one calendar day before the undo. Within a two-calendar-day
+        // window (undo & start on the same day, or the start was the calendar day
+        // before the undo) we keep the relationship: the duration line + the
+        // swarm-start glyph. An older start would clamp its line to the strip's
+        // left edge and drag a long connector across unrelated rows, so for those
+        // we show a lone tombstone — no line, no start glyph, no swarm-start
+        // connection (isStartOutOfWindow drives the renderer skips).
+        let startOutOfWindow = false;
+        if (rawSs && rawSs.started_at) {
+            const undoDay = toLocaleDateString(undo.undone_at, timezone);
+            const startDay = toLocaleDateString(rawSs.started_at, timezone);
+            if (undoDay && startDay) {
+                const dayGap = Math.round(
+                    (Date.parse(`${undoDay}T00:00:00Z`) -
+                        Date.parse(`${startDay}T00:00:00Z`)) / 86400000,
+                );
+                if (dayGap > 1) startOutOfWindow = true;
+            }
+        }
+        const ss = startOutOfWindow ? null : rawSs;
         const canonicalStartedAt = ss?.started_at || undo.undone_at;
         const rawStart = canonicalStartedAt
             ? xPctFn(canonicalStartedAt, timezone, selectedDate)
@@ -112,6 +134,14 @@ export const buildUndoneChips = ({
             Math.abs(leftPct - startPct) < closeThresholdPct
         ) {
             markerMode = 'left';
+        }
+
+        // req #2905 — out-of-window undo: strip every start-relationship signal so
+        // the renderer draws only the tombstone (no line, no glyph, no anchor).
+        if (startOutOfWindow) {
+            startPct = null;
+            startClamped = false;
+            markerMode = 'normal';
         }
 
         const reqId = undo.req_id_at_undo != null ? String(undo.req_id_at_undo) : null;
@@ -139,6 +169,7 @@ export const buildUndoneChips = ({
             session: null,
             swarmStartId: ss ? ss.id : null,
             swarmStart: ss || null,
+            startOutOfWindow,
             groupKey: canonicalStartedAt || '',
             timezone,
             isUndone: true,

--- a/src/SwarmView/KonvaSwarmCanvas.jsx
+++ b/src/SwarmView/KonvaSwarmCanvas.jsx
@@ -140,6 +140,9 @@ const fmtDT = (s, tz) => {
 function durationSegments(chip, usePhases) {
     const endX = xWorld(chip.leftPct);
     let startX;
+    // req #2905 — an undo whose swarm-start is outside the two-calendar-day window
+    // carries no start relationship; draw only the tombstone (no duration line).
+    if (chip.startOutOfWindow) return [];
     if (chip.markerMode === 'left') return [];
     if (chip.startClamped || chip.startPct == null) startX = xWorld(0);
     else startX = xWorld(chip.startPct);

--- a/src/SwarmView/konvaSwarmModel.js
+++ b/src/SwarmView/konvaSwarmModel.js
@@ -469,6 +469,8 @@ export function buildDayModel(date, ctx, { dataKey = 'category', nowIso = null }
 // Keys on `startPct != null`, so a bare completed requirement with no session
 // (markerMode 'left' but startPct === null) correctly yields null — no glyph.
 export function startGlyphPlacement(chip, { cx, cr, trueX, hugGap } = {}) {
+    // req #2905 — out-of-window undo tombstones carry no swarm-start anchor.
+    if (chip?.startOutOfWindow) return null;
     if (!chip || chip.startPct == null || chip.startClamped) return null;
     if (chip.markerMode === 'left') {
         const glyphX = cx - cr - hugGap;


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2905-undo-not-showing-start-1
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2905-undo-not-showing-start-1
- wip(Darwin): 2026-07-07T19:00:41Z
- chore: init swarm session feature/2905-undo-not-showing-start-1

## Files changed
```
 src/CalendarFC/__tests__/undoneChips.test.js | 44 ++++++++++++++++++++++++++++
 src/CalendarFC/swarmGeometry.js              | 33 ++++++++++++++++++++-
 src/SwarmView/KonvaSwarmCanvas.jsx           |  3 ++
 src/SwarmView/konvaSwarmModel.js             |  2 ++
 4 files changed, 81 insertions(+), 1 deletion(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)