### PR TITLE
Reduce aggregator card UI option surface area

### DIFF
--- a/src/SwarmView/ModelEffortChip.jsx
+++ b/src/SwarmView/ModelEffortChip.jsx
@@ -1,15 +1,9 @@
 // Presentational cell for a single Model or Effort value in a requirement row
-// (req #3029). One component covers both axes (`kind`) and all three display
-// modes so RequirementRow stays declarative and the modes render identically
-// wherever they appear.
+// (req #3029; pill is the only rendering as of req #3043 — the compact/text
+// modes were removed). Covers both axes (`kind`) so RequirementRow stays
+// declarative.
 //
-//   pill    → full colored chip, e.g. "Opus" / "XHigh"  (reuses the table-view look)
-//   text    → plain label, no background (theme-colored, low visual weight)
-//   compact → single-letter colored chip, e.g. "O" / "X" — saves horizontal space;
-//             the color still encodes the value and the tooltip names it in full
-//
-// Every mode carries a "Model: X" / "Effort: Y" tooltip so the abbreviated forms
-// are never ambiguous.
+// Carries a "Model: X" / "Effort: Y" tooltip so the value is never ambiguous.
 
 import React from 'react';
 import Chip from '@mui/material/Chip';
@@ -17,33 +11,12 @@ import Tooltip from '@mui/material/Tooltip';
 import { aiModelChipProps, aiModelLabel } from './modelChipStyles';
 import { effortChipProps, effortLabel } from './effortChipStyles';
 
-const ModelEffortChip = ({ kind, value, mode = 'pill', 'data-testid': testId }) => {
+const ModelEffortChip = ({ kind, value, 'data-testid': testId }) => {
     const isModel = kind === 'model';
     const label = isModel ? aiModelLabel(value) : effortLabel(value);
     const chipProps = isModel ? aiModelChipProps(value) : effortChipProps(value);
     const tip = `${isModel ? 'Model' : 'Effort'}: ${label}`;
 
-    if (mode === 'compact') {
-        return (
-            <Tooltip title={tip} enterDelay={400} enterNextDelay={200}>
-                <Chip
-                    label={label.charAt(0)}
-                    size="small"
-                    data-testid={testId}
-                    {...chipProps}
-                    sx={{
-                        ...chipProps.sx,
-                        width: 22,
-                        height: 20,
-                        fontWeight: 600,
-                        '& .MuiChip-label': { px: 0 },
-                    }}
-                />
-            </Tooltip>
-        );
-    }
-
-    // pill (default) — semantic per-value color
     return (
         <Tooltip title={tip} enterDelay={400} enterNextDelay={200}>
             <Chip label={label} size="small" data-testid={testId} {...chipProps} />

--- a/src/SwarmView/RequirementRow.jsx
+++ b/src/SwarmView/RequirementRow.jsx
@@ -51,10 +51,9 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
 
     // Model + Effort column preferences (req #3029). The columns always render in
     // the aggregator card; `showOnAllCards` promotes them onto CategoryCard rows
-    // too. `displayMode` chooses pill / text / compact rendering.
+    // too. Rendering is always the pill style in the standard column order
+    // (req #3043 removed the display-mode/column-order choices).
     const showModelEffortOnAllCards = useModelEffortDisplayStore(s => s.showOnAllCards);
-    const modelEffortDisplayMode = useModelEffortDisplayStore(s => s.displayMode);
-    const modelEffortColumnOrder = useModelEffortDisplayStore(s => s.columnOrder);
 
     // Drag rules (req #2417):
     //   - Drag source is enabled for every non-template row, regardless of
@@ -317,15 +316,16 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
     const showModelEffortColumns = isAggregatorRow || showModelEffortOnAllCards;
     const rowClassName = `task requirement-row${isAggregatorRow ? ' aggregator-row' : ''}${showModelEffortColumns ? ' me-cols' : ''}`;
     const modelEffortGridColumns = showModelEffortColumns
-        ? modelEffortGridTemplate({ isAggregatorRow, displayMode: modelEffortDisplayMode, columnOrder: modelEffortColumnOrder })
+        ? modelEffortGridTemplate({ isAggregatorRow })
         : undefined;
 
     // req #3029 — the display mode actually applied to THIS row's Status /
-    // Autonomy / Model / Effort columns. Only the enhanced rows (aggregator, or
-    // category cards with the option on) follow the user's pill/text/compact
-    // choice; every other row is pinned to 'compact', which reproduces today's
-    // icon look exactly, so plain category cards are visually unchanged.
-    const effectiveDisplayMode = showModelEffortColumns ? modelEffortDisplayMode : 'compact';
+    // Autonomy / Model / Effort columns. The enhanced rows (aggregator, or
+    // category cards with the option on) always render pills (req #3043 removed
+    // the compact/text choice); every other row is pinned to 'compact', which
+    // reproduces today's icon look exactly, so plain category cards are
+    // visually unchanged.
+    const effectiveDisplayMode = showModelEffortColumns ? 'pill' : 'compact';
 
     // Status label + chip color for the pill/text renderings — mirror the icon
     // precedence in getStatusIcon()/getStatusTooltip(): terminal requirement
@@ -345,13 +345,13 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
         if (sessionStatus)         return swarmStatusChipProps(sessionStatus);
         return requirementStatusChipProps(status);
     };
-    // Autonomy label for pill/text — simple capitalization of the coordination type.
+    // Autonomy label for the pill — simple capitalization of the coordination type.
     const coordChipLabel = coordType ? coordType.charAt(0).toUpperCase() + coordType.slice(1) : '';
 
-    // --- Status cell — icon (compact) / colored pill / plain text --------------
+    // --- Status cell — icon (compact) / colored pill ----------------------------
     // Compact preserves today's exact markup (clickable IconButton when the status
-    // is cyclable, bare tooltip'd icon otherwise). Pill/text keep the same tooltip
-    // and the same `status-toggle-<id>` test id + click-to-cycle on cyclable rows.
+    // is cyclable, bare tooltip'd icon otherwise). Pill keeps the same tooltip and
+    // the same `status-toggle-<id>` test id + click-to-cycle on cyclable rows.
     const renderStatusCell = () => {
         if (requirement.id === '') return null;
         if (effectiveDisplayMode === 'compact') {
@@ -385,10 +385,10 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
         );
     };
 
-    // --- Autonomy cell — icon (compact) / colored pill / plain text ------------
+    // --- Autonomy cell — icon (compact) / colored pill --------------------------
     // Visible only for swarm_ready + development; editable only for swarm_ready
     // (unchanged from the icon version). Keeps the `coordination-toggle-<id>` test
-    // id across all three modes.
+    // id across both modes.
     const renderAutonomyCell = () => {
         if (requirement.id === '') return null;
         const showCoord = ['swarm_ready', 'development'].includes(status);
@@ -453,9 +453,9 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
     }
 
     // The two Model/Effort cells (empty placeholders on the template row so the
-    // grid stays aligned), or null when the card isn't showing them. Their
-    // position among the value cells is set by columnOrder below; the grid
-    // template in modelEffortLayout.js orders the tracks to match.
+    // grid stays aligned), or null when the card isn't showing them. They always
+    // sit at the end of the value cells (standard order — req #3043 removed the
+    // column-order choice); the grid template in modelEffortLayout.js matches.
     const modelEffortCells = showModelEffortColumns ? (
         <>
             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', px: '2px' }}>
@@ -463,7 +463,6 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
                     <ModelEffortChip
                         kind="model"
                         value={requirement.ai_model}
-                        mode={modelEffortDisplayMode}
                         data-testid={`model-cell-${requirement.id}`}
                     />
                 )}
@@ -473,7 +472,6 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
                     <ModelEffortChip
                         kind="effort"
                         value={requirement.effort}
-                        mode={modelEffortDisplayMode}
                         data-testid={`effort-cell-${requirement.id}`}
                     />
                 )}
