### PR TITLE
Show model/effort in aggregator

### DIFF
--- a/src/SwarmView/CategoryTabPanel.jsx
+++ b/src/SwarmView/CategoryTabPanel.jsx
@@ -9,6 +9,7 @@ import { categoryKeys } from '../hooks/useQueryKeys';
 import { useCrudCallbacks } from '../hooks/useCrudCallbacks';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { useSwarmTabStore } from '../stores/useSwarmTabStore';
+import { useModelEffortDisplayStore } from '../stores/useModelEffortDisplayStore';
 
 import CategoryCloseDialog from './CategoryCloseDialog';
 import CategoryDeleteDialog from './CategoryDeleteDialog';
@@ -22,6 +23,9 @@ import Box from '@mui/material/Box';
 const CategoryTabPanel = ( { project, projectIndex, activeTab, showClosed, showSwarmStartCard } ) => {
 
     const clearDragTabSwitch = useSwarmTabStore(s => s.clearDragTabSwitch);
+    // req #3029 — when off, the aggregator card stays the same width as the other
+    // cards (the `aggregator-wide` class below gates the wide-viewport span-2).
+    const wideAggregator = useModelEffortDisplayStore(s => s.wideAggregator);
 
     const { idToken, profile } = useContext(AuthContext);
     const { darwinUri } = useContext(AppContext);
@@ -395,7 +399,7 @@ const CategoryTabPanel = ( { project, projectIndex, activeTab, showClosed, showS
                  sx={{ p: 3 }}
             >
                 { categoriesArray &&
-                    <Box className="card swarm-card" ref={panelDrop}>
+                    <Box className={`card swarm-card${(showSwarmStartCard && wideAggregator) ? ' aggregator-wide' : ''}`} ref={panelDrop}>
                         {showSwarmStartCard && <SwarmStartCard />}
                         { categoriesArray.map((category, categoryIndex) => (
                             <CategoryCard {...{key: category.id,

--- a/src/SwarmView/ModelEffortChip.jsx
+++ b/src/SwarmView/ModelEffortChip.jsx
@@ -1,0 +1,54 @@
+// Presentational cell for a single Model or Effort value in a requirement row
+// (req #3029). One component covers both axes (`kind`) and all three display
+// modes so RequirementRow stays declarative and the modes render identically
+// wherever they appear.
+//
+//   pill    → full colored chip, e.g. "Opus" / "XHigh"  (reuses the table-view look)
+//   text    → plain label, no background (theme-colored, low visual weight)
+//   compact → single-letter colored chip, e.g. "O" / "X" — saves horizontal space;
+//             the color still encodes the value and the tooltip names it in full
+//
+// Every mode carries a "Model: X" / "Effort: Y" tooltip so the abbreviated forms
+// are never ambiguous.
+
+import React from 'react';
+import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
+import { aiModelChipProps, aiModelLabel } from './modelChipStyles';
+import { effortChipProps, effortLabel } from './effortChipStyles';
+
+const ModelEffortChip = ({ kind, value, mode = 'pill', 'data-testid': testId }) => {
+    const isModel = kind === 'model';
+    const label = isModel ? aiModelLabel(value) : effortLabel(value);
+    const chipProps = isModel ? aiModelChipProps(value) : effortChipProps(value);
+    const tip = `${isModel ? 'Model' : 'Effort'}: ${label}`;
+
+    if (mode === 'compact') {
+        return (
+            <Tooltip title={tip} enterDelay={400} enterNextDelay={200}>
+                <Chip
+                    label={label.charAt(0)}
+                    size="small"
+                    data-testid={testId}
+                    {...chipProps}
+                    sx={{
+                        ...chipProps.sx,
+                        width: 22,
+                        height: 20,
+                        fontWeight: 600,
+                        '& .MuiChip-label': { px: 0 },
+                    }}
+                />
+            </Tooltip>
+        );
+    }
+
+    // pill (default) — semantic per-value color
+    return (
+        <Tooltip title={tip} enterDelay={400} enterNextDelay={200}>
+            <Chip label={label} size="small" data-testid={testId} {...chipProps} />
+        </Tooltip>
+    );
+};
+
+export default ModelEffortChip;

--- a/src/SwarmView/RequirementRow.jsx
+++ b/src/SwarmView/RequirementRow.jsx
@@ -29,9 +29,14 @@ import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import ForumIcon from '@mui/icons-material/Forum';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import PendingIcon from '@mui/icons-material/Pending';
-import { coordinationIconColor } from './coordinationChipStyles';
+import { coordinationIconColor, coordinationChipProps } from './coordinationChipStyles';
 import SyncIcon from '@mui/icons-material/Sync';
 import DoneAllIcon from '@mui/icons-material/DoneAll';
+import ModelEffortChip from './ModelEffortChip';
+import { modelEffortGridTemplate } from './modelEffortLayout';
+import { useModelEffortDisplayStore } from '../stores/useModelEffortDisplayStore';
+import { requirementStatusChipProps, requirementStatusLabel } from './statusChipStyles';
+import { swarmStatusChipProps, swarmStatusLabel } from './swarmStatusChipProps';
 
 
 const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryName }) => {
@@ -43,6 +48,13 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
         categoryColorMap, sortMode, setCrossCardInsertIndex,
         requirementsArray, setRequirementsArray,
         strikethroughMet = true } = useRequirementActions();
+
+    // Model + Effort column preferences (req #3029). The columns always render in
+    // the aggregator card; `showOnAllCards` promotes them onto CategoryCard rows
+    // too. `displayMode` chooses pill / text / compact rendering.
+    const showModelEffortOnAllCards = useModelEffortDisplayStore(s => s.showOnAllCards);
+    const modelEffortDisplayMode = useModelEffortDisplayStore(s => s.displayMode);
+    const modelEffortColumnOrder = useModelEffortDisplayStore(s => s.columnOrder);
 
     // Drag rules (req #2417):
     //   - Drag source is enabled for every non-template row, regardless of
@@ -288,7 +300,132 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
     };
 
     const isAggregatorRow = Boolean(categoryColorMap);
-    const rowClassName = `task requirement-row${isAggregatorRow ? ' aggregator-row' : ''}`;
+
+    // req #3029 — whether THIS row renders the Model + Effort columns. Decided at
+    // the card level (aggregator always; category cards only when the user opts
+    // in) so every row in a card agrees, keeping the shared grid template aligned.
+    // The two cells are rendered for the template row too (as empty placeholders)
+    // so its Title/delete stay in the same tracks as the data rows above it.
+    //
+    // The full grid-template is built here (single source of truth in
+    // modelEffortLayout.js) and applied via the `--me-grid` CSS custom property +
+    // the `me-cols` class. It must go through the class, NOT `sx`: `sx` compiles
+    // to a single-class rule (0,1,0) that loses to the base
+    // `.task.requirement-row[.aggregator-row]` templates in index.css (0,2,0 /
+    // 0,3,0). The `.me-cols` selectors there outrank those, so the injected
+    // template actually wins and the track count matches the rendered cells.
+    const showModelEffortColumns = isAggregatorRow || showModelEffortOnAllCards;
+    const rowClassName = `task requirement-row${isAggregatorRow ? ' aggregator-row' : ''}${showModelEffortColumns ? ' me-cols' : ''}`;
+    const modelEffortGridColumns = showModelEffortColumns
+        ? modelEffortGridTemplate({ isAggregatorRow, displayMode: modelEffortDisplayMode, columnOrder: modelEffortColumnOrder })
+        : undefined;
+
+    // req #3029 — the display mode actually applied to THIS row's Status /
+    // Autonomy / Model / Effort columns. Only the enhanced rows (aggregator, or
+    // category cards with the option on) follow the user's pill/text/compact
+    // choice; every other row is pinned to 'compact', which reproduces today's
+    // icon look exactly, so plain category cards are visually unchanged.
+    const effectiveDisplayMode = showModelEffortColumns ? modelEffortDisplayMode : 'compact';
+
+    // Status label + chip color for the pill/text renderings — mirror the icon
+    // precedence in getStatusIcon()/getStatusTooltip(): terminal requirement
+    // status first, then the live session status, then the requirement's own
+    // status. Terminal statuses (met/deferred/wontfix) never carry a session.
+    const getStatusChipLabel = () => {
+        if (status === 'met')      return requirementStatusLabel('met');
+        if (status === 'deferred') return requirementStatusLabel('deferred');
+        if (status === 'wontfix')  return requirementStatusLabel('wontfix');
+        if (sessionStatus)         return swarmStatusLabel(sessionStatus);
+        return requirementStatusLabel(status);
+    };
+    const getStatusChipStyle = () => {
+        if (status === 'met')      return requirementStatusChipProps('met');
+        if (status === 'deferred') return requirementStatusChipProps('deferred');
+        if (status === 'wontfix')  return requirementStatusChipProps('wontfix');
+        if (sessionStatus)         return swarmStatusChipProps(sessionStatus);
+        return requirementStatusChipProps(status);
+    };
+    // Autonomy label for pill/text — simple capitalization of the coordination type.
+    const coordChipLabel = coordType ? coordType.charAt(0).toUpperCase() + coordType.slice(1) : '';
+
+    // --- Status cell — icon (compact) / colored pill / plain text --------------
+    // Compact preserves today's exact markup (clickable IconButton when the status
+    // is cyclable, bare tooltip'd icon otherwise). Pill/text keep the same tooltip
+    // and the same `status-toggle-<id>` test id + click-to-cycle on cyclable rows.
+    const renderStatusCell = () => {
+        if (requirement.id === '') return null;
+        if (effectiveDisplayMode === 'compact') {
+            return canCycleStatus ? (
+                <Tooltip title={statusTooltip[status] || status} enterDelay={400} enterNextDelay={200}>
+                    <IconButton
+                        onClick={() => statusClick(requirementIndex, requirement.id)}
+                        data-testid={`status-toggle-${requirement.id}`}
+                        sx={{ maxWidth: 28, maxHeight: 28 }}
+                    >
+                        {getStatusIcon()}
+                    </IconButton>
+                </Tooltip>
+            ) : (
+                <Tooltip title={getStatusTooltip()} enterDelay={400} enterNextDelay={200}>
+                    {getStatusIcon()}
+                </Tooltip>
+            );
+        }
+        // pill — colored status chip, still click-to-cycle on cyclable rows.
+        const label = getStatusChipLabel();
+        const testId = canCycleStatus ? `status-toggle-${requirement.id}` : undefined;
+        const onClick = canCycleStatus ? () => statusClick(requirementIndex, requirement.id) : undefined;
+        const { sx: chipSx, ...chipRest } = getStatusChipStyle();
+        return (
+            <Tooltip title={getStatusTooltip()} enterDelay={400} enterNextDelay={200}>
+                <Chip label={label} size="small" clickable={canCycleStatus} onClick={onClick}
+                      data-testid={testId} {...chipRest}
+                      sx={{ ...(chipSx || {}), maxWidth: '100%', textTransform: 'capitalize' }} />
+            </Tooltip>
+        );
+    };
+
+    // --- Autonomy cell — icon (compact) / colored pill / plain text ------------
+    // Visible only for swarm_ready + development; editable only for swarm_ready
+    // (unchanged from the icon version). Keeps the `coordination-toggle-<id>` test
+    // id across all three modes.
+    const renderAutonomyCell = () => {
+        if (requirement.id === '') return null;
+        const showCoord = ['swarm_ready', 'development'].includes(status);
+        if (!showCoord) return null;
+        const isCoordEditable = status === 'swarm_ready';
+        const tooltip = isCoordEditable
+            ? (coordTooltip[coordType] || 'No autonomy — click to set')
+            : 'Locked — not editable';
+        const testId = `coordination-toggle-${requirement.id}`;
+        if (effectiveDisplayMode === 'compact') {
+            return (
+                <Tooltip title={tooltip} enterDelay={400} enterNextDelay={200}>
+                    <span>
+                        <IconButton
+                            onClick={() => coordinationClick(requirementIndex, requirement.id)}
+                            disabled={!isCoordEditable}
+                            data-testid={testId}
+                            sx={{ maxWidth: 28, maxHeight: 28, '&.Mui-disabled': { opacity: 1 } }}
+                        >
+                            {getCoordinationIcon()}
+                        </IconButton>
+                    </span>
+                </Tooltip>
+            );
+        }
+        // pill — colored autonomy chip, editable only on swarm_ready.
+        const onClick = isCoordEditable ? () => coordinationClick(requirementIndex, requirement.id) : undefined;
+        const { sx: coordSx, ...coordRest } = coordinationChipProps(coordType);
+        return (
+            <Tooltip title={tooltip} enterDelay={400} enterNextDelay={200}>
+                <Chip label={coordChipLabel} size="small" clickable={isCoordEditable} onClick={onClick}
+                      data-testid={testId} {...coordRest}
+                      sx={{ ...(coordSx || {}), maxWidth: '100%', textTransform: 'capitalize',
+                            ...(!isCoordEditable && { opacity: 0.85 }) }} />
+            </Tooltip>
+        );
+    };
 
     // Category color bar fill + delineating edge (req #2752).
     // Verified root cause: the bar already renders the exact category color
@@ -315,11 +452,96 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
         }
     }
 
+    // The two Model/Effort cells (empty placeholders on the template row so the
+    // grid stays aligned), or null when the card isn't showing them. Their
+    // position among the value cells is set by columnOrder below; the grid
+    // template in modelEffortLayout.js orders the tracks to match.
+    const modelEffortCells = showModelEffortColumns ? (
+        <>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', px: '2px' }}>
+                {requirement.id !== '' && (
+                    <ModelEffortChip
+                        kind="model"
+                        value={requirement.ai_model}
+                        mode={modelEffortDisplayMode}
+                        data-testid={`model-cell-${requirement.id}`}
+                    />
+                )}
+            </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', px: '2px' }}>
+                {requirement.id !== '' && (
+                    <ModelEffortChip
+                        kind="effort"
+                        value={requirement.effort}
+                        mode={modelEffortDisplayMode}
+                        data-testid={`effort-cell-${requirement.id}`}
+                    />
+                )}
+            </Box>
+        </>
+    ) : null;
+
+    // Requirement # chip — clickable, navigates to detail.
+    const reqIdCell = (
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minWidth: 44, pr: '2px' }}>
+            {requirement.id !== '' ? (
+                // testid deliberately does NOT start with `requirement-` to avoid colliding with the
+                // E2E prefix selector `[data-testid^="requirement-"]` used in swarm.spec.ts.
+                <Tooltip title="Open requirement details" enterDelay={400} enterNextDelay={200}>
+                    <Chip
+                        label={requirement.id}
+                        size="small"
+                        variant="outlined"
+                        clickable
+                        onClick={() => navigate(`/swarm/requirement/${requirement.id}`)}
+                        aria-label={`Open requirement ${requirement.id}`}
+                        data-testid={`req-id-chip-${requirement.id}`}
+                    />
+                </Tooltip>
+            ) : null}
+        </Box>
+    );
+
+    // Status — icon (compact) / pill per display mode. Clickable cycle for
+    // authoring/approved/swarm_ready in every mode.
+    const statusCell = (
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minWidth: 28,
+                   overflow: 'hidden', ...(effectiveDisplayMode !== 'compact' && { px: '2px' }) }}>
+            {renderStatusCell()}
+        </Box>
+    );
+
+    // Autonomy — icon (compact) / pill per display mode. Visible only for
+    // swarm_ready and development; editable only for swarm_ready.
+    const autonomyCell = (
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minWidth: 28,
+                   overflow: 'hidden', ...(effectiveDisplayMode !== 'compact' && { px: '2px' }) }}>
+            {renderAutonomyCell()}
+        </Box>
+    );
+
+    // Arrange the value cells per the column-order option (req #3029). When the
+    // card isn't showing Model/Effort, modelEffortCells is null and drops out, so
+    // every arrangement collapses to Req# · Status · Autonomy (the base layout).
+    let orderedValueCells;
+    if (modelEffortColumnOrder === 'meFirst') {
+        orderedValueCells = <>{modelEffortCells}{reqIdCell}{statusCell}{autonomyCell}</>;
+    } else if (modelEffortColumnOrder === 'meAfterReq') {
+        orderedValueCells = <>{reqIdCell}{modelEffortCells}{statusCell}{autonomyCell}</>;
+    } else { // 'standard'
+        orderedValueCells = <>{reqIdCell}{statusCell}{autonomyCell}{modelEffortCells}</>;
+    }
+
     return (
         <Box className={rowClassName}
              data-testid={requirement.id === '' ? 'requirement-template' : `requirement-${requirement.id}`}
              key={`box-${requirement.id}`}
              ref={isTemplate ? null : mergedRef}
+             // req #3029 — inline custom property consumed by the `.me-cols` rules
+             // in index.css (see the grid-template comment above). Set via `style`
+             // (a real inline custom property) rather than `sx` so it reliably
+             // reaches the higher-specificity class selector.
+             style={modelEffortGridColumns ? { '--me-grid': modelEffortGridColumns } : undefined}
              sx={{
                  // While dragging, collapse the source row in hand mode (so
                  // the splice preview at the insert indicator is uncluttered).
@@ -363,71 +585,9 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
                 </Box>
             )}
 
-            {/* Col "chip": Requirement # chip — clickable, navigates to detail (replaces numerical ordering + settings button) */}
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minWidth: 44, pr: '2px' }}>
-                {requirement.id !== '' ? (
-                    // testid deliberately does NOT start with `requirement-` to avoid colliding with the
-                    // E2E prefix selector `[data-testid^="requirement-"]` used in swarm.spec.ts.
-                    <Tooltip title="Open requirement details" enterDelay={400} enterNextDelay={200}>
-                        <Chip
-                            label={requirement.id}
-                            size="small"
-                            variant="outlined"
-                            clickable
-                            onClick={() => navigate(`/swarm/requirement/${requirement.id}`)}
-                            aria-label={`Open requirement ${requirement.id}`}
-                            data-testid={`req-id-chip-${requirement.id}`}
-                        />
-                    </Tooltip>
-                ) : null}
-            </Box>
-
-            {/* Status icon — clickable cycle for authoring/approved/swarm_ready */}
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minWidth: 28 }}>
-                {requirement.id !== '' ? (
-                    canCycleStatus ? (
-                        <Tooltip title={statusTooltip[status] || status} enterDelay={400} enterNextDelay={200}>
-                            <IconButton
-                                onClick={() => statusClick(requirementIndex, requirement.id)}
-                                data-testid={`status-toggle-${requirement.id}`}
-                                sx={{ maxWidth: 28, maxHeight: 28 }}
-                            >
-                                {getStatusIcon()}
-                            </IconButton>
-                        </Tooltip>
-                    ) : (
-                        <Tooltip title={getStatusTooltip()} enterDelay={400} enterNextDelay={200}>
-                            {getStatusIcon()}
-                        </Tooltip>
-                    )
-                ) : null}
-            </Box>
-
-            {/* Coordination type icon — visible only for swarm_ready and development; editable only for swarm_ready */}
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minWidth: 28 }}>
-                {requirement.id !== '' ? (() => {
-                    const showCoord = ['swarm_ready', 'development'].includes(status);
-                    if (!showCoord) return null;
-                    const isCoordEditable = status === 'swarm_ready';
-                    const tooltip = isCoordEditable
-                        ? (coordTooltip[coordType] || 'No autonomy — click to set')
-                        : 'Locked — not editable';
-                    return (
-                        <Tooltip title={tooltip} enterDelay={400} enterNextDelay={200}>
-                            <span>
-                                <IconButton
-                                    onClick={() => coordinationClick(requirementIndex, requirement.id)}
-                                    disabled={!isCoordEditable}
-                                    data-testid={`coordination-toggle-${requirement.id}`}
-                                    sx={{ maxWidth: 28, maxHeight: 28, '&.Mui-disabled': { opacity: 1 } }}
-                                >
-                                    {getCoordinationIcon()}
-                                </IconButton>
-                            </span>
-                        </Tooltip>
-                    );
-                })() : null}
-            </Box>
+            {/* Value cells (Req#, Status, Autonomy, Model, Effort) — arranged per
+                the column-order option (req #3029). */}
+            {orderedValueCells}
 
             {/* Title */}
             <TextField variant="outlined"

