### PR TITLE
Instructions are editable

### DIFF
--- a/src/Agents/AgentDetail.jsx
+++ b/src/Agents/AgentDetail.jsx
@@ -4,19 +4,28 @@
 // identity, BINDING instructions in load order, and documents in relationship
 // precedence order with the autoload subset called out. Identity fields are
 // inline-editable (short by design); long content lives in the linked documents.
+//
+// Req #3049 made the instructions section editable. This page owns the
+// RELATIONSHIP — which instructions bind this agent and in what order — because
+// an agent's list is a single ordered thing. It does not own instruction CONTENT:
+// the pencil opens the same dialog /agents/instructions uses, so the blast-radius
+// warning travels with the edit.
 
 import '../index.css';
 import { useContext, useEffect, useMemo, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
+import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
 import Link from '@mui/material/Link';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
 import Table from '@mui/material/Table';
@@ -25,6 +34,10 @@ import TableBody from '@mui/material/TableBody';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import EditIcon from '@mui/icons-material/Edit';
+import LinkOffIcon from '@mui/icons-material/LinkOff';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
 import AppContext from '../Context/AppContext';
@@ -33,14 +46,21 @@ import call_rest_api from '../RestApi/RestApi';
 import {
     useAgents, useInstructions, useArchitectureDocuments,
     useAgentDocuments, useAgentInstructions, agentKeys,
+    instructionKeys, agentInstructionKeys,
 } from '../hooks/useDataQueries';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
 import {
     byId, linksByAgent, instructionLinksByAgent, agentsByInstruction,
     isCommonInstruction, relationshipChipProps, relationshipLabel,
-    docTypeChipProps, documentHref, isAutoload,
+    docTypeChipProps, documentHref, isAutoload, hasRole,
     agentModelChipProps, agentModelLabel,
+    nextInstructionSortOrder, planInstructionSwap, restErrorMessage,
 } from './agentRegistryUtils';
+import {
+    updateInstruction, linkAgentInstruction, unlinkAgentInstruction,
+    setAgentInstructionOrder, syncInstructionAgents,
+} from './actions/instructionsApi';
+import InstructionEditDialog from './InstructionEditDialog';
 
 const AgentDetail = () => {
     const { id } = useParams();
@@ -81,11 +101,31 @@ const AgentDetail = () => {
     const byInstruction = useMemo(
         () => agentsByInstruction(agentInstrs || []), [agentInstrs]);
 
-    const myInstructions = useMemo(
+    // Only OPEN instructions render: closed rows drop out of the agent's real boot
+    // payload, so listing them here would misrepresent what the agent loads. The
+    // count of hidden ones is surfaced instead, so "where did it go?" has an answer.
+    const myLinks = useMemo(
         () => (instrLinks.get(agentId) || [])
             .map(l => ({ link: l, row: instrIndex.get(l.instruction_fk) }))
-            .filter(x => x.row && !x.row.closed),
+            .filter(x => x.row),
         [instrLinks, agentId, instrIndex]);
+
+    const myInstructions = useMemo(
+        () => myLinks.filter(x => !x.row.closed), [myLinks]);
+
+    const closedLinkedCount = myLinks.length - myInstructions.length;
+
+    // Instructions this agent could still bind — open, and not already linked.
+    const linkableInstructions = useMemo(() => {
+        const bound = new Set(myLinks.map(x => x.row.id));
+        return (allInstructions || [])
+            .filter(i => !i.closed && !bound.has(i.id))
+            .sort((a, b) => a.name.localeCompare(b.name));
+    }, [allInstructions, myLinks]);
+
+    const ownerAgentIds = useMemo(() => [...new Set(
+        (agentDocs || []).filter(l => hasRole(l.relationship, 'owned'))
+            .map(l => l.agent_fk))], [agentDocs]);
 
     const myDocuments = useMemo(
         () => (docLinks.get(agentId) || [])
@@ -107,6 +147,116 @@ const AgentDetail = () => {
         } catch (err) {
             showError(err, 'Failed to update agent overview');
             setOverview(agent.overview || '');
+        }
+    };
+
+    // ---------- instruction relationship editing (req #3049) ----------
+
+    const [addSelection, setAddSelection] = useState(null);
+    const [instrBusy, setInstrBusy] = useState(false);
+    const [editOpen, setEditOpen] = useState(false);
+    const [editTarget, setEditTarget] = useState(null);
+    const [editError, setEditError] = useState(null);
+
+    /**
+     * AWAITED on purpose. Returning before the refetch settles would re-enable the
+     * arrows while the list still renders the PRE-change order, and the next click
+     * would plan its swap from stale `sort_order` values — producing duplicate
+     * slots and moving a different row than the one under the cursor.
+     */
+    const invalidateInstructions = () => Promise.all([
+        queryClient.invalidateQueries({ queryKey: instructionKeys.all(creatorFk) }),
+        queryClient.invalidateQueries({ queryKey: agentInstructionKeys.all(creatorFk) }),
+    ]);
+
+    // Resync BEFORE surfacing the error: a display failure must never be able to
+    // skip the refetch, because the write may be half-applied.
+    const reportInstructionError = async (err, fallback) => {
+        await invalidateInstructions();
+        showError(err, restErrorMessage(err, fallback));
+    };
+
+    /**
+     * Move a bound instruction up or down the agent's load order.
+     *
+     * A SWAP, never a renumber. Closed links keep their stored slots and are not
+     * rewritten, so their values are passed as `reserved` to stop a repair pass
+     * colliding with them.
+     */
+    const moveInstruction = async (fromIdx, toIdx) => {
+        const links = myInstructions.map(x => x.link);
+        const reserved = myLinks
+            .filter(x => x.row.closed)
+            .map(x => x.link.sort_order);
+        const plan = planInstructionSwap(links, fromIdx, toIdx, reserved);
+        if (!plan) return;
+        setInstrBusy(true);
+        try {
+            await setAgentInstructionOrder(darwinUri, idToken, plan.writes, plan.originals);
+            await invalidateInstructions();
+        } catch (err) {
+            await reportInstructionError(err, 'Could not change the load order');
+        } finally {
+            setInstrBusy(false);
+        }
+    };
+
+    const unlinkInstruction = async (instruction) => {
+        // Unbinding changes what this agent loads at boot and there is no undo, so
+        // it gets a confirmation like every other destructive action here.
+        if (!window.confirm(
+            `Unbind "${instruction.name}" from ${agent?.name || 'this agent'}?\n\n` +
+            'The agent stops loading it at its next boot. The instruction row itself survives.')) {
+            return;
+        }
+        setInstrBusy(true);
+        try {
+            await unlinkAgentInstruction(darwinUri, idToken, agentId, instruction.id);
+            await invalidateInstructions();
+        } catch (err) {
+            await reportInstructionError(err, 'Could not unlink the instruction');
+        } finally {
+            setInstrBusy(false);
+        }
+    };
+
+    const addInstruction = async () => {
+        if (!addSelection) return;
+        setInstrBusy(true);
+        try {
+            await linkAgentInstruction(darwinUri, idToken, agentId, addSelection.id,
+                nextInstructionSortOrder(agentId, instrLinks));
+            setAddSelection(null);
+            await invalidateInstructions();
+        } catch (err) {
+            await reportInstructionError(err, 'Could not bind the instruction');
+        } finally {
+            setInstrBusy(false);
+        }
+    };
+
+    const saveInstruction = async (values, linkedAgentIds) => {
+        if (!editTarget) return;
+        setInstrBusy(true);
+        setEditError(null);
+        try {
+            await updateInstruction(darwinUri, idToken, editTarget.id, values);
+            await syncInstructionAgents(darwinUri, idToken, {
+                instructionId: editTarget.id,
+                prevAgentIds: byInstruction.get(editTarget.id) || [],
+                nextAgentIds: linkedAgentIds,
+                sortOrderFor: (aid) => nextInstructionSortOrder(aid, instrLinks),
+            });
+            await invalidateInstructions();
+            setEditOpen(false);
+        } catch (err) {
+            // Resync so a retry diffs against what is actually stored — the
+            // membership loop is a sequence of independent writes and may have
+            // applied some of them.
+            await invalidateInstructions();
+            setEditError(restErrorMessage(err, 'Could not save the instruction.'));
+        } finally {
+            setInstrBusy(false);
         }
     };
 
@@ -167,11 +317,20 @@ const AgentDetail = () => {
                     </Typography>
                 </Typography>
 
+                {closedLinkedCount > 0 && (
+                    <Typography variant="caption" color="text.secondary"
+                                sx={{ display: 'block', mb: 1 }}
+                                data-testid="agent-instructions-closed-note">
+                        {closedLinkedCount} linked instruction{closedLinkedCount === 1 ? ' is' : 's are'} closed
+                        and not loaded at boot.
+                    </Typography>
+                )}
+
                 {myInstructions.length === 0 ? (
-                    <Typography color="text.secondary" sx={{ mb: 3 }}>No instructions linked.</Typography>
+                    <Typography color="text.secondary" sx={{ mb: 1 }}>No instructions linked.</Typography>
                 ) : (
-                    <Stack spacing={1} sx={{ mb: 3 }}>
-                        {myInstructions.map(({ link, row }) => {
+                    <Stack spacing={1} sx={{ mb: 1 }}>
+                        {myInstructions.map(({ link, row }, idx) => {
                             const refs = byInstruction.get(row.id) || [];
                             const common = isCommonInstruction(row.id, byInstruction);
                             return (
@@ -188,9 +347,55 @@ const AgentDetail = () => {
                                                   clickable
                                                   data-testid={`agent-instruction-common-${row.id}`} />
                                         )}
-                                        <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
-                                            #{link.sort_order ?? '—'}
-                                        </Typography>
+                                        <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                                            <Tooltip title="Load order — position in this agent's boot payload">
+                                                <Typography variant="caption" color="text.secondary"
+                                                            data-testid={`agent-instruction-order-${row.id}`}>
+                                                    #{link.sort_order ?? '—'}
+                                                </Typography>
+                                            </Tooltip>
+                                            <Tooltip title="Load earlier">
+                                                <span>
+                                                    <IconButton size="small" disabled={idx === 0 || instrBusy}
+                                                                onClick={() => moveInstruction(idx, idx - 1)}
+                                                                data-testid={`agent-instruction-up-${row.id}`}>
+                                                        <ArrowUpwardIcon fontSize="small" />
+                                                    </IconButton>
+                                                </span>
+                                            </Tooltip>
+                                            <Tooltip title="Load later">
+                                                <span>
+                                                    <IconButton size="small"
+                                                                disabled={idx === myInstructions.length - 1 || instrBusy}
+                                                                onClick={() => moveInstruction(idx, idx + 1)}
+                                                                data-testid={`agent-instruction-down-${row.id}`}>
+                                                        <ArrowDownwardIcon fontSize="small" />
+                                                    </IconButton>
+                                                </span>
+                                            </Tooltip>
+                                            <Tooltip title="Edit instruction">
+                                                <span>
+                                                    <IconButton size="small" disabled={instrBusy}
+                                                                onClick={() => {
+                                                                    setEditError(null);
+                                                                    setEditTarget(row);
+                                                                    setEditOpen(true);
+                                                                }}
+                                                                data-testid={`agent-instruction-edit-${row.id}`}>
+                                                        <EditIcon fontSize="small" />
+                                                    </IconButton>
+                                                </span>
+                                            </Tooltip>
+                                            <Tooltip title="Unbind from this agent (the instruction itself survives)">
+                                                <span>
+                                                    <IconButton size="small" disabled={instrBusy}
+                                                                onClick={() => unlinkInstruction(row)}
+                                                                data-testid={`agent-instruction-unlink-${row.id}`}>
+                                                        <LinkOffIcon fontSize="small" />
+                                                    </IconButton>
+                                                </span>
+                                            </Tooltip>
+                                        </Box>
                                     </Box>
                                     <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
                                         {row.content}
@@ -200,6 +405,29 @@ const AgentDetail = () => {
                         })}
                     </Stack>
                 )}
+
+                <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 3, flexWrap: 'wrap' }}>
+                    <Autocomplete
+                        size="small"
+                        sx={{ minWidth: 320 }}
+                        options={linkableInstructions}
+                        getOptionLabel={(o) => o.name || ''}
+                        value={addSelection}
+                        onChange={(_e, v) => setAddSelection(v)}
+                        isOptionEqualToValue={(o, v) => o.id === v.id}
+                        disabled={instrBusy}
+                        renderInput={(params) => (
+                            <TextField {...params} label="Bind an instruction"
+                                       inputProps={{ ...params.inputProps,
+                                                     'data-testid': 'agent-instruction-add' }} />
+                        )}
+                    />
+                    <Button variant="outlined" size="small" onClick={addInstruction}
+                            disabled={!addSelection || instrBusy}
+                            data-testid="agent-instruction-add-btn">
+                        Bind
+                    </Button>
+                </Box>
             </Box>
 
             {/* ---------- documents ---------- */}
@@ -268,6 +496,19 @@ const AgentDetail = () => {
                     </Table>
                 )}
             </Box>
+
+            <InstructionEditDialog
+                open={editOpen}
+                onClose={() => setEditOpen(false)}
+                onSave={saveInstruction}
+                initial={editTarget}
+                allInstructions={allInstructions || []}
+                agents={agents || []}
+                boundAgentIds={editTarget ? (byInstruction.get(editTarget.id) || []) : []}
+                ownerAgentIds={ownerAgentIds}
+                saving={instrBusy}
+                error={editError}
+            />
         </Box>
     );
 };

--- a/src/Agents/InstructionDeleteDialog.jsx
+++ b/src/Agents/InstructionDeleteDialog.jsx
@@ -1,0 +1,115 @@
+// Retire or delete one instruction (req #3049).
+//
+// A dedicated dialog rather than window.confirm — a deliberate departure from the
+// Features exemplar — because `agent_instructions` CASCADEs on both foreign keys.
+// A hard delete silently strips the instruction from every agent that bound it,
+// and window.confirm cannot render WHICH agents those are. Seeing the list is the
+// whole guardrail.
+//
+// Close is presented as the primary path: it has the same runtime effect (closed
+// rows drop out of the boot payload) but preserves the row and all its links, so
+// it is reversible. Delete is for mistakes.
+
+import { useEffect, useState } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+const InstructionDeleteDialog = ({
+    open, onClose, onClose_Instruction, onDelete, instruction,
+    boundAgents = [], busy = false,
+}) => {
+    const [typed, setTyped] = useState('');
+
+    useEffect(() => { if (open) setTyped(''); }, [open, instruction?.id]);
+
+    if (!instruction) return null;
+
+    // Two different counts, deliberately. `refCount` is DATA destroyed — every
+    // junction row cascades away, whether or not its agent is closed. `bootCount`
+    // is RUNTIME impact — only open agents boot. Collapsing them would either
+    // understate the data loss or overstate what stops loading.
+    const refCount = boundAgents.length;
+    const bootCount = boundAgents.filter(a => !a.closed).length;
+    // A typed-name challenge is reserved for shared rows. Requiring it everywhere
+    // would train people to type past it; requiring it on a row that a dozen
+    // architects load is proportionate.
+    const needsChallenge = refCount >= 2;
+    const deleteEnabled = !busy && (!needsChallenge || typed.trim() === instruction.name);
+
+    return (
+        <Dialog open={open} onClose={() => !busy && onClose()} maxWidth="sm" fullWidth
+                data-testid="instruction-delete-dialog">
+            <DialogTitle>Delete “{instruction.name}”?</DialogTitle>
+            <DialogContent>
+                <Stack spacing={2} sx={{ mt: 1 }}>
+                    {refCount > 0 ? (
+                        <>
+                            <Alert severity="error">
+                                This instruction is bound to {refCount} agent{refCount === 1 ? '' : 's'}.
+                                Deleting it removes those bindings permanently — the junction rows
+                                cascade away with no trace.
+                                {bootCount > 0
+                                    ? ` ${bootCount} of them load it at boot today and would silently lose the duty.`
+                                    : ' None of them are open, so nothing changes at boot — but reopening any of them would silently lose the duty.'}
+                            </Alert>
+                            <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                                {boundAgents.map(a => (
+                                    <Chip key={a.name} size="small" color="error" variant="outlined"
+                                          label={a.closed ? `${a.name} (closed)` : a.name} />
+                                ))}
+                            </Stack>
+                            <Typography variant="body2">
+                                <strong>Closing</strong> it instead has the same effect at boot —
+                                closed rows drop out of every payload — but keeps the row and every
+                                binding, so it can be reopened.
+                            </Typography>
+                        </>
+                    ) : (
+                        <Typography variant="body2">
+                            No agent is bound to this instruction, so deleting it affects nothing
+                            at boot.
+                        </Typography>
+                    )}
+
+                    {needsChallenge && (
+                        <TextField
+                            label={`Type "${instruction.name}" to confirm deletion`}
+                            value={typed}
+                            onChange={e => setTyped(e.target.value)}
+                            size="small"
+                            inputProps={{
+                                style: { fontFamily: 'monospace' },
+                                'data-testid': 'instruction-delete-challenge-input',
+                            }}
+                        />
+                    )}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} disabled={busy}
+                        data-testid="instruction-delete-cancel-btn">Cancel</Button>
+                {refCount > 0 && !instruction.closed && (
+                    <Button onClick={onClose_Instruction} variant="contained" disabled={busy}
+                            data-testid="instruction-delete-close-btn">
+                        Close instead
+                    </Button>
+                )}
+                <Button onClick={onDelete} color="error" disabled={!deleteEnabled}
+                        data-testid="instruction-delete-confirm-btn">
+                    {busy ? 'Working…' : 'Delete permanently'}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default InstructionDeleteDialog;

--- a/src/Agents/InstructionEditDialog.jsx
+++ b/src/Agents/InstructionEditDialog.jsx
@@ -1,0 +1,290 @@
+// Create / edit one instruction registry row (req #3049).
+//
+// Shared by /agents/instructions and /agents/:id deliberately: the pencil on an
+// agent's bound instruction opens THIS dialog, so the blast-radius warning
+// travels with the edit no matter where it was started from.
+//
+// The dialog edits the ROW plus its agent MEMBERSHIP. It does not edit per-agent
+// load order — with N agents there are N different orders and no coherent
+// control for them here. Load order lives on AgentDetail, where an agent's list
+// is a single ordered thing.
+
+import { useEffect, useMemo, useState } from 'react';
+
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import Chip from '@mui/material/Chip';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import { instructionNameTaken } from './agentRegistryUtils';
+
+// `instructions.name` is VARCHAR(256) and the RDS sql_mode is NOT strict, so an
+// over-long value is silently TRUNCATED rather than rejected — and the truncated
+// value can then collide on the unique key. The cap has to be enforced here.
+const NAME_MAX = 256;
+
+// `content` is TEXT: 65,535 BYTES. Same non-strict-mode hazard as `name` — over
+// the limit truncates silently. A hard block, unlike the hint below.
+const CONTENT_MAX_BYTES = 65535;
+
+// Long prose belongs in an architecture document, not an instruction row. A hint,
+// never a block — the registry's own guidance, not a schema limit.
+const CONTENT_HINT_LENGTH = 1500;
+
+// `instructions.sort_order` is SMALLINT — MySQL CLAMPS out-of-range values under
+// non-strict sql_mode rather than rejecting them.
+const SORT_ORDER_MIN = -32768;
+const SORT_ORDER_MAX = 32767;
+
+const InstructionEditDialog = ({
+    open, onClose, onSave, initial,
+    allInstructions = [], agents = [], boundAgentIds = [], ownerAgentIds = [],
+    saving = false, error = null, selfId: selfIdProp,
+}) => {
+    const [name, setName] = useState('');
+    const [content, setContent] = useState('');
+    const [sortOrder, setSortOrder] = useState('');
+    const [closed, setClosed] = useState(false);
+    const [linkedAgentIds, setLinkedAgentIds] = useState([]);
+
+    useEffect(() => {
+        if (!open) return;
+        setName(initial?.name || '');
+        setContent(initial?.content || '');
+        setSortOrder(initial?.sort_order ?? '');
+        setClosed(!!initial?.closed);
+        setLinkedAgentIds(boundAgentIds);
+        // `boundAgentIds` is a fresh array each render; depending on it directly
+        // would re-seed (and discard) the user's checkbox edits on every parent
+        // render. Key off the row identity instead — the dialog re-seeds when it
+        // opens or when it is pointed at a different row, which is the intent.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open, initial?.id]);
+
+    const openAgents = useMemo(() => agents.filter(a => !a.closed), [agents]);
+
+    const trimmedName = name.trim();
+
+    // The row this dialog is editing, which is NOT always `initial.id`. If a
+    // create succeeded but the agent-binding phase then failed, the caller latches
+    // the new row's id and keeps the dialog open for a retry — by which point the
+    // refetched catalog contains that row. Excluding it from the uniqueness check
+    // is what makes the retry possible; without it the dialog would flag the row
+    // the user just created as a name collision and disable Save forever.
+    const selfId = selfIdProp ?? initial?.id ?? null;
+    const isExisting = selfId != null;
+
+    const nameTaken = instructionNameTaken(trimmedName, allInstructions, selfId);
+    const nameMissing = !trimmedName;
+    const contentMissing = !content.trim();
+    // `content` is TEXT — 65,535 BYTES — and the RDS sql_mode is not strict, so an
+    // over-long value is silently TRUNCATED mid-sentence rather than rejected. For
+    // text an agent loads verbatim that is a correctness failure, so measure the
+    // encoded byte length, not the JS string length.
+    const contentBytes = useMemo(
+        () => new TextEncoder().encode(content).length, [content]);
+    const contentTooLong = contentBytes > CONTENT_MAX_BYTES;
+    // `sort_order` is SMALLINT. Non-strict sql_mode CLAMPS an out-of-range value
+    // to 32767 instead of rejecting it — the same silent-corruption class as the
+    // name and content limits, so guard it the same way.
+    const sortOrderNum = sortOrder === '' ? null : parseInt(sortOrder, 10);
+    const sortOrderInvalid = sortOrder !== '' && (
+        !Number.isFinite(sortOrderNum)
+        || sortOrderNum < SORT_ORDER_MIN || sortOrderNum > SORT_ORDER_MAX);
+    const renamed = !!initial && trimmedName !== (initial.name || '');
+
+    // Blast radius is measured on what is CURRENTLY bound in the database, not on
+    // the pending checkbox state: it answers "who does this edit disturb?".
+    //
+    // Counted over OPEN agents only — a closed agent never boots, so it loads
+    // nothing. Counting it would also disagree with the checkbox list below, which
+    // shows open agents only.
+    const boundAgentNames = useMemo(
+        () => boundAgentIds
+            .map(id => agents.find(a => a.id === id))
+            .filter(a => a && !a.closed)
+            .map(a => a.name),
+        [boundAgentIds, agents]);
+    const refCount = boundAgentNames.length;
+
+    // The contradiction rule: an agent's binding instruction must not contradict a
+    // document that same agent owns. Not machine-checkable — surfaced at the one
+    // moment it can actually be violated.
+    const bindsAnOwner = boundAgentIds.some(id => ownerAgentIds.includes(id));
+
+    const invalid = nameMissing || contentMissing || nameTaken
+        || contentTooLong || sortOrderInvalid;
+
+    const toggleAgent = (id) => setLinkedAgentIds(prev =>
+        prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]);
+
+    const submit = () => {
+        if (invalid || saving) return;
+        onSave({
+            name: trimmedName,
+            content,
+            sort_order: sortOrderNum,
+            closed: closed ? 1 : 0,
+        }, linkedAgentIds);
+    };
+
+    return (
+        <Dialog open={open} onClose={() => !saving && onClose()} maxWidth="md" fullWidth
+                data-testid="instruction-edit-dialog">
+            <DialogTitle>{isExisting ? 'Edit instruction' : 'New instruction'}</DialogTitle>
+            <DialogContent>
+                <Stack spacing={2} sx={{ mt: 1 }}>
+
+                    {initial && refCount > 0 && (
+                        <Alert severity={refCount >= 2 ? 'warning' : 'info'}
+                               data-testid="instruction-blast-radius-alert">
+                            <AlertTitle sx={{ mb: 0.5 }}>
+                                {refCount} agent{refCount === 1 ? '' : 's'} load this at boot
+                            </AlertTitle>
+                            <Typography variant="body2" sx={{ mb: 1 }}>
+                                Saving changes their duty at their <strong>next boot</strong>.
+                                Sessions already running keep the old text.
+                            </Typography>
+                            <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                                {boundAgentNames.map(n => (
+                                    <Chip key={n} label={n} size="small" variant="outlined" />
+                                ))}
+                            </Stack>
+                        </Alert>
+                    )}
+
+                    {renamed && refCount >= 2 && (
+                        <Alert severity="warning" data-testid="instruction-rename-warning">
+                            Renaming <code>{initial.name}</code> breaks no code — no production
+                            path resolves an instruction by name — but the name appears verbatim
+                            in the charter stubs and the memory docs. Grep the workspace for the
+                            old name after saving.
+                        </Alert>
+                    )}
+
+                    {error && (
+                        <Alert severity="error" data-testid="instruction-save-error">{error}</Alert>
+                    )}
+
+                    <TextField
+                        autoFocus
+                        label="Name"
+                        value={name}
+                        onChange={e => setName(e.target.value)}
+                        required
+                        error={nameTaken}
+                        helperText={nameTaken
+                            ? `An instruction named "${trimmedName}" already exists (it may be closed).`
+                            : 'Kebab-case by convention. Unique across the registry.'}
+                        inputProps={{
+                            maxLength: NAME_MAX,
+                            style: { fontFamily: 'monospace' },
+                            'data-testid': 'instruction-name-input',
+                        }}
+                    />
+
+                    <TextField
+                        label="Content"
+                        value={content}
+                        onChange={e => setContent(e.target.value)}
+                        required
+                        multiline
+                        minRows={8}
+                        maxRows={24}
+                        error={contentTooLong}
+                        helperText={
+                            contentTooLong
+                                ? `Too long: ${contentBytes.toLocaleString()} bytes of a ${CONTENT_MAX_BYTES.toLocaleString()}-byte limit. `
+                                  + 'The database would truncate it silently.'
+                                : content.length > CONTENT_HINT_LENGTH
+                                    ? 'Long content usually belongs in an architecture document — instructions are short binding rules.'
+                                    : bindsAnOwner
+                                        ? 'Check this does not contradict a document the bound agent owns.'
+                                        : 'BINDING text. Loaded verbatim into the agent at boot.'
+                        }
+                        inputProps={{ 'data-testid': 'instruction-content-input' }}
+                    />
+
+                    <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start', flexWrap: 'wrap' }}>
+                        <TextField
+                            label="Catalog order"
+                            type="number"
+                            value={sortOrder}
+                            onChange={e => setSortOrder(e.target.value)}
+                            sx={{ width: 240 }}
+                            error={sortOrderInvalid}
+                            helperText={sortOrderInvalid
+                                ? `Must be a whole number between ${SORT_ORDER_MIN} and ${SORT_ORDER_MAX}.`
+                                : 'Browse-list position only — does not affect what any agent loads.'}
+                            inputProps={{
+                                min: SORT_ORDER_MIN,
+                                max: SORT_ORDER_MAX,
+                                'data-testid': 'instruction-sort-order-input',
+                            }}
+                        />
+                        {isExisting && (
+                            <FormControlLabel
+                                sx={{ mt: 1 }}
+                                control={
+                                    <Switch
+                                        checked={closed}
+                                        onChange={e => setClosed(e.target.checked)}
+                                        data-testid="instruction-closed-switch"
+                                    />
+                                }
+                                label="Closed (retired — drops out of every boot payload)"
+                            />
+                        )}
+                    </Box>
+
+                    <Box>
+                        <Typography variant="subtitle2">Bound agents</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                            Membership only. A newly bound instruction lands at the end of that
+                            agent&apos;s load order; reorder it on the agent&apos;s own page.
+                        </Typography>
+                        <Box sx={{ maxHeight: 220, overflow: 'auto', border: 1,
+                                    borderColor: 'divider', p: 1, borderRadius: 1, mt: 1 }}
+                             data-testid="instruction-agent-link-list">
+                            {openAgents.map(a => (
+                                <FormControlLabel
+                                    key={a.id}
+                                    control={
+                                        <Checkbox
+                                            checked={linkedAgentIds.includes(a.id)}
+                                            onChange={() => toggleAgent(a.id)}
+                                            data-testid={`link-agent-${a.id}`}
+                                        />
+                                    }
+                                    label={a.name}
+                                    sx={{ display: 'block' }}
+                                />
+                            ))}
+                        </Box>
+                    </Box>
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} disabled={saving}
+                        data-testid="instruction-cancel-btn">Cancel</Button>
+                <Button onClick={submit} variant="contained" disabled={invalid || saving}
+                        data-testid="instruction-save-btn">
+                    {saving ? 'Saving…' : isExisting ? 'Save' : 'Create'}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default InstructionEditDialog;

--- a/src/Agents/InstructionsPage.jsx
+++ b/src/Agents/InstructionsPage.jsx
@@ -1,65 +1,235 @@
-// /agents/instructions — the instruction registry (req #2998).
+// /agents/instructions — the instruction registry (req #2998, editable req #3049).
 //
 // The point of this page is BLAST RADIUS. An instruction is a row, and a "common"
 // instruction is simply a row that many agents link — there is no common flag in
 // the schema. Editing one changes the duty for every agent that references it at
 // their next boot, so every row shows chips for all referencing agents BEFORE
 // anyone edits it.
+//
+// Req #3049 made the rows editable in place. The card list survives the change on
+// purpose: `content` is prose, and a DataGrid would either truncate it into
+// uselessness or need auto row height. The card is the only view that shows the
+// text and its blast radius together, which is the read this page exists for.
 
 import '../index.css';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
 
+import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
 import {
-    useInstructions, useAgents, useAgentInstructions,
+    useInstructions, useAgents, useAgentInstructions, useAgentDocuments,
+    instructionKeys, agentInstructionKeys,
 } from '../hooks/useDataQueries';
-import { byId, agentsByInstruction, isCommonInstruction } from './agentRegistryUtils';
+import { useSnackBarStore } from '../stores/useSnackBarStore';
+import {
+    byId, agentsByInstruction, isCommonInstruction, instructionLinksByAgent,
+    nextInstructionSortOrder, restErrorMessage, hasRole,
+} from './agentRegistryUtils';
+import {
+    createInstruction, updateInstruction, deleteInstruction, syncInstructionAgents,
+} from './actions/instructionsApi';
+import InstructionEditDialog from './InstructionEditDialog';
+import InstructionDeleteDialog from './InstructionDeleteDialog';
 
 const InstructionsPage = () => {
     const navigate = useNavigate();
-    const { profile } = useContext(AuthContext);
+    const { profile, idToken } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
+    const queryClient = useQueryClient();
+    const showError = useSnackBarStore(s => s.showError);
     const isMobile = useMediaQuery('(max-width:899px)');
     const creatorFk = profile?.userName;
 
     const { data: instructions, isLoading } = useInstructions(creatorFk);
     const { data: agents } = useAgents(creatorFk);
     const { data: agentInstrs } = useAgentInstructions(creatorFk);
+    const { data: agentDocs } = useAgentDocuments(creatorFk);
+
+    const [showClosed, setShowClosed] = useState(false);
+    const [editOpen, setEditOpen] = useState(false);
+    const [editTarget, setEditTarget] = useState(null);
+    const [deleteTarget, setDeleteTarget] = useState(null);
+    const [busy, setBusy] = useState(false);
+    const [saveError, setSaveError] = useState(null);
+    const [createdId, setCreatedId] = useState(null);
 
     const agentIndex = useMemo(() => byId(agents || []), [agents]);
     const byInstruction = useMemo(
         () => agentsByInstruction(agentInstrs || []), [agentInstrs]);
+    const instrLinks = useMemo(
+        () => instructionLinksByAgent(agentInstrs || []), [agentInstrs]);
+
+    // Agents that own at least one document — drives the contradiction hint in the
+    // edit dialog (a binding instruction must not contradict a document its agent
+    // owns).
+    const ownerAgentIds = useMemo(() => [...new Set(
+        (agentDocs || []).filter(l => hasRole(l.relationship, 'owned'))
+            .map(l => l.agent_fk))], [agentDocs]);
+
+    const hasClosed = useMemo(
+        () => (instructions || []).some(i => i.closed), [instructions]);
 
     const rows = useMemo(() => {
         if (!instructions) return [];
         return instructions
-            .filter(i => !i.closed)
+            .filter(i => showClosed || !i.closed)
             .map(i => ({ ...i, refs: byInstruction.get(i.id) || [] }))
             .sort((a, b) =>
-                // Common rows first (biggest blast radius at the top), then by
-                // the sort_order that drives boot load order.
+                // Open rows first — a closed row binds nothing, so it never
+                // belongs above a live one.
+                (a.closed ? 1 : 0) - (b.closed ? 1 : 0) ||
+                // Then the biggest blast radius, then the catalog order. NOTE:
+                // `instructions.sort_order` is a CATALOG hint only. Boot load
+                // order is `agent_instructions.sort_order`, which is per-agent
+                // and shown on each agent's own page.
                 b.refs.length - a.refs.length ||
                 (a.sort_order ?? Infinity) - (b.sort_order ?? Infinity) ||
                 a.name.localeCompare(b.name));
-    }, [instructions, byInstruction]);
+    }, [instructions, byInstruction, showClosed]);
+
+    // Awaited by every caller: the membership diff reads `byInstruction`, so a
+    // retry after a partial failure must diff against what is actually stored.
+    const invalidate = () => Promise.all([
+        queryClient.invalidateQueries({ queryKey: instructionKeys.all(creatorFk) }),
+        // A hard delete cascades junction rows, and every membership edit writes
+        // them, so the junction cache is stale even when only the row changed.
+        queryClient.invalidateQueries({ queryKey: agentInstructionKeys.all(creatorFk) }),
+    ]);
+
+    const openCreate = () => {
+        setSaveError(null); setEditTarget(null); setCreatedId(null); setEditOpen(true);
+    };
+    const openEdit = (row) => { setSaveError(null); setEditTarget(row); setEditOpen(true); };
+
+    const handleSave = async (values, linkedAgentIds) => {
+        setBusy(true);
+        setSaveError(null);
+        try {
+            // `createdId` latches a row this dialog already created. Without it, a
+            // retry after the LINK phase failed would call createInstruction again
+            // and hit the unique-name 500 — leaving an orphan row and a dialog that
+            // can never be completed.
+            let instructionId = editTarget?.id || createdId;
+            if (editTarget) {
+                await updateInstruction(darwinUri, idToken, editTarget.id, values);
+            } else if (instructionId) {
+                await updateInstruction(darwinUri, idToken, instructionId, values);
+            } else {
+                let saved = await createInstruction(darwinUri, idToken,
+                    { ...values, creator_fk: creatorFk });
+                if (Array.isArray(saved)) saved = saved[0];
+                instructionId = saved?.id;
+                // rest_post.py returns 201 with an EMPTY body on three fallback
+                // paths. Silently skipping the agent bindings there would report
+                // success while binding nothing, so fail loudly instead.
+                if (!instructionId) {
+                    throw new Error(
+                        'The instruction was created but the server did not return its id, '
+                        + 'so the agent bindings were not applied. Reload and edit the row.');
+                }
+                setCreatedId(instructionId);
+            }
+
+            await syncInstructionAgents(darwinUri, idToken, {
+                instructionId,
+                prevAgentIds: byInstruction.get(instructionId) || [],
+                nextAgentIds: linkedAgentIds,
+                sortOrderFor: (agentId) => nextInstructionSortOrder(agentId, instrLinks),
+            });
+            await invalidate();
+            setCreatedId(null);
+            setEditOpen(false);
+        } catch (err) {
+            // Resync first so a retry diffs against reality — the membership loop
+            // is a sequence of independent writes and may be half-applied.
+            await invalidate();
+            // A constraint violation arrives as an opaque 500 — show the mapped
+            // message inline on the dialog, where the offending field is.
+            setSaveError(restErrorMessage(err, err?.message
+                || (editTarget ? 'Could not save the instruction.'
+                               : 'Could not create the instruction.')));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleClose = async () => {
+        if (!deleteTarget) return;
+        setBusy(true);
+        try {
+            await updateInstruction(darwinUri, idToken, deleteTarget.id, { closed: 1 });
+            await invalidate();
+            setDeleteTarget(null);
+        } catch (err) {
+            await invalidate();
+            showError(err, restErrorMessage(err, 'Could not close the instruction'));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!deleteTarget) return;
+        setBusy(true);
+        try {
+            await deleteInstruction(darwinUri, idToken, deleteTarget.id);
+            await invalidate();
+            setDeleteTarget(null);
+        } catch (err) {
+            await invalidate();
+            showError(err, restErrorMessage(err, 'Could not delete the instruction'));
+        } finally {
+            setBusy(false);
+        }
+    };
 
     if (isLoading || !instructions) {
         return <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }}><CircularProgress /></Box>;
     }
 
+    const openCount = rows.filter(r => !r.closed).length;
+
     return (
         <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }}>
-            <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ mb: 0.5 }}>Instructions</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5, flexWrap: 'wrap' }}>
+                <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ flex: 1 }}>Instructions</Typography>
+                {hasClosed && (
+                    <Tooltip title={showClosed ? 'Hide closed instructions' : 'Show closed instructions'}>
+                        <Chip
+                            label="Closed"
+                            size="small"
+                            color={showClosed ? 'primary' : 'default'}
+                            variant={showClosed ? 'filled' : 'outlined'}
+                            onClick={() => setShowClosed(v => !v)}
+                            sx={{ cursor: 'pointer' }}
+                            data-testid="instructions-show-closed"
+                        />
+                    </Tooltip>
+                )}
+                <Button variant="contained" size="small" startIcon={<AddIcon />}
+                        onClick={openCreate} data-testid="new-instruction-btn">
+                    New Instruction
+                </Button>
+            </Box>
+
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                {rows.length} binding instruction rows. Chips show every agent bound by each row —
+                {openCount} binding instruction rows. Chips show every agent bound by each row —
                 editing a row changes the duty for all of them at their next boot.
             </Typography>
 