@@ -520,17 +518,11 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
         </Box>
     );
 
-    // Arrange the value cells per the column-order option (req #3029). When the
-    // card isn't showing Model/Effort, modelEffortCells is null and drops out, so
-    // every arrangement collapses to Req# · Status · Autonomy (the base layout).
-    let orderedValueCells;
-    if (modelEffortColumnOrder === 'meFirst') {
-        orderedValueCells = <>{modelEffortCells}{reqIdCell}{statusCell}{autonomyCell}</>;
-    } else if (modelEffortColumnOrder === 'meAfterReq') {
-        orderedValueCells = <>{reqIdCell}{modelEffortCells}{statusCell}{autonomyCell}</>;
-    } else { // 'standard'
-        orderedValueCells = <>{reqIdCell}{statusCell}{autonomyCell}{modelEffortCells}</>;
-    }
+    // Value cells in the standard order (req #3029; req #3043 removed the
+    // column-order choice, so this is the only arrangement now). When the card
+    // isn't showing Model/Effort, modelEffortCells is null and drops out,
+    // collapsing to Req# · Status · Autonomy.
+    const orderedValueCells = <>{reqIdCell}{statusCell}{autonomyCell}{modelEffortCells}</>;
 
     return (
         <Box className={rowClassName}
@@ -585,8 +577,8 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
                 </Box>
             )}
 
-            {/* Value cells (Req#, Status, Autonomy, Model, Effort) — arranged per
-                the column-order option (req #3029). */}
+            {/* Value cells (Req#, Status, Autonomy, Model, Effort) — standard
+                order (req #3029). */}
             {orderedValueCells}
 
             {/* Title */}