--- a/src/SwarmView/SwarmView.jsx
+++ b/src/SwarmView/SwarmView.jsx
@@ -7,6 +7,7 @@ import { useSwarmTabStore } from '../stores/useSwarmTabStore';
 import { useWorkingProjectStore } from '../stores/useWorkingProjectStore';
 import { useShowClosedStore, ALL_REQUIREMENT_STATUSES } from '../stores/useShowClosedStore';
 import { useSwarmStartCardStore } from '../stores/useSwarmStartCardStore';
+import { useModelEffortDisplayStore } from '../stores/useModelEffortDisplayStore';
 import { useRequirementDrillStore } from '../stores/useRequirementDrillStore';
 import { useProjects } from '../hooks/useDataQueries';
 import { projectKeys } from '../hooks/useQueryKeys';
@@ -34,6 +35,13 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Divider from '@mui/material/Divider';
+import Check from '@mui/icons-material/Check';
+import TuneIcon from '@mui/icons-material/Tune';
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
@@ -75,6 +83,17 @@ const SwarmView = () => {
     const toggleRequirementStatus = useShowClosedStore(s => s.toggleRequirementStatus);
     const showSwarmStartCard = useSwarmStartCardStore(s => s.show);
     const toggleSwarmStartCard = useSwarmStartCardStore(s => s.toggle);
+    // Model/Effort column display options (req #3029) — surfaced as a Tune menu in
+    // the cards-view header ("title row").
+    const meShowOnAllCards = useModelEffortDisplayStore(s => s.showOnAllCards);
+    const meToggleShowOnAllCards = useModelEffortDisplayStore(s => s.toggleShowOnAllCards);
+    const meDisplayMode = useModelEffortDisplayStore(s => s.displayMode);
+    const meSetDisplayMode = useModelEffortDisplayStore(s => s.setDisplayMode);
+    const meWideAggregator = useModelEffortDisplayStore(s => s.wideAggregator);
+    const meToggleWideAggregator = useModelEffortDisplayStore(s => s.toggleWideAggregator);
+    const meColumnOrder = useModelEffortDisplayStore(s => s.columnOrder);
+    const meSetColumnOrder = useModelEffortDisplayStore(s => s.setColumnOrder);
+    const [meMenuAnchor, setMeMenuAnchor] = useState(null);
     // req #2850 — a Trends drill-down is active; in Table view the status-filter
     // chips are replaced by the drill pill (the chips don't apply while drilled).
     const drill = useRequirementDrillStore(s => s.drill);
@@ -312,6 +331,100 @@ const SwarmView = () => {
                                     <RocketLaunchIcon />
                                 </IconButton>
                             </Tooltip>
+                        )}
+                        {view === 'cards' && (
+                            <>
+                                <Tooltip title="Model / Effort display options">
+                                    <IconButton
+                                        size="small"
+                                        onClick={(e) => setMeMenuAnchor(e.currentTarget)}
+                                        color={meShowOnAllCards ? 'primary' : 'default'}
+                                        data-testid="model-effort-display-menu"
+                                        sx={{ flexShrink: 0 }}
+                                    >
+                                        <TuneIcon />
+                                    </IconButton>
+                                </Tooltip>
+                                <Menu
+                                    anchorEl={meMenuAnchor}
+                                    open={Boolean(meMenuAnchor)}
+                                    onClose={() => setMeMenuAnchor(null)}
+                                    anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                                    transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                                >
+                                    <MenuItem
+                                        onClick={meToggleShowOnAllCards}
+                                        data-testid="model-effort-show-all-cards"
+                                    >
+                                        <ListItemIcon>
+                                            {meShowOnAllCards && <Check fontSize="small" />}
+                                        </ListItemIcon>
+                                        <ListItemText>Show Model &amp; Effort on all cards</ListItemText>
+                                    </MenuItem>
+                                    <Divider />
+                                    <ListItemText
+                                        sx={{ px: 2, py: 0.5, color: 'text.secondary' }}
+                                        primaryTypographyProps={{ variant: 'caption' }}
+                                    >
+                                        Display
+                                    </ListItemText>
+                                    {[
+                                        { mode: 'pill', label: 'Pill' },
+                                        { mode: 'compact', label: 'Compact' },
+                                    ].map(({ mode, label }) => (
+                                        <MenuItem
+                                            key={mode}
+                                            onClick={() => meSetDisplayMode(mode)}
+                                            data-testid={`model-effort-mode-${mode}`}
+                                        >
+                                            <ListItemIcon>
+                                                {meDisplayMode === mode && <Check fontSize="small" />}
+                                            </ListItemIcon>
+                                            <ListItemText>{label}</ListItemText>
+                                        </MenuItem>
+                                    ))}
+                                    <Divider />
+                                    <ListItemText
+                                        sx={{ px: 2, py: 0.5, color: 'text.secondary' }}
+                                        primaryTypographyProps={{ variant: 'caption' }}
+                                    >
+                                        Column order
+                                    </ListItemText>
+                                    <Box sx={{ px: 2, py: 0.5 }}>
+                                        <ToggleButtonGroup
+                                            value={meColumnOrder}
+                                            exclusive
+                                            size="small"
+                                            onChange={(e, v) => { if (v) meSetColumnOrder(v); }}
+                                            data-testid="model-effort-order"
+                                        >
+                                            {[
+                                                { value: 'standard',   label: 'Default',     tip: 'Req · Status · Autonomy · Model · Effort' },
+                                                { value: 'meFirst',     label: 'M/E First',   tip: 'Model · Effort · Req · Status · Autonomy' },
+                                                { value: 'meAfterReq',  label: 'M/E After #', tip: 'Req · Model · Effort · Status · Autonomy' },
+                                            ].map(({ value, label, tip }) => (
+                                                <ToggleButton
+                                                    key={value}
+                                                    value={value}
+                                                    data-testid={`model-effort-order-${value}`}
+                                                    sx={{ textTransform: 'none', px: 1 }}
+                                                >
+                                                    <Tooltip title={tip}><span>{label}</span></Tooltip>
+                                                </ToggleButton>
+                                            ))}
+                                        </ToggleButtonGroup>
+                                    </Box>
+                                    <MenuItem
+                                        onClick={meToggleWideAggregator}
+                                        data-testid="model-effort-wide-aggregator"
+                                    >
+                                        <ListItemIcon>
+                                            {meWideAggregator && <Check fontSize="small" />}
+                                        </ListItemIcon>
+                                        <ListItemText>Wide aggregator card</ListItemText>
+                                    </MenuItem>
+                                </Menu>
+                            </>
                         )}
                         <SettingsMenu
                             tooltipTitle="Manage Projects & Categories"