@@ -67,7 +237,8 @@ const InstructionsPage = () => {
                 {rows.map(row => {
                     const common = isCommonInstruction(row.id, byInstruction);
                     return (
-                        <Paper key={row.id} variant="outlined" sx={{ p: 2 }}
+                        <Paper key={row.id} variant="outlined"
+                               sx={{ p: 2, ...(row.closed && { opacity: 0.55 }) }}
                                data-testid={`instruction-row-${row.id}`}>
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 1 }}>
                                 <Typography variant="subtitle2" sx={{ fontFamily: 'monospace' }}>
@@ -77,8 +248,32 @@ const InstructionsPage = () => {
                                     <Chip label="common" size="small" color="secondary" variant="outlined"
                                           data-testid={`instruction-common-${row.id}`} />
                                 )}
-                                <Chip label={`${row.refs.length} agent${row.refs.length === 1 ? '' : 's'}`}
-                                      size="small" variant="outlined" />
+                                {row.refs.length === 0 ? (
+                                    <Chip label="0 agents — not bound" size="small" color="warning"
+                                          variant="outlined"
+                                          data-testid={`instruction-unbound-${row.id}`} />
+                                ) : (
+                                    <Chip label={`${row.refs.length} agent${row.refs.length === 1 ? '' : 's'}`}
+                                          size="small" variant="outlined" />
+                                )}
+                                {row.closed && (
+                                    <Chip label="closed" size="small"
+                                          data-testid={`instruction-closed-${row.id}`} />
+                                )}
+                                <Box sx={{ ml: 'auto', flexShrink: 0 }}>
+                                    <Tooltip title="Edit instruction">
+                                        <IconButton size="small" onClick={() => openEdit(row)}
+                                                    data-testid={`instruction-edit-${row.id}`}>
+                                            <EditIcon fontSize="small" />
+                                        </IconButton>
+                                    </Tooltip>
+                                    <Tooltip title="Retire or delete">
+                                        <IconButton size="small" onClick={() => setDeleteTarget(row)}
+                                                    data-testid={`instruction-delete-${row.id}`}>
+                                            <DeleteIcon fontSize="small" />
+                                        </IconButton>
+                                    </Tooltip>
+                                </Box>
                             </Box>
 
                             <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', mb: 1.5 }}>
@@ -105,6 +300,43 @@ const InstructionsPage = () => {
                     );
                 })}
             </Stack>