--- a/src/SwarmView/SwarmView.jsx
+++ b/src/SwarmView/SwarmView.jsx
@@ -84,15 +84,12 @@ const SwarmView = () => {
     const showSwarmStartCard = useSwarmStartCardStore(s => s.show);
     const toggleSwarmStartCard = useSwarmStartCardStore(s => s.toggle);
     // Model/Effort column display options (req #3029) — surfaced as a Tune menu in
-    // the cards-view header ("title row").
+    // the cards-view header ("title row"). req #3043 trimmed this to the two
+    // remaining toggles (pill rendering + standard order are now unconditional).
     const meShowOnAllCards = useModelEffortDisplayStore(s => s.showOnAllCards);
     const meToggleShowOnAllCards = useModelEffortDisplayStore(s => s.toggleShowOnAllCards);
-    const meDisplayMode = useModelEffortDisplayStore(s => s.displayMode);
-    const meSetDisplayMode = useModelEffortDisplayStore(s => s.setDisplayMode);
     const meWideAggregator = useModelEffortDisplayStore(s => s.wideAggregator);
     const meToggleWideAggregator = useModelEffortDisplayStore(s => s.toggleWideAggregator);
-    const meColumnOrder = useModelEffortDisplayStore(s => s.columnOrder);
-    const meSetColumnOrder = useModelEffortDisplayStore(s => s.setColumnOrder);
     const [meMenuAnchor, setMeMenuAnchor] = useState(null);
     // req #2850 — a Trends drill-down is active; in Table view the status-filter
     // chips are replaced by the drill pill (the chips don't apply while drilled).
@@ -362,58 +359,6 @@ const SwarmView = () => {
                                         <ListItemText>Show Model &amp; Effort on all cards</ListItemText>
                                     </MenuItem>
                                     <Divider />
-                                    <ListItemText
-                                        sx={{ px: 2, py: 0.5, color: 'text.secondary' }}
-                                        primaryTypographyProps={{ variant: 'caption' }}
-                                    >
-                                        Display
-                                    </ListItemText>
-                                    {[
-                                        { mode: 'pill', label: 'Pill' },
-                                        { mode: 'compact', label: 'Compact' },
-                                    ].map(({ mode, label }) => (
-                                        <MenuItem
-                                            key={mode}
-                                            onClick={() => meSetDisplayMode(mode)}
-                                            data-testid={`model-effort-mode-${mode}`}
-                                        >
-                                            <ListItemIcon>
-                                                {meDisplayMode === mode && <Check fontSize="small" />}
-                                            </ListItemIcon>
-                                            <ListItemText>{label}</ListItemText>
-                                        </MenuItem>
-                                    ))}
-                                    <Divider />
-                                    <ListItemText
-                                        sx={{ px: 2, py: 0.5, color: 'text.secondary' }}
-                                        primaryTypographyProps={{ variant: 'caption' }}
-                                    >
-                                        Column order
-                                    </ListItemText>
-                                    <Box sx={{ px: 2, py: 0.5 }}>
-                                        <ToggleButtonGroup
-                                            value={meColumnOrder}
-                                            exclusive
-                                            size="small"
-                                            onChange={(e, v) => { if (v) meSetColumnOrder(v); }}
-                                            data-testid="model-effort-order"
-                                        >
-                                            {[
-                                                { value: 'standard',   label: 'Default',     tip: 'Req · Status · Autonomy · Model · Effort' },
-                                                { value: 'meFirst',     label: 'M/E First',   tip: 'Model · Effort · Req · Status · Autonomy' },
-                                                { value: 'meAfterReq',  label: 'M/E After #', tip: 'Req · Model · Effort · Status · Autonomy' },
-                                            ].map(({ value, label, tip }) => (
-                                                <ToggleButton
-                                                    key={value}
-                                                    value={value}
-                                                    data-testid={`model-effort-order-${value}`}
-                                                    sx={{ textTransform: 'none', px: 1 }}
-                                                >
-                                                    <Tooltip title={tip}><span>{label}</span></Tooltip>
-                                                </ToggleButton>
-                                            ))}
-                                        </ToggleButtonGroup>
-                                    </Box>
                                     <MenuItem
                                         onClick={meToggleWideAggregator}
                                         data-testid="model-effort-wide-aggregator"

--- a/src/SwarmView/__tests__/ModelEffortChip.test.jsx
+++ b/src/SwarmView/__tests__/ModelEffortChip.test.jsx
@@ -1,10 +1,9 @@
 // @vitest-environment jsdom
 //
-// Req #3029 — the Model/Effort cell renders one value in one of two modes. The
-// rules that matter for correctness: the right label (with the documented
-// null/unknown fallbacks — Opus for model, High for effort), and the right DOM
-// shape per mode (pill = full label in a Chip, compact = the single leading
-// letter in a Chip).
+// Req #3029 — the Model/Effort cell renders one value. req #3043 removed the
+// compact/text modes, so pill (full label in a Chip) is the only rendering.
+// The rules that matter for correctness: the right label (with the documented
+// null/unknown fallbacks — Opus for model, High for effort), and the DOM shape.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import React from 'react';
@@ -36,41 +35,31 @@ afterEach(() => {
 
 const hasChip = () => Boolean(container.querySelector('.MuiChip-root'));
 
-describe('ModelEffortChip (req #3029)', () => {
-    it('pill mode renders the full model label inside a chip', () => {
-        render(<ModelEffortChip kind="model" value="opus" mode="pill" />);
+describe('ModelEffortChip (req #3029 / #3043)', () => {
+    it('renders the full model label inside a chip', () => {
+        render(<ModelEffortChip kind="model" value="opus" />);
         expect(container.textContent).toContain('Opus');
         expect(hasChip()).toBe(true);
     });
 
-    it('compact mode renders only the leading letter, inside a chip', () => {
-        render(<ModelEffortChip kind="model" value="fable" mode="compact" />);
-        expect(container.textContent.trim()).toBe('F');
+    it('renders the full effort label inside a chip', () => {
+        render(<ModelEffortChip kind="effort" value="xhigh" />);
+        expect(container.textContent).toContain('XHigh');
         expect(hasChip()).toBe(true);
     });
 
-    it('effort pill uses the effort label (XHigh)', () => {
-        render(<ModelEffortChip kind="effort" value="xhigh" mode="pill" />);
-        expect(container.textContent).toContain('XHigh');
-    });
-
-    it('effort compact uses the leading letter of the effort label', () => {
-        render(<ModelEffortChip kind="effort" value="ultracode" mode="compact" />);
-        expect(container.textContent.trim()).toBe('U');
-    });
-
     it('falls back to Opus for a null model value', () => {
-        render(<ModelEffortChip kind="model" value={null} mode="pill" />);
+        render(<ModelEffortChip kind="model" value={null} />);
         expect(container.textContent).toContain('Opus');
     });
 
     it('falls back to High for a null effort value', () => {
-        render(<ModelEffortChip kind="effort" value={null} mode="pill" />);
+        render(<ModelEffortChip kind="effort" value={null} />);
         expect(container.textContent).toContain('High');
     });
 
     it('forwards data-testid to the rendered node', () => {
-        render(<ModelEffortChip kind="model" value="opus" mode="pill" data-testid="model-cell-42" />);
+        render(<ModelEffortChip kind="model" value="opus" data-testid="model-cell-42" />);
         expect(container.querySelector('[data-testid="model-cell-42"]')).toBeTruthy();
     });
 });

--- a/src/SwarmView/__tests__/modelEffortLayout.test.js
+++ b/src/SwarmView/__tests__/modelEffortLayout.test.js
@@ -4,96 +4,45 @@ import {
     modelEffortGridTemplate,
     baseGridTemplate,
 } from '../modelEffortLayout';
-import {
-    MODEL_EFFORT_DISPLAY_MODES,
-    MODEL_EFFORT_COLUMN_ORDERS,
-} from '../../stores/useModelEffortDisplayStore';
 
 // req #3029 — the Model/Effort columns override grid-template-columns inline, so
 // the invariant that matters is: the injected template has exactly TWO more
-// tracks than the base template, in the order chosen by columnOrder. A miscount
-// silently shoves Title/delete into the wrong column for every row in the card.
+// tracks than the base template, in the standard order. A miscount silently
+// shoves Title/delete into the wrong column for every row in the card.
+// req #3043 removed the display-mode/column-order options — this is now the
+// only layout the module produces.
 
 const tracks = (tpl) => tpl.split(/\s+/).filter(Boolean);
 
-describe('modelEffortGridTemplate (req #3029)', () => {
-    it('defines a width for all four mode columns in every supported display mode', () => {
-        for (const mode of MODEL_EFFORT_DISPLAY_MODES) {
-            expect(MODEL_EFFORT_COL_WIDTHS[mode]).toBeTruthy();
-            for (const col of ['status', 'autonomy', 'model', 'effort']) {
-                expect(MODEL_EFFORT_COL_WIDTHS[mode][col]).toBeGreaterThan(0);
-            }
+describe('modelEffortGridTemplate (req #3029 / #3043)', () => {
+    it('defines a width for all four value columns', () => {
+        for (const col of ['status', 'autonomy', 'model', 'effort']) {
+            expect(MODEL_EFFORT_COL_WIDTHS[col]).toBeGreaterThan(0);
         }
-    });
-
-    it('supports exactly pill + compact display modes', () => {
-        expect(Object.keys(MODEL_EFFORT_COL_WIDTHS).sort()).toEqual(['compact', 'pill']);
-    });
-
-    it('keeps Status/Autonomy at the icon width (28px) in compact mode', () => {
-        expect(MODEL_EFFORT_COL_WIDTHS.compact.status).toBe(28);
-        expect(MODEL_EFFORT_COL_WIDTHS.compact.autonomy).toBe(28);
     });
 
     it('adds exactly two tracks over the base template — category card', () => {
         const base = tracks(baseGridTemplate({ isAggregatorRow: false }));
-        const withME = tracks(modelEffortGridTemplate({ isAggregatorRow: false, displayMode: 'pill', columnOrder: 'standard' }));
+        const withME = tracks(modelEffortGridTemplate({ isAggregatorRow: false }));
         expect(base.length).toBe(5);
         expect(withME.length).toBe(base.length + 2);
     });
 
     it('adds exactly two tracks over the base template — aggregator card', () => {
         const base = tracks(baseGridTemplate({ isAggregatorRow: true }));
-        const withME = tracks(modelEffortGridTemplate({ isAggregatorRow: true, displayMode: 'pill', columnOrder: 'standard' }));
+        const withME = tracks(modelEffortGridTemplate({ isAggregatorRow: true }));
         expect(base.length).toBe(6);
         expect(withME.length).toBe(base.length + 2);
     });
 
-    it('standard order: Req·Status·Autonomy·Model·Effort before Title (aggregator, pill)', () => {
+    it('standard order: Req·Status·Autonomy·Model·Effort before Title (aggregator)', () => {
         // color-bar · Req# · Status · Autonomy · Model · Effort · Title(1fr) · delete(auto)
-        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: true, displayMode: 'pill', columnOrder: 'standard' }));
+        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: true }));
         expect(t).toEqual(['24px', '56px', '116px', '112px', '66px', '88px', '1fr', 'auto']);
     });
 
-    it('standard order (category, pill)', () => {
-        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: false, displayMode: 'pill', columnOrder: 'standard' }));
+    it('standard order (category)', () => {
+        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: false }));
         expect(t).toEqual(['56px', '116px', '112px', '66px', '88px', '1fr', 'auto']);
-    });
-
-    it('meFirst order leads with Model·Effort, keeping color-bar first (aggregator)', () => {
-        // color-bar · Model · Effort · Req# · Status · Autonomy · Title · delete
-        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: true, displayMode: 'pill', columnOrder: 'meFirst' }));
-        expect(t).toEqual(['24px', '66px', '88px', '56px', '116px', '112px', '1fr', 'auto']);
-    });
-
-    it('meAfterReq order places Model·Effort between Req# and Status (aggregator)', () => {
-        // color-bar · Req# · Model · Effort · Status · Autonomy · Title · delete
-        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: true, displayMode: 'pill', columnOrder: 'meAfterReq' }));
-        expect(t).toEqual(['24px', '56px', '66px', '88px', '116px', '112px', '1fr', 'auto']);
-    });
-
-    it('meAfterReq order (category)', () => {
-        // Req# · Model · Effort · Status · Autonomy · Title · delete
-        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: false, displayMode: 'pill', columnOrder: 'meAfterReq' }));
-        expect(t).toEqual(['56px', '66px', '88px', '116px', '112px', '1fr', 'auto']);
-    });
-
-    it('collapses to icon/letter widths in compact mode (matches today for Status/Autonomy)', () => {
-        const t = tracks(modelEffortGridTemplate({ isAggregatorRow: false, displayMode: 'compact', columnOrder: 'standard' }));
-        expect(t).toEqual(['56px', '28px', '28px', '30px', '30px', '1fr', 'auto']);
-    });
-
-    it('falls back to pill widths for an unknown mode', () => {
-        const unknown = modelEffortGridTemplate({ isAggregatorRow: false, displayMode: 'nope', columnOrder: 'standard' });
-        const pill = modelEffortGridTemplate({ isAggregatorRow: false, displayMode: 'pill', columnOrder: 'standard' });
-        expect(unknown).toBe(pill);
-    });
-
-    it('every column order still adds exactly two tracks over base', () => {
-        const base = tracks(baseGridTemplate({ isAggregatorRow: true }));
-        for (const columnOrder of MODEL_EFFORT_COLUMN_ORDERS) {
-            const withME = tracks(modelEffortGridTemplate({ isAggregatorRow: true, displayMode: 'compact', columnOrder }));
-            expect(withME.length).toBe(base.length + 2);
-        }
     });
 });

