### PR TITLE
Exterminate seed-agents-registry.py

### DIFF
--- a/src/hooks/factory/devopsQueries.js
+++ b/src/hooks/factory/devopsQueries.js
@@ -198,9 +198,10 @@ export const machines = createEntityQueries({
 // agents registry (req #2997 / #2998) — the five tables behind /agents.
 //
 // Routes through the default `darwinUri` (dev/prod split, req #2683). NOT `ops`
-// tables: the registry is content the user manages, and the MCP daemon reads it
-// from production while the dev UI reads seeded darwin_dev rows. Both databases
-// are seeded by scripts/seed-agents-registry.py, so dev review sees real data.
+// tables: the registry is content the user manages via the /agents UI + MCP
+// tools, and the MCP daemon reads it from production while the dev UI reads
+// darwin_dev rows. The registry is present in both databases (the DB is the sole
+// source of truth — no git-hardcoded row source), so dev review sees real data.
 //
 // `agent_documents` and `agent_instructions` are JUNCTIONS with composite PKs
 // and NO `id` column — never request `fields=id` on them, and they take no


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3017-exterminate-seed-agents-registrypy-1
- wip(Darwin): 2026-07-23T07:29:09Z
- chore: init swarm session feature/3017-exterminate-seed-agents-registrypy-1

## Files changed
```
 src/hooks/factory/devopsQueries.js | 7 ++++---
 1 file changed, 4 insertions(+), 3 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)