### PR TITLE
Views show autonomy

### DIFF
--- a/src/SwarmView/RequirementDeleteDialog.jsx
+++ b/src/SwarmView/RequirementDeleteDialog.jsx
@@ -34,9 +34,9 @@ const getStatusIcon = (status) => {
     return <EditNoteIcon sx={{ fontSize: 18, color: '#fbc02d' }} />;
 };
 
-// Mirror RequirementRow getCoordinationIcon — visible only for swarm_ready/development.
-const getCoordinationIcon = (status, coordType) => {
-    if (!['swarm_ready', 'development'].includes(status)) return null;
+// Mirror RequirementRow getCoordinationIcon — always visible (locked in this
+// preview, since nothing here is editable), for every status (req #3056).
+const getCoordinationIcon = (coordType) => {
     // Autonomy-progression colors — pink → purple → blue → green (req #2866).
     if (coordType === 'discuss')     return <ForumIcon sx={{ fontSize: 18, color: coordinationIconColor('discuss') }} />;
     if (coordType === 'planned')     return <DescriptionIcon sx={{ fontSize: 18, color: coordinationIconColor('planned') }} />;
@@ -81,7 +81,7 @@ const RequirementDeleteDialog = ({ deleteDialogOpen, setDeleteDialogOpen, setDel
                             {getStatusIcon(status)}
                         </Box>
                         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minWidth: 28 }}>
-                            {getCoordinationIcon(status, coordType)}
+                            {getCoordinationIcon(coordType)}
                         </Box>
                         <Box sx={{
                             flex: 1,

--- a/src/SwarmView/RequirementRow.jsx
+++ b/src/SwarmView/RequirementRow.jsx
@@ -345,13 +345,15 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
     };
 
     // --- Autonomy cell — small icon ------------------------------------------
-    // Visible only for swarm_ready + development; editable only for swarm_ready.
-    // Keeps the `coordination-toggle-<id>` test id.
+    // Always visible, for every status — including authoring/approved and the
+    // terminal met/wontfix/deferred — so every card shows which autonomy mode
+    // a requirement is set to or shipped under (req #3056). Editable window
+    // matches RequirementDetail's coordination_type editor (req #3054):
+    // authoring/approved/swarm_ready; locked everywhere else. Keeps the
+    // `coordination-toggle-<id>` test id.
     const renderAutonomyCell = () => {
         if (requirement.id === '') return null;
-        const showCoord = ['swarm_ready', 'development'].includes(status);
-        if (!showCoord) return null;
-        const isCoordEditable = status === 'swarm_ready';
+        const isCoordEditable = ['authoring', 'approved', 'swarm_ready'].includes(status);
         const tooltip = isCoordEditable
             ? (coordTooltip[coordType] || 'No autonomy — click to set')
             : 'Locked — not editable';
@@ -454,8 +456,8 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
         </Box>
     );
 
-    // Autonomy — small icon. Visible only for swarm_ready and development;
-    // editable only for swarm_ready.
+    // Autonomy — small icon, always visible; editable only for swarm_ready
+    // (req #3056).
     const autonomyCell = (
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minWidth: 28,
                    overflow: 'hidden' }}>

--- a/src/SwarmView/__tests__/RequirementRow.autonomy.test.jsx
+++ b/src/SwarmView/__tests__/RequirementRow.autonomy.test.jsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+//
+// Req #3056 — the Autonomy (coordination_type) icon must render for every
+// requirement_status, with no exceptions — including authoring/approved and
+// the terminal/historical statuses met/wontfix/deferred, all of which were
+// previously hidden. It's editable for authoring/approved/swarm_ready
+// (matching RequirementDetail's coordination_type editor, req #3054) and
+// locked everywhere else.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { DndProvider } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
+
+import RequirementRow from '../RequirementRow';
+import { RequirementActionsContext } from '../../hooks/useRequirementActions';
+
+const noop = () => {};
+
+let roots = [];
+function mount(requirement) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => {
+        root.render(
+            <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
+                <RequirementActionsContext.Provider value={{
+                    statusClick: noop, coordinationClick: noop,
+                    titleChange: noop, titleKeyDown: noop, titleOnBlur: noop,
+                    deleteClick: noop, sessionStatusMap: {}, sortMode: 'created',
+                    setCrossCardInsertIndex: noop, requirementsArray: [requirement],
+                    setRequirementsArray: noop,
+                }}>
+                    <RequirementRow requirement={requirement} requirementIndex={0} />
+                </RequirementActionsContext.Provider>
+            </DndProvider>
+        );
+    });
+    return container;
+}
+
+afterEach(() => {
+    act(() => { roots.forEach((r) => r.unmount()); });
+    roots = [];
+    document.body.innerHTML = '';
+});
+
+const reqWithStatus = (status) => ({
+    id: 42, title: 'Test requirement', requirement_status: status,
+    coordination_type: 'implemented', category_fk: 5, sort_order: 0,
+});
+
+const ALL_STATUSES = ['authoring', 'approved', 'swarm_ready', 'development', 'met', 'wontfix', 'deferred'];
+
+describe('RequirementRow autonomy icon visibility (req #3056)', () => {
+    it.each(ALL_STATUSES)(
+        'shows the autonomy icon for status=%s',
+        (status) => {
+            const container = mount(reqWithStatus(status));
+            expect(container.querySelector('[data-testid="coordination-toggle-42"]')).not.toBeNull();
+        }
+    );
+
+    const EDITABLE_STATUSES = ['authoring', 'approved', 'swarm_ready'];
+
+    it('is editable for authoring/approved/swarm_ready and locked elsewhere', () => {
+        for (const status of ALL_STATUSES) {
+            const container = mount(reqWithStatus(status));
+            const button = container.querySelector('[data-testid="coordination-toggle-42"]');
+            expect(button.disabled).toBe(!EDITABLE_STATUSES.includes(status));
+        }
+    });
+});

--- a/src/TaskPlanView/SwarmStartCard.jsx
+++ b/src/TaskPlanView/SwarmStartCard.jsx
@@ -22,8 +22,10 @@ import { RequirementActionsContext } from '../hooks/useRequirementActions';
 import { useSwarmStartCardStore } from '../stores/useSwarmStartCardStore';
 import { requirementStatusChipProps, requirementStatusLabel } from '../SwarmView/statusChipStyles';
 
-// Chip statuses shown on this card. Mirrors the requirements page filter chips minus 'deferred'
-// (retired from the aggregator per req #2584). 'met' is special-cased: it shows only
+// Chip statuses shown on this card. Mirrors the requirements page filter chips minus
+// 'deferred' and 'wontfix' — both terminal/historical states outside this card's
+// "active work" scope ('deferred' retired from the aggregator per req #2584;
+// 'wontfix' was never added, same reasoning). 'met' is special-cased: it shows only
 // the trailing-24h Met list — recent completions, not the full Met history.
 const SWARM_START_STATUSES = ['authoring', 'approved', 'swarm_ready', 'development', 'met'];
 const MET_TRAILING_HOURS = 24;


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3056-views-show-autonomy-1
- wip(Darwin): 2026-07-25T10:02:12Z
- chore: init swarm session feature/3056-views-show-autonomy-1

## Files changed
```
 src/SwarmView/RequirementDeleteDialog.jsx          |  8 +--
 src/SwarmView/RequirementRow.jsx                   | 16 +++--
 .../__tests__/RequirementRow.autonomy.test.jsx     | 81 ++++++++++++++++++++++
 src/TaskPlanView/SwarmStartCard.jsx                |  6 +-
 4 files changed, 98 insertions(+), 13 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related PRs: BillWilliams79/DarwinAI-Config#629