--- a/src/SwarmView/modelEffortLayout.js
+++ b/src/SwarmView/modelEffortLayout.js
@@ -1,10 +1,11 @@
-// Grid geometry for the mode-driven requirement-row columns (req #3029).
+// Grid geometry for the Model + Effort requirement-row columns (req #3029;
+// simplified in req #3043 — the display-mode and column-order options were
+// removed, so this module now builds exactly one layout).
 //
-// The pill / text / compact display mode governs FOUR value columns — Status,
-// Autonomy, Model, Effort — wherever the enhanced columns are shown (the
-// aggregator always; category cards when the user opts in). 'compact' reproduces
-// today's look exactly: Status/Autonomy are their small icons and Model/Effort
-// are single-letter chips.
+// Pill rendering governs FOUR value columns — Status, Autonomy, Model, Effort
+// — wherever the enhanced columns are shown (the aggregator always; category
+// cards when the user opts in), always in the standard order: Req# · Status ·
+// Autonomy · Model · Effort.
 //
 // Each RequirementRow is its OWN CSS grid (`.task { display:grid }`), so column
 // tracks do NOT share sizing across rows automatically — vertical alignment
@@ -12,17 +13,13 @@
 // these tracks must be FIXED widths (never `auto`), otherwise a row with a wide
 // value ("Implementing" / "Ultracode") would misalign against a narrow one.
 //
