### PR TITLE
Add Machine setting to requirements + machine-aware swarm skills

### DIFF
--- a/src/SwarmView/RequirementsTableView.jsx
+++ b/src/SwarmView/RequirementsTableView.jsx
@@ -22,7 +22,7 @@ import { DataGrid, GridToolbar } from '@mui/x-data-grid';
 import AuthContext from '../Context/AuthContext';
 import AppContext from '../Context/AppContext';
 import call_rest_api from '../RestApi/RestApi';
-import { useAllRequirements, useAllCategories, useSessions } from '../hooks/useDataQueries';
+import { useAllRequirements, useAllCategories, useSessions, useMachines } from '../hooks/useDataQueries';
 import { requirementKeys } from '../hooks/useQueryKeys';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
 import { requirementStatusChipProps, requirementStatusLabel } from './statusChipStyles';
@@ -37,11 +37,11 @@ import { requirementBucketKey } from '../utils/aggregateRequirementTrends';
 // + checkbox column). Exported so SwarmView.jsx can align the header row (toggle + chips +
 // settings) to the same width — keeps the settings icon flush with the table's right edge.
 // Columns: checkbox(50) + id(70) + category(150) + title(220) + status(140)
-//          + autonomy(110) + model(100) + effort(100) + sessions(200)
-//          + created(105) + completed(105) = 1350
-export const SWARM_TABLE_WIDTH = 1400;
+//          + autonomy(110) + model(100) + effort(100) + machine(120) + sessions(200)
+//          + created(105) + completed(105) = 1470
+export const SWARM_TABLE_WIDTH = 1520;
 
-const FIELDS = 'id,title,requirement_status,category_fk,coordination_type,ai_model,effort,completed_at,create_ts';
+const FIELDS = 'id,title,requirement_status,category_fk,coordination_type,ai_model,effort,machine_fk,completed_at,create_ts';
 
 const WRAP_CELL_SX = {
     whiteSpace: 'normal',
@@ -91,11 +91,22 @@ const RequirementsTableView = () => {
     });
     const { data: sessions = [] } = useSessions(creatorFk);
 
+    // req #2978 — machine pin. Includes CLOSED machines: a requirement pinned to
+    // a since-retired machine must still resolve to a name here rather than
+    // falling back to the raw id.
+    const { data: machines = [] } = useMachines(creatorFk);
+
     const categoryMap = useMemo(() => {
         const m = new Map();
         for (const c of categories) m.set(c.id, c.category_name);
         return m;
     }, [categories]);
