### PR TITLE
Machines entity - track which machine runs each session and start

### DIFF
--- a/src/DevServers/DevServersView.jsx
+++ b/src/DevServers/DevServersView.jsx
@@ -1,6 +1,6 @@
 import '../index.css';
 import AuthContext from '../Context/AuthContext';
-import { useDevServers, useSessions, useAllRequirements } from '../hooks/useDataQueries';
+import { useDevServers, useSessions, useAllRequirements, useMachines } from '../hooks/useDataQueries';
 import { formatDateTime, formatDate } from '../utils/dateFormat';
 import { DataGrid, GridToolbar } from '@mui/x-data-grid';
 
@@ -82,6 +82,16 @@ const getDevServerColumns = (navigate, timezone) => [
               </a>
             : '—',
     },
+    {
+        // req #2943 — which machine hosts this dev server. Name resolved
+        // client-side from the machines cache; NULL / unresolved → em-dash. (The
+        // browser can't detect which machine it is on, so the column itself is
+        // the disambiguator — `https://localhost:<port>` only works locally.)
+        field: 'machine_name',
+        headerName: 'Machine',
+        width: 130,
+        renderCell: (params) => params.value || '—',
+    },
     { field: 'pid',            headerName: 'PID',        width: 90,  type: 'number' },
 ];
 
@@ -158,6 +168,14 @@ const DevServersView = () => {
     const { data: devServersArray } = useDevServers(profile?.userName);
     const { data: sessionsArray } = useSessions(profile?.userName);
     const { data: allRequirements } = useAllRequirements(profile?.userName);
+    const { data: machinesData } = useMachines(profile?.userName);
+
+    // req #2943 — machine id → friendly name for the Machine column.
+    const machineNameById = useMemo(() => {
+        const map = {};
+        (machinesData || []).forEach(m => { map[m.id] = m.title; });
+        return map;
+    }, [machinesData]);
 
     const sessionToRequirementId = useMemo(() => {
         if (!sessionsArray) return {};
@@ -182,7 +200,8 @@ const DevServersView = () => {
         requirement_title: s.session_fk
             ? requirementMap[sessionToRequirementId[s.session_fk]]?.title ?? null
             : null,
-    })), [devServersArray, sessionToRequirementId, requirementMap]);
+        machine_name: s.machine_fk != null ? (machineNameById[s.machine_fk] ?? null) : null,
+    })), [devServersArray, sessionToRequirementId, requirementMap, machineNameById]);
 
     const sortedServers = enrichedServers
         ? [...enrichedServers].sort((a, b) => b.id - a.id)