+
+            <InstructionEditDialog
+                open={editOpen}
+                onClose={() => setEditOpen(false)}
+                onSave={handleSave}
+                initial={editTarget}
+                // The row being edited is `createdId` when a create succeeded but
+                // its agent-binding phase failed: the dialog stays open for a
+                // retry, and by then the refetched catalog contains that row.
+                // Without this the uniqueness check would flag it and disable Save.
+                selfId={editTarget?.id ?? createdId ?? null}
+                allInstructions={instructions}
+                agents={agents || []}
+                boundAgentIds={editTarget ? (byInstruction.get(editTarget.id) || []) : []}
+                ownerAgentIds={ownerAgentIds}
+                saving={busy}
+                error={saveError}
+            />
+
+            <InstructionDeleteDialog
+                open={!!deleteTarget}
+                onClose={() => setDeleteTarget(null)}
+                onClose_Instruction={handleClose}
+                onDelete={handleDelete}
+                instruction={deleteTarget}
+                // EVERY binding, including closed agents': a hard delete cascades
+                // all of them away, so all of them belong in the warning. The
+                // dialog counts the open ones separately for the "load at boot"
+                // wording — data loss and boot impact are different questions.
+                boundAgents={deleteTarget
+                    ? (byInstruction.get(deleteTarget.id) || [])
+                        .map(aid => agentIndex.get(aid))
+                        .filter(Boolean)
+                        .map(a => ({ name: a.name, closed: !!a.closed }))
+                    : []}
+                busy={busy}
+            />
         </Box>
     );
 };

