### PR TITLE
Add ability to delete Context

### DIFF
--- a/src/Agents/ContextPage.jsx
+++ b/src/Agents/ContextPage.jsx
@@ -16,6 +16,7 @@
 
 import '../index.css';
 import { Fragment, useContext, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -23,12 +24,20 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 import CircularProgress from '@mui/material/CircularProgress';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
+import DeleteIcon from '@mui/icons-material/Delete';
 
+import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
-import { useAgentTelemetryRuns, useAgentTelemetryRowsByRun } from '../hooks/useDataQueries';
+import {
+    useAgentTelemetryRuns, useAgentTelemetryRowsByRun, agentTelemetryRunKeys,
+} from '../hooks/useDataQueries';
+import { useSnackBarStore } from '../stores/useSnackBarStore';
+import { deleteAgentTelemetryRun } from './actions/contextApi';
 import { NA as NA_TEXT, sortRows, assignMarkers, computeCells } from './contextRenderUtils';
 
 // The 9 fixed column definitions — verbatim from the artifact glossary. The
@@ -93,15 +102,19 @@ const TABLE_CSS = `
 const NA = <span className="fn">n/a</span>;
 
 const ContextPage = () => {
-    const { profile } = useContext(AuthContext);
+    const { profile, idToken } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
     const theme = useTheme();
     const isMobile = useMediaQuery('(max-width:899px)');
     const creatorFk = profile?.userName;
+    const queryClient = useQueryClient();
+    const showError = useSnackBarStore(s => s.showError);
 
     const { data: runs, isLoading: runsLoading } = useAgentTelemetryRuns(creatorFk);
 
     // Runs arrive newest-first (captured_at:desc); default to the newest capture.
     const [selectedId, setSelectedId] = useState(null);
+    const [deleting, setDeleting] = useState(false);
     const runsSorted = useMemo(() => runs || [], [runs]);
     const activeRunId = selectedId ?? runsSorted[0]?.id ?? null;
     const activeRun = useMemo(
@@ -110,15 +123,34 @@ const ContextPage = () => {
 
     const { data: rows, isLoading: rowsLoading } = useAgentTelemetryRowsByRun(activeRunId);
 
-    const rendered = useMemo(() => {
-        const list = sortRows(rows);
-        return { list, markerByText: assignMarkers(list) };
-    }, [rows]);
-
     const dateLabel = (r) => {
         const d = r.captured_at ? String(r.captured_at).slice(0, 10) : '';
         return d ? `${r.label} — ${d}` : r.label;
     };
+
+    const handleDelete = async () => {
+        if (!activeRun) return;
+        const targetId = activeRun.id;
+        if (!window.confirm(`Delete capture "${dateLabel(activeRun)}"? This cannot be undone.`)) return;
+        setDeleting(true);
+        try {
+            await deleteAgentTelemetryRun(darwinUri, idToken, targetId);
+            // Only clear an explicit selection that still points at the row we just
+            // deleted — if the user picked a different capture while this delete was
+            // in flight, that pick must survive, not get silently overwritten.
+            setSelectedId(prev => (prev === targetId ? null : prev));
+            await queryClient.invalidateQueries({ queryKey: agentTelemetryRunKeys.all(creatorFk) });
+        } catch (err) {
+            showError(err, 'Could not delete the capture');
+        } finally {
+            setDeleting(false);
+        }
+    };
+
+    const rendered = useMemo(() => {
+        const list = sortRows(rows);
+        return { list, markerByText: assignMarkers(list) };
+    }, [rows]);
 
     if (runsLoading) {
         return <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }}><CircularProgress /></Box>;
@@ -151,6 +183,20 @@ const ContextPage = () => {
                             ))}
                         </Select>
                     </FormControl>
+                )}
+                {activeRun && (
+                    <Tooltip title="Delete this capture">
+                        <span>
+                            <IconButton
+                                size="small"
+                                onClick={handleDelete}
+                                disabled={deleting}
+                                data-testid="agent-context-delete-btn"
+                            >
+                                <DeleteIcon fontSize="small" />
+                            </IconButton>
+                        </span>
+                    </Tooltip>
                 )}
             </Box>
 

--- a/src/Agents/__tests__/contextApi.test.js
+++ b/src/Agents/__tests__/contextApi.test.js
@@ -1,0 +1,44 @@
+// Req #3062 — delete mutation for Agent Context Telemetry captures.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../RestApi/RestApi', () => ({ default: vi.fn() }));
+
+import call_rest_api from '../../RestApi/RestApi';
+import { deleteAgentTelemetryRun } from '../actions/contextApi';
+
+const URI = 'https://api.test/darwin_dev';
+const TOKEN = 'id-token';
+
+const ok = (status = 200, data = null) =>
+    ({ data, httpStatus: { httpStatus: status, httpMessage: 'OK' } });
+
+beforeEach(() => {
+    call_rest_api.mockReset();
+});
+
+describe('deleteAgentTelemetryRun', () => {
+    it('DELETEs the run by id', async () => {
+        call_rest_api.mockResolvedValue(ok(200));
+
+        await deleteAgentTelemetryRun(URI, TOKEN, 42);
+
+        expect(call_rest_api).toHaveBeenCalledWith(
+            `${URI}/agent_telemetry_runs`, 'DELETE', { id: 42 }, TOKEN);
+    });
+
+    it('resolves with the response data on success', async () => {
+        call_rest_api.mockResolvedValue(ok(200, { affected: 1 }));
+
+        await expect(deleteAgentTelemetryRun(URI, TOKEN, 42))
+            .resolves.toEqual({ affected: 1 });
+    });
+
+    it('throws when the delete fails', async () => {
+        call_rest_api.mockResolvedValue(
+            { data: null, httpStatus: { httpStatus: 404, httpMessage: 'NOT FOUND' } });
+
+        await expect(deleteAgentTelemetryRun(URI, TOKEN, 999))
+            .rejects.toThrow('deleteAgentTelemetryRun failed: HTTP 404 NOT FOUND');
+    });
+});

--- a/src/Agents/actions/contextApi.js
+++ b/src/Agents/actions/contextApi.js
@@ -1,0 +1,27 @@
+// Mutation utilities for Agent Context Telemetry captures (req #3062).
+// Pattern mirrors src/Customers/customersApi.js — call_rest_api directly,
+// callers handle TanStack Query cache invalidation via queryClient.invalidateQueries.
+//
+// `agent_telemetry_runs` is in Lambda-Rest CREATOR_FK_TABLES, so the DELETE is
+// scoped server-side to the authenticated user. `agent_telemetry_rows.run_fk`
+// is `ON DELETE CASCADE`, so deleting a run removes its per-agent rows too —
+// no separate row cleanup call needed here.
+
+import call_rest_api from '../../RestApi/RestApi';
+
+const isOk = (status) => status === 200 || status === 201 || status === 204;
+
+function assertOk(result, action) {
+    const status = result.httpStatus?.httpStatus;
+    if (!isOk(status)) {
+        const msg = result.httpStatus?.httpMessage || 'unknown';
+        throw new Error(`${action} failed: HTTP ${status} ${msg}`);
+    }
+    return result.data;
+}
+
+export async function deleteAgentTelemetryRun(darwinUri, idToken, id) {
+    const r = await call_rest_api(`${darwinUri}/agent_telemetry_runs`, 'DELETE',
+        { id }, idToken);
+    return assertOk(r, 'deleteAgentTelemetryRun');
+}


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-07-25T03:09:05Z
- chore: init swarm session feature/3062-add-ability-to-delete-context-1

## Files changed
```
 src/Agents/ContextPage.jsx              | 60 +++++++++++++++++++++++++++++----
 src/Agents/__tests__/contextApi.test.js | 44 ++++++++++++++++++++++++
 src/Agents/actions/contextApi.js        | 27 +++++++++++++++
 3 files changed, 124 insertions(+), 7 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)