--- a/src/SwarmView/__tests__/ModelEffortChip.test.jsx
+++ b/src/SwarmView/__tests__/ModelEffortChip.test.jsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+//
+// Req #3029 — the Model/Effort cell renders one value in one of two modes. The
+// rules that matter for correctness: the right label (with the documented
+// null/unknown fallbacks — Opus for model, High for effort), and the right DOM
+// shape per mode (pill = full label in a Chip, compact = the single leading
+// letter in a Chip).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import ModelEffortChip from '../ModelEffortChip';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container;
+let root;
+
+const render = (el) => {
+    act(() => {
+        root.render(el);
+    });
+};
+
+beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+});
+
+const hasChip = () => Boolean(container.querySelector('.MuiChip-root'));
+
+describe('ModelEffortChip (req #3029)', () => {
+    it('pill mode renders the full model label inside a chip', () => {
+        render(<ModelEffortChip kind="model" value="opus" mode="pill" />);
+        expect(container.textContent).toContain('Opus');
+        expect(hasChip()).toBe(true);
+    });
+
+    it('compact mode renders only the leading letter, inside a chip', () => {
+        render(<ModelEffortChip kind="model" value="fable" mode="compact" />);
+        expect(container.textContent.trim()).toBe('F');
+        expect(hasChip()).toBe(true);
+    });
+
+    it('effort pill uses the effort label (XHigh)', () => {
+        render(<ModelEffortChip kind="effort" value="xhigh" mode="pill" />);
+        expect(container.textContent).toContain('XHigh');
+    });
+
+    it('effort compact uses the leading letter of the effort label', () => {
+        render(<ModelEffortChip kind="effort" value="ultracode" mode="compact" />);
+        expect(container.textContent.trim()).toBe('U');
+    });
+
+    it('falls back to Opus for a null model value', () => {
+        render(<ModelEffortChip kind="model" value={null} mode="pill" />);
+        expect(container.textContent).toContain('Opus');
+    });
+
+    it('falls back to High for a null effort value', () => {
+        render(<ModelEffortChip kind="effort" value={null} mode="pill" />);
+        expect(container.textContent).toContain('High');
+    });
+
+    it('forwards data-testid to the rendered node', () => {
+        render(<ModelEffortChip kind="model" value="opus" mode="pill" data-testid="model-cell-42" />);
+        expect(container.querySelector('[data-testid="model-cell-42"]')).toBeTruthy();
+    });
+});