--- a/src/Agents/__tests__/agentRegistryUtils.test.js
+++ b/src/Agents/__tests__/agentRegistryUtils.test.js
@@ -1,0 +1,237 @@
+// Req #3049 — the pure helpers behind editable instructions.
+//
+// The load-order helpers carry the two invariants that make reordering safe:
+// a swap must never renumber (the live registry parks `common-documents` at
+// sort_order 100 so it always loads last), and it must never touch more than
+// two rows (a half-applied write must not be able to strip an agent's whole
+// instruction set).
+
+import { describe, it, expect } from 'vitest';
+import {
+    nextInstructionSortOrder, planInstructionSwap, repairInstructionOrders,
+    instructionNameTaken, restErrorMessage,
+} from '../agentRegistryUtils';
+
+const link = (instruction_fk, sort_order, agent_fk = 7) =>
+    ({ agent_fk, instruction_fk, sort_order });
+
+describe('nextInstructionSortOrder', () => {
+    it('returns 1 for an agent with no links', () => {
+        expect(nextInstructionSortOrder(7, new Map())).toBe(1);
+    });
+
+    it('lands past the highest existing slot', () => {
+        const links = new Map([[7, [link(1, 1), link(2, 2), link(3, 5)]]]);
+        expect(nextInstructionSortOrder(7, links)).toBe(6);
+    });
+
+    it('ignores NULL slots rather than treating them as zero', () => {
+        const links = new Map([[7, [link(1, 3), link(2, null)]]]);
+        expect(nextInstructionSortOrder(7, links)).toBe(4);
+    });
+
+    it('returns 1 when every existing slot is NULL', () => {
+        const links = new Map([[7, [link(1, null), link(2, null)]]]);
+        expect(nextInstructionSortOrder(7, links)).toBe(1);
+    });
+
+    it('does not leak one agent\'s slots into another\'s', () => {
+        const links = new Map([[7, [link(1, 9)]], [8, [link(2, 1, 8)]]]);
+        expect(nextInstructionSortOrder(8, links)).toBe(2);
+    });
+});
+
+describe('repairInstructionOrders', () => {
+    it('leaves an already-valid list completely alone', () => {
+        const links = [link(10, 1), link(11, 2), link(12, 3)];
+        expect(repairInstructionOrders(links).map(l => l.sort_order)).toEqual([1, 2, 3]);
+    });
+
+    it('keeps a deliberate outlier instead of flattening to 1..N', () => {
+        // The real registry shape: a run of small slots, then common-documents
+        // parked at 100 so it always loads last. A NULL in the middle must not
+        // cost that intent.
+        const links = [link(10, 1), link(11, null), link(12, 100)];
+        expect(repairInstructionOrders(links).map(l => l.sort_order)).toEqual([1, 2, 100]);
+    });
+
+    it('repairs only the duplicate, keeping the values around it', () => {
+        const links = [link(10, 4), link(11, 4), link(12, 9)];
+        expect(repairInstructionOrders(links).map(l => l.sort_order)).toEqual([4, 5, 9]);
+    });
+
+    it('repairs a value that would go backwards', () => {
+        const links = [link(10, 5), link(11, 2), link(12, 8)];
+        expect(repairInstructionOrders(links).map(l => l.sort_order)).toEqual([5, 6, 8]);
+    });
+
+    it('skips slots reserved by links it is not rewriting (closed links)', () => {
+        const links = [link(10, null), link(11, null)];
+        expect(repairInstructionOrders(links, [1, 3]).map(l => l.sort_order)).toEqual([2, 4]);
+    });
+
+    it('will not KEEP a stored value that a reserved link already holds', () => {
+        const links = [link(10, 1), link(11, 2)];
+        expect(repairInstructionOrders(links, [2]).map(l => l.sort_order)).toEqual([1, 3]);
+    });
+
+    it('never produces a duplicate, whatever the input', () => {
+        const links = [link(10, null), link(11, 1), link(12, 1), link(13, null)];
+        const orders = repairInstructionOrders(links).map(l => l.sort_order);
+        expect(new Set(orders).size).toBe(orders.length);
+    });
+
+    it('keeps a deliberate 0 or negative slot instead of rewriting it', () => {
+        const links = [link(10, -5), link(11, 0), link(12, 2)];
+        expect(repairInstructionOrders(links).map(l => l.sort_order)).toEqual([-5, 0, 2]);
+    });
+
+    it('still floors a NEWLY assigned slot at 1', () => {
+        const links = [link(10, null), link(11, null)];
+        expect(repairInstructionOrders(links).map(l => l.sort_order)).toEqual([1, 2]);
+    });
+
+    it('preserves the live banded shape (per-agent 1..N, common 100..102)', () => {
+        // The real registry: verified live 2026-07-24 on all 12 architects.
+        const links = [link(1, 1), link(2, 2), link(3, 3),
+                       link(4, 100), link(5, 101), link(6, 102)];
+        expect(repairInstructionOrders(links).map(l => l.sort_order))
+            .toEqual([1, 2, 3, 100, 101, 102]);
+    });
+});
+
+describe('planInstructionSwap', () => {
+    const clean = [link(10, 1), link(11, 2), link(12, 3)];
+    const orderOf = (plan, id) =>
+        plan.writes.find(r => r.instruction_fk === id)?.sort_order;
+
+    it('swaps two adjacent rows and writes nothing else', () => {
+        const plan = planInstructionSwap(clean, 1, 0);
+        expect(plan.writes).toHaveLength(2);
+        expect(orderOf(plan, 11)).toBe(1);
+        expect(orderOf(plan, 10)).toBe(2);
+        // Row 12 is never written — that is the blast-radius guarantee.
+        expect(plan.writes.some(r => r.instruction_fk === 12)).toBe(false);
+    });
+
+    it('preserves a deliberate always-last slot instead of renumbering it', () => {
+        const seeded = [link(1, 1), link(2, 2), link(3, 100)];
+        const plan = planInstructionSwap(seeded, 2, 1);
+        expect(plan.writes.map(r => r.sort_order).sort((a, b) => a - b)).toEqual([2, 100]);
+        expect(orderOf(plan, 3)).toBe(2);     // moved up
+        expect(orderOf(plan, 2)).toBe(100);   // 100 survives; nothing collapses to 3
+    });
+
+    it('returns rollback originals aligned with the writes', () => {
+        const plan = planInstructionSwap(clean, 0, 1);
+        expect(plan.originals).toHaveLength(plan.writes.length);
+        plan.writes.forEach((w, i) => {
+            expect(plan.originals[i].instruction_fk).toBe(w.instruction_fk);
+        });
+        expect(plan.originals.map(o => o.sort_order)).toEqual([1, 2]);
+    });
+
+    it('repairs NULL slots as part of the same single write set', () => {
+        const dirty = [link(10, 1), link(11, null), link(12, null)];
+        const plan = planInstructionSwap(dirty, 0, 1);
+        // Display order [10,11,12] with 10 moved down one → [11,10,12].
+        expect(orderOf(plan, 11)).toBe(1);
+        expect(orderOf(plan, 10)).toBe(2);
+        expect(orderOf(plan, 12)).toBe(3);
+    });
+
+    it('repairs a duplicated slot without flattening the list', () => {
+        const dupes = [link(10, 4), link(11, 4), link(12, 9)];
+        const plan = planInstructionSwap(dupes, 0, 2);
+        expect(orderOf(plan, 12)).toBe(4);
+        expect(orderOf(plan, 10)).toBe(9);
+        expect(orderOf(plan, 11)).toBe(5);   // the repaired duplicate
+    });
+
+    it('writes nothing extra for a merely sparse list', () => {
+        const sparse = [link(10, 2), link(11, 40), link(12, 700)];
+        const plan = planInstructionSwap(sparse, 0, 1);
+        expect(plan.writes).toHaveLength(2);
+        expect(orderOf(plan, 10)).toBe(40);
+        expect(orderOf(plan, 11)).toBe(2);
+    });
+
+    it('avoids a closed link\'s reserved slot when repairing', () => {
+        const links = [link(10, null), link(11, null)];
+        const plan = planInstructionSwap(links, 0, 1, [1]);
+        expect(plan.writes.map(r => r.sort_order).sort((a, b) => a - b)).toEqual([2, 3]);
+    });
+
+    it('returns null at the bounds and for a no-op move', () => {
+        expect(planInstructionSwap(clean, 0, -1)).toBeNull();
+        expect(planInstructionSwap(clean, 2, 3)).toBeNull();
+        expect(planInstructionSwap(clean, 1, 1)).toBeNull();
+        expect(planInstructionSwap([], 0, 1)).toBeNull();
+    });
+
+    it('does not mutate the input links', () => {
+        const input = [link(10, 1), link(11, 2)];
+        planInstructionSwap(input, 0, 1);
+        expect(input.map(l => l.sort_order)).toEqual([1, 2]);
+    });
+});
+
+describe('instructionNameTaken', () => {
+    const catalog = [
+        { id: 1, name: 'common-documents', closed: 0 },
+        { id: 2, name: 'Retired-Rule', closed: 1 },
+    ];
+
+    it('detects a collision', () => {
+        expect(instructionNameTaken('common-documents', catalog)).toBe(true);
+    });
+
+    it('collides against a CLOSED row — the unique key does not exclude them', () => {
+        expect(instructionNameTaken('retired-rule', catalog)).toBe(true);
+    });
+
+    it('is case- and whitespace-insensitive, matching MySQL collation', () => {
+        expect(instructionNameTaken('  COMMON-Documents ', catalog)).toBe(true);
+    });
+
+    it('does not collide a row with itself', () => {
+        expect(instructionNameTaken('common-documents', catalog, 1)).toBe(false);
+    });
+
+    it('treats an empty name as not taken (the required-field check owns that)', () => {
+        expect(instructionNameTaken('   ', catalog)).toBe(false);
+    });
+
+    it('allows a genuinely new name', () => {
+        expect(instructionNameTaken('new-rule', catalog)).toBe(false);
+    });
+});
+
+describe('restErrorMessage', () => {
+    const thrown = (httpMessage) => ({ httpStatus: { httpStatus: 500, httpMessage } });
+
+    it('maps a duplicate instruction name', () => {
+        const err = thrown("HTTP PUT SQL FAILED: 1062 Duplicate entry 'x' for key 'instructions.uq_instructions_name'");
+        expect(restErrorMessage(err, 'fallback')).toMatch(/already in use/);
+    });
+
+    it('maps a duplicate agent link', () => {
+        const err = thrown("HTTP POST bulk failed: 1062 Duplicate entry '10-6' for key 'agent_instructions.PRIMARY'");
+        expect(restErrorMessage(err, 'fallback')).toMatch(/already bound/);
+    });
+
+    it('maps a foreign key failure', () => {
+        const err = thrown('HTTP POST bulk failed: 1452 Cannot add or update a child row: a foreign key constraint fails');
+        expect(restErrorMessage(err, 'fallback')).toMatch(/no longer exists/);
+    });
+
+    it('falls back for an unrecognised error', () => {
+        expect(restErrorMessage(thrown('HTTP PUT SQL FAILED: 2013 Lost connection'), 'fallback'))
+            .toBe('fallback');
+    });
+
+    it('falls back when the thrown value has no message at all', () => {
+        expect(restErrorMessage(new Error('boom'), 'fallback')).toBe('fallback');
+        expect(restErrorMessage(undefined, 'fallback')).toBe('fallback');
+    });
+});

