### PR TITLE
Surface ai_model/effort across all swarm UI — session/start/complete cards, tables, visualizer, detail + stats pages, and requirement detail

### DIFF
--- a/src/SwarmCompletes/SwarmCompleteDetail.jsx
+++ b/src/SwarmCompletes/SwarmCompleteDetail.jsx
@@ -38,6 +38,8 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { DataGrid } from '@mui/x-data-grid';
 import { coordinationChipProps } from '../SwarmView/coordinationChipStyles';
+import { aiModelChipProps, aiModelLabel } from '../SwarmView/modelChipStyles';
+import { effortChipProps, effortLabel } from '../SwarmView/effortChipStyles';
 
 const statusChipProps = (status) => {
     switch (status) {
@@ -69,6 +71,27 @@ const getLinkedSessionColumns = (timezone) => [
     },
     { field: 'title',    headerName: 'Title',  flex: 1, minWidth: 220 },
     { field: 'branch',   headerName: 'Branch', width: 360 },
+    {
+        // req #2955 — each linked session carries its own ai_model/effort.
+        field: 'ai_model',
+        headerName: 'Model',
+        width: 90,
+        renderCell: (params) => (
+            <Chip label={aiModelLabel(params.value)} size="small"
+                  {...aiModelChipProps(params.value)}
+                  data-testid="chip-ai-model" />
+        ),
+    },
+    {
+        field: 'effort',
+        headerName: 'Effort',
+        width: 100,
+        renderCell: (params) => (
+            <Chip label={effortLabel(params.value)} size="small"
+                  {...effortChipProps(params.value)}
+                  data-testid="chip-effort" />
+        ),
+    },
     {
         field: 'duration',
         headerName: 'Duration',
@@ -193,6 +216,15 @@ export default function SwarmCompleteDetail() {
                         <Chip label={`coordination: ${row.coordination_type}`} size="small"
                               {...coordinationChipProps(row.coordination_type)} />
                     )}
+                    {/* req #2955 — the finalizing session's model/effort (#2949's
+                        swarm_completes columns), the model/effort that incurred
+                        this complete's cost. */}
+                    <Chip label={aiModelLabel(row.ai_model)} size="small"
+                          {...aiModelChipProps(row.ai_model)}
+                          data-testid="chip-ai-model" />
+                    <Chip label={effortLabel(row.effort)} size="small"
+                          {...effortChipProps(row.effort)}
+                          data-testid="chip-effort" />
                     <Chip label={`${row.session_count} session${row.session_count === 1 ? '' : 's'}`}
                           size="small" variant="outlined"
                           {...(row.session_count > 0

--- a/src/SwarmCompletes/SwarmCompletesPage.jsx
+++ b/src/SwarmCompletes/SwarmCompletesPage.jsx
@@ -13,6 +13,8 @@ import { useViewPreference } from '../hooks/useViewPreference';
 import { formatDateTime } from '../utils/dateFormat';
 import { formatDuration } from '../utils/formatDuration';
 import SwarmCompletesStatsView from './SwarmCompletesStatsView';
+import { aiModelChipProps, aiModelLabel } from '../SwarmView/modelChipStyles';
+import { effortChipProps, effortLabel } from '../SwarmView/effortChipStyles';
 
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
@@ -90,6 +92,29 @@ export default function SwarmCompletesPage() {
             renderCell: (params) => (
                 <Chip label={params.value} size="small"
                       {...statusChipProps(params.value)} />
+            ),
+        },
+        {
+            // req #2955 (backed by #2949's swarm_completes.ai_model column) — the
+            // finalizing session's model, i.e. the model that incurred this
+            // complete's cost.
+            field: 'ai_model',
+            headerName: 'Model',
+            width: 90,
+            renderCell: (params) => (
+                <Chip label={aiModelLabel(params.value)} size="small"
+                      {...aiModelChipProps(params.value)}
+                      data-testid="chip-ai-model" />
+            ),
+        },
+        {
+            field: 'effort',
+            headerName: 'Effort',
+            width: 100,
+            renderCell: (params) => (
+                <Chip label={effortLabel(params.value)} size="small"
+                      {...effortChipProps(params.value)}
+                      data-testid="chip-effort" />
             ),
         },
         { field: 'wall_seconds', headerName: 'Wall Clock Time', width: 140, type: 'number',

--- a/src/SwarmCompletes/SwarmCompletesStatsView.jsx
+++ b/src/SwarmCompletes/SwarmCompletesStatsView.jsx
@@ -29,6 +29,8 @@ import {
 } from 'recharts';
 
 import { parsePhaseBreakdown } from './SwarmCompleteDetail';
+import { AI_MODELS, AI_MODEL_COLOR, aiModelLabel } from '../SwarmView/modelChipStyles';
+import { EFFORTS, EFFORT_COLOR, effortLabel } from '../SwarmView/effortChipStyles';
 
 const STATS_WIDTH = 1140;
 const TOP_PHASES_LIMIT = 12;
@@ -92,6 +94,8 @@ const emptyStats = () => ({
     phaseAggregate: [],
     phaseTokenTotal: 0,
     throughput: [],
+    modelHistogram: AI_MODELS.map(m => ({ label: aiModelLabel(m), count: 0 })),
+    effortHistogram: EFFORTS.map(e => ({ label: effortLabel(e), count: 0 })),
 });
 
 // Pure aggregator — rows → stats object. Exported for unit testing.
@@ -115,6 +119,12 @@ export function computeSwarmCompleteStats(rows) {
     const skillMap = new Map();          // skill_name → count
     const wallHistMap = Object.fromEntries(WALL_BUCKETS.map(b => [b.label, 0]));
     const turnsHistMap = Object.fromEntries(TURN_BUCKETS.map(b => [b.label, 0]));
+    // req #2955 (#2949's swarm_completes.ai_model/effort columns) — the
+    // finalizing session's model/effort. Unknown/NULL normalizes to the
+    // documented backfill defaults ('opus' / 'high'), same rule as
+    // SessionsStatsView's per-model/effort rollup.
+    const modelMap = Object.fromEntries(AI_MODELS.map(m => [m, 0]));
+    const effortMap = Object.fromEntries(EFFORTS.map(e => [e, 0]));
     // phase name → { phase, completes, tokens, wall }
     const phaseMap = new Map();
     // calendar date (YYYY-MM-DD from started_at) → { date, count, tokens }
@@ -130,6 +140,10 @@ export function computeSwarmCompleteStats(rows) {
         // Skill
         const skill = row.skill_name || '—';
         skillMap.set(skill, (skillMap.get(skill) || 0) + 1);
+
+        // Model/Effort (req #2955)
+        modelMap[AI_MODEL_COLOR[row.ai_model] ? row.ai_model : 'opus'] += 1;
+        effortMap[EFFORT_COLOR[row.effort] ? row.effort : 'high'] += 1;
 
         // Tokens
         inputTotal += Number(row.tokens_input) || 0;
@@ -227,6 +241,8 @@ export function computeSwarmCompleteStats(rows) {
         phaseAggregate,
         phaseTokenTotal,
         throughput,
+        modelHistogram: AI_MODELS.map(m => ({ label: aiModelLabel(m), count: modelMap[m] })),
+        effortHistogram: EFFORTS.map(e => ({ label: effortLabel(e), count: effortMap[e] })),
     };
 }
 
@@ -313,6 +329,12 @@ const SKILL_COLORS = {
     'swarm-complete': '#26c6da',
     'primary-ai-swarm-complete': '#ffa726',
 };
+// Model/effort pie colors (req #2955), keyed by capitalized label — mirrors
+// SessionsStatsView's MODEL_PIE_COLORS/EFFORT_PIE_COLORS.
+const MODEL_PIE_COLORS = Object.fromEntries(
+    AI_MODELS.map(m => [aiModelLabel(m), AI_MODEL_COLOR[m]]));
+const EFFORT_PIE_COLORS = Object.fromEntries(
+    EFFORTS.map(e => [effortLabel(e), EFFORT_COLOR[e]]));
 const PIE_FALLBACK = ['#7E57C2', '#E91E63', '#ffca28', '#66bb6a', '#42a5f5'];
 
 const colorFor = (label, map, idx) => map[label] || PIE_FALLBACK[idx % PIE_FALLBACK.length];
@@ -431,6 +453,28 @@ export default function SwarmCompletesStatsView({ rows = [] }) {
                     <PieDistribution data={stats.skillHistogram}
                                      colorMap={SKILL_COLORS}
                                      testId="pie-skill" />
+                </ChartCard>
+
+                {/* Model/Effort Split (req #2955) — cost-by-model/effort at a
+                    glance, mirroring SessionsStatsView's Model/Effort Split. */}
+                <ChartCard
+                    title="Model Split"
+                    height={240}
+                    testId="chart-model-histogram"
+                >
+                    <PieDistribution data={stats.modelHistogram}
+                                     colorMap={MODEL_PIE_COLORS}
+                                     testId="pie-model" />
+                </ChartCard>
+
+                <ChartCard
+                    title="Effort Split"
+                    height={240}
+                    testId="chart-effort-histogram"
+                >
+                    <PieDistribution data={stats.effortHistogram}
+                                     colorMap={EFFORT_PIE_COLORS}
+                                     testId="pie-effort" />
                 </ChartCard>
 
                 <ChartCard

--- a/src/SwarmCompletes/__tests__/swarmCompletesStats.test.js
+++ b/src/SwarmCompletes/__tests__/swarmCompletesStats.test.js
@@ -156,4 +156,44 @@ describe('computeSwarmCompleteStats (req #2794)', () => {
             { date: '2026-06-08', count: 2, tokens: 15 },
         ]);
     });
+
+    // req #2955 — model/effort histograms (backed by #2949's swarm_completes columns).
+    describe('modelHistogram / effortHistogram (req #2955)', () => {
+        it('returns all-zero histograms with full label set for empty input', () => {
+            const s = computeSwarmCompleteStats([]);
+            expect(s.modelHistogram.map(b => b.label)).toEqual(['Haiku', 'Sonnet', 'Opus', 'Fable']);
+            expect(s.modelHistogram.every(b => b.count === 0)).toBe(true);
+            expect(s.effortHistogram.map(b => b.label)).toEqual(['Low', 'Medium', 'High', 'XHigh', 'Ultracode']);
+            expect(s.effortHistogram.every(b => b.count === 0)).toBe(true);
+        });
+
+        it('counts rows into their model/effort bucket', () => {
+            const rows = [
+                mkRow({ ai_model: 'sonnet', effort: 'xhigh' }),
+                mkRow({ ai_model: 'sonnet', effort: 'low' }),
+                mkRow({ ai_model: 'opus', effort: 'high' }),
+            ];
+            const s = computeSwarmCompleteStats(rows);
+            const models = Object.fromEntries(s.modelHistogram.map(b => [b.label, b.count]));
+            const efforts = Object.fromEntries(s.effortHistogram.map(b => [b.label, b.count]));
+            expect(models.Sonnet).toBe(2);
+            expect(models.Opus).toBe(1);
+            expect(models.Haiku).toBe(0);
+            expect(efforts.XHigh).toBe(1);
+            expect(efforts.Low).toBe(1);
+            expect(efforts.High).toBe(1);
+        });
+
+        it('normalizes unknown/NULL model to opus and effort to high (documented backfill rule)', () => {
+            const rows = [
+                mkRow({ ai_model: null, effort: null }),
+                mkRow({ ai_model: 'bogus', effort: 'bogus' }),
+            ];
+            const s = computeSwarmCompleteStats(rows);
+            const models = Object.fromEntries(s.modelHistogram.map(b => [b.label, b.count]));
+            const efforts = Object.fromEntries(s.effortHistogram.map(b => [b.label, b.count]));
+            expect(models.Opus).toBe(2);
+            expect(efforts.High).toBe(2);
+        });
+    });
 });

--- a/src/SwarmStarts/SwarmStartDetail.jsx
+++ b/src/SwarmStarts/SwarmStartDetail.jsx
@@ -17,6 +17,8 @@ import {
 import { formatDateTime } from '../utils/dateFormat';
 import { formatDuration } from '../utils/formatDuration';
 import { swarmStatusChipProps, swarmStatusLabel } from '../SwarmView/swarmStatusChipProps';
+import { aiModelChipProps, aiModelLabel } from '../SwarmView/modelChipStyles';
+import { effortChipProps, effortLabel } from '../SwarmView/effortChipStyles';
 import { parseSummary } from './SwarmStartsPage';
 import { selectSessionsForSwarmStart } from './sessionFilter';
 
@@ -57,6 +59,27 @@ const getLinkedSessionColumns = (timezone) => [
     // darwinai-config-directly-to-1`) on one line at density="compact"; anything
     // narrower wraps and inflates row height.
     { field: 'branch',   headerName: 'Branch', width: 360 },
+    {
+        // req #2955 — each linked session carries its own ai_model/effort.
+        field: 'ai_model',
+        headerName: 'Model',
+        width: 70,
+        renderCell: (params) => (
+            <Chip label={aiModelLabel(params.value)} size="small"
+                  {...aiModelChipProps(params.value)}
+                  data-testid="chip-ai-model" />
+        ),
+    },
+    {
+        field: 'effort',
+        headerName: 'Effort',
+        width: 90,
+        renderCell: (params) => (
+            <Chip label={effortLabel(params.value)} size="small"
+                  {...effortChipProps(params.value)}
+                  data-testid="chip-effort" />
+        ),
+    },
     {
         field: 'duration',
         headerName: 'Duration',
@@ -204,6 +227,14 @@ export default function SwarmStartDetail() {
                         <Chip label={machineName} size="small" variant="outlined"
                               data-testid="swarm-start-machine" />
                     }
+                    {/* req #2955 — the launcher's model/effort (#2949's swarm_starts
+                        columns), the model/effort that incurred this start's cost. */}
+                    <Chip label={aiModelLabel(row.ai_model)} size="small"
+                          {...aiModelChipProps(row.ai_model)}
+                          data-testid="chip-ai-model" />
+                    <Chip label={effortLabel(row.effort)} size="small"
+                          {...effortChipProps(row.effort)}
+                          data-testid="chip-effort" />
                 </Box>
             </Box>
 

--- a/src/SwarmStarts/SwarmStartsPage.jsx
+++ b/src/SwarmStarts/SwarmStartsPage.jsx
@@ -23,7 +23,11 @@ import { formatDuration } from '../utils/formatDuration';
 import { selectRequirementsForSwarmStart } from './requirementsList';
 import SwarmStartsStatsView from './SwarmStartsStatsView';
 
+import { aiModelChipProps, aiModelLabel } from '../SwarmView/modelChipStyles';
+import { effortChipProps, effortLabel } from '../SwarmView/effortChipStyles';
+
 import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -101,9 +105,31 @@ export default function SwarmStartsPage() {
             valueGetter: (_v, row) => Boolean(row.auto_start),
         },
         {
+            // req #2955 (backed by #2949's swarm_starts.ai_model column) — the
+            // launcher's model, i.e. the model that incurred this start's cost.
+            field: 'ai_model',
+            headerName: 'Model',
+            width: 70,
+            renderCell: (params) => (
+                <Chip label={aiModelLabel(params.value)} size="small"
+                      {...aiModelChipProps(params.value)}
+                      data-testid="chip-ai-model" />
+            ),
+        },
+        {
+            field: 'effort',
+            headerName: 'Effort',
+            width: 90,
+            renderCell: (params) => (
+                <Chip label={effortLabel(params.value)} size="small"
+                      {...effortChipProps(params.value)}
+                      data-testid="chip-effort" />
+            ),
+        },
+        {
             field: 'arguments',
             headerName: 'Arguments',
-            width: 390,
+            width: 150,
             renderCell: (params) => (
                 <Tooltip title={params.value || '—'}>
                     <Typography variant="body2" component="span"

--- a/src/SwarmStarts/SwarmStartsStatsView.jsx
+++ b/src/SwarmStarts/SwarmStartsStatsView.jsx
@@ -31,10 +31,13 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import {
     ResponsiveContainer, BarChart, Bar, LineChart, Line,
+    PieChart, Pie, Cell, Legend,
     XAxis, YAxis, CartesianGrid, Tooltip as RTooltip,
 } from 'recharts';
 
 import { parsePhaseBreakdown } from '../utils/phaseTelemetry';
+import { AI_MODELS, AI_MODEL_COLOR, aiModelLabel } from '../SwarmView/modelChipStyles';
+import { EFFORTS, EFFORT_COLOR, effortLabel } from '../SwarmView/effortChipStyles';
 
 const STATS_WIDTH = 1140;
 const ARG_DISPLAY_LIMIT = 60;
@@ -105,6 +108,8 @@ export function computeSwarmStartStats(rows) {
             topPatterns: [],
             phaseAggregate: [],
             phaseAvgTokenTotal: 0,
+            modelHistogram: AI_MODELS.map(m => ({ label: aiModelLabel(m), count: 0 })),
+            effortHistogram: EFFORTS.map(e => ({ label: effortLabel(e), count: 0 })),
         };
     }
 
@@ -132,6 +137,12 @@ export function computeSwarmStartStats(rows) {
     // phase name → { phase, invocations, tokens, wall } — aggregated from each
     // start's TOKEN_TELEMETRY `phases` blob (req #2811, analog of completes).
     const phaseMap = new Map();
+    // req #2955 (#2949's swarm_starts.ai_model/effort columns) — the
+    // launcher's model/effort. Unknown/NULL normalizes to the documented
+    // backfill defaults ('opus' / 'high'), same rule as SessionsStatsView's
+    // per-model/effort rollup.
+    const modelMap = Object.fromEntries(AI_MODELS.map(m => [m, 0]));
+    const effortMap = Object.fromEntries(EFFORTS.map(e => [e, 0]));
 
     for (const row of rows) {
         const sessionCount = Number(row.session_count) || 0;
@@ -140,6 +151,8 @@ export function computeSwarmStartStats(rows) {
         if (maxRequirements === null || sessionCount > maxRequirements.count) {
             maxRequirements = { id: row.id, count: sessionCount };
         }
+        modelMap[AI_MODEL_COLOR[row.ai_model] ? row.ai_model : 'opus'] += 1;
+        effortMap[EFFORT_COLOR[row.effort] ? row.effort : 'high'] += 1;
 
         // Tokens
         inputTotal += Number(row.tokens_input) || 0;
@@ -274,6 +287,8 @@ export function computeSwarmStartStats(rows) {
         topPatterns,
         phaseAggregate,
         phaseAvgTokenTotal,
+        modelHistogram: AI_MODELS.map(m => ({ label: aiModelLabel(m), count: modelMap[m] })),
+        effortHistogram: EFFORTS.map(e => ({ label: effortLabel(e), count: effortMap[e] })),
     };
 }
 
@@ -365,6 +380,64 @@ const tooltipStyle = {
     },
     labelStyle: { color: '#e8e1d5' },
 };
+
+// Model/effort pie colors (req #2955), keyed by capitalized label — mirrors
+// SessionsStatsView's MODEL_PIE_COLORS/EFFORT_PIE_COLORS and
+// SwarmCompletesStatsView's parallel constants.
+const MODEL_PIE_COLORS = Object.fromEntries(
+    AI_MODELS.map(m => [aiModelLabel(m), AI_MODEL_COLOR[m]]));
+const EFFORT_PIE_COLORS = Object.fromEntries(
+    EFFORTS.map(e => [effortLabel(e), EFFORT_COLOR[e]]));
+const PIE_FALLBACK = ['#7E57C2', '#E91E63', '#ffca28', '#66bb6a', '#42a5f5'];
+
+const colorFor = (label, map, idx) => map[label] || PIE_FALLBACK[idx % PIE_FALLBACK.length];
+
+// % label drawn just outside each slice (short → no clipping for long names).
+const piePctLabel = ({ percent }) => `${(percent * 100).toFixed(0)}%`;
+
+// Tooltip shows both count and % for the hovered slice.
+const piePieFormatter = (value, _name, item) => {
+    const pct = ((item?.payload?.percent ?? 0) * 100).toFixed(0);
+    return [`${value} (${pct}%)`, item?.payload?.label];
+};
+
+// Legend renders the category name plus its raw count, so count + % are both
+// always on-screen without crowding the slices.
+const legendWithCount = (value, entry) => {
+    const c = entry?.payload?.count ?? entry?.payload?.value ?? 0;
+    return `${value} (${c})`;
+};
+
+// Distribution rendered as a donut. `data` is [{ label, count }]; zero-count
+// categories are dropped so the pie shows only present values. Ported from
+// SwarmCompletesStatsView (req #2955) — this file had no pie chart before.
+function PieDistribution({ data, colorMap, testId }) {
+    const slices = data.filter(d => d.count > 0);
+    if (slices.length === 0) {
+        return (
+            <Box sx={{ display: 'flex', alignItems: 'center',
+                        justifyContent: 'center', height: '100%' }}>
+                <Typography variant="body2" color="text.secondary">No data.</Typography>
+            </Box>
+        );
+    }
+    return (
+        <ResponsiveContainer width="100%" height="100%" data-testid={testId}>
+            <PieChart margin={{ top: 5, right: 10, left: 10, bottom: 5 }}>
+                <Pie data={slices} dataKey="count" nameKey="label"
+                     cx="50%" cy="50%" innerRadius={45} outerRadius={75}
+                     paddingAngle={2} label={piePctLabel} labelLine={false}>
+                    {slices.map((d, i) => (
+                        <Cell key={d.label} fill={colorFor(d.label, colorMap, i)} />
+                    ))}
+                </Pie>
+                <RTooltip {...tooltipStyle} formatter={piePieFormatter} />
+                <Legend formatter={legendWithCount}
+                        wrapperStyle={{ fontSize: 12, color: '#9a9186' }} />
+            </PieChart>
+        </ResponsiveContainer>
+    );
+}
 
 export default function SwarmStartsStatsView({ rows = [] }) {
     const stats = computeSwarmStartStats(rows);
@@ -477,6 +550,28 @@ export default function SwarmStartsStatsView({ rows = [] }) {
                             <Bar dataKey="count" fill="#26c6da" radius={[4, 4, 0, 0]} />
                         </BarChart>
                     </ResponsiveContainer>
+                </ChartCard>
+
+                {/* Model/Effort Split (req #2955) — cost-by-model/effort at a
+                    glance, mirroring SessionsStatsView's Model/Effort Split. */}
+                <ChartCard
+                    title="Model Split"
+                    height={240}
+                    testId="chart-model-histogram"
+                >
+                    <PieDistribution data={stats.modelHistogram}
+                                     colorMap={MODEL_PIE_COLORS}
+                                     testId="pie-model" />
+                </ChartCard>
+
+                <ChartCard
+                    title="Effort Split"
+                    height={240}
+                    testId="chart-effort-histogram"
+                >
+                    <PieDistribution data={stats.effortHistogram}
+                                     colorMap={EFFORT_PIE_COLORS}
+                                     testId="pie-effort" />
                 </ChartCard>
 
                 {/* Throughput Over Time — invocations per calendar day, range-windowed

--- a/src/SwarmStarts/__tests__/swarmStartsStats.test.js
+++ b/src/SwarmStarts/__tests__/swarmStartsStats.test.js
@@ -316,4 +316,44 @@ describe('computeSwarmStartStats — phase cost leaderboard (req #2811, avg-base
         const allSum = Array.from({ length: 20 }, (_, i) => i + 1).reduce((a, b) => a + b, 0);
         expect(s.phaseAvgTokenTotal).toBe(allSum);
     });
+
+    // req #2955 — model/effort histograms (backed by #2949's swarm_starts columns).
+    describe('modelHistogram / effortHistogram (req #2955)', () => {
+        it('returns all-zero histograms with full label set for empty input', () => {
+            const s = computeSwarmStartStats([]);
+            expect(s.modelHistogram.map(b => b.label)).toEqual(['Haiku', 'Sonnet', 'Opus', 'Fable']);
+            expect(s.modelHistogram.every(b => b.count === 0)).toBe(true);
+            expect(s.effortHistogram.map(b => b.label)).toEqual(['Low', 'Medium', 'High', 'XHigh', 'Ultracode']);
+            expect(s.effortHistogram.every(b => b.count === 0)).toBe(true);
+        });
+
+        it('counts rows into their model/effort bucket', () => {
+            const rows = [
+                mkRow({ ai_model: 'sonnet', effort: 'xhigh' }),
+                mkRow({ ai_model: 'sonnet', effort: 'low' }),
+                mkRow({ ai_model: 'opus', effort: 'high' }),
+            ];
+            const s = computeSwarmStartStats(rows);
+            const models = Object.fromEntries(s.modelHistogram.map(b => [b.label, b.count]));
+            const efforts = Object.fromEntries(s.effortHistogram.map(b => [b.label, b.count]));
+            expect(models.Sonnet).toBe(2);
+            expect(models.Opus).toBe(1);
+            expect(models.Haiku).toBe(0);
+            expect(efforts.XHigh).toBe(1);
+            expect(efforts.Low).toBe(1);
+            expect(efforts.High).toBe(1);
+        });
+
+        it('normalizes unknown/NULL model to opus and effort to high (documented backfill rule)', () => {
+            const rows = [
+                mkRow({ ai_model: null, effort: null }),
+                mkRow({ ai_model: 'bogus', effort: 'bogus' }),
+            ];
+            const s = computeSwarmStartStats(rows);
+            const models = Object.fromEntries(s.modelHistogram.map(b => [b.label, b.count]));
+            const efforts = Object.fromEntries(s.effortHistogram.map(b => [b.label, b.count]));
+            expect(models.Opus).toBe(2);
+            expect(efforts.High).toBe(2);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-07-11T23:05:15Z
- chore: init swarm session feature/2955-surface-ai-modeleffort-across-all-1

## Files changed
```
 src/SwarmCompletes/SwarmCompleteDetail.jsx         | 32 ++++++++
 src/SwarmCompletes/SwarmCompletesPage.jsx          | 25 ++++++
 src/SwarmCompletes/SwarmCompletesStatsView.jsx     | 44 ++++++++++
 .../__tests__/swarmCompletesStats.test.js          | 40 +++++++++
 src/SwarmStarts/SwarmStartDetail.jsx               | 31 +++++++
 src/SwarmStarts/SwarmStartsPage.jsx                | 28 ++++++-
 src/SwarmStarts/SwarmStartsStatsView.jsx           | 95 ++++++++++++++++++++++
 src/SwarmStarts/__tests__/swarmStartsStats.test.js | 40 +++++++++
 8 files changed, 334 insertions(+), 1 deletion(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)