-// Widths are per display-mode, sized to the widest label each column must hold:
+// Widths are sized to the widest label each column must hold:
 //   • Status  — "Implementing" (session) / "Swarm-Start" (requirement)
 //   • Autonomy — "Implemented"
 //   • Effort  — "Ultracode"
 //   • Model   — "Sonnet"
-// 'compact' keeps Status/Autonomy at the icon width (28px) they use today.
 
-export const MODEL_EFFORT_COL_WIDTHS = {
-    pill:    { status: 116, autonomy: 112, model: 66, effort: 88 },
-    compact: { status: 28,  autonomy: 28,  model: 30, effort: 30 },
-};
+export const MODEL_EFFORT_COL_WIDTHS = { status: 116, autonomy: 112, model: 66, effort: 88 };
 
 // Base (no mode columns) row templates — mirror the CSS in index.css so this
 // module is the single source of truth when the columns ARE injected.
@@ -31,31 +28,20 @@ export const MODEL_EFFORT_COL_WIDTHS = {
 const BASE_CATEGORY = ['56px', '28px', '28px', '1fr', 'auto'];
 const BASE_AGGREGATOR = ['24px', '56px', '28px', '28px', '1fr', 'auto'];
 
-// Build the `grid-template-columns` value for a row rendering the mode columns.
-// The five value tracks (Req# always 56px; Status/Autonomy/Model/Effort at their
-// per-mode widths) are arranged per `columnOrder`:
-//   'standard'   : … · Req# · Status · Autonomy · Model · Effort · Title · delete
-//   'meFirst'    : … · Model · Effort · Req# · Status · Autonomy · Title · delete
-//   'meAfterReq' : … · Req# · Model · Effort · Status · Autonomy · Title · delete
-// The color-bar (aggregator only) always stays leftmost. The rendered cell order
+// Build the `grid-template-columns` value for a row rendering the Model/Effort
+// columns: … · Req# · Status · Autonomy · Model · Effort · Title · delete. The
+// color-bar (aggregator only) always stays leftmost. The rendered cell order
 // in RequirementRow mirrors this exactly.
 //
 // Returns a space-joined string suitable for the `--me-grid` custom property.
-export const modelEffortGridTemplate = ({ isAggregatorRow, displayMode, columnOrder }) => {
-    const w = MODEL_EFFORT_COL_WIDTHS[displayMode] || MODEL_EFFORT_COL_WIDTHS.pill;
+export const modelEffortGridTemplate = ({ isAggregatorRow }) => {
+    const w = MODEL_EFFORT_COL_WIDTHS;
     const req = '56px';
     const status = `${w.status}px`;
     const autonomy = `${w.autonomy}px`;
     const model = `${w.model}px`;
     const effort = `${w.effort}px`;
-    let ordered;
-    if (columnOrder === 'meFirst') {
-        ordered = [model, effort, req, status, autonomy];
-    } else if (columnOrder === 'meAfterReq') {
-        ordered = [req, model, effort, status, autonomy];
-    } else { // 'standard'
-        ordered = [req, status, autonomy, model, effort];
-    }
+    const ordered = [req, status, autonomy, model, effort];
     const bar = isAggregatorRow ? ['24px'] : [];
     return [...bar, ...ordered, '1fr', 'auto'].join(' ');
 };

--- a/src/index.css
+++ b/src/index.css
@@ -121,11 +121,11 @@
 
 /* req #3029 — Model + Effort columns. When present, RequirementRow adds `me-cols`
    and sets the `--me-grid` custom property to the full grid-template (built in
-   modelEffortLayout.js, per display mode). These selectors carry one more class
-   than the base row templates above, so they outrank them regardless of source
-   order — the reason the template is applied here rather than via MUI `sx` (which
-   would generate only a single-class rule and lose to the base templates). No
-   media variant is needed: with higher specificity these win at every width. */
+   modelEffortLayout.js). These selectors carry one more class than the base row
+   templates above, so they outrank them regardless of source order — the reason
+   the template is applied here rather than via MUI `sx` (which would generate
+   only a single-class rule and lose to the base templates). No media variant is
+   needed: with higher specificity these win at every width. */
 .task.requirement-row.me-cols {
     grid-template-columns: var(--me-grid);
 }

--- a/src/stores/__tests__/useModelEffortDisplayStore.test.js
+++ b/src/stores/__tests__/useModelEffortDisplayStore.test.js
@@ -1,40 +1,33 @@
 // @vitest-environment jsdom
 //
-// Req #3029 — display preferences for the Model + Effort row columns. Exercises
-// the REAL store actions because the behaviors most likely to regress are the
-// toggles and the enum-validation guards that keep a bad value (a retired
-// display mode / column order) from ever reaching the render path.
+// Req #3029 — display preferences for the Model + Effort row columns. req #3043
+// trimmed the store to just `showOnAllCards` + `wideAggregator` (removed
+// `displayMode`/`columnOrder`). Exercises the REAL store actions, including the
+// merge() guard that strips a stale persisted `displayMode`/`columnOrder` so a
+// removed option can never reach the render path via old localStorage.
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import {
-    useModelEffortDisplayStore,
-    MODEL_EFFORT_DISPLAY_MODES,
-    MODEL_EFFORT_COLUMN_ORDERS,
-} from '../useModelEffortDisplayStore';
+import { useModelEffortDisplayStore } from '../useModelEffortDisplayStore';
 
 const state = () => useModelEffortDisplayStore.getState();
 
-describe('useModelEffortDisplayStore (req #3029)', () => {
+describe('useModelEffortDisplayStore (req #3029 / #3043)', () => {
     beforeEach(() => {
         useModelEffortDisplayStore.setState({
-            showOnAllCards: false, displayMode: 'pill',
-            wideAggregator: true, columnOrder: 'standard',
+            showOnAllCards: false, wideAggregator: true,
         });
     });
 
-    it('defaults to aggregator-only + pill, wide aggregator, standard column order', () => {
+    it('defaults to aggregator-only + wide aggregator', () => {
         expect(state().showOnAllCards).toBe(false);
-        expect(state().displayMode).toBe('pill');
         expect(state().wideAggregator).toBe(true);
-        expect(state().columnOrder).toBe('standard');
     });
 
-    it('lists exactly the two supported display modes', () => {
-        expect(MODEL_EFFORT_DISPLAY_MODES).toEqual(['pill', 'compact']);
-    });
-
-    it('lists exactly the three supported column orders', () => {
-        expect(MODEL_EFFORT_COLUMN_ORDERS).toEqual(['standard', 'meFirst', 'meAfterReq']);
+    it('no longer exposes displayMode/columnOrder state or setters', () => {
+        expect(state().displayMode).toBeUndefined();
+        expect(state().columnOrder).toBeUndefined();
+        expect(state().setDisplayMode).toBeUndefined();
+        expect(state().setColumnOrder).toBeUndefined();
     });
 
     it('toggleShowOnAllCards flips the boolean both directions', () => {
@@ -58,33 +51,14 @@ describe('useModelEffortDisplayStore (req #3029)', () => {
         expect(state().wideAggregator).toBe(true);
     });
 
-    it('setDisplayMode accepts each supported mode', () => {
-        for (const mode of MODEL_EFFORT_DISPLAY_MODES) {
-            state().setDisplayMode(mode);
-            expect(state().displayMode).toBe(mode);
-        }
-    });
-
-    it('setDisplayMode falls back to pill for an unknown/retired mode', () => {
-        state().setDisplayMode('compact');
-        state().setDisplayMode('clean'); // retired
-        expect(state().displayMode).toBe('pill');
-        state().setDisplayMode(null);
-        expect(state().displayMode).toBe('pill');
-    });
-
-    it('setColumnOrder accepts each supported order', () => {
-        for (const order of MODEL_EFFORT_COLUMN_ORDERS) {
-            state().setColumnOrder(order);
-            expect(state().columnOrder).toBe(order);
-        }
-    });
-
-    it('setColumnOrder falls back to standard for an unknown order', () => {
-        state().setColumnOrder('meFirst');
-        state().setColumnOrder('bogus');
-        expect(state().columnOrder).toBe('standard');
-        state().setColumnOrder(null);
-        expect(state().columnOrder).toBe('standard');
+    it('merge() strips a stale persisted displayMode/columnOrder', () => {
+        const merged = useModelEffortDisplayStore.persist.getOptions().merge(
+            { showOnAllCards: true, displayMode: 'compact', columnOrder: 'meFirst' },
+            { showOnAllCards: false, wideAggregator: true },
+        );
+        expect(merged.showOnAllCards).toBe(true);
+        expect(merged.wideAggregator).toBe(true);
+        expect(merged.displayMode).toBeUndefined();
+        expect(merged.columnOrder).toBeUndefined();
     });
 });

--- a/src/stores/useModelEffortDisplayStore.js
+++ b/src/stores/useModelEffortDisplayStore.js
@@ -1,7 +1,10 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-// Global display preferences for the Model + Effort row columns (req #3029).
+// Global display preferences for the Model + Effort row columns (req #3029;
+// trimmed to just these two toggles in req #3043 — the display-mode
+// (pill/compact) and column-order options were removed, leaving pill
+// rendering and the standard column order as the only (hardcoded) behavior).
 //
 // The Model and Effort columns render inside the aggregator (Swarm-Start) card
 // and, when opted in, on every CategoryCard row. These preferences control the
@@ -9,23 +12,11 @@ import { persist } from 'zustand/middleware';
 //
 //   • `showOnAllCards` — promote the columns onto every CategoryCard row too, not
 //                        just the aggregator. Default false (aggregator only).
-//   • `displayMode`    — how each value is drawn:
-//        'pill'    → full semantic-colored chip (e.g. "Opus", "XHigh")   [default]
-//        'compact' → single-letter colored chip ("O", "X") for Model/Effort and
-//                    the small icons for Status/Autonomy — the horizontal-space saver
-//   • `columnOrder`    — arrangement of the five value columns (Req# always follows
-//                        the aggregator color-bar):
-//        'standard'   → Req# · Status · Autonomy · Model · Effort   [default]
-//        'meFirst'    → Model · Effort · Req# · Status · Autonomy
-//        'meAfterReq' → Req# · Model · Effort · Status · Autonomy
 //   • `wideAggregator` — on wide viewports let the aggregator card span two grid
 //                        tracks so its extra columns fit. Default true; off keeps
 //                        it the same width as every other card.
 //
 // Persisted so the choice survives reloads, mirroring useSwarmStartCardStore.
-
-export const MODEL_EFFORT_DISPLAY_MODES = ['pill', 'compact'];
-export const MODEL_EFFORT_COLUMN_ORDERS = ['standard', 'meFirst', 'meAfterReq'];
 
 export const useModelEffortDisplayStore = create(
     persist(
@@ -34,35 +25,17 @@ export const useModelEffortDisplayStore = create(
             toggleShowOnAllCards: () => set({ showOnAllCards: !get().showOnAllCards }),
             setShowOnAllCards: (value) => set({ showOnAllCards: Boolean(value) }),
 
-            displayMode: 'pill',
-            // Guard against a stale/invalid persisted value re-pointing at the default.
-            setDisplayMode: (mode) => set({
-                displayMode: MODEL_EFFORT_DISPLAY_MODES.includes(mode) ? mode : 'pill',
-            }),
-
-            columnOrder: 'standard',
-            setColumnOrder: (order) => set({
-                columnOrder: MODEL_EFFORT_COLUMN_ORDERS.includes(order) ? order : 'standard',
-            }),
-
             wideAggregator: true,
             toggleWideAggregator: () => set({ wideAggregator: !get().wideAggregator }),
         }),
         {
             name: 'darwin_model_effort_display',
-            // Coerce stale persisted enums (e.g. a retired 'clean'/'text' displayMode,
-            // or the pre-3-way `modelEffortFirst` boolean) back to valid defaults so a
-            // removed option can never leave the UI in an unselectable state.
+            // Strip retired keys (`displayMode`/`columnOrder`, removed in req #3043)
+            // out of any stale persisted value so they can never resurrect a
+            // removed option in state.
             merge: (persisted, current) => {
-                const p = persisted || {};
-                return {
-                    ...current,
-                    ...p,
-                    displayMode: MODEL_EFFORT_DISPLAY_MODES.includes(p.displayMode)
-                        ? p.displayMode : current.displayMode,
-                    columnOrder: MODEL_EFFORT_COLUMN_ORDERS.includes(p.columnOrder)
-                        ? p.columnOrder : current.columnOrder,
-                };
+                const { displayMode, columnOrder, ...rest } = persisted || {};
+                return { ...current, ...rest };
             },
         }
     )


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-07-23T17:59:48Z
- chore: init swarm session feature/3043-reduce-aggregator-card-ui-option-1

## Files changed
```
 src/SwarmView/ModelEffortChip.jsx                  | 37 ++--------
 src/SwarmView/RequirementRow.jsx                   | 58 +++++++---------
 src/SwarmView/SwarmView.jsx                        | 59 +---------------
 src/SwarmView/__tests__/ModelEffortChip.test.jsx   | 37 ++++------
 src/SwarmView/__tests__/modelEffortLayout.test.js  | 79 ++++------------------
 src/SwarmView/modelEffortLayout.js                 | 44 ++++--------
 src/index.css                                      | 10 +--
 .../__tests__/useModelEffortDisplayStore.test.js   | 72 +++++++-------------
 src/stores/useModelEffortDisplayStore.js           | 45 +++---------
 9 files changed, 111 insertions(+), 330 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)