--- a/src/Machines/MachinesView.jsx
+++ b/src/Machines/MachinesView.jsx
@@ -1,0 +1,232 @@
+import '../index.css';
+import React, { useContext, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { CircularProgress, Typography } from '@mui/material';
+import { DataGrid, GridToolbar, useGridApiRef } from '@mui/x-data-grid';
+
+import AppContext from '../Context/AppContext';
+import AuthContext from '../Context/AuthContext';
+import call_rest_api from '../RestApi/RestApi';
+import { useMachines, machineKeys } from '../hooks/useDataQueries';
+import { useSnackBarStore } from '../stores/useSnackBarStore';
+import { formatDateTime } from '../utils/dateFormat';
+
+// Platform chip colouring — a small visual anchor per OS family.
+const platformChipProps = (platform) => {
+    switch (platform) {
+        case 'darwin': return { color: 'primary' };
+        case 'wsl':    return { color: 'secondary' };
+        case 'linux':  return { color: 'default', variant: 'outlined' };
+        default:       return { color: 'default', variant: 'outlined' };
+    }
+};
+
+/**
+ * MachinesView — the /swarm/machines management page (req #2943).
+ *
+ * Table of the machines that run Darwin swarm work. Name + Description are
+ * inline-editable (DataGrid processRowUpdate → REST PUT). The Closed column is a
+ * click-to-toggle retire/re-open chip (soft-close via `closed`). Follows the Dev
+ * Servers page shape; no Cards/Trends views (minimal by design).
+ */
+const MachinesView = () => {
+    const { profile } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
+    const { idToken } = useContext(AuthContext);
+    const queryClient = useQueryClient();
+    const showError = useSnackBarStore(s => s.showError);
+    const isMobile = useMediaQuery('(max-width:899px)');
+    const apiRef = useGridApiRef();
+
+    const creatorFk = profile?.userName;
+    const { data: machinesArray, isLoading } = useMachines(creatorFk);
+
+    const invalidate = () =>
+        queryClient.invalidateQueries({ queryKey: machineKeys.all(creatorFk) });
+
+    // Inline edit of Name (title) or Description → REST PUT (body is always an
+    // array; NULL description sent as the string "NULL" per Darwin convention).
+    const handleProcessRowUpdate = async (newRow, oldRow) => {
+        const patch = {};
+        if (newRow.title !== oldRow.title) {
+            const t = (newRow.title || '').trim();
+            if (!t) return oldRow;              // title is NOT NULL — reject blanks
+            patch.title = t;
+        }
+        if (newRow.description !== oldRow.description) {
+            const d = (newRow.description || '').trim();
+            patch.description = d === '' ? 'NULL' : d;
+        }
+        if (Object.keys(patch).length === 0) return oldRow;
+        try {
+            await call_rest_api(`${darwinUri}/machines`, 'PUT',
+                [{ id: newRow.id, ...patch }], idToken);
+            invalidate();
+            return { ...newRow, ...patch, description: patch.description === 'NULL' ? null : newRow.description };
+        } catch (err) {
+            showError(err, 'Failed to update machine');
+            return oldRow;
+        }
+    };
+
+    const toggleClosed = async (row) => {
+        try {
+            await call_rest_api(`${darwinUri}/machines`, 'PUT',
+                [{ id: row.id, closed: row.closed ? 0 : 1 }], idToken);
+            invalidate();
+        } catch (err) {
+            showError(err, 'Failed to retire/re-open machine');
+        }
+    };
+
+    const columns = useMemo(() => [
+        { field: 'id', headerName: 'ID', width: 60 },
+        {
+            field: 'title',
+            headerName: 'Name',
+            width: 180,
+            editable: true,
+            renderCell: (params) => (
+                <span data-testid={`machine-name-${params.row.id}`}>{params.value}</span>
+            ),
+        },
+        { field: 'hostname', headerName: 'Hostname', width: 160 },
+        {
+            field: 'platform',
+            headerName: 'Platform',
+            width: 110,
+            renderCell: (params) => (
+                <Chip label={params.value || '—'} size="small"
+                      {...platformChipProps(params.value)}
+                      data-testid={`machine-platform-${params.row.id}`} />
+            ),
+        },
+        { field: 'arch', headerName: 'Arch', width: 90 },
+        {
+            field: 'hw_model',
+            headerName: 'HW Model',
+            width: 140,
+            valueFormatter: (value) => value || '—',
+        },
+        {
+            field: 'os_version',
+            headerName: 'OS Version',
+            width: 150,
+            valueFormatter: (value) => value || '—',
+        },
+        {
+            field: 'description',
+            headerName: 'Description',
+            width: 200,
+            editable: true,
+            valueFormatter: (value) => value || '—',
+        },
+        {
+            field: 'last_seen_at',
+            headerName: 'Last Seen',
+            width: 170,
+            valueFormatter: (value) => value ? formatDateTime(value, profile?.timezone) : '—',
+        },
+        {
+            field: 'closed',
+            headerName: 'Status',
+            width: 110,
+            sortable: false,
+            renderCell: (params) => (
+                <Chip
+                    label={params.value ? 'Retired' : 'Active'}
+                    size="small"
+                    color={params.value ? 'default' : 'success'}
+                    variant={params.value ? 'outlined' : 'filled'}
+                    onClick={() => toggleClosed(params.row)}
+                    clickable
+                    data-testid={`machine-toggle-closed-${params.row.id}`}
+                />
+            ),
+        },
+    ], [profile?.timezone]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const sortedMachines = machinesArray
+        ? [...machinesArray].sort((a, b) => {
+            // sort_order NULLs last, then id
+            const ao = a.sort_order == null ? Infinity : a.sort_order;
+            const bo = b.sort_order == null ? Infinity : b.sort_order;
+            return ao - bo || a.id - b.id;
+        })
+        : null;
+
+    return (
+        <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }}>
+            <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ mb: 1 }}>Machines</Typography>
+
+            {isLoading || !machinesArray ? (
+                <CircularProgress />
+            ) : isMobile ? (
+                <Box data-testid="machines-datagrid">
+                    {sortedMachines.length === 0 ? (
+                        <Typography color="text.secondary" sx={{ p: 2 }}>No machines</Typography>
+                    ) : (
+                        sortedMachines.map(m => (
+                            <Card key={m.id} variant="outlined" sx={{ mb: 1 }}>
+                                <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
+                                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
+                                        <Typography variant="body1" sx={{ fontWeight: 500 }}
+                                                    data-testid={`machine-name-${m.id}`}>
+                                            {m.title}
+                                        </Typography>
+                                        <Chip label={m.closed ? 'Retired' : 'Active'} size="small"
+                                              color={m.closed ? 'default' : 'success'}
+                                              variant={m.closed ? 'outlined' : 'filled'}
+                                              onClick={() => toggleClosed(m)} clickable
+                                              data-testid={`machine-toggle-closed-${m.id}`} />
+                                    </Box>
+                                    <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+                                        <Chip label={m.platform || '—'} size="small" {...platformChipProps(m.platform)} />
+                                        <Typography variant="caption" color="text.secondary">{m.hostname}</Typography>
+                                        <Typography variant="caption" color="text.secondary">{m.arch}</Typography>
+                                    </Stack>
+                                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                                        {m.hw_model || ''} {m.os_version ? `· ${m.os_version}` : ''}
+                                    </Typography>
+                                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                                        Last seen: {m.last_seen_at ? formatDateTime(m.last_seen_at, profile?.timezone) : '—'}
+                                    </Typography>
+                                </CardContent>
+                            </Card>
+                        ))
+                    )}
+                </Box>
+            ) : (
+                <Box sx={{ width: '100%' }} data-testid="machines-datagrid">
+                    <DataGrid
+                        apiRef={apiRef}
+                        autoHeight
+                        rows={sortedMachines ?? []}
+                        columns={columns}
+                        processRowUpdate={handleProcessRowUpdate}
+                        onProcessRowUpdateError={(err) => showError(err, 'Failed to update machine')}
+                        slots={{ toolbar: GridToolbar }}
+                        slotProps={{ toolbar: { showQuickFilter: true } }}
+                        initialState={{
+                            pagination: { paginationModel: { pageSize: 25 } },
+                            sorting: { sortModel: [{ field: 'id', sort: 'asc' }] },
+                        }}
+                        pageSizeOptions={[10, 25, 50, 100]}
+                        disableRowSelectionOnClick
+                        density="compact"
+                        data-testid="machines-grid"
+                    />
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+export default MachinesView;

--- a/src/NavBar/navConfig.js
+++ b/src/NavBar/navConfig.js
@@ -16,6 +16,7 @@ import TimelineIcon from '@mui/icons-material/Timeline';
 import BusinessIcon from '@mui/icons-material/Business';
 import UndoIcon from '@mui/icons-material/Undo';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ComputerIcon from '@mui/icons-material/Computer';
 
 export const NAV_GROUPS = [
     { id: 'calendar', label: '' },
@@ -65,6 +66,7 @@ export const NAV_LINKS = [
     { path: '/swarm/swarm-completes', label: 'Completes', icon: CheckCircleIcon, group: 'swarm' },
     { path: '/swarm/swarm-undos', label: 'Undos', icon: UndoIcon, group: 'swarm' },
     { path: '/devservers', label: 'Dev Servers', icon: DnsIcon, group: 'swarm' },
+    { path: '/swarm/machines', label: 'Machines', icon: ComputerIcon, group: 'swarm' },
     { path: '/swarm/features', label: 'Features', icon: FactCheckIcon, group: 'swarm-validate' },
     { path: '/swarm/testcases', label: 'Test Cases', icon: ChecklistIcon, group: 'swarm-validate' },
     { path: '/swarm/testplans', label: 'Test Plans', icon: PlaylistAddCheckIcon, group: 'swarm-validate' },

--- a/src/SwarmStarts/SwarmStartDetail.jsx
+++ b/src/SwarmStarts/SwarmStartDetail.jsx
@@ -12,6 +12,7 @@ import {
     useSwarmStartById,
     useSessions,
     useAllSwarmStartSessions,
+    useMachines,
 } from '../hooks/useDataQueries';
 import { formatDateTime } from '../utils/dateFormat';
 import { formatDuration } from '../utils/formatDuration';
@@ -100,6 +101,13 @@ export default function SwarmStartDetail() {
     // out naturally when filtered against the user's own `useSessions` list.
     const { data: sessionsArray, isLoading: sessionsLoading } = useSessions(creatorFk);
     const { data: junction, isLoading: junctionLoading } = useAllSwarmStartSessions(creatorFk);
+    // req #2943 — resolve this start's machine name from the machines cache.
+    const { data: machinesData = [] } = useMachines(creatorFk);
+    const machineName = useMemo(() => {
+        if (!row || row.machine_fk == null) return null;
+        const m = machinesData.find(x => x.id === row.machine_fk);
+        return m ? m.title : `#${row.machine_fk}`;
+    }, [machinesData, row]);
 
     const linkedSessions = useMemo(
         () => selectSessionsForSwarmStart(sessionsArray, junction, swarmStartId),
@@ -192,6 +200,10 @@ export default function SwarmStartDetail() {
                               }
                               : {})}
                           data-testid="swarm-start-session-count-chip" />
+                    {machineName &&
+                        <Chip label={machineName} size="small" variant="outlined"
+                              data-testid="swarm-start-machine" />
+                    }
                 </Box>
             </Box>
 

--- a/src/SwarmStarts/SwarmStartsPage.jsx
+++ b/src/SwarmStarts/SwarmStartsPage.jsx
@@ -15,6 +15,7 @@ import {
     useAllSwarmStarts,
     useSessions,
     useAllSwarmStartSessions,
+    useMachines,
 } from '../hooks/useDataQueries';
 import { useViewPreference } from '../hooks/useViewPreference';
 import { formatDateTime } from '../utils/dateFormat';
@@ -56,6 +57,14 @@ export default function SwarmStartsPage() {
     // SessionsView); reusing them keeps this page free of extra round-trips.
     const { data: sessionsArray = [] } = useSessions(creatorFk);
     const { data: junction = [] } = useAllSwarmStartSessions(creatorFk);
+    const { data: machinesData = [] } = useMachines(creatorFk);
+
+    // req #2943 — machine id → friendly name for the Machine column.
+    const machineNameById = useMemo(() => {
+        const m = {};
+        machinesData.forEach(x => { m[x.id] = x.title; });
+        return m;
+    }, [machinesData]);
 
     // View toggle (Table | Stats) — req #2686.
     const [view, setView] = useViewPreference(VIEW_STORAGE_KEY, 'table');
@@ -178,12 +187,21 @@ export default function SwarmStartsPage() {
             valueFormatter: formatNum },
         { field: 'turn_count', headerName: 'Turns', width: 80, type: 'number' },
         {
+            // req #2943 — which machine ran this /swarm-start. Name resolved
+            // client-side from the machines cache; NULL / unresolved → em-dash.
+            field: 'machine_fk',
+            headerName: 'Machine',
+            width: 130,
+            valueGetter: (_v, row) =>
+                row.machine_fk != null ? (machineNameById[row.machine_fk] ?? '—') : '—',
+        },
+        {
             field: 'started_at',
             headerName: 'Started',
             width: 200,
             valueFormatter: (value) => value ? formatDateTime(value, timezone) : '—',
         },
-    ], [timezone, requirementsByStart]);
+    ], [timezone, requirementsByStart, machineNameById]);
 
     // Req #2685 — row height grows to fit one line per linked session.
     // Empty rows fall back to the prior fixed 52px so the table doesn't

--- a/src/SwarmView/SessionsView.jsx
+++ b/src/SwarmView/SessionsView.jsx
@@ -1,6 +1,6 @@
 import '../index.css';
 import AuthContext from '../Context/AuthContext';
-import { useSessions, useDevServers, useAllSwarmStartSessions } from '../hooks/useDataQueries';
+import { useSessions, useDevServers, useAllSwarmStartSessions, useMachines } from '../hooks/useDataQueries';
 import { useShowClosedStore, ALL_SESSION_STATUSES } from '../stores/useShowClosedStore';
 import { useViewPreference } from '../hooks/useViewPreference';
 import { formatDateTime, formatDate } from '../utils/dateFormat';
@@ -125,6 +125,14 @@ const getSessionColumns = (navigate, timezone) => [
             : '—',
     },
     {
+        // req #2943 — which machine ran this session. Name resolved client-side
+        // from the machines query cache; NULL / unresolved renders em-dash.
+        field: 'machine_name',
+        headerName: 'Machine',
+        width: 130,
+        renderCell: (params) => params.value || '—',
+    },
+    {
         field: 'duration',
         headerName: 'Duration',
         width: 120,
@@ -227,6 +235,14 @@ const SessionsView = () => {
     const { data: sessionsArray } = useSessions(profile?.userName);
     const { data: devServersData } = useDevServers(profile?.userName);
     const { data: swarmStartSessions } = useAllSwarmStartSessions(profile?.userName);
+    const { data: machinesData } = useMachines(profile?.userName);
+
+    // req #2943 — machine id → friendly name for the Machine column.
+    const machineNameById = useMemo(() => {
+        const map = {};
+        (machinesData || []).forEach(m => { map[m.id] = m.title; });
+        return map;
+    }, [machinesData]);
     const sessionStatusFilter = useShowClosedStore(s => s.sessionStatusFilter);
     const toggleSessionStatus = useShowClosedStore(s => s.toggleSessionStatus);
 
@@ -264,6 +280,7 @@ const SessionsView = () => {
             ...s,
             dev_server_port: devServerMap[s.id] || null,
             swarm_start_fk: swarmStartBySession[s.id] || null,
+            machine_name: s.machine_fk != null ? (machineNameById[s.machine_fk] ?? null) : null,
           }))
         : null;
 

--- a/src/SwarmView/detail/SwarmSessionDetail.jsx
+++ b/src/SwarmView/detail/SwarmSessionDetail.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
-import { useSession, useDevServersBySession, useAllSwarmStartSessions, useAllSwarmStarts, useAllSwarmCompleteSessions, useAllSwarmCompletes, useAllRequirements } from '../../hooks/useDataQueries';
+import { useSession, useDevServersBySession, useAllSwarmStartSessions, useAllSwarmStarts, useAllSwarmCompleteSessions, useAllSwarmCompletes, useAllRequirements, useMachines } from '../../hooks/useDataQueries';
 import { sessionKeys } from '../../hooks/useQueryKeys';
 import { useConfirmDialog } from '../../hooks/useConfirmDialog';
 import { useSnackBarStore } from '../../stores/useSnackBarStore';
@@ -43,6 +43,13 @@ const SwarmSessionDetail = () => {
 
     const { data: session, isLoading } = useSession(id);
     const { data: devServers = [] } = useDevServersBySession(id);
+    // req #2943 — resolve the session's machine name from the machines cache.
+    const { data: machinesData = [] } = useMachines(profile?.userName);
+    const machineName = React.useMemo(() => {
+        if (!session || session.machine_fk == null) return null;
+        const m = machinesData.find(x => x.id === session.machine_fk);
+        return m ? m.title : null;
+    }, [machinesData, session]);
     // Req #2422 — reverse junction lookup for the parent swarm_start.
     // Multi-parent policy: pick the most-recent swarm_start (highest fk).
     // Matches SessionsView's last-most-recent-wins map and the MCP resource's
@@ -278,6 +285,15 @@ const SwarmSessionDetail = () => {
                         <Typography variant="subtitle2" color="text.secondary" sx={labelSx}>Worktree Path</Typography>
                         <Typography variant="body2" data-testid="session-worktree-path">
                             {session.worktree_path}
+                        </Typography>
+                    </Box>
+                }
+
+                {session.machine_fk != null &&
+                    <Box sx={{ mb: 1 }}>
+                        <Typography variant="subtitle2" color="text.secondary" sx={labelSx}>Machine</Typography>
+                        <Typography variant="body2" data-testid="session-machine">
+                            {machineName || `#${session.machine_fk}`}
                         </Typography>
                     </Box>
                 }

--- a/src/hooks/__tests__/machinesQueries.test.js
+++ b/src/hooks/__tests__/machinesQueries.test.js
@@ -1,0 +1,31 @@
+// Req #2943 — machines query factory shape: keys + hook exports. Mirrors the
+// devopsQueriesParity pattern for the newest devops entity.
+
+import { describe, it, expect } from 'vitest';
+import { machines } from '../factory/devopsQueries';
+import { useMachines, useMachine, machineKeys } from '../useDataQueries';
+
+describe('machineKeys', () => {
+    it('all(creator) → ["machines", creator]', () => {
+        expect(machineKeys.all('alice')).toEqual(['machines', 'alice']);
+    });
+    it('byId(creator, id) → ["machines", creator, { id }]', () => {
+        expect(machineKeys.byId('alice', 3)).toEqual(['machines', 'alice', { id: 3 }]);
+    });
+    it('byId is prefix-compatible with all() for invalidation', () => {
+        const allKey = machineKeys.all('alice');
+        const byIdKey = machineKeys.byId('alice', 3);
+        expect(byIdKey.slice(0, allKey.length)).toEqual(allKey);
+    });
+});
+
+describe('machines hook exports', () => {
+    it('useMachines / useMachine are functions', () => {
+        expect(typeof useMachines).toBe('function');
+        expect(typeof useMachine).toBe('function');
+    });
+    it('factory exposes keys.all and keys.byId', () => {
+        expect(typeof machines.keys.all).toBe('function');
+        expect(typeof machines.keys.byId).toBe('function');
+    });
+});

--- a/src/hooks/factory/devopsQueries.js
+++ b/src/hooks/factory/devopsQueries.js
@@ -80,7 +80,7 @@ export const devServers = createEntityQueries({
 // phase_tokens regardless of this projection.
 const SWARM_SESSION_DEFAULT_FIELDS =
     'id,branch,task_name,source_type,source_ref,title,pr_url,swarm_status,ai_model,effort,' +
-    'worktree_path,started_at,completed_at,last_transition_at,' +
+    'worktree_path,machine_fk,started_at,completed_at,last_transition_at,' +
     'starting_secs,waiting_secs,planning_secs,implementing_secs,review_secs,' +
     'completion_secs,paused_secs,legacy_secs,instrumented,pre_pause_status,' +
     'phase_tokens,creator_fk,create_ts,update_ts';
@@ -97,7 +97,7 @@ export const sessions = createEntityQueries({
 // useSwarmStartById (creator-scoped key).
 // ---------------------------------------------------------------------------
 const SWARM_START_DEFAULT_FIELDS =
-    'id,arguments,auto_start,session_count,' +
+    'id,arguments,auto_start,session_count,machine_fk,' +
     'tokens_input,tokens_cache_write,tokens_cache_read,tokens_output,' +
     'wall_seconds,turn_count,start_summary,telemetry,started_at,creator_fk';
 
@@ -170,4 +170,26 @@ export const swarmCompletes = createEntityQueries({
 export const swarmCompleteSessions = createEntityQueries({
     entity: 'swarm_complete_sessions',
     defaultFields: 'swarm_complete_fk,session_fk',
+});
+
+// ---------------------------------------------------------------------------
+// machines (req #2943) — which machine ran a session / start / dev-server claim.
+// Hooks: useMachines (all) + useMachine (byId, creator-scoped).
+//
+// Routes through the default `darwinUri` (dev/prod split, req #2683): dev reads
+// darwin_dev.machines (seeded fixtures), prod reads darwin.machines. NOT an
+// `ops` table — machine attribution is real content the user manages on the
+// /swarm/machines page. `fieldsInKey` so a projection change doesn't collide on
+// the shared cache entry. `closed` machines still render (page shows a Closed
+// column) so no closed-filter here — sort_order-then-id, NULLs last, server-side.
+// ---------------------------------------------------------------------------
+const MACHINE_DEFAULT_FIELDS =
+    'id,title,description,hostname,platform,arch,hw_model,os_version,' +
+    'last_seen_at,closed,sort_order,creator_fk,create_ts,update_ts';
+
+export const machines = createEntityQueries({
+    entity: 'machines',
+    defaultFields: MACHINE_DEFAULT_FIELDS,
+    fieldsInKey: true,
+    defaultSort: 'sort_order:asc',
 });

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -3,7 +3,7 @@ import { useContext } from 'react';
 import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
 import { domainKeys, areaKeys, taskKeys, projectKeys, categoryKeys, requirementKeys, priorityCardOrderKeys, recurringTaskKeys, mapRunKeys, mapRouteKeys, mapCoordinateKeys, mapViewKeys, mapPartnerKeys, mapRunPartnerKeys, featureKeys, testCaseKeys, featureTestCaseKeys, testPlanKeys, testPlanCaseKeys, testRunKeys, testResultKeys, customerKeys, buildProjectKeys, branchKeys, buildKeys, customerReleaseKeys } from './useQueryKeys';
-import { devServers, sessions, swarmStarts, swarmStartSessions, swarmUndos, swarmCompletes, swarmCompleteSessions } from './factory/devopsQueries';
+import { devServers, sessions, swarmStarts, swarmStartSessions, swarmUndos, swarmCompletes, swarmCompleteSessions, machines } from './factory/devopsQueries';
 // `fetchEntity` is shared with the factory so both layers handle REST errors
 // identically (req #2593).
 import { fetchEntity } from './factory/createEntityQueries';
@@ -320,6 +320,15 @@ export function usePriorityCardOrder(creatorFk, domainId, { enabled = true } = {
 
 // Req #2593 — produced by createEntityQueries via factory/devopsQueries.js.
 export const useDevServersBySession = devServers.useBySession;
+
+// Req #2943 — machines registry: which machine ran a session / start / dev-server
+// claim. useMachines drives the /swarm/machines management page AND the client-
+// side id→title resolution for the Machine columns on Sessions / Starts / Dev
+// Servers. machineKeys.all(creatorFk) is the invalidation prefix after an inline
+// rename / close.
+export const useMachines = machines.useAll;
+export const useMachine  = machines.useById;
+export const machineKeys = machines.keys;
 
 export function useRecurringTasks(creatorFk, {
     fields = 'id,description,recurrence,anchor_date,area_fk,priority,accumulate,insert_position,active,last_generated',

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -31,6 +31,7 @@ import RequirementDetail from './SwarmView/detail/RequirementDetail';
 import SessionsView from './SwarmView/SessionsView';
 import SwarmSessionDetail from './SwarmView/detail/SwarmSessionDetail';
 import DevServersView from './DevServers/DevServersView';
+import MachinesView from './Machines/MachinesView';
 import SetupWizard from './SetupWizard/SetupWizard';
 import RecurringPlanView from './RecurringTaskEdit/RecurringPlanView';
 import MapsPage from './Maps/MapsPage';
@@ -165,6 +166,9 @@ root.render(
                                                          </AuthenticatedRoute>} />
                     <Route path="devservers" element= {<AuthenticatedRoute>
                                                              <DevServersView />
+                                                         </AuthenticatedRoute>} />
+                    <Route path="swarm/machines" element= {<AuthenticatedRoute>
+                                                             <MachinesView />
                                                          </AuthenticatedRoute>} />
                     <Route path="recurring" element= {<AuthenticatedRoute>
                                                              <RecurringPlanView />

--- a/tests/tests/machines.spec.ts
+++ b/tests/tests/machines.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+// Req #2943 — Machines management page (/swarm/machines). Loads the DataGrid of
+// registered machines; Name is inline-editable. Data comes from darwin_dev
+// (dev/prod split) — seed 2-3 machines rows before running the rename test.
+
+test.describe('Machines View', () => {
+  test('MACH-01: /swarm/machines renders DataGrid', async ({ page }) => {
+    await page.goto('/swarm/machines');
+    await expect(page.getByTestId('machines-datagrid')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('MACH-02: Machines navbar link navigates correctly', async ({ page }) => {
+    await page.goto('/taskcards');
+    await page.getByRole('link', { name: /^machines$/i }).click();
+    await expect(page).toHaveURL(/\/swarm\/machines/);
+    await expect(page.getByTestId('machines-datagrid')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('MACH-03: Machines page shows heading', async ({ page }) => {
+    await page.goto('/swarm/machines');
+    await expect(page.getByRole('heading', { name: 'Machines' })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('MACH-04: inline rename persists across reload (requires ≥1 seeded machine)', async ({ page }) => {
+    await page.goto('/swarm/machines');
+    await expect(page.getByTestId('machines-datagrid')).toBeVisible({ timeout: 10000 });
+
+    // Find the first Name cell (data-testid machine-name-<id>). Skip if the dev
+    // DB has no machines seeded — the load/nav tests above still cover the page.
+    const nameCell = page.locator('[data-testid^="machine-name-"]').first();
+    const count = await nameCell.count();
+    test.skip(count === 0, 'no machines seeded in darwin_dev — seed before running rename test');
+
+    const testid = await nameCell.getAttribute('data-testid');
+    const original = (await nameCell.innerText()).trim();
+    const renamed = `${original}-e2e`;
+
+    // Enter edit mode on the Name column (single click starts edit via the grid's
+    // onCellClick handler / double-click as fallback), type, commit with Enter.
+    await nameCell.dblclick();
+    const input = page.locator('input[type="text"]').first();
+    await input.fill(renamed);
+    await input.press('Enter');
+
+    // Reload and confirm the new value stuck.
+    await page.reload();
+    await expect(page.getByTestId(testid!)).toHaveText(renamed, { timeout: 10000 });
+
+    // Restore the original name to keep the fixture idempotent.
+    const restored = page.getByTestId(testid!);
+    await restored.dblclick();
+    const input2 = page.locator('input[type="text"]').first();
+    await input2.fill(original);
+    await input2.press('Enter');
+  });
+});


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-07-11T20:59:07Z
- chore: init swarm session feature/2943-machines-entity-track-which-machine-1

## Files changed
```
 src/DevServers/DevServersView.jsx           |  23 ++-
 src/Machines/MachinesView.jsx               | 232 ++++++++++++++++++++++++++++
 src/NavBar/navConfig.js                     |   2 +
 src/SwarmStarts/SwarmStartDetail.jsx        |  12 ++
 src/SwarmStarts/SwarmStartsPage.jsx         |  20 ++-
 src/SwarmView/SessionsView.jsx              |  19 ++-
 src/SwarmView/detail/SwarmSessionDetail.jsx |  18 ++-
 src/hooks/__tests__/machinesQueries.test.js |  31 ++++
 src/hooks/factory/devopsQueries.js          |  26 +++-
 src/hooks/useDataQueries.js                 |  11 +-
 src/index.jsx                               |   4 +
 tests/tests/machines.spec.ts                |  57 +++++++
 12 files changed, 447 insertions(+), 8 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)