+
+    const machineMap = useMemo(() => {
+        const m = new Map();
+        for (const mc of machines) m.set(mc.id, mc.title);
+        return m;
+    }, [machines]);
 
     // requirement_id -> sessions linked via source_ref, newest first.
     const sessionsByRequirementId = useMemo(() => {
@@ -290,6 +301,20 @@ const RequirementsTableView = () => {
                     <Chip label={effortLabel(params.value)} size="small"
                           {...effortChipProps(params.value)} />
                 </Box>
+            ),
+        },
+        {
+            // req #2978 — the machine this requirement is PINNED to (where it is
+            // allowed to run). NULL renders "Any", the default and common case —
+            // deliberately not an em-dash: unpinned is a meaningful state, not a
+            // missing value.
+            field: 'machine_fk',
+            headerName: 'Machine',
+            width: 120,
+            valueGetter: (value, row) => (
+                row.machine_fk == null
+                    ? 'Any'
+                    : (machineMap.get(row.machine_fk) || `#${row.machine_fk}`)
             ),
         },
         {

--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import call_rest_api from '../../RestApi/RestApi';
 import { useSnackBarStore } from '../../stores/useSnackBarStore';
 import { useShowClosedStore, ALL_REQUIREMENT_STATUSES } from '../../stores/useShowClosedStore';
-import { useAllCategories } from '../../hooks/useDataQueries';
+import { useAllCategories, useMachines } from '../../hooks/useDataQueries';
 import { siblingActiveSort } from './requirementSort';
 import { formatDateTime, formatDate } from '../../utils/dateFormat';
 import AuthContext from '../../Context/AuthContext';
@@ -104,6 +104,7 @@ const RequirementDetail = () => {
         coordination_type: 'implemented',
         ai_model: 'opus',
         effort: 'xhigh',
+        machine_fk: null,   // req #2978 — every requirement is born "Any machine"
         started_at: null,
         completed_at: null,
         deferred_at: null,
@@ -142,6 +143,26 @@ const RequirementDetail = () => {
         fields: 'id,category_name',
         closed: 0,
     });
+
+    // Req #2978 — machine pin options. Machines are an OPEN set (rows in the
+    // `machines` table), so the chip list is data-driven rather than a static
+    // constant like AI_MODELS/EFFORTS. Only OPEN machines are offerable: a
+    // retired machine must not be a new pin target. A requirement already
+    // pinned to a since-retired machine still renders that pin (see
+    // `pinnedMachineMissing` below) so the state is never silently lost.
+    const { data: machinesData = [] } = useMachines(profile?.userName);
+    const openMachines = useMemo(
+        () => (machinesData || [])
+            .filter(m => !m.closed)
+            .sort((a, b) => {
+                // Hand sort_order first (NULL sinks to the end), then title.
+                const ao = a.sort_order ?? Number.MAX_SAFE_INTEGER;
+                const bo = b.sort_order ?? Number.MAX_SAFE_INTEGER;
+                if (ao !== bo) return ao - bo;
+                return (a.title || '').localeCompare(b.title || '');
+            }),
+        [machinesData]
+    );
     // Filter chips now match DB status values directly
     const siblingStatuses = [...requirementStatusFilter];
 
@@ -353,6 +374,14 @@ const RequirementDetail = () => {
         // values; no deselect-to-null path, mirroring autonomy and model.
         setRequirement(prev => ({ ...prev, effort: newVal }));
         saveField('effort', newVal);
+    };
+
+    const handleMachineChange = (newVal) => {
+        // Req #2978 — unlike autonomy/model/effort, NULL is a REAL value here:
+        // it means "Any machine". newVal is either a machines.id or null (Any).
+        setRequirement(prev => ({ ...prev, machine_fk: newVal }));
+        // REST PUT NULL convention: the literal string 'NULL' clears the column.
+        saveField('machine_fk', newVal === null ? 'NULL' : newVal);
     };
 
     const handleCategoryChange = async (event) => {
@@ -701,6 +730,76 @@ const RequirementDetail = () => {
                                 })}
                             </Stack>
                         </Box>
+                    </Box>
+                );
+            })()}
+
+            {/* Machine pin (req #2978) — WHERE this requirement is allowed to run.
+                "Any" (NULL) is the default and the common case; a pin restricts
+                /swarm-start, /swarm-restart and /swarm-resume to that machine.
+                Same editability/fade/new-mode rules as Autonomy/Model/Effort.
+                Chips are deliberately NEUTRAL (outlined → filled when selected):
+                machines are an open set, so there is no per-machine color file
+                to mirror modelChipStyles/effortChipStyles. */}
+            {(() => {
+                // The Machine pin is editable in authoring, approved AND swarm_ready.
+                // Fade tracks EDITABILITY, not swarm_ready alone: the pin is a
+                // planning-time decision the user makes while authoring, so fading it
+                // in authoring/approved would misrepresent a fully-editable control as
+                // disabled. (The AI Settings group above still fades on !swarm_ready —
+                // a deliberate difference, not an oversight.)
+                const isEditable = ['authoring', 'approved', 'swarm_ready'].includes(currentStatus);
+                const isFaded = !isEditable;
+                const labelColor = isFaded ? 'text.disabled' : 'text.secondary';
+                const currentMachine = requirement.machine_fk ?? null;
+                // A pin pointing at a machine that is closed (or already gone
+                // from the list) still has to render — otherwise the chip row
+                // would silently show "Any" for a requirement that is in fact
+                // pinned, and the user could never see or clear it.
+                const pinnedMachineMissing =
+                    currentMachine !== null &&
+                    !openMachines.some(m => m.id === currentMachine);
+                const pinnedMachine = pinnedMachineMissing
+                    ? (machinesData || []).find(m => m.id === currentMachine)
+                    : null;
+
+                return (
+                    <Box sx={{ mb: 2, display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap', ...NARROW,
+                               opacity: isFaded ? 0.4 : 1,
+                               ...(isNew && { visibility: 'hidden', pointerEvents: 'none' }) }}>
+                        <Typography variant="subtitle2" color={labelColor} sx={{ minWidth: 72 }}>
+                            Machine
+                        </Typography>
+                        <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap data-testid="machine-selector">
+                            {[
+                                { id: null, label: 'Any' },
+                                ...openMachines.map(m => ({ id: m.id, label: m.title })),
+                                // Retired-but-pinned tail entry (see above).
+                                ...(pinnedMachineMissing
+                                    ? [{ id: currentMachine,
+                                         label: pinnedMachine ? `${pinnedMachine.title} (retired)` : `#${currentMachine}` }]
+                                    : []),
+                            ].map(({ id: machineId, label }) => {
+                                const selected = currentMachine === machineId;
+                                return (
+                                    <Chip
+                                        key={machineId === null ? 'any' : machineId}
+                                        label={label}
+                                        size="small"
+                                        disabled={!isEditable}
+                                        // `disabled` only stops pointer events via CSS on a
+                                        // MUI Chip — guard the handler too so a non-editable
+                                        // status can never write a pin.
+                                        onClick={() => { if (isEditable && !selected) handleMachineChange(machineId); }}
+                                        data-testid={`machine-${machineId === null ? 'any' : machineId}`}
+                                        {...(selected
+                                            ? { sx: { cursor: isEditable ? 'pointer' : 'default' } }
+                                            : { variant: 'outlined', sx: { cursor: isEditable ? 'pointer' : 'default', opacity: !isEditable ? 0.3 : 0.6 } }
+                                        )}
+                                    />
+                                );
+                            })}
+                        </Stack>
                     </Box>
                 );
             })()}

