### PR TITLE
Persist agent-context telemetry runs + render the actual-token view (multi-run, variable agent count)

### DIFF
--- a/src/Agents/ContextPage.jsx
+++ b/src/Agents/ContextPage.jsx
@@ -1,0 +1,245 @@
+// /agents/context — Agent Context: Actual Tokens (req #3031).
+//
+// Renders the published visual-acceptance artifact
+// (660a8b6b-b215-4b7a-b5a4-91c31e82460d) VERBATIM from stored telemetry: the
+// multi-row grouped header [Boot time | Initial context: CC base / CLAUDE.md /
+// Charter stub | Loaded per-agent: Boot payload / Autoload / Docs | Start Work
+// Context], zebra rows, a sticky Agent column, the teal Start-Work-Context
+// emphasis, and the glossary block. A run picker selects which capture to show;
+// variable agent counts render as-is (nothing assumes a fixed roster).
+//
+// All values are ACTUAL tokens (real tokenizer via transcript usage deltas),
+// except Boot time (ms). Columns are NULL where a phase does not apply
+// (PrimaryAI has no boot/autoload; the Code Reviewer bundles its charter stub
+// into CC base) — those cells render "n/a" or a footnote marker, matching the
+// artifact.
+
+import '../index.css';
+import { Fragment, useContext, useMemo, useState } from 'react';
+
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import CircularProgress from '@mui/material/CircularProgress';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/material/styles';
+
+import AuthContext from '../Context/AuthContext';
+import { useAgentTelemetryRuns, useAgentTelemetryRowsByRun } from '../hooks/useDataQueries';
+import { NA as NA_TEXT, sortRows, assignMarkers, computeCells } from './contextRenderUtils';
+
+// The 9 fixed column definitions — verbatim from the artifact glossary. The
+// per-row footnote definitions (*, †, …) are appended dynamically per run.
+const GLOSSARY = [
+    ['Units', <>All values are <strong>actual tokens</strong> (real tokenizer, from transcript usage deltas), except <strong>Boot time</strong> which is milliseconds.</>],
+    ['Boot time', <>Latency of the <code>darwin://agents/&lt;Name&gt;</code> boot call, measured <strong>sequentially</strong> (one boot at a time; parallel launch inflates it ~2&times;).</>],
+    ['CC base', <>The Claude Code system prompt: harness instructions + tool schemas + skills listing + MCP listing. Equals Initial context minus CLAUDE.md and the charter stub.</>],
+    ['CLAUDE.md', <>The project instruction file, loaded into every session.</>],
+    ['Charter stub', <>The agent's <code>.claude/agents/*.md</code> file, loaded as its system prompt.</>],
+    ['Boot payload', <>Context added by the boot call — identity row, binding instructions, and document pointers (not document contents).</>],
+    ['Autoload', <>Context added by reading the agent's autoload documents in full.</>],
+    ['Docs', <>Autoload documents loaded / expected.</>],
+    ['Start Work Context', <>Total context once loaded and ready to work — the <code>/context</code> figure.</>],
+];
+
+function cssVars(mode) {
+    // The artifact's two palettes, keyed off the MUI theme mode so the page
+    // tracks Darwin's light/dark toggle (not prefers-color-scheme).
+    return mode === 'dark'
+        ? {
+            '--panel': '#151a22', '--ink': '#e7ebf1', '--muted': '#8b94a3',
+            '--line': '#232b36', '--line-strong': '#333d4b', '--head': '#1a212b',
+            '--accent': '#2dd4bf', '--accent-soft': '#2dd4bf1f', '--zebra': '#121821',
+        }
+        : {
+            '--panel': '#ffffff', '--ink': '#171c26', '--muted': '#5c6675',
+            '--line': '#e3e8ee', '--line-strong': '#cdd5df', '--head': '#eef2f6',
+            '--accent': '#0f766e', '--accent-soft': '#0f766e14', '--zebra': '#fafbfc',
+        };
+}
+
+// Scoped CSS — every selector under .atc-root so nothing leaks into the app.
+const TABLE_CSS = `
+.atc-root { --mono: ui-monospace,"SF Mono",Menlo,Consolas,monospace; }
+.atc-scroll { overflow-x:auto; border:1px solid var(--line); border-radius:12px; background:var(--panel); }
+.atc-root table { border-collapse:collapse; width:100%; font-size:13.5px; }
+.atc-root caption { caption-side:top; text-align:left; padding:14px 16px 12px; font-size:12px; letter-spacing:.08em; text-transform:uppercase; color:var(--muted); }
+.atc-root thead th { background:var(--head); color:var(--ink); font-weight:600; padding:9px 13px; border-bottom:1px solid var(--line-strong); white-space:nowrap; }
+.atc-root thead tr:first-of-type th { font-size:11px; letter-spacing:.05em; text-transform:uppercase; color:var(--muted); border-bottom:1px solid var(--line); }
+.atc-root .grp { text-align:center; border-left:1px solid var(--line); border-right:1px solid var(--line); }
+.atc-root th.num, .atc-root td.num { text-align:right; font-family:var(--mono); font-variant-numeric:tabular-nums; }
+.atc-root th.mid, .atc-root td.mid { text-align:center; }
+.atc-root th.agent, .atc-root td.agent { text-align:left; position:sticky; left:0; background:var(--panel); font-weight:600; white-space:nowrap; box-shadow:1px 0 0 var(--line); }
+.atc-root thead th.agent { background:var(--head); }
+.atc-root tbody td { padding:8px 13px; border-bottom:1px solid var(--line); color:var(--ink); }
+.atc-root tbody tr:nth-of-type(even) td { background:var(--zebra); }
+.atc-root tbody tr:nth-of-type(even) td.agent { background:var(--zebra); }
+.atc-root tbody tr:hover td, .atc-root tbody tr:hover td.agent { background:var(--accent-soft); }
+.atc-root .swc { font-weight:700; color:var(--accent); }
+.atc-root tr.primary td { border-top:2px solid var(--line-strong); }
+.atc-root tr.primary td.agent { color:var(--accent); }
+.atc-root .fn { color:var(--muted); font-family:inherit; }
+.atc-root dl { margin:0; display:grid; grid-template-columns:minmax(140px,180px) 1fr; gap:1px; background:var(--line); border:1px solid var(--line); border-radius:12px; overflow:hidden; }
+.atc-root dt { background:var(--panel); padding:10px 14px; font-weight:600; font-size:13px; color:var(--ink); }
+.atc-root dd { background:var(--panel); padding:10px 14px; margin:0; color:var(--muted); font-size:13px; }
+.atc-root dt code, .atc-root dd code { font-family:var(--mono); font-size:.9em; color:var(--ink); }
+.atc-root .gloss-h2 { font-size:12px; letter-spacing:.1em; text-transform:uppercase; color:var(--muted); margin:0 0 14px; font-weight:600; }
+@media (max-width:560px){ .atc-root dl{ grid-template-columns:1fr; } .atc-root dt{ padding-bottom:2px; } .atc-root dd{ padding-top:2px; } }
+`;
+
+const NA = <span className="fn">n/a</span>;
+
+const ContextPage = () => {
+    const { profile } = useContext(AuthContext);
+    const theme = useTheme();
+    const isMobile = useMediaQuery('(max-width:899px)');
+    const creatorFk = profile?.userName;
+
+    const { data: runs, isLoading: runsLoading } = useAgentTelemetryRuns(creatorFk);
+
+    // Runs arrive newest-first (captured_at:desc); default to the newest capture.
+    const [selectedId, setSelectedId] = useState(null);
+    const runsSorted = useMemo(() => runs || [], [runs]);
+    const activeRunId = selectedId ?? runsSorted[0]?.id ?? null;
+    const activeRun = useMemo(
+        () => runsSorted.find(r => r.id === activeRunId) || null,
+        [runsSorted, activeRunId]);
+
+    const { data: rows, isLoading: rowsLoading } = useAgentTelemetryRowsByRun(activeRunId);
+
+    const rendered = useMemo(() => {
+        const list = sortRows(rows);
+        return { list, markerByText: assignMarkers(list) };
+    }, [rows]);
+
+    const dateLabel = (r) => {
+        const d = r.captured_at ? String(r.captured_at).slice(0, 10) : '';
+        return d ? `${r.label} — ${d}` : r.label;
+    };
+
+    if (runsLoading) {
+        return <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }}><CircularProgress /></Box>;
+    }
+
+    const vars = cssVars(theme.palette.mode);
+
+    return (
+        <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }} data-testid="agent-context-page">
+            <style>{TABLE_CSS}</style>
+
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, flexWrap: 'wrap', gap: 2 }}>
+                <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ flex: 1 }}>
+                    Agent Context — Actual Tokens
+                </Typography>
+                {runsSorted.length > 0 && (
+                    <FormControl size="small" sx={{ minWidth: 260 }}>
+                        <InputLabel id="atc-run-label">Capture</InputLabel>
+                        <Select
+                            labelId="atc-run-label"
+                            label="Capture"
+                            value={activeRunId ?? ''}
+                            onChange={(e) => setSelectedId(e.target.value)}
+                            data-testid="agent-context-run-picker"
+                        >
+                            {runsSorted.map(r => (
+                                <MenuItem key={r.id} value={r.id} data-testid={`agent-context-run-option-${r.id}`}>
+                                    {dateLabel(r)}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                )}
+            </Box>
+
+            {runsSorted.length === 0 ? (
+                <Typography color="text.secondary" sx={{ p: 2 }}>
+                    No telemetry captures recorded yet.
+                </Typography>
+            ) : (
+                <Box className="atc-root" sx={{ ...vars, display: 'flex', flexDirection: 'column', gap: '34px', maxWidth: 1120 }}>
+                    {activeRun?.source_note && (
+                        <Typography variant="body2" color="text.secondary" data-testid="agent-context-source-note">
+                            {activeRun.source_note}
+                        </Typography>
+                    )}
+
+                    <div className="atc-scroll">
+                        <table data-testid="agent-context-table">
+                            <caption>Agent context — actual tokens</caption>
+                            <thead>
+                                <tr>
+                                    <th className="agent" rowSpan={2}>Agent</th>
+                                    <th className="num" rowSpan={2}>Boot time<br />(ms)</th>
+                                    <th className="grp" colSpan={3}>Initial context — fixed overhead</th>
+                                    <th className="grp" colSpan={3}>Loaded per-agent</th>
+                                    <th className="num" rowSpan={2}>Start Work<br />Context</th>
+                                </tr>
+                                <tr>
+                                    <th className="num">CC base</th>
+                                    <th className="num">CLAUDE.md</th>
+                                    <th className="num">Charter stub</th>
+                                    <th className="num">Boot payload</th>
+                                    <th className="num">Autoload</th>
+                                    <th className="mid">Docs</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {rowsLoading ? (
+                                    <tr><td className="agent"><CircularProgress size={16} /></td>
+                                        <td colSpan={8} /></tr>
+                                ) : rendered.list.map((r) => {
+                                    const c = computeCells(r, rendered.markerByText);
+                                    // A cell string that equals the n/a sentinel renders muted.
+                                    const cell = (text) => (text === NA_TEXT
+                                        ? <span className="fn">n/a</span> : text);
+                                    return (
+                                        <tr key={r.id} className={c.isPrimary ? 'primary' : undefined}
+                                            data-testid={`agent-context-row-${r.id}`}>
+                                            <td className="agent">{r.agent_name}</td>
+                                            <td className="num">{cell(c.bootMs)}</td>
+                                            <td className="num">
+                                                {cell(c.ccBase)}
+                                                {c.ccBaseMarker && <span className="fn">{c.ccBaseMarker}</span>}
+                                            </td>
+                                            <td className="num">{cell(c.claudeMd)}</td>
+                                            <td className="num">
+                                                {c.stub.kind === 'value'
+                                                    ? c.stub.text
+                                                    : <span className="fn">{c.stub.kind === 'marker' ? c.stub.text : 'n/a'}</span>}
+                                            </td>
+                                            <td className="num">{cell(c.bootPayload)}</td>
+                                            <td className="num">{cell(c.autoload)}</td>
+                                            <td className="mid">{cell(c.docs)}</td>
+                                            <td className="num swc">{c.swc}</td>
+                                        </tr>
+                                    );
+                                })}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <section>
+                        <h2 className="gloss-h2">Glossary</h2>
+                        <dl data-testid="agent-context-glossary">
+                            {GLOSSARY.map(([term, def]) => (
+                                <Fragment key={term}>
+                                    <dt>{term}</dt><dd>{def}</dd>
+                                </Fragment>
+                            ))}
+                            {[...rendered.markerByText.entries()].map(([text, mark]) => (
+                                <Fragment key={mark}>
+                                    <dt>{mark}</dt><dd>{text}</dd>
+                                </Fragment>
+                            ))}
+                        </dl>
+                    </section>
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+export default ContextPage;

--- a/src/Agents/__tests__/contextRenderUtils.test.js
+++ b/src/Agents/__tests__/contextRenderUtils.test.js
@@ -1,0 +1,118 @@
+// Req #3031 — the artifact-faithful cell decisions for /agents/context.
+// Uses the seeded 2026-07-22 baseline rows as the fixture so the test doubles as
+// a regression guard against the published visual-acceptance spec.
+
+import { describe, it, expect } from 'vitest';
+import { fmt, NA, sortRows, assignMarkers, computeCells } from '../contextRenderUtils';
+
+const architect = (over) => ({
+    id: 1, agent_name: 'AWS', role: 'architect', session_kind: 'subagent',
+    boot_time_ms: 388, cc_base_tokens: 15401, claude_md_tokens: 10033,
+    charter_stub_tokens: 1821, boot_payload_tokens: 4973, autoload_tokens: 6768,
+    docs_loaded: 4, docs_expected: 4, start_work_context_tokens: 38996,
+    footnote: null, sort_order: 1, ...over,
+});
+
+const reviewer = {
+    id: 12, agent_name: 'Code Reviewer', role: 'reviewer', session_kind: 'subagent',
+    boot_time_ms: 358, cc_base_tokens: 6230, claude_md_tokens: 10033,
+    charter_stub_tokens: null, boot_payload_tokens: 3240, autoload_tokens: 148,
+    docs_loaded: 0, docs_expected: 1, start_work_context_tokens: 19651,
+    footnote: 'Code Reviewer pins tools ...; charter stub bundled into CC base.',
+    sort_order: 12,
+};
+
+const primary = {
+    id: 13, agent_name: 'Darwin PrimaryAI', role: 'primary', session_kind: 'top_level',
+    boot_time_ms: null, cc_base_tokens: 24526, claude_md_tokens: 10033,
+    charter_stub_tokens: null, boot_payload_tokens: null, autoload_tokens: null,
+    docs_loaded: null, docs_expected: null, start_work_context_tokens: 34559,
+    footnote: 'Darwin PrimaryAI is a top-level session (no boot/autoload phase) ...',
+    sort_order: 99,
+};
+
+describe('fmt', () => {
+    it('adds thousands separators', () => {
+        expect(fmt(15401)).toBe('15,401');
+        expect(fmt(200805)).toBe('200,805');
+    });
+    it('returns null for null/undefined', () => {
+        expect(fmt(null)).toBeNull();
+        expect(fmt(undefined)).toBeNull();
+    });
+});
+
+describe('sortRows', () => {
+    it('orders by sort_order, NULLs last, then id', () => {
+        const out = sortRows([
+            { id: 3, sort_order: null }, { id: 1, sort_order: 99 },
+            { id: 2, sort_order: 1 },
+        ]);
+        expect(out.map(r => r.id)).toEqual([2, 1, 3]);
+    });
+    it('does not mutate input', () => {
+        const input = [{ id: 2, sort_order: 2 }, { id: 1, sort_order: 1 }];
+        sortRows(input);
+        expect(input.map(r => r.id)).toEqual([2, 1]);
+    });
+});
+
+describe('assignMarkers', () => {
+    it('assigns * then † to distinct footnotes in row order', () => {
+        const list = sortRows([architect(), reviewer, primary]);
+        const m = assignMarkers(list);
+        expect(m.get(reviewer.footnote)).toBe('*');
+        expect(m.get(primary.footnote)).toBe('†');
+        expect(m.size).toBe(2);
+    });
+    it('ignores rows with no footnote', () => {
+        expect(assignMarkers([architect()]).size).toBe(0);
+    });
+});
+
+describe('computeCells — architect (all present)', () => {
+    const m = assignMarkers([architect()]);
+    const c = computeCells(architect(), m);
+    it('formats every numeric cell, no marker, no n/a', () => {
+        expect(c.bootMs).toBe('388');
+        expect(c.ccBase).toBe('15,401');
+        expect(c.ccBaseMarker).toBeNull();
+        expect(c.claudeMd).toBe('10,033');
+        expect(c.stub).toEqual({ kind: 'value', text: '1,821' });
+        expect(c.bootPayload).toBe('4,973');
+        expect(c.autoload).toBe('6,768');
+        expect(c.docs).toBe('4 / 4');
+        expect(c.swc).toBe('38,996');
+        expect(c.isPrimary).toBe(false);
+    });
+});
+
+describe('computeCells — reviewer (bundled stub)', () => {
+    const list = sortRows([architect(), reviewer, primary]);
+    const m = assignMarkers(list);
+    const c = computeCells(reviewer, m);
+    it('marks CC base and renders the stub cell as the footnote marker', () => {
+        expect(c.ccBase).toBe('6,230');
+        expect(c.ccBaseMarker).toBe('*');
+        expect(c.stub).toEqual({ kind: 'marker', text: '*' });
+        expect(c.docs).toBe('0 / 1');
+        expect(c.swc).toBe('19,651');
+    });
+});
+
+describe('computeCells — primary (no boot/autoload phase)', () => {
+    const list = sortRows([architect(), reviewer, primary]);
+    const m = assignMarkers(list);
+    const c = computeCells(primary, m);
+    it('renders n/a for the phases that do not apply, dagger on CC base', () => {
+        expect(c.isPrimary).toBe(true);
+        expect(c.bootMs).toBe(NA);
+        expect(c.ccBase).toBe('24,526');
+        expect(c.ccBaseMarker).toBe('†');
+        expect(c.stub).toEqual({ kind: 'na', text: NA });
+        expect(c.bootPayload).toBe(NA);
+        expect(c.autoload).toBe(NA);
+        expect(c.docs).toBe(NA);
+        expect(c.swc).toBe('34,559');
+    });
+});

--- a/src/Agents/contextRenderUtils.js
+++ b/src/Agents/contextRenderUtils.js
@@ -1,0 +1,62 @@
+// Pure render decisions for /agents/context (req #3031), extracted so the
+// artifact-faithful cell logic (NULL → "n/a", bundled-stub → footnote marker,
+// docs "loaded / expected", marker assignment) is unit-testable without a DOM.
+// The component turns these primitives into JSX.
+
+// Footnote markers, assigned in row order to each DISTINCT footnote text.
+export const MARKERS = ['*', '†', '‡', '§', '¶', '#'];
+
+// The sentinel a cell carries when a phase does not apply. The component renders
+// it muted; here it is a plain string so tests can assert on it.
+export const NA = 'n/a';
+
+export function fmt(n) {
+    return (n === null || n === undefined) ? null : Number(n).toLocaleString('en-US');
+}
+
+// Render order within a run: sort_order ASC (NULLs last), then id.
+export function sortRows(rows) {
+    return [...(rows || [])].sort(
+        (a, b) => (a.sort_order ?? Infinity) - (b.sort_order ?? Infinity) || a.id - b.id);
+}
+
+// Map each distinct footnote text → its marker, in sorted-row order. Rows with
+// no footnote contribute nothing; a repeated footnote reuses its first marker.
+// Past the symbol set (>6 distinct footnotes in one run) fall back to a bracketed
+// index so markers never collide (a plain '*' repeat would alias the first note).
+export function assignMarkers(sortedRows) {
+    const m = new Map();
+    for (const r of sortedRows) {
+        if (r.footnote && !m.has(r.footnote)) {
+            m.set(r.footnote, MARKERS[m.size] || `[${m.size + 1}]`);
+        }
+    }
+    return m;
+}
+
+// Resolve every cell for one row into display primitives. `markerByText` comes
+// from assignMarkers over the same run.
+export function computeCells(row, markerByText) {
+    const marker = row.footnote ? (markerByText.get(row.footnote) || null) : null;
+    const num = (v) => (v !== null && v !== undefined ? fmt(v) : NA);
+    return {
+        isPrimary: row.role === 'primary',
+        bootMs: num(row.boot_time_ms),
+        ccBase: num(row.cc_base_tokens),
+        ccBaseMarker: marker,                      // superscript appended to CC base
+        claudeMd: num(row.claude_md_tokens),
+        // Charter stub: a real number when present; the footnote marker when the
+        // agent BUNDLES its stub into CC base (reviewer); otherwise n/a (primary).
+        stub: row.charter_stub_tokens !== null && row.charter_stub_tokens !== undefined
+            ? { kind: 'value', text: fmt(row.charter_stub_tokens) }
+            : (row.role === 'reviewer'
+                ? { kind: 'marker', text: marker }
+                : { kind: 'na', text: NA }),
+        bootPayload: num(row.boot_payload_tokens),
+        autoload: num(row.autoload_tokens),
+        docs: (row.docs_loaded !== null && row.docs_loaded !== undefined
+               && row.docs_expected !== null && row.docs_expected !== undefined)
+            ? `${row.docs_loaded} / ${row.docs_expected}` : NA,
+        swc: fmt(row.start_work_context_tokens),   // always present — bold teal
+    };
+}

--- a/src/NavBar/navConfig.js
+++ b/src/NavBar/navConfig.js
@@ -20,6 +20,7 @@ import ComputerIcon from '@mui/icons-material/Computer';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
 import RuleIcon from '@mui/icons-material/Rule';
 import DescriptionIcon from '@mui/icons-material/Description';
+import DataUsageIcon from '@mui/icons-material/DataUsage';
 
 export const NAV_GROUPS = [
     { id: 'calendar', label: '' },
@@ -78,6 +79,8 @@ export const NAV_LINKS = [
     { path: '/agents', label: 'Agents', icon: SmartToyIcon, group: 'agents' },
     { path: '/agents/instructions', label: 'Instructions', icon: RuleIcon, group: 'agents' },
     { path: '/agents/documents', label: 'Documents', icon: DescriptionIcon, group: 'agents' },
+    // Req #3031 — Context: persisted actual-token telemetry of the agents pattern.
+    { path: '/agents/context', label: 'Context', icon: DataUsageIcon, group: 'agents' },
     { path: '/swarm/features', label: 'Features', icon: FactCheckIcon, group: 'swarm-validate' },
     { path: '/swarm/testcases', label: 'Test Cases', icon: ChecklistIcon, group: 'swarm-validate' },
     { path: '/swarm/testplans', label: 'Test Plans', icon: PlaylistAddCheckIcon, group: 'swarm-validate' },

--- a/src/hooks/factory/devopsQueries.js
+++ b/src/hooks/factory/devopsQueries.js
@@ -256,3 +256,37 @@ export const agentInstructions = createEntityQueries({
         { field: 'instruction_fk', as: 'instruction', creatorScoped: false },
     ],
 });
+
+// ---------------------------------------------------------------------------
+// agent context telemetry (req #3031) — persisted ACTUAL-token captures behind
+// /agents/context. A run header + N per-agent rows (variable N per capture).
+//
+// Routes through the default `darwinUri` (dev/prod split, req #2683): dev reads
+// darwin_dev fixtures, prod reads darwin. Both databases are seeded by
+// scripts/agents/capture-telemetry-run.py so dev review sees the real baseline.
+// Both tables carry creator_fk (in Lambda-Rest CREATOR_FK_TABLES), so the row
+// list is fetched by run_fk and the Lambda scopes it to the authenticated user
+// — the `byRun` FK hook is therefore creatorScoped:false (run_fk is the filter).
+// ---------------------------------------------------------------------------
+
+export const agentTelemetryRuns = createEntityQueries({
+    entity: 'agent_telemetry_runs',
+    defaultFields:
+        'id,captured_at,label,agent_count,harness_version,source_note,' +
+        'creator_fk,create_ts,update_ts',
+    fieldsInKey: true,
+    defaultSort: 'captured_at:desc',
+});
+
+export const agentTelemetryRows = createEntityQueries({
+    entity: 'agent_telemetry_rows',
+    defaultFields:
+        'id,run_fk,agent_name,role,session_kind,boot_time_ms,cc_base_tokens,' +
+        'claude_md_tokens,charter_stub_tokens,boot_payload_tokens,autoload_tokens,' +
+        'docs_loaded,docs_expected,start_work_context_tokens,footnote,sort_order,' +
+        'creator_fk',
+    fieldsInKey: true,
+    foreignKeys: [
+        { field: 'run_fk', as: 'run', creatorScoped: false },
+    ],
+});

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -3,7 +3,7 @@ import { useContext } from 'react';
 import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
 import { domainKeys, areaKeys, taskKeys, projectKeys, categoryKeys, requirementKeys, priorityCardOrderKeys, recurringTaskKeys, mapRunKeys, mapRouteKeys, mapCoordinateKeys, mapViewKeys, mapPartnerKeys, mapRunPartnerKeys, featureKeys, testCaseKeys, featureTestCaseKeys, testPlanKeys, testPlanCaseKeys, testRunKeys, testResultKeys, customerKeys, buildProjectKeys, branchKeys, buildKeys, customerReleaseKeys } from './useQueryKeys';
-import { devServers, sessions, swarmStarts, swarmStartSessions, swarmUndos, swarmCompletes, swarmCompleteSessions, machines, agents, instructions, architectureDocuments, agentDocuments, agentInstructions } from './factory/devopsQueries';
+import { devServers, sessions, swarmStarts, swarmStartSessions, swarmUndos, swarmCompletes, swarmCompleteSessions, machines, agents, instructions, architectureDocuments, agentDocuments, agentInstructions, agentTelemetryRuns, agentTelemetryRows } from './factory/devopsQueries';
 // `fetchEntity` is shared with the factory so both layers handle REST errors
 // identically (req #2593).
 import { fetchEntity } from './factory/createEntityQueries';
@@ -750,3 +750,11 @@ export const agentDocumentKeys    = agentDocuments.keys;
 
 export const useAgentInstructions = agentInstructions.useAll;
 export const agentInstructionKeys = agentInstructions.keys;
+
+// Req #3031 — agent context telemetry. The run list drives the /agents/context
+// run picker; the per-agent rows (fetched by run_fk) drive the table body.
+export const useAgentTelemetryRuns      = agentTelemetryRuns.useAll;
+export const useAgentTelemetryRun       = agentTelemetryRuns.useById;
+export const agentTelemetryRunKeys      = agentTelemetryRuns.keys;
+export const useAgentTelemetryRowsByRun = agentTelemetryRows.useByRun;
+export const agentTelemetryRowKeys      = agentTelemetryRows.keys;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -36,6 +36,7 @@ import AgentsPage from './Agents/AgentsPage';
 import AgentDetail from './Agents/AgentDetail';
 import InstructionsPage from './Agents/InstructionsPage';
 import DocumentsPage from './Agents/DocumentsPage';
+import ContextPage from './Agents/ContextPage';
 import SetupWizard from './SetupWizard/SetupWizard';
 import RecurringPlanView from './RecurringTaskEdit/RecurringPlanView';
 import MapsPage from './Maps/MapsPage';
@@ -187,6 +188,9 @@ root.render(
                                                          </AuthenticatedRoute>} />
                     <Route path="agents/documents" element= {<AuthenticatedRoute>
                                                              <DocumentsPage />
+                                                         </AuthenticatedRoute>} />
+                    <Route path="agents/context" element= {<AuthenticatedRoute>
+                                                             <ContextPage />
                                                          </AuthenticatedRoute>} />
                     <Route path="agents/:id" element= {<AuthenticatedRoute>
                                                              <AgentDetail />


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3031-persist-agent-context-telemetry-1
- wip(Darwin): 2026-07-23T08:10:01Z
- chore: init swarm session feature/3031-persist-agent-context-telemetry-1

## Files changed
```
 src/Agents/ContextPage.jsx                      | 245 ++++++++++++++++++++++++
 src/Agents/__tests__/contextRenderUtils.test.js | 118 ++++++++++++
 src/Agents/contextRenderUtils.js                |  62 ++++++
 src/NavBar/navConfig.js                         |   3 +
 src/hooks/factory/devopsQueries.js              |  34 ++++
 src/hooks/useDataQueries.js                     |  10 +-
 src/index.jsx                                   |   4 +
 7 files changed, 475 insertions(+), 1 deletion(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)