--- a/src/Agents/__tests__/instructionsApi.test.js
+++ b/src/Agents/__tests__/instructionsApi.test.js
@@ -1,0 +1,296 @@
+// Req #3049 — the REST mutation layer for editable instructions.
+//
+// agentRegistryUtils.test.js covers the PURE planning helpers. This file covers
+// the part that actually talks to the network, where the risk lives:
+//
+//   * `agent_instructions` has no `id` column, so a SINGLE-OBJECT POST commits
+//     the row and THEN returns 500 (rest_post.py re-reads `WHERE id = ...`).
+//     Every insert must therefore use an array body. Locked in Lambda-Rest by
+//     tests/test_agent_instructions.py; locked on the client side here.
+//   * A load-order change is DELETE + re-POST across two non-atomic Lambda
+//     invocations under autocommit. The restore-on-failure path is the only
+//     thing standing between a failed write and an agent booting without its
+//     binding instructions — and it is unreachable from an integration test.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../RestApi/RestApi', () => ({ default: vi.fn() }));
+
+import call_rest_api from '../../RestApi/RestApi';
+import {
+    linkAgentInstruction, linkAgentInstructions,
+    unlinkAgentInstruction, setAgentInstructionOrder, syncInstructionAgents,
+    createInstruction, updateInstruction, deleteInstruction,
+} from '../actions/instructionsApi';
+
+const URI = 'https://api.test/darwin_dev';
+const TOKEN = 'id-token';
+
+const ok = (status = 200, data = null) =>
+    ({ data, httpStatus: { httpStatus: status, httpMessage: 'OK' } });
+
+// call_rest_api rejects with a bare object (`throw {data, httpStatus}`), not an
+// Error — the 404-tolerant paths read that shape directly.
+const rejectWith = (status, httpMessage = '') =>
+    Promise.reject({ data: null, httpStatus: { httpStatus: status, httpMessage } });
+
+const calls = () => call_rest_api.mock.calls.map(
+    ([url, method, body]) => ({ table: url.split('/').pop(), method, body }));
+
+beforeEach(() => {
+    call_rest_api.mockReset();
+    call_rest_api.mockResolvedValue(ok(201, { inserted: 1 }));
+});
+
+describe('junction inserts never use the single-object POST path', () => {
+    it('sends an ARRAY body even for one link', async () => {
+        await linkAgentInstruction(URI, TOKEN, 7, 42, 3);
+
+        const [c] = calls();
+        expect(c.table).toBe('agent_instructions');
+        expect(c.method).toBe('POST');
+        expect(Array.isArray(c.body)).toBe(true);
+        expect(c.body).toEqual([{ agent_fk: 7, instruction_fk: 42, sort_order: 3 }]);
+    });
+
+    it('normalizes every row to the same key set', async () => {
+        // _rest_post_bulk builds ONE multi-value INSERT from the FIRST item's key
+        // list and then reads `item[k]` on every later item. A row missing a key
+        // raises KeyError inside the Lambda (an unhandled 500, not a pymysql
+        // error); a row with EXTRA keys silently drops them. Both are prevented
+        // by normalizing here, so assert the normalization rather than trusting it.
+        await linkAgentInstructions(URI, TOKEN, [
+            { agent_fk: 7, instruction_fk: 1, sort_order: 1, stray: 'x' },
+            { agent_fk: 7, instruction_fk: 2 },
+        ]);
+
+        const [c] = calls();
+        expect(c.body).toEqual([
+            { agent_fk: 7, instruction_fk: 1, sort_order: 1 },
+            { agent_fk: 7, instruction_fk: 2, sort_order: null },
+        ]);
+        expect(c.body.every(r => Object.keys(r).length === 3)).toBe(true);
+    });
+
+    it('issues no request at all for an empty row list', async () => {
+        expect(await linkAgentInstructions(URI, TOKEN, [])).toBeNull();
+        expect(call_rest_api).not.toHaveBeenCalled();
+    });
+});
+
+describe('unlinkAgentInstruction', () => {
+    it('deletes by composite key', async () => {
+        await unlinkAgentInstruction(URI, TOKEN, 7, 42);
+        expect(calls()[0]).toEqual({
+            table: 'agent_instructions', method: 'DELETE',
+            body: { agent_fk: 7, instruction_fk: 42 },
+        });
+    });
+
+    it('reports true when a row was actually removed', async () => {
+        await expect(unlinkAgentInstruction(URI, TOKEN, 7, 42)).resolves.toBe(true);
+    });
+
+    it('swallows a 404 and reports false — an absent link IS the desired end state', async () => {
+        // The boolean matters: setAgentInstructionOrder restores only what it
+        // genuinely deleted, so resurrecting a row that was never there is itself
+        // a corruption it has to avoid.
+        call_rest_api.mockReturnValue(rejectWith(404, 'NOT FOUND'));
+        await expect(unlinkAgentInstruction(URI, TOKEN, 7, 42)).resolves.toBe(false);
+    });
+
+    it('rethrows anything that is not a 404', async () => {
+        call_rest_api.mockReturnValue(rejectWith(500, 'SQL FAILED'));
+        await expect(unlinkAgentInstruction(URI, TOKEN, 7, 42)).rejects.toMatchObject(
+            { httpStatus: { httpStatus: 500 } });
+    });
+});
+
+describe('setAgentInstructionOrder — the non-atomic reorder', () => {
+    const rows = [
+        { agent_fk: 7, instruction_fk: 10, sort_order: 2 },
+        { agent_fk: 7, instruction_fk: 11, sort_order: 1 },
+    ];
+    const originals = [
+        { agent_fk: 7, instruction_fk: 10, sort_order: 1 },
+        { agent_fk: 7, instruction_fk: 11, sort_order: 2 },
+    ];
+
+    it('deletes every affected row BEFORE re-posting any of them', async () => {
+        await setAgentInstructionOrder(URI, TOKEN, rows, originals);
+
+        expect(calls().map(c => c.method)).toEqual(['DELETE', 'DELETE', 'POST']);
+        // One POST, not one per row — the whole point of the array body.
+        expect(calls()[2].body).toEqual(rows);
+    });
+
+    it('touches only the two swapped rows', async () => {
+        await setAgentInstructionOrder(URI, TOKEN, rows, originals);
+        const touched = new Set(calls().flatMap(c =>
+            Array.isArray(c.body) ? c.body.map(r => r.instruction_fk)
+                                  : [c.body.instruction_fk]));
+        expect([...touched].sort()).toEqual([10, 11]);
+    });
+
+    it('restores the ORIGINAL sort_orders when the re-POST fails', async () => {
+        // The failure that matters: the DELETEs landed, the POST did not. Without
+        // the restore the agent boots missing both instructions.
+        call_rest_api
+            .mockResolvedValueOnce(ok(200))                    // DELETE 10
+            .mockResolvedValueOnce(ok(200))                    // DELETE 11
+            .mockReturnValueOnce(rejectWith(500, 'bulk failed'))// POST (fails)
+            .mockResolvedValueOnce(ok(201, { inserted: 2 }));  // restore POST
+
+        await expect(setAgentInstructionOrder(URI, TOKEN, rows, originals))
+            .rejects.toMatchObject({ httpStatus: { httpStatus: 500 } });
+
+        const posts = calls().filter(c => c.method === 'POST');
+        expect(posts).toHaveLength(2);
+        expect(posts[1].body).toEqual(originals);   // pre-change state, restored
+    });
+
+    it('propagates the ORIGINAL error when the restore also fails', async () => {
+        // A restore failure must not mask the real cause — the first error is the
+        // one worth putting in front of a human.
+        call_rest_api
+            .mockResolvedValueOnce(ok(200))
+            .mockResolvedValueOnce(ok(200))
+            .mockReturnValueOnce(rejectWith(500, 'ORIGINAL bulk failure'))
+            .mockReturnValueOnce(rejectWith(503, 'restore also failed'));
+
+        await expect(setAgentInstructionOrder(URI, TOKEN, rows, originals))
+            .rejects.toMatchObject({ httpStatus: { httpMessage: 'ORIGINAL bulk failure' } });
+    });
+
+    it('tolerates a DELETE that 404s — the row was already gone', async () => {
+        call_rest_api
+            .mockReturnValueOnce(rejectWith(404, 'NOT FOUND'))
+            .mockResolvedValueOnce(ok(200))
+            .mockResolvedValueOnce(ok(201, { inserted: 2 }));
+
+        await expect(setAgentInstructionOrder(URI, TOKEN, rows, originals))
+            .resolves.toBeTruthy();
+        expect(calls().filter(c => c.method === 'POST')).toHaveLength(1);
+    });
+
+    it('restores what it already deleted when a MID-LOOP DELETE fails', async () => {
+        // The DELETE loop is inside the same try as the re-POST, so a non-404
+        // failure on the second delete restores the first row rather than leaving
+        // the agent silently short a binding instruction.
+        call_rest_api
+            .mockResolvedValueOnce(ok(200))                     // DELETE 10 — lands
+            .mockReturnValueOnce(rejectWith(500, 'SQL FAILED')) // DELETE 11 — fails
+            .mockResolvedValueOnce(ok(201, { inserted: 1 }));   // restore POST
+
+        await expect(setAgentInstructionOrder(URI, TOKEN, rows, originals))
+            .rejects.toMatchObject({ httpStatus: { httpStatus: 500 } });
+
+        const posts = calls().filter(c => c.method === 'POST');
+        expect(posts).toHaveLength(1);
+        // Only row 10 was actually deleted, so only row 10 is restored — at its
+        // ORIGINAL sort_order.
+        expect(posts[0].body).toEqual([
+            { agent_fk: 7, instruction_fk: 10, sort_order: 1 },
+        ]);
+    });
+
+    it('does not resurrect a link that was already absent', async () => {
+        // DELETE 10 → 404 (already gone), DELETE 11 lands, then the POST fails.
+        // Only row 11 was genuinely removed, so only row 11 may be restored.
+        call_rest_api
+            .mockReturnValueOnce(rejectWith(404, 'NOT FOUND'))  // DELETE 10
+            .mockResolvedValueOnce(ok(200))                     // DELETE 11
+            .mockReturnValueOnce(rejectWith(500, 'bulk failed'))// POST
+            .mockResolvedValueOnce(ok(201, { inserted: 1 }));   // restore POST
+
+        await expect(setAgentInstructionOrder(URI, TOKEN, rows, originals))
+            .rejects.toMatchObject({ httpStatus: { httpStatus: 500 } });
+
+        const posts = calls().filter(c => c.method === 'POST');
+        expect(posts[1].body).toEqual([
+            { agent_fk: 7, instruction_fk: 11, sort_order: 2 },
+        ]);
+    });
+
+    it('does nothing for an empty plan', async () => {
+        expect(await setAgentInstructionOrder(URI, TOKEN, [], originals)).toBeNull();
+        expect(call_rest_api).not.toHaveBeenCalled();
+    });
+});
+
+describe('syncInstructionAgents — the shared membership diff', () => {
+    // Lives in ONE place and is called by both /agents/instructions and
+    // /agents/:id. Two copies of this diff would drift, and a drifted diff binds
+    // or unbinds the wrong agents silently.
+
+    it('binds only the additions and unbinds only the removals', async () => {
+        await syncInstructionAgents(URI, TOKEN, {
+            instructionId: 42,
+            prevAgentIds: [1, 2, 3],
+            nextAgentIds: [2, 3, 4],
+            sortOrderFor: () => 7,
+        });
+
+        const posts = calls().filter(c => c.method === 'POST');
+        const deletes = calls().filter(c => c.method === 'DELETE');
+        expect(posts).toHaveLength(1);
+        expect(posts[0].body).toEqual([{ agent_fk: 4, instruction_fk: 42, sort_order: 7 }]);
+        expect(deletes).toHaveLength(1);
+        expect(deletes[0].body).toEqual({ agent_fk: 1, instruction_fk: 42 });
+    });
+
+    it('is a no-op when the membership is unchanged', async () => {
+        await syncInstructionAgents(URI, TOKEN, {
+            instructionId: 42, prevAgentIds: [1, 2], nextAgentIds: [2, 1],
+        });
+        expect(call_rest_api).not.toHaveBeenCalled();
+    });
+
+    it('asks for a per-agent load-order slot rather than reusing one', async () => {
+        const sortOrderFor = vi.fn((agentId) => agentId * 10);
+        await syncInstructionAgents(URI, TOKEN, {
+            instructionId: 42, prevAgentIds: [], nextAgentIds: [1, 2], sortOrderFor,
+        });
+        expect(sortOrderFor.mock.calls.map(([a]) => a)).toEqual([1, 2]);
+        const posted = calls().filter(c => c.method === 'POST')
+            .flatMap(c => c.body);
+        expect(posted).toEqual([
+            { agent_fk: 1, instruction_fk: 42, sort_order: 10 },
+            { agent_fk: 2, instruction_fk: 42, sort_order: 20 },
+        ]);
+    });
+
+    it('preserves a binding to an agent the caller never listed', async () => {
+        // The dialog lists OPEN agents only, but seeds its selection from every
+        // stored binding — so a closed agent's link must survive a save untouched.
+        await syncInstructionAgents(URI, TOKEN, {
+            instructionId: 42, prevAgentIds: [9], nextAgentIds: [9],
+        });
+        expect(call_rest_api).not.toHaveBeenCalled();
+    });
+});
+
+describe('instruction row mutations', () => {
+    it('PUT sends an array — rest_put.py requires one even for a single row', async () => {
+        await updateInstruction(URI, TOKEN, 42, { closed: 1 });
+        expect(calls()[0]).toEqual({
+            table: 'instructions', method: 'PUT', body: [{ id: 42, closed: 1 }],
+        });
+    });
+
+    it('POST sends a single object — `instructions` HAS an id column', async () => {
+        await createInstruction(URI, TOKEN,
+            { name: 'n', content: 'c', creator_fk: 'sub' });
+        const [c] = calls();
+        expect(c.method).toBe('POST');
+        expect(Array.isArray(c.body)).toBe(false);
+        expect(c.body).toMatchObject({ name: 'n', content: 'c', sort_order: null, closed: 0 });
+    });
+
+    it('DELETE targets the row by id', async () => {
+        await deleteInstruction(URI, TOKEN, 42);
+        expect(calls()[0]).toEqual({
+            table: 'instructions', method: 'DELETE', body: { id: 42 },
+        });
+    });
+});

