### PR TITLE
Agent Card has black text on gray

### DIFF
--- a/src/Agents/__tests__/agentRegistryUtils.test.js
+++ b/src/Agents/__tests__/agentRegistryUtils.test.js
@@ -1,0 +1,40 @@
+// req #3053 — the Agents card's model pin chip used a hardcoded black text +
+// pastel fill regardless of theme.palette.mode. Against a white light-mode
+// card the pastel fill measures well under 3:1 (verified with dataviz's
+// validate_palette.js `contrast()`), reading as a washed-out, near-grey patch
+// even though the black text on it is independently legible. agentModelChipProps
+// now resolves its fill through modelChipStyles.js's mode-aware modelFillColor.
+
+import { describe, it, expect } from 'vitest';
+import { agentModelChipProps, agentModelLabel } from '../agentRegistryUtils';
+
+const lightTheme = { palette: { mode: 'light' } };
+const darkTheme = { palette: { mode: 'dark' } };
+
+describe('agentModelChipProps (req #3053)', () => {
+    it('extracts the base model from the frontmatter-style pin ("opus[1m]" -> opus)', () => {
+        expect(agentModelChipProps('opus[1m]').sx(darkTheme)).toEqual({ bgcolor: '#81c784', color: '#000' });
+    });
+
+    it('keeps the original ramp unchanged in dark mode (already clears the dark card)', () => {
+        expect(agentModelChipProps('haiku').sx(darkTheme)).toEqual({ bgcolor: '#e57373', color: '#000' });
+        expect(agentModelChipProps('opus[1m]').sx(darkTheme)).toEqual({ bgcolor: '#81c784', color: '#000' });
+        expect(agentModelChipProps('fable[1m]').sx(darkTheme)).toEqual({ bgcolor: '#388e3c', color: '#000' });
+    });
+
+    it('darkens the pastel rungs (not fable) in light mode so the fill clears 3:1 on white', () => {
+        expect(agentModelChipProps('haiku').sx(lightTheme)).toEqual({ bgcolor: 'rgb(217, 109, 109)', color: '#000' });
+        expect(agentModelChipProps('opus[1m]').sx(lightTheme)).toEqual({ bgcolor: 'rgb(99, 153, 101)', color: '#000' });
+        expect(agentModelChipProps('fable[1m]').sx(lightTheme)).toEqual({ bgcolor: '#388e3c', color: '#000' });
+    });
+
+    it('falls back to opus styling for null/unknown, per mode', () => {
+        expect(agentModelChipProps(null).sx(darkTheme)).toEqual({ bgcolor: '#81c784', color: '#000' });
+        expect(agentModelChipProps(null).sx(lightTheme)).toEqual({ bgcolor: 'rgb(99, 153, 101)', color: '#000' });
+    });
+
+    it('agentModelLabel shows the stored value verbatim (keeps the [1m] suffix)', () => {
+        expect(agentModelLabel('opus[1m]')).toBe('opus[1m]');
+        expect(agentModelLabel(null)).toBe('—');
+    });
+});

--- a/src/Agents/agentRegistryUtils.js
+++ b/src/Agents/agentRegistryUtils.js
@@ -6,7 +6,7 @@
 // single place that relationship logic lives, so /agents, /agents/:id,
 // /agents/instructions, and /agents/documents all agree.
 
-import { AI_MODEL_COLOR } from '../SwarmView/modelChipStyles';
+import { AI_MODEL_COLOR, modelFillColor } from '../SwarmView/modelChipStyles';
 
 // Relationship roles (req #3012). `relationship` is now a MySQL SET, so a link
 // may carry several roles at once (e.g. "owned,autoload") and REST returns them
@@ -60,7 +60,10 @@ export const relationshipLabel = (rel) =>
  *
  * The colour map IS the base-model palette (single source of truth in
  * modelChipStyles) so agent pins track the red→green ramp automatically and can
