### PR TITLE
New model/effort defaults

### DIFF
--- a/src/SwarmView/SessionsStatsView.jsx
+++ b/src/SwarmView/SessionsStatsView.jsx
@@ -187,7 +187,7 @@ export function computeSessionStats(rows) {
 
     // Per-effort aggregation (req #2916) — same shape as the model rollup.
     // Unknown/NULL effort normalizes to 'high' (the documented pre-#2916
-    // backfill rule; NOT the new-row default xhigh).
+    // backfill rule, which is also the new-row default since req #3007).
     const normalizeEffort = (e) => (EFFORT_COLOR[e] ? e : 'high');
     const effortMap = Object.fromEntries(
         EFFORTS.map(e => [e, { count: 0, secs: 0, tokens: 0 }]));

--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -103,7 +103,7 @@ const RequirementDetail = () => {
         requirement_status: 'authoring',
         coordination_type: 'implemented',
         ai_model: 'opus',
-        effort: 'xhigh',
+        effort: 'high',
         machine_fk: null,   // req #2978 — every requirement is born "Any machine"
         started_at: null,
         completed_at: null,

--- a/src/SwarmView/effortChipStyles.js
+++ b/src/SwarmView/effortChipStyles.js
@@ -17,7 +17,7 @@
 // is the user-facing name for the CLI's top effort level (injected as
 // `claude --effort max`). Pre-#2916 rows were backfilled to 'high' — the
 // documented assumption for all historical data — so null/unknown falls back
-// to high styling, NOT to the new-row default (xhigh).
+// to high styling, which is also the new-row default (req #3007).
 
 export const EFFORT_COLOR = {
     low:       '#e0e0e0', // grey


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3007-new-modeleffort-defaults-1
- wip(Darwin): 2026-07-22T08:31:23Z
- chore: init swarm session feature/3007-new-modeleffort-defaults-1

## Files changed
```
 src/SwarmView/SessionsStatsView.jsx        | 2 +-
 src/SwarmView/detail/RequirementDetail.jsx | 2 +-
 src/SwarmView/effortChipStyles.js          | 2 +-
 3 files changed, 3 insertions(+), 3 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)