--- a/src/Agents/actions/instructionsApi.js
+++ b/src/Agents/actions/instructionsApi.js
@@ -1,0 +1,205 @@
+// Mutation utilities for the instruction registry (req #3049).
+// Peer to Features/actions/validationApi.js: all mutations go through
+// call_rest_api; callers own TanStack Query invalidation.
+//
+// REST contracts that shape this file — all verified against the live API, not
+// assumed:
+//
+// - `instructions` is in Lambda-Rest CREATOR_FK_TABLES, so POST overwrites any
+//   client-supplied creator_fk with the authenticated Cognito sub, and PUT /
+//   DELETE are scoped to it. We still send creator_fk on create: it is NOT NULL
+//   with an FK to profiles, and being explicit costs nothing.
+//
+// - `agent_instructions` has a composite PK and NO `id` column. Two consequences:
+//     * PUT is impossible (rest_put.py requires `id`) — a load-order change is a
+//       DELETE + re-POST, never an update.
+//     * A SINGLE-OBJECT POST COMMITS THE ROW AND THEN RETURNS 500. rest_post.py
+//       re-reads the new row with `WHERE id = ...`, which raises 1054 on a table
+//       with no id column — after the INSERT has already committed (autocommit).
+//       Every junction insert here therefore sends an ARRAY body, which routes to
+//       _rest_post_bulk: no read-back, returns 201 {"inserted": N}.
+//
+// - Lambda-Rest emits no 409. A duplicate name or link is an HTTP 500 whose body
+//   carries the pymysql message; agentRegistryUtils.restErrorMessage maps the
+//   known ones to human text.
+//
+// - call_rest_api THROWS on any status outside 200/201/204 — including 404. A
+//   DELETE that matched nothing throws, so the 404-tolerant paths catch it
+//   explicitly rather than testing the returned status.
+
+import call_rest_api from '../../RestApi/RestApi';
+
+const isOk = (status) => status === 200 || status === 201 || status === 204;
+
+/**
+ * Deliberately duplicated from validationApi rather than imported: that module
+ * is Features-scoped, and coupling two unrelated registries through a ten-line
+ * helper is worse than the duplication. validationApi is itself self-contained.
+ *
+ * The thrown error CARRIES `httpStatus`. call_rest_api rejects with a bare
+ * `{data, httpStatus}` object for any non-2xx, but it RETURNS (does not throw) a
+ * synthetic 503 when `fetch` itself rejects — so this is the one path that
+ * produces an error of a different shape. Every consumer downstream reads
+ * `err.httpStatus.httpStatus`: `isNotFound`, `restErrorMessage`, and
+ * `useSnackBarStore.showError`. An error without it would make all three
+ * misbehave, and showError would throw a TypeError from inside a catch block —
+ * killing the resync that catch block exists to perform.
+ */
+function assertOk(result, action) {
+    const status = result?.httpStatus?.httpStatus;
+    if (!isOk(status)) {
+        const httpStatus = result?.httpStatus
+            || { httpStatus: 0, httpMessage: 'unknown' };
+        const msg = httpStatus.httpMessage || 'unknown';
+        throw Object.assign(
+            new Error(`${action} failed: HTTP ${status} ${msg}`), { httpStatus });
+    }
+    return result.data;
+}
+
+const isNotFound = (err) => err?.httpStatus?.httpStatus === 404;
+
+// ----- instructions -----
+
+export async function createInstruction(darwinUri, idToken,
+    { name, content, sort_order = null, closed = 0, creator_fk }) {
+    const r = await call_rest_api(`${darwinUri}/instructions`, 'POST',
+        { name, content, sort_order, closed, creator_fk }, idToken);
+    return assertOk(r, 'createInstruction');
+}
+
+export async function updateInstruction(darwinUri, idToken, id, fields) {
+    const r = await call_rest_api(`${darwinUri}/instructions`, 'PUT',
+        [{ id, ...fields }], idToken);
+    return assertOk(r, 'updateInstruction');
+}
+
+/**
+ * Hard delete. `agent_instructions` CASCADEs on both FKs, so this silently
+ * strips the instruction from every agent that bound it — callers must have
+ * shown the blast radius first. Closing (`{ closed: 1 }`) is the retire path.
+ */
+export async function deleteInstruction(darwinUri, idToken, id) {
+    const r = await call_rest_api(`${darwinUri}/instructions`, 'DELETE',
+        { id }, idToken);
+    return assertOk(r, 'deleteInstruction');
+}
+
+// ----- agent_instructions (junction — array-body POST, composite-key DELETE) -----
+
+/** Bind one instruction to one agent at a given load-order slot. */
+export async function linkAgentInstruction(darwinUri, idToken,
+    agent_fk, instruction_fk, sort_order = null) {
+    return linkAgentInstructions(darwinUri, idToken,
+        [{ agent_fk, instruction_fk, sort_order }]);
+}
+
+/**
+ * Bind several links in ONE round trip. Array body → _rest_post_bulk, which is
+ * the only POST path that works on a table with no `id` column.
+ *
+ * Every item must carry the same keys — _rest_post_bulk builds one multi-value
+ * INSERT from the FIRST item's key list, so a row missing `sort_order` would
+ * silently take its neighbour's value. Normalize before sending.
+ */
+export async function linkAgentInstructions(darwinUri, idToken, rows) {
+    if (!rows.length) return null;
+    const body = rows.map(({ agent_fk, instruction_fk, sort_order = null }) =>
+        ({ agent_fk, instruction_fk, sort_order }));
+    const r = await call_rest_api(`${darwinUri}/agent_instructions`, 'POST',
+        body, idToken);
+    return assertOk(r, 'linkAgentInstructions');
+}
+
+/**
+ * Unbind one instruction from one agent. Tolerates an already-absent link.
+ * Returns true when a row was actually removed, false when it was already gone —
+ * the reorder path needs that distinction to know what it must restore.
+ */
+export async function unlinkAgentInstruction(darwinUri, idToken,
+    agent_fk, instruction_fk) {
+    try {
+        const r = await call_rest_api(`${darwinUri}/agent_instructions`, 'DELETE',
+            { agent_fk, instruction_fk }, idToken);
+        assertOk(r, 'unlinkAgentInstruction');
+        return true;
+    } catch (err) {
+        if (isNotFound(err)) return false;  // already gone — the desired end state
+        throw err;
+    }
+}
+
+const linkKey = (r) => `${r.agent_fk}:${r.instruction_fk}`;
+
+/**
+ * Apply a planned load-order change (see agentRegistryUtils.planInstructionSwap).
+ *
+ * Sequence: DELETE every row being rewritten, THEN one array POST re-creating
+ * them all. Each call is a separate Lambda invocation under autocommit, so
+ * nothing here is atomic — and the failure mode is severe: an agent that boots
+ * missing binding instructions fails silently and looks fine.
+ *
+ * So EVERY failure path restores what was actually removed, including a failure
+ * partway through the DELETE loop. Only rows this function genuinely deleted are
+ * restored — a link that was already absent (404) is not resurrected, because
+ * recreating a row that did not exist is its own corruption.
+ *
+ * @param rows      the rows to write, each { agent_fk, instruction_fk, sort_order }
+ * @param originals the same links at their pre-change sort_order, for rollback
+ */
+export async function setAgentInstructionOrder(darwinUri, idToken, rows, originals) {
+    if (!rows.length) return null;
+
+    const originalByKey = new Map((originals || []).map(o => [linkKey(o), o]));
+    const removed = [];
+
+    // Best-effort. A failed restore must not mask the error that caused it — the
+    // original failure is the one worth putting in front of a human.
+    const restore = async () => {
+        if (!removed.length) return;
+        try { await linkAgentInstructions(darwinUri, idToken, removed); }
+        catch { /* original error propagates from the caller */ }
+    };
+
+    try {
+        for (const row of rows) {
+            const deleted = await unlinkAgentInstruction(darwinUri, idToken,
+                row.agent_fk, row.instruction_fk);
+            const original = deleted ? originalByKey.get(linkKey(row)) : null;
+            if (original) removed.push(original);
+        }
+        return await linkAgentInstructions(darwinUri, idToken, rows);
+    } catch (err) {
+        await restore();
+        throw err;
+    }
+}
+
+/**
+ * Apply a membership diff for one instruction: bind it to every agent in `next`
+ * that is not already in `prev`, and unbind it from every agent in `prev` that
+ * is not in `next`.
+ *
+ * Lives here, called by BOTH /agents/instructions and /agents/:id, because two
+ * copies of a diff drift — and a drifted diff silently binds or unbinds the
+ * wrong agents.
+ *
+ * `sortOrderFor(agentId)` supplies the load-order slot for a NEW binding; the
+ * caller owns that policy (today: land at the end of that agent's order).
+ */
+export async function syncInstructionAgents(darwinUri, idToken, {
+    instructionId, prevAgentIds = [], nextAgentIds = [], sortOrderFor = () => null,
+}) {
+    const prev = new Set(prevAgentIds);
+    const next = new Set(nextAgentIds);
+
+    for (const agentId of next) {
+        if (prev.has(agentId)) continue;
+        await linkAgentInstruction(darwinUri, idToken, agentId, instructionId,
+            sortOrderFor(agentId));
+    }
+    for (const agentId of prev) {
+        if (next.has(agentId)) continue;
+        await unlinkAgentInstruction(darwinUri, idToken, agentId, instructionId);
+    }
+}