--- a/src/SwarmView/__tests__/modelEffortLayout.test.js
+++ b/src/SwarmView/__tests__/modelEffortLayout.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+    MODEL_EFFORT_COL_WIDTHS,
+    modelEffortGridTemplate,
+    baseGridTemplate,
+} from '../modelEffortLayout';
+import {
+    MODEL_EFFORT_DISPLAY_MODES,
+    MODEL_EFFORT_COLUMN_ORDERS,
+} from '../../stores/useModelEffortDisplayStore';
+
+// req #3029 — the Model/Effort columns override grid-template-columns inline, so
+// the invariant that matters is: the injected template has exactly TWO more
+// tracks than the base template, in the order chosen by columnOrder. A miscount
+// silently shoves Title/delete into the wrong column for every row in the card.
+
+const tracks = (tpl) => tpl.split(/\s+/).filter(Boolean);
+
+describe('modelEffortGridTemplate (req #3029)', () => {
+    it('defines a width for all four mode columns in every supported display mode', () => {
+        for (const mode of MODEL_EFFORT_DISPLAY_MODES) {
+            expect(MODEL_EFFORT_COL_WIDTHS[mode]).toBeTruthy();
+            for (const col of ['status', 'autonomy', 'model', 'effort']) {
+                expect(MODEL_EFFORT_COL_WIDTHS[mode][col]).toBeGreaterThan(0);
+            }
+        }
+    });
+
+    it('supports exactly pill + compact display modes', () => {
+        expect(Object.keys(MODEL_EFFORT_COL_WIDTHS).sort()).toEqual(['compact', 'pill']);
+    });
+
+    it('keeps Status/Autonomy at the icon width (28px) in compact mode', () => {
+        expect(MODEL_EFFORT_COL_WIDTHS.compact.status).toBe(28);
+        expect(MODEL_EFFORT_COL_WIDTHS.compact.autonomy).toBe(28);
+    });
+
+    it('adds exactly two tracks over the base template — category card', () => {
+        const base = tracks(baseGridTemplate({ isAggregatorRow: false }));
+        const withME = tracks(modelEffortGridTemplate({ isAggregatorRow: false, displayMode: 'pill', columnOrder: 'standard' }));
+        expect(base.length).toBe(5);
+        expect(withME.length).toBe(base.length + 2);
+    });
+
+    it('adds exactly two tracks over the base template — aggregator card', () => {
+        const base = tracks(baseGridTemplate({ isAggregatorRow: true }));
+        const withME = tracks(modelEffortGridTemplate({ isAggregatorRow: true, displayMode: 'pill', columnOrder: 'standard' }));
+        expect(base.length).toBe(6);
+        expect(withME.length).toBe(base.length + 2);
+    });
+
+    it('standard order: Req·Status·Autonomy·Model·Effort before Title (aggregator, pill)', () => {
+        // color-bar · Req# · Status · Autonomy · Model · Effort · Title(1fr) · delete(auto)
+        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: true, displayMode: 'pill', columnOrder: 'standard' }));
+        expect(t).toEqual(['24px', '56px', '116px', '112px', '66px', '88px', '1fr', 'auto']);
+    });
+
+    it('standard order (category, pill)', () => {
+        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: false, displayMode: 'pill', columnOrder: 'standard' }));
+        expect(t).toEqual(['56px', '116px', '112px', '66px', '88px', '1fr', 'auto']);
+    });
+
+    it('meFirst order leads with Model·Effort, keeping color-bar first (aggregator)', () => {
+        // color-bar · Model · Effort · Req# · Status · Autonomy · Title · delete
+        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: true, displayMode: 'pill', columnOrder: 'meFirst' }));
+        expect(t).toEqual(['24px', '66px', '88px', '56px', '116px', '112px', '1fr', 'auto']);
+    });
+
+    it('meAfterReq order places Model·Effort between Req# and Status (aggregator)', () => {
+        // color-bar · Req# · Model · Effort · Status · Autonomy · Title · delete
+        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: true, displayMode: 'pill', columnOrder: 'meAfterReq' }));
+        expect(t).toEqual(['24px', '56px', '66px', '88px', '116px', '112px', '1fr', 'auto']);
+    });
+
+    it('meAfterReq order (category)', () => {
+        // Req# · Model · Effort · Status · Autonomy · Title · delete
+        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: false, displayMode: 'pill', columnOrder: 'meAfterReq' }));
+        expect(t).toEqual(['56px', '66px', '88px', '116px', '112px', '1fr', 'auto']);
+    });
+
+    it('collapses to icon/letter widths in compact mode (matches today for Status/Autonomy)', () => {
+        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: false, displayMode: 'compact', columnOrder: 'standard' }));
+        expect(t).toEqual(['56px', '28px', '28px', '30px', '30px', '1fr', 'auto']);
+    });
+
+    it('falls back to pill widths for an unknown mode', () => {
+        const unknown = modelEffortGridTemplate({ isAggregatorRow: false, displayMode: 'nope', columnOrder: 'standard' });
+        const pill = modelEffortGridTemplate({ isAggregatorRow: false, displayMode: 'pill', columnOrder: 'standard' });
+        expect(unknown).toBe(pill);
+    });
+
+    it('every column order still adds exactly two tracks over base', () => {
+        const base = tracks(baseGridTemplate({ isAggregatorRow: true }));
+        for (const columnOrder of MODEL_EFFORT_COLUMN_ORDERS) {
+            const withME = tracks(modelEffortGridTemplate({ isAggregatorRow: true, displayMode: 'compact', columnOrder }));
+            expect(withME.length).toBe(base.length + 2);
+        }
+    });
+});