--- a/src/SwarmView/detail/__tests__/RequirementDetail.machine.test.jsx
+++ b/src/SwarmView/detail/__tests__/RequirementDetail.machine.test.jsx
@@ -1,0 +1,246 @@
+// @vitest-environment jsdom
+//
+// Req #2978 — the Machine pin chip group on the requirement detail page.
+//
+// A requirement can be pinned to a specific machine, or left "Any" (NULL, the
+// default). The pin is what /swarm-start, /swarm-restart and /swarm-resume gate
+// on, so the two directions that matter most are:
+//   - picking a machine saves its `machines.id`
+//   - picking "Any" saves NULL (via the REST 'NULL' string convention)
+// A regression in either direction silently mis-routes swarm launches, so both
+// are asserted against the REAL component and the REAL saveField PUT.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-router-dom', () => ({
+    useParams: () => ({ id: '42' }),
+    useNavigate: () => () => {},
+    useLocation: () => ({ state: {} }),
+}));
+
+const MACHINES = [
+    { id: 7, title: 'Mac mini',  closed: 0, sort_order: 1 },
+    { id: 9, title: 'WSL box',   closed: 0, sort_order: 2 },
+    { id: 12, title: 'Old iMac', closed: 1, sort_order: 3 },  // retired — must NOT be offered
+];
+
+// `useMachines` is produced by createEntityQueries, so its fetch happens INSIDE
+// the factory module and a fetchEntity mock would not intercept it. Override the
+// hook the component actually consumes instead.
+vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        useMachines: () => ({ data: MACHINES }),
+        useAllCategories: () => ({ data: [{ id: 1, category_name: 'Swarm' }] }),
+    };
+});
+
+// The detail page's own fetches go through call_rest_api directly. Serve the
+// requirement on GET and record PUTs so we can assert what was saved.
+let requirementRow;
+const putBodies = [];
+vi.mock('../../../RestApi/RestApi', () => ({
+    default: vi.fn((uri, method, body) => {
+        if (method === 'PUT') {
+            putBodies.push(body);
+            return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+        }
+        if (method === 'GET' && uri.includes('/requirements?id=')) {
+            return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [requirementRow] });
+        }
+        return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+    }),
+}));
+
+import RequirementDetail from '../RequirementDetail';
+import AuthContext from '../../../Context/AuthContext';
+import AppContext from '../../../Context/AppContext';
+
+let mountedRoots = [];
+
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0, refetchOnWindowFocus: false } },
+    });
+    const root = createRoot(container);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <RequirementDetail />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    mountedRoots.push(root);
+    return { container };
+}
+
+async function flush() {
+    await act(async () => {
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+        await new Promise((r) => setTimeout(r, 0));
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+    });
+}
+
+const chip = (container, key) =>
+    container.querySelector(`[data-testid="machine-${key}"]`);
+
+// MUI renders the Chip label in a span; the clickable node is the chip root.
+const chipLabels = (container) =>
+    Array.from(container.querySelectorAll('[data-testid="machine-selector"] .MuiChip-root'))
+        .map(el => el.textContent);
+
+const isSelected = (el) => !el.classList.contains('MuiChip-outlined');
+
+function baseRequirement(overrides = {}) {
+    return {
+        id: 42,
+        title: 'pin me',
+        description: '',
+        category_fk: 1,
+        requirement_status: 'swarm_ready',   // editable AND un-faded
+        coordination_type: 'implemented',
+        ai_model: 'opus',
+        effort: 'xhigh',
+        machine_fk: null,
+        started_at: null, completed_at: null, deferred_at: null,
+        create_ts: null, update_ts: null,
+        ...overrides,
+    };
+}
+
+describe('RequirementDetail machine pin (req #2978)', () => {
+    beforeEach(() => {
+        putBodies.length = 0;
+        requirementRow = baseRequirement();
+        mountedRoots = [];
+    });
+    afterEach(() => {
+        act(() => { mountedRoots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+    });
+
+    it('offers Any first plus only OPEN machines, in sort_order', async () => {
+        const { container } = mount();
+        await flush();
+
+        expect(chipLabels(container)).toEqual(['Any', 'Mac mini', 'WSL box']);
+        // The retired machine must not be offerable as a new pin.
+        expect(chip(container, 12)).toBeNull();
+    });
+
+    it('selects Any when machine_fk is NULL', async () => {
+        const { container } = mount();
+        await flush();
+
+        expect(isSelected(chip(container, 'any'))).toBe(true);
+        expect(isSelected(chip(container, 7))).toBe(false);
+    });
+
+    it('selects the pinned machine when machine_fk is set', async () => {
+        requirementRow = baseRequirement({ machine_fk: 9 });
+        const { container } = mount();
+        await flush();
+
+        expect(isSelected(chip(container, 9))).toBe(true);
+        expect(isSelected(chip(container, 'any'))).toBe(false);
+    });
+
+    it('saves the machine id when a machine chip is clicked', async () => {
+        const { container } = mount();
+        await flush();
+
+        await act(async () => { chip(container, 7).click(); });
+        await flush();
+
+        expect(putBodies).toEqual([[{ id: 42, machine_fk: 7 }]]);
+    });
+
+    it('saves NULL when Any is clicked (clears the pin)', async () => {
+        requirementRow = baseRequirement({ machine_fk: 7 });
+        const { container } = mount();
+        await flush();
+
+        await act(async () => { chip(container, 'any').click(); });
+        await flush();
+
+        // REST PUT NULL convention — the literal string, not JS null.
+        expect(putBodies).toEqual([[{ id: 42, machine_fk: 'NULL' }]]);
+    });
+
+    it('does not re-save when the already-selected chip is clicked', async () => {
+        const { container } = mount();
+        await flush();
+
+        await act(async () => { chip(container, 'any').click(); });
+        await flush();
+
+        expect(putBodies).toEqual([]);
+    });
+
+    it('still renders a pin to a RETIRED machine so it can be seen and cleared', async () => {
+        requirementRow = baseRequirement({ machine_fk: 12 });
+        const { container } = mount();
+        await flush();
+
+        const retired = chip(container, 12);
+        expect(retired).not.toBeNull();
+        expect(retired.textContent).toContain('Old iMac');
+        expect(isSelected(retired)).toBe(true);
+        // ...and it must not have silently fallen back to "Any".
+        expect(isSelected(chip(container, 'any'))).toBe(false);
+    });
+
+    // The pin is a planning-time decision, so it must be BOTH clickable and
+    // visually live in all three editable statuses. A regression that fades the
+    // row in authoring/approved (e.g. by copying the AI Settings group's
+    // `!swarm_ready` fade rule) makes a working control look disabled.
+    for (const status of ['authoring', 'approved', 'swarm_ready']) {
+        it(`is editable and NOT faded in '${status}'`, async () => {
+            requirementRow = baseRequirement({ requirement_status: status });
+            const { container } = mount();
+            await flush();
+
+            const macMini = chip(container, 7);
+            expect(macMini.classList.contains('Mui-disabled')).toBe(false);
+
+            // The row wrapper must not be dimmed.
+            // The row wrapper must not be dimmed. MUI's `sx` compiles to a CSS
+            // class, so the inline `style.opacity` is always empty — assert the
+            // COMPUTED value or this check silently passes on a faded row.
+            const row = container.querySelector('[data-testid="machine-selector"]').parentElement;
+            expect(row).not.toBeNull();
+            expect(getComputedStyle(row).opacity).toBe('1');
+
+            // ...and the click must actually persist.
+            await act(async () => { macMini.click(); });
+            await flush();
+            expect(putBodies).toEqual([[{ id: 42, machine_fk: 7 }]]);
+        });
+    }
+
+    it('disables the chips when the requirement is not in an editable status', async () => {
+        requirementRow = baseRequirement({ requirement_status: 'met' });
+        const { container } = mount();
+        await flush();
+
+        expect(chip(container, 7).classList.contains('Mui-disabled')).toBe(true);
+
+        await act(async () => { chip(container, 7).click(); });
+        await flush();
+        expect(putBodies).toEqual([]);
+    });
+});

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -181,7 +181,7 @@ export function useRequirementCounts(creatorFk, { enabled = true } = {}) {
     });
 }
 