--- a/src/Agents/agentRegistryUtils.js
+++ b/src/Agents/agentRegistryUtils.js
@@ -158,6 +158,149 @@ export const agentsByInstruction = (agentInstructions = []) => {
 export const isCommonInstruction = (instructionId, byInstruction, threshold = 2) =>
     (byInstruction.get(instructionId)?.length || 0) >= threshold;
 
+// ---------------------------------------------------------------------------
+// Editing helpers (req #3049).
+//
+// TWO `sort_order` COLUMNS EXIST AND ONLY ONE DRIVES BOOT.
+//   agent_instructions.sort_order — the per-(agent, instruction) LOAD ORDER the
+//       boot payload uses. This is the one an agent actually feels.
+//   instructions.sort_order       — a CATALOG hint that orders the browse list
+//       and nothing else.
+// The helpers below operate exclusively on the JUNCTION column. Never sync the
+// two; presenting them as one control is the likeliest defect in this area.
+// ---------------------------------------------------------------------------
+
+/**
+ * Next free load-order slot for an agent — max(sort_order) + 1, 1-indexed.
+ * Used when binding a new instruction so it lands at the end of the agent's
+ * load order rather than colliding with an existing slot.
+ */
+export const nextInstructionSortOrder = (agentId, instrLinks) => {
+    const links = instrLinks.get(agentId) || [];
+    const orders = links.map(l => l.sort_order).filter(o => Number.isFinite(o));
+    return orders.length ? Math.max(...orders) + 1 : 1;
+};
+
+/**
+ * Repair a link list's `sort_order` values IN PLACE-PRESERVING fashion.
+ *
+ * A stored value is KEPT whenever it can be: it must be a finite number, strictly
+ * greater than the previous kept/assigned value, and not claimed by a link
+ * outside this list. Anything else (NULL, or a value that would duplicate or go
+ * backwards) gets the next free slot.
+ *
+ * This is deliberately NOT a 1..N renumber. The live registry uses BANDED slots:
+ * per-agent instructions occupy 1..N, and the shared "common-*" rows sit together
+ * at 100, 101, 102 on every architect. Renumbering would collapse both bands into
+ * one undifferentiated run, permanently destroying the separation and the gap
+ * that keeps it extensible. Keeping good values means a single NULL in the middle
+ * repairs to 1, 2, 100 rather than 1, 2, 3.
+ *
+ * `reserved` carries sort_order values held by links the caller is NOT
+ * rewriting — in practice an agent's CLOSED links, which stay in the table and
+ * would otherwise collide with a repaired value.
+ */
+export const repairInstructionOrders = (links = [], reserved = []) => {
+    const taken = new Set(reserved.filter(o => Number.isFinite(o)));
+    // Starts below zero so a deliberate 0 or negative slot is KEPT rather than
+    // silently rewritten; the assignment path still floors new slots at 1.
+    let last = -Infinity;
+    return links.map(l => {
+        const current = l.sort_order;
+        if (Number.isFinite(current) && current > last && !taken.has(current)) {
+            last = current;
+            return l;
+        }
+        let next = Math.max(last, 0) + 1;
+        while (taken.has(next)) next += 1;
+        last = next;
+        return { ...l, sort_order: next };
+    });
+};
+
+/**
+ * Plan a load-order move as a SWAP of two rows' sort_order values.
+ *
+ * Why a swap and not a renumber: see repairInstructionOrders. A swap preserves
+ * the value SET, so the banded slots survive every reorder, and it bounds the
+ * blast radius — the write set is the two moved rows plus only those rows a
+ * repair genuinely had to touch, never the whole list by default.
+ *
+ * `links` must be the agent's links already in display order (the order
+ * `instructionLinksByAgent` produces: sort_order asc, NULLs last).
+ *
+ * Returns { writes, originals } — the rows whose stored value actually changes,
+ * and the same rows at their PRE-change value for rollback. Returns null when
+ * the move is out of bounds or would change nothing.
+ */
+export const planInstructionSwap = (links = [], fromIdx, toIdx, reserved = []) => {
+    if (fromIdx === toIdx) return null;
+    if (fromIdx < 0 || toIdx < 0) return null;
+    if (fromIdx >= links.length || toIdx >= links.length) return null;
+
+    const repaired = repairInstructionOrders(links, reserved);
+    const fromOrder = repaired[fromIdx].sort_order;
+    const toOrder = repaired[toIdx].sort_order;
+
+    const final = repaired.map((l, i) => {
+        if (i === fromIdx) return { ...l, sort_order: toOrder };
+        if (i === toIdx) return { ...l, sort_order: fromOrder };
+        return l;
+    });
+
+    const writes = [];
+    const originals = [];
+    final.forEach((l, i) => {
+        if (l.sort_order === links[i].sort_order) return;   // untouched — don't write it
+        writes.push(l);
+        originals.push(links[i]);
+    });
+
+    return writes.length ? { writes, originals } : null;
+};
+
+/**
+ * Is this instruction name already taken?
+ *
+ * `instructions.name` carries a UNIQUE key that does NOT exclude closed rows, so
+ * the check must run against the UNFILTERED catalog — colliding with an
+ * invisible closed row is the confusing failure this prevents. Compared
+ * case-insensitively on the trimmed value: MySQL's default collation is
+ * case-insensitive, so "Foo" and "foo" collide in the database too.
+ */
+export const instructionNameTaken = (name, instructions = [], selfId = null) => {
+    const candidate = (name || '').trim().toLowerCase();
+    if (!candidate) return false;
+    return instructions.some(
+        i => i.id !== selfId && (i.name || '').trim().toLowerCase() === candidate);
+};
+
+/**
+ * Turn a thrown call_rest_api rejection into something a human can act on.
+ *
+ * Lambda-Rest has no 409: a constraint violation arrives as HTTP 500 whose body
+ * is the raw pymysql message (`"HTTP PUT SQL FAILED: 1062 Duplicate entry ..."`).
+ * Matching on the message is the only way to tell "you picked a taken name" from
+ * "the database is broken" — mapping IntegrityError to a real status code is
+ * filed as its own requirement.
+ */
+export const restErrorMessage = (err, fallback) => {
+    const msg = typeof err?.httpStatus?.httpMessage === 'string'
+        ? err.httpStatus.httpMessage
+        : '';
+
+    if (/Duplicate entry .* for key '.*uq_instructions_name'/i.test(msg)) {
+        return 'That instruction name is already in use (the existing row may be closed).';
+    }
+    if (/Duplicate entry .* for key '.*agent_instructions\.PRIMARY'/i.test(msg)) {
+        return 'That instruction is already bound to this agent.';
+    }
+    if (/foreign key constraint fails/i.test(msg)) {
+        return 'The agent or instruction no longer exists — reload the page and retry.';
+    }
+    return fallback;
+};
+
 /** Build an id→row lookup for any entity list. */
 export const byId = (rows = []) => {
     const m = new Map();

--- a/src/stores/useSnackBarStore.js
+++ b/src/stores/useSnackBarStore.js
@@ -4,7 +4,21 @@ export const useSnackBarStore = create((set) => ({
     open: false,
     message: '',
     showError: (error, errorText) => {
-        set({ message: `${errorText} ${error.httpStatus.httpStatus}`, open: true });
+        // Tolerate an error WITHOUT `httpStatus`. call_rest_api throws a bare
+        // {data, httpStatus} for non-2xx, but a fetch-level failure is RETURNED
+        // as a synthetic 503 and callers may wrap it in a plain Error. Reading
+        // `error.httpStatus.httpStatus` unguarded threw a TypeError from inside
+        // the caller's catch block, killing whatever recovery followed the
+        // showError call (req #3049).
+        // Single-argument callers pass the message itself as `error` (several in
+        // Customers / CustomerReleases do). Without this they render an empty
+        // snackbar — previously they threw instead, so neither form ever worked.
+        if (typeof error === 'string' && errorText === undefined) {
+            set({ message: error, open: true });
+            return;
+        }
+        const status = error?.httpStatus?.httpStatus;
+        set({ message: status ? `${errorText} ${status}` : errorText, open: true });
     },
     close: () => set({ open: false }),
 }));


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-07-25T01:26:52Z
- wip(Darwin): 2026-07-25T01:25:26Z
- chore: init swarm session feature/3049-instructions-are-editable-1

## Files changed
```
 src/Agents/AgentDetail.jsx                      | 259 ++++++++++++++++++++-
 src/Agents/InstructionDeleteDialog.jsx          | 115 +++++++++
 src/Agents/InstructionEditDialog.jsx            | 290 +++++++++++++++++++++++
 src/Agents/InstructionsPage.jsx                 | 260 +++++++++++++++++++--
 src/Agents/__tests__/agentRegistryUtils.test.js | 246 +++++++++++++++++++-
 src/Agents/__tests__/instructionsApi.test.js    | 296 ++++++++++++++++++++++++
 src/Agents/actions/instructionsApi.js           | 205 ++++++++++++++++
 src/Agents/agentRegistryUtils.js                | 143 ++++++++++++
 src/stores/useSnackBarStore.js                  |  16 +-
 9 files changed, 1803 insertions(+), 27 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)