- * never drift from it (req #3044).
+ * never drift from it (req #3044). Exported as the raw (dark-mode-equivalent)
+ * hex for any external reader that wants it; the chip itself resolves its
+ * actual fill through `modelFillColor`, which additionally accounts for
+ * `theme.palette.mode` (req #3053) — see that function's doc comment.
  */
 export const AGENT_MODEL_COLOR = AI_MODEL_COLOR;
 
@@ -68,7 +71,10 @@ export const agentModelLabel = (m) => m || '—';
 
 export const agentModelChipProps = (m) => {
     const base = (m || '').split('[')[0];        // 'opus[1m]' -> 'opus'
-    return { sx: { bgcolor: AGENT_MODEL_COLOR[base] || AGENT_MODEL_COLOR.opus, color: '#000' } };
+    // req #3053: mode-aware fill — see modelFillColor's doc comment. The
+    // light-mode pastel step reads as washed-out/grey on a white card even
+    // though the black text on it is independently legible.
+    return { sx: (theme) => ({ bgcolor: modelFillColor(base, theme.palette.mode), color: '#000' }) };
 };
 
 export const docTypeChipProps = (t) =>

--- a/src/SwarmView/__tests__/effortChipStyles.test.js
+++ b/src/SwarmView/__tests__/effortChipStyles.test.js
@@ -4,10 +4,14 @@ import {
     EFFORTS,
     effortLabel,
     effortChipProps,
+    effortFillColor,
     effortIconColor,
 } from '../effortChipStyles';
 import { AI_MODEL_COLOR } from '../modelChipStyles';
 import { COORDINATION_COLOR } from '../coordinationChipStyles';
+
+const lightTheme = { palette: { mode: 'light' } };
+const darkTheme = { palette: { mode: 'dark' } };
 
 // req #2916 — effort chip palette: low·medium·high·xhigh·ultracode. Recolored to
 // a red → green intensity ramp in req #3044 (red = least effort, dark green =
@@ -55,17 +59,37 @@ describe('effortChipStyles (req #2916, recolored #3044)', () => {
         expect(effortLabel('max')).toBe('High');
     });
 
-    it('effortChipProps yields a filled chip (bg + black text) per effort', () => {
-        expect(effortChipProps('low')).toEqual({ sx: { bgcolor: '#e57373', color: '#000' } });
-        expect(effortChipProps('medium')).toEqual({ sx: { bgcolor: '#ffb74d', color: '#000' } });
-        expect(effortChipProps('high')).toEqual({ sx: { bgcolor: '#ffd54f', color: '#000' } });
-        expect(effortChipProps('xhigh')).toEqual({ sx: { bgcolor: '#81c784', color: '#000' } });
-        expect(effortChipProps('ultracode')).toEqual({ sx: { bgcolor: '#388e3c', color: '#000' } });
+    // req #3053 — dark mode keeps the original ramp verbatim (already clears
+    // 3.6–10.5:1 against the dark card surface).
+    it('effortChipProps yields the original ramp + black text in dark mode', () => {
+        expect(effortChipProps('low').sx(darkTheme)).toEqual({ bgcolor: '#e57373', color: '#000' });
+        expect(effortChipProps('medium').sx(darkTheme)).toEqual({ bgcolor: '#ffb74d', color: '#000' });
+        expect(effortChipProps('high').sx(darkTheme)).toEqual({ bgcolor: '#ffd54f', color: '#000' });
+        expect(effortChipProps('xhigh').sx(darkTheme)).toEqual({ bgcolor: '#81c784', color: '#000' });
+        expect(effortChipProps('ultracode').sx(darkTheme)).toEqual({ bgcolor: '#388e3c', color: '#000' });
+    });
+
+    // req #3053 — light mode darkens the four pastel rungs so the fill clears
+    // 3:1 against a white card instead of reading as a washed-out grey patch.
+    // Ultracode is untouched: it already sits at the dark green-700 step.
+    it('effortChipProps darkens the pastel rungs (not ultracode) in light mode', () => {
+        expect(effortChipProps('low').sx(lightTheme)).toEqual({ bgcolor: 'rgb(217, 109, 109)', color: '#000' });
+        expect(effortChipProps('medium').sx(lightTheme)).toEqual({ bgcolor: 'rgb(183, 131, 55)', color: '#000' });
+        expect(effortChipProps('high').sx(lightTheme)).toEqual({ bgcolor: 'rgb(165, 138, 51)', color: '#000' });
+        expect(effortChipProps('xhigh').sx(lightTheme)).toEqual({ bgcolor: 'rgb(99, 153, 101)', color: '#000' });
+        expect(effortChipProps('ultracode').sx(lightTheme)).toEqual({ bgcolor: '#388e3c', color: '#000' });
     });
 
     it('effortChipProps falls back to high styling for null/unknown (NOT the xhigh default)', () => {
-        expect(effortChipProps(null)).toEqual({ sx: { bgcolor: '#ffd54f', color: '#000' } });
-        expect(effortChipProps('bogus')).toEqual({ sx: { bgcolor: '#ffd54f', color: '#000' } });
+        expect(effortChipProps(null).sx(darkTheme)).toEqual({ bgcolor: '#ffd54f', color: '#000' });
+        expect(effortChipProps('bogus').sx(darkTheme)).toEqual({ bgcolor: '#ffd54f', color: '#000' });
+        expect(effortChipProps(null).sx(lightTheme)).toEqual({ bgcolor: 'rgb(165, 138, 51)', color: '#000' });
+    });
+
+    it('effortFillColor resolves per mode directly (no theme object required)', () => {
+        expect(effortFillColor('xhigh', 'dark')).toBe('#81c784');
+        expect(effortFillColor('xhigh', 'light')).toBe('rgb(99, 153, 101)');
+        expect(effortFillColor('ultracode', 'light')).toBe('#388e3c');
     });
 
     // req #3046 — Effort renders as a small icon (glyph FILL = ramp hex).

--- a/src/SwarmView/__tests__/modelChipStyles.test.js
+++ b/src/SwarmView/__tests__/modelChipStyles.test.js
@@ -4,9 +4,13 @@ import {
     AI_MODELS,
     aiModelLabel,
     aiModelChipProps,
+    modelFillColor,
     aiModelIconColor,
 } from '../modelChipStyles';
 import { COORDINATION_COLOR } from '../coordinationChipStyles';
+
+const lightTheme = { palette: { mode: 'light' } };
+const darkTheme = { palette: { mode: 'dark' } };
 
 // req #2909 — ai_model chip palette: haiku·sonnet·opus·fable. Recolored to a
 // red → green capability ramp in req #3044 (red = least capable, dark green =
@@ -43,16 +47,35 @@ describe('modelChipStyles (req #2909, recolored #3044)', () => {
         expect(aiModelLabel('gpt4')).toBe('Opus');
     });
 
-    it('aiModelChipProps yields a filled chip (bg + black text) per model', () => {
-        expect(aiModelChipProps('haiku')).toEqual({ sx: { bgcolor: '#e57373', color: '#000' } });
-        expect(aiModelChipProps('sonnet')).toEqual({ sx: { bgcolor: '#ffd54f', color: '#000' } });
-        expect(aiModelChipProps('opus')).toEqual({ sx: { bgcolor: '#81c784', color: '#000' } });
-        expect(aiModelChipProps('fable')).toEqual({ sx: { bgcolor: '#388e3c', color: '#000' } });
+    // req #3053 — dark mode keeps the original ramp verbatim (already clears
+    // 3.6–10.5:1 against the dark card surface).
+    it('aiModelChipProps yields the original ramp + black text in dark mode', () => {
+        expect(aiModelChipProps('haiku').sx(darkTheme)).toEqual({ bgcolor: '#e57373', color: '#000' });
+        expect(aiModelChipProps('sonnet').sx(darkTheme)).toEqual({ bgcolor: '#ffd54f', color: '#000' });
+        expect(aiModelChipProps('opus').sx(darkTheme)).toEqual({ bgcolor: '#81c784', color: '#000' });
+        expect(aiModelChipProps('fable').sx(darkTheme)).toEqual({ bgcolor: '#388e3c', color: '#000' });
+    });
+
+    // req #3053 — light mode darkens the three pastel rungs so the fill clears
+    // 3:1 against a white card instead of reading as a washed-out grey patch.
+    // Fable is untouched: it already sits at the dark green-700 step.
+    it('aiModelChipProps darkens the pastel rungs (not fable) in light mode', () => {
+        expect(aiModelChipProps('haiku').sx(lightTheme)).toEqual({ bgcolor: 'rgb(217, 109, 109)', color: '#000' });
+        expect(aiModelChipProps('sonnet').sx(lightTheme)).toEqual({ bgcolor: 'rgb(165, 138, 51)', color: '#000' });
+        expect(aiModelChipProps('opus').sx(lightTheme)).toEqual({ bgcolor: 'rgb(99, 153, 101)', color: '#000' });
+        expect(aiModelChipProps('fable').sx(lightTheme)).toEqual({ bgcolor: '#388e3c', color: '#000' });
     });
 
     it('aiModelChipProps falls back to opus styling for null/unknown', () => {
-        expect(aiModelChipProps(null)).toEqual({ sx: { bgcolor: '#81c784', color: '#000' } });
-        expect(aiModelChipProps('bogus')).toEqual({ sx: { bgcolor: '#81c784', color: '#000' } });
+        expect(aiModelChipProps(null).sx(darkTheme)).toEqual({ bgcolor: '#81c784', color: '#000' });
+        expect(aiModelChipProps('bogus').sx(darkTheme)).toEqual({ bgcolor: '#81c784', color: '#000' });
+        expect(aiModelChipProps(null).sx(lightTheme)).toEqual({ bgcolor: 'rgb(99, 153, 101)', color: '#000' });
+    });
+
+    it('modelFillColor resolves per mode directly (no theme object required)', () => {
+        expect(modelFillColor('opus', 'dark')).toBe('#81c784');
+        expect(modelFillColor('opus', 'light')).toBe('rgb(99, 153, 101)');
+        expect(modelFillColor('fable', 'light')).toBe('#388e3c');
     });
 
     // req #3046 — Model renders as a small icon (glyph FILL = ramp hex).

--- a/src/SwarmView/effortChipStyles.js
+++ b/src/SwarmView/effortChipStyles.js
@@ -1,4 +1,7 @@
-// Shared coloring for effort CHIPS (req #2916; recolored #3044).
+import { darken } from '@mui/material/styles';
+
+// Shared coloring for effort CHIPS (req #2916; recolored #3044; light-surface
+// fix #3053).
 //
 // Single source of truth so every effort chip across the app reads the same
 // way — parallel to modelChipStyles.js for ai_model and
@@ -34,6 +37,33 @@ export const EFFORT_COLOR = {
     ultracode: '#388e3c', // dark green
 };
 
+// req #3053: on a white/light card, four of the five rungs measure well under
+// the 3:1 mark-vs-surface floor (low 2.99, medium 1.73, high 1.41, xhigh 2.01 —
+// verified with dataviz's validate_palette.js `contrast()`), because they're
+// MUI's shade-300 (pastel) step of their hue. The fill reads as a washed-out,
+// near-neutral patch on a light card — easily perceived as "grey" — even
+// though the black text drawn ON it is independently high-contrast. Ultracode
+// already sits at shade-700 (deliberately dark per req #3044) and clears 4.1:1
+// as-is, so it's excluded here.
+//
+// `darken(hex, coef)` is MUI's own color-manipulation utility, not an
+// eyeballed value. The coefficient is PER RUNG — the smallest value that
+// lands that rung's fill at ~3.3:1 on white — rather than one blanket value
+// sized for the palest rung (amber/high): a shared 0.35 would clear the
+// surface floor for every rung but needlessly over-darken low/medium/xhigh,
+// dragging their own black-text-on-fill contrast down toward the 3:1 floor.
+// Tuned per rung, every fill keeps black text at ~6.3:1 instead. Dark mode is
+// unaffected: the original EFFORT_COLOR rungs already clear 3.6–10.5:1
+// against the dark card surface.
+const LIGHT_SURFACE_DARKEN = { low: 0.05, medium: 0.28, high: 0.35, xhigh: 0.23 };
+const EFFORT_COLOR_LIGHT = {
+    ...EFFORT_COLOR,
+    low:    darken(EFFORT_COLOR.low, LIGHT_SURFACE_DARKEN.low),
+    medium: darken(EFFORT_COLOR.medium, LIGHT_SURFACE_DARKEN.medium),
+    high:   darken(EFFORT_COLOR.high, LIGHT_SURFACE_DARKEN.high),
+    xhigh:  darken(EFFORT_COLOR.xhigh, LIGHT_SURFACE_DARKEN.xhigh),
+};
+
 export const EFFORTS = ['low', 'medium', 'high', 'xhigh', 'ultracode'];
 
 // Display labels — 'xhigh' renders as 'XHigh' (not 'Xhigh'); the rest are
@@ -49,10 +79,17 @@ const EFFORT_LABEL = {
 
 export const effortLabel = (e) => EFFORT_LABEL[e] || 'High';
 
+// Mode-aware fill resolver (req #3053) — light mode uses the darkened,
+// surface-legible variant; dark mode uses the original ramp unchanged.
+export const effortFillColor = (e, mode) => {
+    const map = mode === 'light' ? EFFORT_COLOR_LIGHT : EFFORT_COLOR;
+    return map[e] || map.high;
+};
+
 // Filled-chip props for an effort — pastel bg + black text.
 // Null/unknown → high styling (the backfill default), never unstyled.
 export const effortChipProps = (e) => ({
-    sx: { bgcolor: EFFORT_COLOR[e] || EFFORT_COLOR.high, color: '#000' },
+    sx: (theme) => ({ bgcolor: effortFillColor(e, theme.palette.mode), color: '#000' }),
 });
 
 // Icon `color` for an effort glyph — the ramp hex used as the glyph FILL (req

--- a/src/SwarmView/modelChipStyles.js
+++ b/src/SwarmView/modelChipStyles.js
@@ -1,4 +1,7 @@
-// Shared coloring for ai_model CHIPS (req #2909; recolored #3044).
+import { darken } from '@mui/material/styles';
+
+// Shared coloring for ai_model CHIPS (req #2909; recolored #3044; light-surface
+// fix #3053).
 //
 // Single source of truth so every model chip across the app reads the same
 // way — parallel to coordinationChipStyles.js for autonomy. The hues form a
@@ -28,6 +31,27 @@ export const AI_MODEL_COLOR = {
     fable:  '#388e3c', // dark green
 };
 
+// req #3053: same fix as EFFORT_COLOR_LIGHT (effortChipStyles.js) — haiku/
+// sonnet/opus are MUI's shade-300 pastel step and measure well under 3:1
+// against a white/light card (verified with dataviz's validate_palette.js
+// `contrast()`), reading as a washed-out, near-grey fill even with fully
+// legible black text on top. Fable already sits at shade-700 (deliberately
+// dark per req #3044) and clears 4.1:1 as-is, so it's excluded. Dark mode is
+// unaffected — the original AI_MODEL_COLOR rungs already clear 3.6–10.5:1
+// against the dark card surface.
+//
+// Coefficient is PER RUNG (same values as EFFORT_COLOR_LIGHT's identical
+// hues) — the smallest darken() that clears ~3.3:1 on white for that specific
+// rung, so black-text-on-fill contrast stays ~6.3:1 instead of sagging toward
+// 3:1 under one blanket coefficient sized for the palest rung.
+const LIGHT_SURFACE_DARKEN = { haiku: 0.05, sonnet: 0.35, opus: 0.23 };
+const AI_MODEL_COLOR_LIGHT = {
+    ...AI_MODEL_COLOR,
+    haiku:  darken(AI_MODEL_COLOR.haiku, LIGHT_SURFACE_DARKEN.haiku),
+    sonnet: darken(AI_MODEL_COLOR.sonnet, LIGHT_SURFACE_DARKEN.sonnet),
+    opus:   darken(AI_MODEL_COLOR.opus, LIGHT_SURFACE_DARKEN.opus),
+};
+
 export const AI_MODELS = ['haiku', 'sonnet', 'opus', 'fable'];
 
 // Capitalized display label; falls back to 'Opus' for null/unknown — every
@@ -35,10 +59,19 @@ export const AI_MODELS = ['haiku', 'sonnet', 'opus', 'fable'];
 export const aiModelLabel = (m) =>
     AI_MODEL_COLOR[m] ? m.charAt(0).toUpperCase() + m.slice(1) : 'Opus';
 
+// Mode-aware fill resolver (req #3053) — light mode uses the darkened,
+// surface-legible variant; dark mode uses the original ramp unchanged. Shared
+// with agentRegistryUtils.js's agentModelChipProps (registry agents pin the
+// same ramp, keyed off the base model name).
+export const modelFillColor = (m, mode) => {
+    const map = mode === 'light' ? AI_MODEL_COLOR_LIGHT : AI_MODEL_COLOR;
+    return map[m] || map.opus;
+};
+
 // Filled-chip props for a model — pastel bg + black text.
 // Null/unknown → opus styling (the backfill default), never unstyled.
 export const aiModelChipProps = (m) => ({
-    sx: { bgcolor: AI_MODEL_COLOR[m] || AI_MODEL_COLOR.opus, color: '#000' },
+    sx: (theme) => ({ bgcolor: modelFillColor(m, theme.palette.mode), color: '#000' }),
 });
 
 // Icon `color` for a model glyph — the ramp hex used as the glyph FILL (req


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3053-agent-card-has-black-text-on-gray-1
- wip(Darwin): 2026-07-25T00:15:43Z
- chore: init swarm session feature/3053-agent-card-has-black-text-on-gray-1

## Files changed
```
 src/Agents/__tests__/agentRegistryUtils.test.js  | 40 +++++++++++++++++++++++
 src/Agents/agentRegistryUtils.js                 | 12 +++++--
 src/SwarmView/__tests__/effortChipStyles.test.js | 40 ++++++++++++++++++-----
 src/SwarmView/__tests__/modelChipStyles.test.js  | 37 +++++++++++++++++----
 src/SwarmView/effortChipStyles.js                | 41 ++++++++++++++++++++++--
 src/SwarmView/modelChipStyles.js                 | 37 +++++++++++++++++++--
 6 files changed, 185 insertions(+), 22 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)