-export function useRequirements(creatorFk, categoryId, { fields = 'id,title,requirement_status,category_fk,completed_at,deferred_at,started_at,coordination_type,ai_model,effort,sort_order', enabled = true } = {}) {
+export function useRequirements(creatorFk, categoryId, { fields = 'id,title,requirement_status,category_fk,completed_at,deferred_at,started_at,coordination_type,ai_model,effort,machine_fk,sort_order', enabled = true } = {}) {
     const { darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
 
@@ -229,7 +229,7 @@ export const useAllSwarmCompletes        = swarmCompletes.useAll;
 export const useSwarmCompleteById        = swarmCompletes.useById;
 export const useAllSwarmCompleteSessions = swarmCompleteSessions.useAll;
 
-export function useRequirementsByStatus(creatorFk, status, { fields = 'id,title,requirement_status,coordination_type,ai_model,effort,category_fk', enabled = true } = {}) {
+export function useRequirementsByStatus(creatorFk, status, { fields = 'id,title,requirement_status,coordination_type,ai_model,effort,machine_fk,category_fk', enabled = true } = {}) {
     const { darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
 


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/2978-add-machine-setting-to-requirements-1
- wip(Darwin): 2026-07-19T11:40:29Z
- chore: init swarm session feature/2978-add-machine-setting-to-requirements-1

## Files changed
```
 src/SwarmView/RequirementsTableView.jsx            |  35 ++-
 src/SwarmView/detail/RequirementDetail.jsx         | 101 ++++++++-
 .../__tests__/RequirementDetail.machine.test.jsx   | 246 +++++++++++++++++++++
 src/hooks/useDataQueries.js                        |   4 +-
 4 files changed, 378 insertions(+), 8 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)