--- a/src/SwarmView/modelEffortLayout.js
+++ b/src/SwarmView/modelEffortLayout.js
@@ -1,0 +1,66 @@
+// Grid geometry for the mode-driven requirement-row columns (req #3029).
+//
+// The pill / text / compact display mode governs FOUR value columns — Status,
+// Autonomy, Model, Effort — wherever the enhanced columns are shown (the
+// aggregator always; category cards when the user opts in). 'compact' reproduces
+// today's look exactly: Status/Autonomy are their small icons and Model/Effort
+// are single-letter chips.
+//
+// Each RequirementRow is its OWN CSS grid (`.task { display:grid }`), so column
+// tracks do NOT share sizing across rows automatically — vertical alignment
+// within a card holds only because every row uses the SAME template. That means
+// these tracks must be FIXED widths (never `auto`), otherwise a row with a wide
+// value ("Implementing" / "Ultracode") would misalign against a narrow one.
+//
+// Widths are per display-mode, sized to the widest label each column must hold:
+//   • Status  — "Implementing" (session) / "Swarm-Start" (requirement)
+//   • Autonomy — "Implemented"
+//   • Effort  — "Ultracode"
+//   • Model   — "Sonnet"
+// 'compact' keeps Status/Autonomy at the icon width (28px) they use today.
+
+export const MODEL_EFFORT_COL_WIDTHS = {
+    pill:    { status: 116, autonomy: 112, model: 66, effort: 88 },
+    compact: { status: 28,  autonomy: 28,  model: 30, effort: 30 },
+};
+
+// Base (no mode columns) row templates — mirror the CSS in index.css so this
+// module is the single source of truth when the columns ARE injected.
+//   category  : Req# · Status · Autonomy · Title · delete
+//   aggregator: color-bar · Req# · Status · Autonomy · Title · delete
+const BASE_CATEGORY = ['56px', '28px', '28px', '1fr', 'auto'];
+const BASE_AGGREGATOR = ['24px', '56px', '28px', '28px', '1fr', 'auto'];
+
+// Build the `grid-template-columns` value for a row rendering the mode columns.
+// The five value tracks (Req# always 56px; Status/Autonomy/Model/Effort at their
+// per-mode widths) are arranged per `columnOrder`:
+//   'standard'   : … · Req# · Status · Autonomy · Model · Effort · Title · delete
+//   'meFirst'    : … · Model · Effort · Req# · Status · Autonomy · Title · delete
+//   'meAfterReq' : … · Req# · Model · Effort · Status · Autonomy · Title · delete
+// The color-bar (aggregator only) always stays leftmost. The rendered cell order
+// in RequirementRow mirrors this exactly.
+//
+// Returns a space-joined string suitable for the `--me-grid` custom property.
+export const modelEffortGridTemplate = ({ isAggregatorRow, displayMode, columnOrder }) => {
+    const w = MODEL_EFFORT_COL_WIDTHS[displayMode] || MODEL_EFFORT_COL_WIDTHS.pill;
+    const req = '56px';
+    const status = `${w.status}px`;
+    const autonomy = `${w.autonomy}px`;
+    const model = `${w.model}px`;
+    const effort = `${w.effort}px`;
+    let ordered;
+    if (columnOrder === 'meFirst') {
+        ordered = [model, effort, req, status, autonomy];
+    } else if (columnOrder === 'meAfterReq') {
+        ordered = [req, model, effort, status, autonomy];
+    } else { // 'standard'
+        ordered = [req, status, autonomy, model, effort];
+    }
+    const bar = isAggregatorRow ? ['24px'] : [];
+    return [...bar, ...ordered, '1fr', 'auto'].join(' ');
+};
+
+// Exposed for tests: the base templates the CSS provides when the columns are
+// NOT injected (so the count-of-tracks assertions have a reference point).
+export const baseGridTemplate = ({ isAggregatorRow }) =>
+    (isAggregatorRow ? BASE_AGGREGATOR : BASE_CATEGORY).join(' ');

