### PR TITLE
Dev version numbers incorrectly placed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5292,24 +5292,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yet-another-react-lightbox": {
       "version": "3.30.1",
       "resolved": "https://registry.npmjs.org/yet-another-react-lightbox/-/yet-another-react-lightbox-3.30.1.tgz",

--- a/src/BuildVisualizer/__tests__/d3LayoutEngine.test.js
+++ b/src/BuildVisualizer/__tests__/d3LayoutEngine.test.js
@@ -427,20 +427,20 @@ describe('build records — branchType and releaseDetails', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 5b. MAIN-FACING VERSION LABELS (req #2899) — build numbers hug main; the
-//     stack direction differs above vs below main. Above-main + main render
-//     numbers BELOW the dot (toward main); below-main (dev) flips ABOVE the dot.
+// 5b. VERSION LABEL DIRECTION (req #3003) — build numbers always render
+//     BELOW the dot, for every branch type including below-main (dev).
+//     req #2899 previously flipped dev labels ABOVE the dot; that produced
+//     incorrectly-placed dev build numbers and has been reverted.
 // ---------------------------------------------------------------------------
-describe('version-label direction — main-facing (req #2899)', () => {
+describe('version-label direction — always below the dot (req #3003)', () => {
     const { versionCloseOffset, versionLaneGap } = DEFAULT_OPTS;
 
-    it('above-main branch keeps numbers BELOW the dot (toward main) — unchanged', () => {
+    it('above-main branch keeps numbers BELOW the dot', () => {
         const layout = computeLayout(makeModel({
             mainBuilds: 3,
             subBranches: [{ id: 'sr1', type: 'sample-release', parentBuildId: 'm1', buildCount: 2 }],
         }));
         const b0 = layout.builds.find(b => b.id === 'sr1-b1'); // index 0 → close lane
-        // Below the dot: versionY strictly greater than the dot center.
         expect(b0.versionY).toBe(b0.y + b0.radius + versionCloseOffset);
     });
 
@@ -450,45 +450,32 @@ describe('version-label direction — main-facing (req #2899)', () => {
         expect(m0.versionY).toBe(m0.y + m0.radius + versionCloseOffset);
     });
 
-    it('below-main dev branch flips numbers ABOVE the dot (toward main)', () => {
+    it('below-main dev branch renders numbers BELOW the dot, same as every other type', () => {
         const layout = computeLayout(makeModel({
             mainBuilds: 3,
             subBranches: [{ id: 'dev1', type: 'development', parentBuildId: 'm1', buildCount: 2 }],
         }));
         const d0 = layout.builds.find(b => b.id === 'dev1-b1'); // index 0 → close lane
         const d1 = layout.builds.find(b => b.id === 'dev1-b2'); // index 1 → far lane
-        // Above the dot (smaller Y = higher on canvas = toward main).
-        expect(d0.versionY).toBe(d0.y - d0.radius - versionCloseOffset);
-        // Far lane steps FURTHER up (toward main), not down.
-        expect(d1.versionY).toBe(d1.y - d1.radius - versionCloseOffset - versionLaneGap);
-        expect(d1.versionY).toBeLessThan(d0.versionY);
-        // And both sit above the main line (numbers hug main from below).
-        expect(d0.versionY).toBeLessThan(d0.y);
+        expect(d0.versionY).toBe(d0.y + d0.radius + versionCloseOffset);
+        // Far lane steps FURTHER down, not up.
+        expect(d1.versionY).toBe(d1.y + d1.radius + versionCloseOffset + versionLaneGap);
+        expect(d1.versionY).toBeGreaterThan(d0.versionY);
+        expect(d0.versionY).toBeGreaterThan(d0.y);
     });
 
-    it('below-main numbers sit between the dev dot and main (closer to main than the dot)', () => {
-        const layout = computeLayout(makeModel({
-            mainBuilds: 3,
-            subBranches: [{ id: 'dev1', type: 'development', parentBuildId: 'm1', buildCount: 1 }],
-        }));
-        const d0 = layout.builds.find(b => b.id === 'dev1-b1');
-        const dev = layout.branches.find(b => b.id === 'dev1');
-        expect(dev.y).toBeGreaterThan(layout.mainY);     // dev is below main
-        expect(d0.versionY).toBeLessThan(dev.y);          // numbers are above the dev dot
-        expect(d0.versionY).toBeGreaterThan(layout.mainY); // …but still below the main line
-    });
-
-    it('below-main build that BEARS a release keeps numbers BELOW the dot (clears its star)', () => {
+    it('below-main build that bears a release still renders numbers BELOW the dot', () => {
         const layout = computeLayout(makeModel({
             mainBuilds: 3,
             subBranches: [{ id: 'dev1', type: 'development', parentBuildId: 'm1', buildCount: 2 }],
             releaseEvents: { 'dev1-b1': ['Acme'] },
         }));
-        const rel = layout.builds.find(b => b.id === 'dev1-b1');   // release-bearing → below
-        const plain = layout.builds.find(b => b.id === 'dev1-b2'); // no release → flips above
+        const rel = layout.builds.find(b => b.id === 'dev1-b1');
+        const plain = layout.builds.find(b => b.id === 'dev1-b2');
         expect(rel.versionY).toBe(rel.y + rel.radius + versionCloseOffset);
         expect(rel.versionY).toBeGreaterThan(rel.y);
-        expect(plain.versionY).toBeLessThan(plain.y);
+        expect(plain.versionY).toBe(plain.y + plain.radius + versionCloseOffset + versionLaneGap);
+        expect(plain.versionY).toBeGreaterThan(plain.y);
     });
 });
 

--- a/src/BuildVisualizer/d3LayoutEngine.js
+++ b/src/BuildVisualizer/d3LayoutEngine.js
@@ -644,16 +644,11 @@ export function computeLayout(model, opts = {}) {
     for (const b of branches) {
         if (isHidden(b.id)) continue;
         const r = dotRadiusFor(b.type);
-        // req #2899 — build-number labels sit on the MAIN-FACING side of the dot
-        // so the version stack always grows toward main, and the stack direction
-        // is DIFFERENT above vs below main. Above-main branches already render
-        // their numbers BELOW the dot (which points toward main), so they are
-        // unchanged; below-main (dev) branches flip to ABOVE the dot so their
-        // numbers hug main too. Main itself (center) keeps numbers below.
-        // Guard: release stars always render ABOVE the dot for every branch type
-        // (KonvaBuildCanvas — b.y − 22/50), so a below-main build that carries a
-        // release keeps its numbers BELOW the dot to clear its own star.
-        const isBelowMain = (branchY.get(b.id) ?? mainY) > mainY;
+        // req #3003 — build-number labels always render BELOW the dot, for
+        // every branch type including dev (below-main). req #2899 previously
+        // flipped below-main (dev) labels ABOVE the dot to keep the version
+        // stack growing toward main; that produced incorrectly-placed dev
+        // build numbers and has been reverted.
         (b.buildIds || []).forEach((bid, i) => {
             const pos = positions[bid];
             if (isGapId(bid)) {
@@ -663,11 +658,7 @@ export function computeLayout(model, opts = {}) {
             const data = buildsMap[bid];
             if (!pos || !data) return;
             const laneOffset = (o.versionLanes && i % 2 === 1) ? o.versionLaneGap : 0;
-            const bearsRelease = (releaseEvents[bid]?.length || 0) > 0;
-            const flipUp = isBelowMain && !bearsRelease;
-            const versionY = flipUp
-                ? pos.y - r - o.versionCloseOffset - laneOffset
-                : pos.y + r + o.versionCloseOffset + laneOffset;
+            const versionY = pos.y + r + o.versionCloseOffset + laneOffset;
             buildRecords.push({
                 id: bid,
                 branchId: b.id,


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-07-20T08:48:33Z
- chore: init swarm session feature/3003-dev-version-numbers-incorrectly-1

## Files changed
```
 package-lock.json                                  | 18 ---------
 .../__tests__/d3LayoutEngine.test.js               | 47 ++++++++--------------
 src/BuildVisualizer/d3LayoutEngine.js              | 21 +++-------
 3 files changed, 23 insertions(+), 63 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)