--- a/src/TaskPlanView/SwarmStartCard.jsx
+++ b/src/TaskPlanView/SwarmStartCard.jsx
@@ -132,7 +132,9 @@ const SwarmStartCard = () => {
         profile?.userName,
         metWindow.startStr,
         metWindow.endStr,
-        { fields: 'id,title,requirement_status,coordination_type,category_fk,completed_at' },
+        // ai_model,effort included so the Met chip's rows can render the Model +
+        // Effort columns too (req #3029); the active-status query already carries them.
+        { fields: 'id,title,requirement_status,coordination_type,ai_model,effort,category_fk,completed_at' },
     );
 
     // The array that drives the card body for the currently selected chip.

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -253,7 +253,13 @@ export function useRequirementsDone(creatorFk, startStr, endStr, { fields = 'id,
     const { idToken } = useContext(AuthContext);
 
     const uri = `${darwinUri}/requirements?requirement_status=met&filter_ts=(completed_at,${startStr},${endStr})&fields=${fields}`;
-    const queryKey = requirementKeys.done(creatorFk, `${startStr}_${endStr}`);
+    // Include `fields` in the cache key (mirrors useAllRequirements) — multiple
+    // consumers hit this hook for the SAME window with DIFFERENT projections
+    // (SwarmStartCard needs ai_model,effort for its Model/Effort chips; CalendarFC
+    // does not). Without `fields` in the key they'd share one cache entry and the
+    // narrower fetch could win, blanking the Model/Effort columns to fallbacks
+    // (req #3029). Prefix invalidation via requirementKeys.all still matches.
+    const queryKey = [...requirementKeys.done(creatorFk, `${startStr}_${endStr}`), { fields }];
 
     return useQuery({
         queryKey,

--- a/src/index.css
+++ b/src/index.css
@@ -78,6 +78,19 @@
     }
 }
 
+/* req #3029 — the aggregator (Swarm-Start) card carries two extra columns
+   (Model + Effort), so on wide viewports let it span two grid tracks and read
+   as slightly larger than the category cards while the rest reflow around it.
+   Gated on `.aggregator-wide` (a UI option): when the user turns the wide
+   aggregator off, the class is absent and the card stays one track — the same
+   width as every other card. Below this width it spans one track regardless, so
+   the grid still collapses to the ~3× layout and, on mobile, to a single column. */
+@media screen and (min-width: 1600px) {
+    .card.swarm-card.aggregator-wide > [data-testid="swarm-start-card"] {
+        grid-column: span 2;
+    }
+}
+
 .task {
     display: grid;
     grid-template-columns: auto auto 1fr auto;
@@ -104,6 +117,21 @@
     .task.requirement-row.aggregator-row {
         grid-template-columns: 24px 56px 28px 28px 1fr auto;
     }
+}
+
+/* req #3029 — Model + Effort columns. When present, RequirementRow adds `me-cols`
+   and sets the `--me-grid` custom property to the full grid-template (built in
+   modelEffortLayout.js, per display mode). These selectors carry one more class
+   than the base row templates above, so they outrank them regardless of source
+   order — the reason the template is applied here rather than via MUI `sx` (which
+   would generate only a single-class rule and lose to the base templates). No
+   media variant is needed: with higher specificity these win at every width. */
+.task.requirement-row.me-cols {
+    grid-template-columns: var(--me-grid);
+}
+
+.task.requirement-row.aggregator-row.me-cols {
+    grid-template-columns: var(--me-grid);
 }
 
 .app-navbar{

--- a/src/stores/__tests__/useModelEffortDisplayStore.test.js
+++ b/src/stores/__tests__/useModelEffortDisplayStore.test.js
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+//
+// Req #3029 — display preferences for the Model + Effort row columns. Exercises
+// the REAL store actions because the behaviors most likely to regress are the
+// toggles and the enum-validation guards that keep a bad value (a retired
+// display mode / column order) from ever reaching the render path.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    useModelEffortDisplayStore,
+    MODEL_EFFORT_DISPLAY_MODES,
+    MODEL_EFFORT_COLUMN_ORDERS,
+} from '../useModelEffortDisplayStore';
+
+const state = () => useModelEffortDisplayStore.getState();
+
+describe('useModelEffortDisplayStore (req #3029)', () => {
+    beforeEach(() => {
+        useModelEffortDisplayStore.setState({
+            showOnAllCards: false, displayMode: 'pill',
+            wideAggregator: true, columnOrder: 'standard',
+        });
+    });
+
+    it('defaults to aggregator-only + pill, wide aggregator, standard column order', () => {
+        expect(state().showOnAllCards).toBe(false);
+        expect(state().displayMode).toBe('pill');
+        expect(state().wideAggregator).toBe(true);
+        expect(state().columnOrder).toBe('standard');
+    });
+
+    it('lists exactly the two supported display modes', () => {
+        expect(MODEL_EFFORT_DISPLAY_MODES).toEqual(['pill', 'compact']);
+    });
+
+    it('lists exactly the three supported column orders', () => {
+        expect(MODEL_EFFORT_COLUMN_ORDERS).toEqual(['standard', 'meFirst', 'meAfterReq']);
+    });
+
+    it('toggleShowOnAllCards flips the boolean both directions', () => {
+        state().toggleShowOnAllCards();
+        expect(state().showOnAllCards).toBe(true);
+        state().toggleShowOnAllCards();
+        expect(state().showOnAllCards).toBe(false);
+    });
+
+    it('setShowOnAllCards coerces to a boolean', () => {
+        state().setShowOnAllCards(1);
+        expect(state().showOnAllCards).toBe(true);
+        state().setShowOnAllCards(0);
+        expect(state().showOnAllCards).toBe(false);
+    });
+
+    it('toggleWideAggregator flips the boolean both directions', () => {
+        state().toggleWideAggregator();
+        expect(state().wideAggregator).toBe(false);
+        state().toggleWideAggregator();
+        expect(state().wideAggregator).toBe(true);
+    });
+
+    it('setDisplayMode accepts each supported mode', () => {
+        for (const mode of MODEL_EFFORT_DISPLAY_MODES) {
+            state().setDisplayMode(mode);
+            expect(state().displayMode).toBe(mode);
+        }
+    });
+
+    it('setDisplayMode falls back to pill for an unknown/retired mode', () => {
+        state().setDisplayMode('compact');
+        state().setDisplayMode('clean'); // retired
+        expect(state().displayMode).toBe('pill');
+        state().setDisplayMode(null);
+        expect(state().displayMode).toBe('pill');
+    });
+
+    it('setColumnOrder accepts each supported order', () => {
+        for (const order of MODEL_EFFORT_COLUMN_ORDERS) {
+            state().setColumnOrder(order);
+            expect(state().columnOrder).toBe(order);
+        }
+    });
+
+    it('setColumnOrder falls back to standard for an unknown order', () => {
+        state().setColumnOrder('meFirst');
+        state().setColumnOrder('bogus');
+        expect(state().columnOrder).toBe('standard');
+        state().setColumnOrder(null);
+        expect(state().columnOrder).toBe('standard');
+    });
+});

--- a/src/stores/useModelEffortDisplayStore.js
+++ b/src/stores/useModelEffortDisplayStore.js
@@ -1,0 +1,69 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+// Global display preferences for the Model + Effort row columns (req #3029).
+//
+// The Model and Effort columns render inside the aggregator (Swarm-Start) card
+// and, when opted in, on every CategoryCard row. These preferences control the
+// user-facing options:
+//
+//   • `showOnAllCards` — promote the columns onto every CategoryCard row too, not
+//                        just the aggregator. Default false (aggregator only).
+//   • `displayMode`    — how each value is drawn:
+//        'pill'    → full semantic-colored chip (e.g. "Opus", "XHigh")   [default]
+//        'compact' → single-letter colored chip ("O", "X") for Model/Effort and
+//                    the small icons for Status/Autonomy — the horizontal-space saver
+//   • `columnOrder`    — arrangement of the five value columns (Req# always follows
+//                        the aggregator color-bar):
+//        'standard'   → Req# · Status · Autonomy · Model · Effort   [default]
+//        'meFirst'    → Model · Effort · Req# · Status · Autonomy
+//        'meAfterReq' → Req# · Model · Effort · Status · Autonomy
+//   • `wideAggregator` — on wide viewports let the aggregator card span two grid
+//                        tracks so its extra columns fit. Default true; off keeps
+//                        it the same width as every other card.
+//
+// Persisted so the choice survives reloads, mirroring useSwarmStartCardStore.
+
+export const MODEL_EFFORT_DISPLAY_MODES = ['pill', 'compact'];
+export const MODEL_EFFORT_COLUMN_ORDERS = ['standard', 'meFirst', 'meAfterReq'];
+
+export const useModelEffortDisplayStore = create(
+    persist(
+        (set, get) => ({
+            showOnAllCards: false,
+            toggleShowOnAllCards: () => set({ showOnAllCards: !get().showOnAllCards }),
+            setShowOnAllCards: (value) => set({ showOnAllCards: Boolean(value) }),
+
+            displayMode: 'pill',
+            // Guard against a stale/invalid persisted value re-pointing at the default.
+            setDisplayMode: (mode) => set({
+                displayMode: MODEL_EFFORT_DISPLAY_MODES.includes(mode) ? mode : 'pill',
+            }),
+
+            columnOrder: 'standard',
+            setColumnOrder: (order) => set({
+                columnOrder: MODEL_EFFORT_COLUMN_ORDERS.includes(order) ? order : 'standard',
+            }),
+
+            wideAggregator: true,
+            toggleWideAggregator: () => set({ wideAggregator: !get().wideAggregator }),
+        }),
+        {
+            name: 'darwin_model_effort_display',
+            // Coerce stale persisted enums (e.g. a retired 'clean'/'text' displayMode,
+            // or the pre-3-way `modelEffortFirst` boolean) back to valid defaults so a
+            // removed option can never leave the UI in an unselectable state.
+            merge: (persisted, current) => {
+                const p = persisted || {};
+                return {
+                    ...current,
+                    ...p,
+                    displayMode: MODEL_EFFORT_DISPLAY_MODES.includes(p.displayMode)
+                        ? p.displayMode : current.displayMode,
+                    columnOrder: MODEL_EFFORT_COLUMN_ORDERS.includes(p.columnOrder)
+                        ? p.columnOrder : current.columnOrder,
+                };
+            },
+        }
+    )
+);


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3029-show-modeleffort-in-aggregator-1
- wip(Darwin): 2026-07-23T08:06:09Z
- chore: init swarm session feature/3029-show-modeleffort-in-aggregator-1

## Files changed
```
 src/SwarmView/CategoryTabPanel.jsx                 |   6 +-
 src/SwarmView/ModelEffortChip.jsx                  |  54 ++++
 src/SwarmView/RequirementRow.jsx                   | 294 ++++++++++++++++-----
 src/SwarmView/SwarmView.jsx                        | 113 ++++++++
 src/SwarmView/__tests__/ModelEffortChip.test.jsx   |  76 ++++++
 src/SwarmView/__tests__/modelEffortLayout.test.js  |  99 +++++++
 src/SwarmView/modelEffortLayout.js                 |  66 +++++
 src/TaskPlanView/SwarmStartCard.jsx                |   4 +-
 src/hooks/useDataQueries.js                        |   8 +-
 src/index.css                                      |  28 ++
 .../__tests__/useModelEffortDisplayStore.test.js   |  90 +++++++
 src/stores/useModelEffortDisplayStore.js           |  69 +++++
 12 files changed, 837 insertions(+), 70 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)