### PR TITLE
Replace remaining window.confirm calls under /agents with the house dialog

### DIFF
--- a/src/Agents/AgentDetail.jsx
+++ b/src/Agents/AgentDetail.jsx
@@ -54,7 +54,9 @@ import {
     useAgentDocuments, useAgentInstructions, agentKeys,
     instructionKeys, agentInstructionKeys,
 } from '../hooks/useDataQueries';
+import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
+import InstructionUnbindDialog from './InstructionUnbindDialog';
 import {
     byId, linksByAgent, instructionLinksByAgent, agentsByInstruction,
     isCommonInstruction, relationshipChipProps, relationshipLabel,
@@ -198,14 +200,12 @@ const AgentDetail = () => {
         }
     };
 
+    /**
+     * Unbinding changes what this agent loads at boot and there is no undo, so it
+     * is confirmed — but this function no longer asks. It is the WRITE half only;
+     * `unbindConfirm` below decides whether it runs.
+     */
     const unlinkInstruction = async (instruction) => {
-        // Unbinding changes what this agent loads at boot and there is no undo, so
-        // it gets a confirmation like every other destructive action here.
-        if (!window.confirm(
-            `Unbind "${instruction.name}" from ${agent?.name || 'this agent'}?\n\n` +
-            'The agent stops loading it at its next boot. The instruction row itself survives.')) {
-            return;
-        }
         setInstrBusy(true);
         try {
             await unlinkAgentInstruction(darwinUri, idToken, agentId, instruction.id);
@@ -216,6 +216,22 @@ const AgentDetail = () => {
             setInstrBusy(false);
         }
     };
+
+    /**
+     * Unbind confirmation, in the house parent-owns-state shape (req #3071): the
+     * dialog only sets `confirmed`, and this effect-driven callback performs the
+     * write. Replaces a `window.confirm` — the last one on this page, and the same
+     * action the instructions page already confirmed properly since #3063.
+     *
+     * Deliberately the SAME component as the instructions page uses. It is one
+     * junction row approached from the other end, so a second dialog would only be
+     * a second copy of the same three facts to keep true. The `window.confirm` this
+     * replaces is evidence of exactly that: it had never picked up the slot warning.
+     */
+    const unbindConfirm = useConfirmDialog({
+        onConfirm: ({ row }) => { if (row) unlinkInstruction(row); },
+        defaultInfo: {},
+    });
 
     const addInstruction = async () => {
         if (!addSelection) return;
@@ -359,8 +375,15 @@ const AgentDetail = () => {
                                             </Tooltip>
                                             <Tooltip title="Unbind from this agent (the instruction itself survives)">
                                                 <span>
+                                                    {/* The junction slot is folded into the
+                                                        agent the dialog is handed, because THIS
+                                                        row's link is the only place it is known
+                                                        — and it is the one consequence the card
+                                                        cannot show: a rebind appends at max+1
+                                                        rather than restoring #{link.sort_order}. */}
                                                     <IconButton size="small" disabled={instrBusy}
-                                                                onClick={() => unlinkInstruction(row)}
+                                                                onClick={() => unbindConfirm.openDialog(
+                                                                    { row, agent: { ...agent, slot: link.sort_order } })}
                                                                 data-testid={`agent-instruction-unlink-${row.id}`}>
                                                         <LinkOffIcon fontSize="small" />
                                                     </IconButton>
@@ -467,6 +490,14 @@ const AgentDetail = () => {
                     </Table>
                 )}
             </Box>
+
+            <InstructionUnbindDialog
+                open={unbindConfirm.dialogOpen}
+                setOpen={unbindConfirm.setDialogOpen}
+                setConfirmed={unbindConfirm.setConfirmed}
+                instruction={unbindConfirm.infoObject?.row}
+                agent={unbindConfirm.infoObject?.agent}
+            />
 
         </Box>
     );

--- a/src/Agents/ContextPage.jsx
+++ b/src/Agents/ContextPage.jsx
@@ -36,9 +36,11 @@ import AuthContext from '../Context/AuthContext';
 import {
     useAgentTelemetryRuns, useAgentTelemetryRowsByRun, agentTelemetryRunKeys,
 } from '../hooks/useDataQueries';
+import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
 import { deleteAgentTelemetryRun } from './actions/contextApi';
 import { NA as NA_TEXT, sortRows, assignMarkers, computeCells } from './contextRenderUtils';
+import TelemetryRunDeleteDialog from './TelemetryRunDeleteDialog';
 
 // The 9 fixed column definitions — verbatim from the artifact glossary. The
 // per-row footnote definitions (*, †, …) are appended dynamically per run.
@@ -128,10 +130,15 @@ const ContextPage = () => {
         return d ? `${r.label} — ${d}` : r.label;
     };
 
-    const handleDelete = async () => {
-        if (!activeRun) return;
-        const targetId = activeRun.id;
-        if (!window.confirm(`Delete capture "${dateLabel(activeRun)}"? This cannot be undone.`)) return;
+    /**
+     * The WRITE half only — it no longer asks. `deleteConfirm` below decides
+     * whether it runs (req #3071, replacing a `window.confirm`).
+     *
+     * Takes the id rather than reading `activeRun`, because by the time this fires
+     * the user may have changed the picker: the row to delete is the one the dialog
+     * was opened on, not whichever one is selected when the confirm lands.
+     */
+    const performDelete = async (targetId) => {
         setDeleting(true);
         try {
             await deleteAgentTelemetryRun(darwinUri, idToken, targetId);
@@ -146,6 +153,17 @@ const ContextPage = () => {
             setDeleting(false);
         }
     };
+
+    /**
+     * Delete confirmation, in the house parent-owns-state shape: the dialog only
+     * sets `confirmed`, and this effect-driven callback performs the write. The
+     * `window.confirm` it replaces was unthemed, could not show the capture's size,
+     * and would have HUNG the first Playwright spec written against this route.
+     */
+    const deleteConfirm = useConfirmDialog({
+        onConfirm: ({ run }) => { if (run) performDelete(run.id); },
+        defaultInfo: {},
+    });
 
     const rendered = useMemo(() => {
         const list = sortRows(rows);
@@ -187,9 +205,24 @@ const ContextPage = () => {
                 {activeRun && (
                     <Tooltip title="Delete this capture">
                         <span>
+                            {/* The dialog is handed the capture's SIZE as well as the
+                                capture, and both are snapshotted here because both
+                                describe THIS run — they must not follow the picker if
+                                the selection moves while the dialog is open. `rows` is
+                                the active run's rows and the dialog only ever opens on
+                                the active run, so the count actually loaded and
+                                rendered below is the honest one; the stored
+                                `agent_count` covers the frames before it lands.
+                                How many captures REMAIN is a fact about the list, not
+                                about this run, so it is passed live at render instead. */}
                             <IconButton
                                 size="small"
-                                onClick={handleDelete}
+                                onClick={() => deleteConfirm.openDialog({
+                                    run: activeRun,
+                                    rowCount: (!rowsLoading && Array.isArray(rows))
+                                        ? rows.length
+                                        : activeRun.agent_count,
+                                })}
                                 disabled={deleting}
                                 data-testid="agent-context-delete-btn"
                             >
@@ -284,6 +317,21 @@ const ContextPage = () => {
                     </section>
                 </Box>
             )}
+
+            {/* Rendered OUTSIDE the runs-exist branch on purpose: deleting the last
+                capture empties `runsSorted` in the same commit, and a dialog mounted
+                inside that branch would be torn out mid-close.
+                `remainingCount` is clamped for the same reason — the list empties the
+                moment the delete lands, and "-1 remaining" is a nonsense value to hand
+                across a prop boundary even though only `=== 0` reads it today. */}
+            <TelemetryRunDeleteDialog
+                open={deleteConfirm.dialogOpen}
+                setOpen={deleteConfirm.setDialogOpen}
+                setConfirmed={deleteConfirm.setConfirmed}
+                run={deleteConfirm.infoObject?.run}
+                rowCount={deleteConfirm.infoObject?.rowCount}
+                remainingCount={Math.max(0, runsSorted.length - 1)}
+            />
         </Box>
     );
 };

--- a/src/Agents/InstructionUnbindDialog.jsx
+++ b/src/Agents/InstructionUnbindDialog.jsx
@@ -7,6 +7,19 @@
 // away from InstructionDeleteDialog, whose own header explains at length why a
 // real dialog beats `window.confirm` for exactly this class of action.
 //
+// ONE DIALOG, BOTH DIRECTIONS (req #3071). InstructionsPage unbinds by clicking an
+// agent chip on an instruction row; AgentDetail unbinds by clicking the link-off
+// icon on an instruction card. Those are the SAME DELETE of the SAME
+// `agent_instructions` row, approached from either end of it, and #3063 left them
+// inconsistent only because the agent-side one did not exist yet.
+//
+// So the copy here is deliberately DIRECTION-NEUTRAL — it names the agent, names
+// the instruction, and states the slot consequence, none of which depends on which
+// page you arrived from. Two components would have meant two places to keep that
+// wording true; the agent-side `window.confirm` this replaced had already drifted
+// (it never mentioned the slot at all). The caller supplies both halves of the
+// pair, so neither page is privileged.
+//
 // PARENT-OWNS-STATE, the house pattern (see the `frontend-*` template-row
 // instruction, and TaskDeleteDialog / RecurringDeleteDialog): this component holds
 // NO action logic. It sets `confirmed = true` and closes; `useConfirmDialog`'s

--- a/src/Agents/TelemetryRunDeleteDialog.jsx
+++ b/src/Agents/TelemetryRunDeleteDialog.jsx
@@ -1,0 +1,155 @@
+// Confirm deleting one agent-context telemetry capture (req #3071).
+//
+// Replaces the last `window.confirm` under /agents. Of the two this requirement
+// retired, this is the one that deserved a real dialog most: unbinding an
+// instruction is reversible by rebinding it, and this is not reversible at all.
+//
+// WHY A CAPTURE CANNOT BE RE-CREATED. A run is not a saved view of live data — it
+// is a MEASUREMENT. `/agent-telemetry-run` produces one by launching a
+// load-and-stop probe per agent and reading actual token deltas out of each
+// transcript, against whatever harness, CLAUDE.md, charter stubs and autoload
+// documents existed that day. Re-running it later is a new measurement of a
+// different system; it cannot reproduce the numbers in this row. `window.confirm`'s
+// "This cannot be undone" said the words without ever saying why, and the why is
+// the whole reason to hesitate.
+//
+// WHAT ELSE GOES. `agent_telemetry_rows.run_fk` is ON DELETE CASCADE (migration
+// 069), so the per-agent rows are deleted server-side with the header. The picker
+// shows a capture as ONE line, so its size — the thing actually being destroyed —
+// is invisible until this dialog states it.
+//
+// PARENT-OWNS-STATE, the house pattern (see InstructionUnbindDialog, TaskDeleteDialog,
+// RecurringDeleteDialog): this component holds NO action logic. It sets
+// `confirmed = true` and closes; `useConfirmDialog`'s effect in the parent then runs
+// the delete, the selection fix-up and the cache invalidation.
+
+import { useRef } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+
+/**
+ * `run` and `rowCount` describe the capture being deleted, so they arrive in the
+ * confirm payload and are SNAPSHOTTED — they must not follow the picker.
+ *
+ * `remainingCount` is the opposite: it describes the LIST, which is live behind
+ * the dialog. A capture arriving from another session (or from
+ * `/agent-telemetry-run` finishing) while this is open would leave a snapshotted
+ * count asserting "this is the only capture" after it had stopped being true. So
+ * it is passed as an ordinary prop, read at render — but only WHILE OPEN. Once the
+ * user has confirmed, the delete and its refetch routinely beat MUI's ~195ms fade,
+ * and a still-live count would rewrite the closing dialog to describe the world
+ * AFTER the decision — growing or dropping the last-capture line in a dialog that
+ * asked a question about the world BEFORE it. Live while it is still a question,
+ * frozen once it is an answer.
+ */
+const TelemetryRunDeleteDialog = ({
+    open, setOpen, setConfirmed, run, rowCount, remainingCount,
+}) => {
+    /**
+     * `useConfirmDialog` resets `infoObject` to its default in the SAME effect pass
+     * that fires the confirm callback, so `run` goes undefined the instant the user
+     * clicks Delete. Returning null there would rip the dialog out mid-close and
+     * skip its exit transition. Hold the last real payload so the closing frames
+     * still have something to render; `open` is what controls visibility.
+     *
+     * There is deliberately no `busy` state, for the same reason as
+     * InstructionUnbindDialog: the write starts AFTER this dialog has closed, so a
+     * spinner here could never be seen. Progress shows on the page's delete button.
+     */
+    const lastShown = useRef(null);
+    if (run) lastShown.current = { run, rowCount };
+    const shown = run ? { run, rowCount } : lastShown.current;
+
+    // Tracked separately from `lastShown` because it is latched on a different
+    // event: `lastShown` freezes when the PAYLOAD clears (at confirm), this one
+    // when the dialog CLOSES. They coincide on confirm and diverge on cancel.
+    const lastRemaining = useRef(null);
+    if (open) lastRemaining.current = remainingCount;
+
+    if (!shown) return null;
+
+    const { run: target } = shown;
+    const capturedOn = target.captured_at ? String(target.captured_at).slice(0, 10) : null;
+    const rows = Number.isFinite(shown.rowCount) ? shown.rowCount : null;
+    const liveRemaining = open ? remainingCount : lastRemaining.current;
+    const remaining = Number.isFinite(liveRemaining) ? liveRemaining : null;
+
+    const cancel = () => setOpen(false);
+
+    const confirm = () => {
+        setConfirmed(true);
+        setOpen(false);
+    };
+
+    return (
+        <Dialog open={open} onClose={cancel} maxWidth="sm" fullWidth
+                data-testid="telemetry-run-delete-dialog">
+            <DialogTitle>Delete this capture?</DialogTitle>
+            <DialogContent>
+                <Stack spacing={2} sx={{ mt: 1 }}>
+                    <Stack direction="row" spacing={0.5} alignItems="center" flexWrap="wrap" useFlexGap>
+                        <Chip size="small" color="error" variant="outlined"
+                              label={target.label || `Capture #${target.id}`} />
+                        {capturedOn && (
+                            <Chip size="small" variant="outlined" label={capturedOn} />
+                        )}
+                        {target.harness_version && (
+                            <Chip size="small" variant="outlined"
+                                  label={`harness ${target.harness_version}`} />
+                        )}
+                    </Stack>
+
+                    {/* Zero is a real state, not a missing count: the run header and
+                        its rows are stored by separate MCP calls, so an aborted
+                        capture leaves a header with nothing under it. Sending it
+                        through the numeric branch would read "All 0 rows … are
+                        deleted with it", which is both odd and beside the point —
+                        what is being deleted there is the header. */}
+                    <DialogContentText data-testid="telemetry-run-delete-rows">
+                        {rows === null
+                            ? 'Every per-agent measurement row in this capture is deleted with it.'
+                            : rows === 0
+                                ? 'It holds no per-agent measurement rows — only the capture '
+                                  + 'header is deleted.'
+                                : `All ${rows} per-agent measurement row${rows === 1 ? '' : 's'} `
+                                  + 'in this capture are deleted with it.'}
+                    </DialogContentText>
+
+                    {/* The irreversibility that matters, stated as the reason rather
+                        than the slogan: this is a measurement of a system that has
+                        since moved on, not a view that can be rebuilt. */}
+                    <Alert severity="error" data-testid="telemetry-run-delete-warning">
+                        This cannot be undone. A capture measures the agent harness as it stood
+                        {capturedOn ? ` on ${capturedOn}` : ' when it was taken'} — re-running{' '}
+                        <code>/agent-telemetry-run</code> records today&apos;s numbers, not these.
+                    </Alert>
+
+                    {remaining === 0 && (
+                        <DialogContentText data-testid="telemetry-run-delete-last">
+                            It is the only capture stored. This page will be empty until another
+                            one is taken.
+                        </DialogContentText>
+                    )}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={cancel}
+                        data-testid="telemetry-run-delete-cancel-btn">Cancel</Button>
+                <Button onClick={confirm} color="error" variant="contained"
+                        data-testid="telemetry-run-delete-confirm-btn">
+                    Delete
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default TelemetryRunDeleteDialog;

--- a/src/Agents/__tests__/AgentDetail.unbind.test.jsx
+++ b/src/Agents/__tests__/AgentDetail.unbind.test.jsx
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+//
+// Req #3071 — the agent-side unbind now goes through the SHARED dialog.
+//
+// What is actually at risk in this change is the WIRING, not the dialog: the page
+// stopped calling `window.confirm` and started handing a payload to
+// `useConfirmDialog`, whose effect fires the write one tick later with an
+// `infoObject` that the hook clears in the same pass. Three ways that goes wrong,
+// all of which a "does the dialog appear?" test would miss:
+//
+//   * the write runs anyway (the confirm gate was removed but nothing replaced it);
+//   * the write runs on the WRONG instruction (the payload is read from the last
+//     render rather than from the row that was clicked);
+//   * the slot warning is empty, because the junction `sort_order` lives on the
+//     link and not on the instruction row — so a version that passed the
+//     instruction alone still renders a dialog, just a less honest one.
+//
+// Mounted harness with raw react-dom + act, the house pattern — same shape as
+// InstructionsPage.test.jsx, which pins the other direction of this same unbind.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const navigateSpy = vi.fn();
+vi.mock('react-router-dom', () => ({
+    useNavigate: () => navigateSpy,
+    useParams: () => ({ id: '1' }),
+}));
+
+// Module-level query data — reassigned per test before mount.
+let agentsData = [];
+let instructionsData = [];
+let junctionData = [];
+
+vi.mock('../../hooks/useDataQueries', () => ({
+    useAgents: () => ({ data: agentsData, isLoading: false }),
+    useInstructions: () => ({ data: instructionsData }),
+    useArchitectureDocuments: () => ({ data: [] }),
+    useAgentDocuments: () => ({ data: [] }),
+    useAgentInstructions: () => ({ data: junctionData }),
+    agentKeys: { all: (c) => ['agents', c] },
+    instructionKeys: { all: (c) => ['instructions', c] },
+    agentInstructionKeys: { all: (c) => ['agent_instructions', c] },
+}));
+
+vi.mock('../actions/instructionsApi', () => ({
+    linkAgentInstruction: vi.fn(),
+    unlinkAgentInstruction: vi.fn(),
+    setAgentInstructionOrder: vi.fn(),
+}));
+
+// Only reached by the overview field's blur, which no test here touches — mocked
+// so an accidental one cannot make a network call.
+vi.mock('../../RestApi/RestApi', () => ({ default: vi.fn() }));
+
+import AgentDetail from '../AgentDetail';
+import * as api from '../actions/instructionsApi';
+import AppContext from '../../Context/AppContext';
+import AuthContext from '../../Context/AuthContext';
+import { useSnackBarStore } from '../../stores/useSnackBarStore';
+
+const URI = 'http://test.local';
+const TOKEN = 'tok';
+const CREATOR = 'tester';
+
+// ---------------------------------------------------------------------------
+// Fixture. ONE agent with TWO bound instructions at DIFFERENT junction slots —
+// equal slots would let a version that reads the wrong link still pass the slot
+// assertion, and a single bound row would let one that reads "the only row"
+// pass the row-identity assertion.
+// ---------------------------------------------------------------------------
+const AGENT = {
+    id: 1, name: 'Alpha', closed: 0, ai_model: 'opus', effort: 'high',
+    overview: 'the alpha agent', location: 'alpha.md', file_name: 'alpha.md',
+};
+const INSTRUCTIONS = [
+    { id: 10, name: 'First Rule', content: 'body ten', closed: 0 },
+    { id: 11, name: 'Second Rule', content: 'body eleven', closed: 0 },
+];
+const JUNCTION = [
+    { agent_fk: 1, instruction_fk: 10, sort_order: 3 },
+    { agent_fk: 1, instruction_fk: 11, sort_order: 7 },
+];
+
+let container;
+let root;
+let queryClient;
+
+const mount = () => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: URI }}>
+                    <AuthContext.Provider value={{ idToken: TOKEN, profile: { userName: CREATOR } }}>
+                        <AgentDetail />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+};
+
+beforeEach(() => {
+    agentsData = [{ ...AGENT }];
+    instructionsData = INSTRUCTIONS.map(i => ({ ...i }));
+    junctionData = JUNCTION.map(l => ({ ...l }));
+
+    for (const fn of Object.values(api)) {
+        fn.mockReset();
+        fn.mockResolvedValue({});
+    }
+    navigateSpy.mockReset();
+    useSnackBarStore.setState({ open: false, message: '' });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.body.innerHTML = '';
+});
+
+// Dialogs render into a portal on document.body, so lookups are document-wide.
+const byTestId = (id) => document.querySelector(`[data-testid="${id}"]`);
+
+const clickAsync = async (el) => { await act(async () => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+}); };
+
+const flush = async () => { await act(async () => {
+    await Promise.resolve(); await Promise.resolve();
+}); };
+
+const unlinkBtn = (instructionId) => byTestId(`agent-instruction-unlink-${instructionId}`);
+
+describe('AgentDetail — unbind goes through useConfirmDialog, not window.confirm', () => {
+    it('opens the shared dialog rather than unbinding on the spot', async () => {
+        // The regression this whole requirement exists for: a `window.confirm` here
+        // would have BLOCKED this click instead of rendering anything, which is the
+        // same thing that hangs a Playwright run with no dialog handler registered.
+        mount();
+        await clickAsync(unlinkBtn(10));
+
+        expect(api.unlinkAgentInstruction).not.toHaveBeenCalled();
+        expect(byTestId('instruction-unbind-dialog')).not.toBeNull();
+    });
+
+    it('reuses the instructions page dialog — same component, both directions', async () => {
+        // The testids are InstructionUnbindDialog's own. Asserting on them is what
+        // pins the sharing decision: a second, agent-side-only dialog would render
+        // different ones and this fails rather than silently duplicating the copy.
+        mount();
+        await clickAsync(unlinkBtn(10));
+
+        expect(byTestId('instruction-unbind-cancel-btn')).not.toBeNull();
+        expect(byTestId('instruction-unbind-confirm-btn')).not.toBeNull();
+        expect(document.querySelector('.MuiDialogTitle-root').textContent)
+            .toBe('Unbind from Alpha?');
+    });
+
+    it('names BOTH halves of the pair, so the agent-side dialog says which instruction', async () => {
+        // From this page the agent is obvious and the instruction is the question —
+        // the reverse of the instructions page. The shared copy has to answer both.
+        mount();
+        await clickAsync(unlinkBtn(11));
+
+        const text = document.querySelector('.MuiDialog-container').textContent;
+        expect(text).toContain('Second Rule');
+        expect(text).toContain('Alpha');
+    });
+
+    it('carries the JUNCTION slot, which the window.confirm it replaced never did', async () => {
+        // sort_order lives on the link, not on the instruction. Passing the
+        // instruction alone still renders a dialog — just one missing the single
+        // consequence a rebind cannot restore.
+        mount();
+        await clickAsync(unlinkBtn(11));
+
+        const warning = byTestId('instruction-unbind-slot-warning');
+        expect(warning).not.toBeNull();
+        expect(warning.textContent).toContain('#7');   // Second Rule's junction slot
+    });
+
+    it('writes nothing when the dialog is cancelled', async () => {
+        mount();
+        await clickAsync(unlinkBtn(10));
+        await clickAsync(byTestId('instruction-unbind-cancel-btn'));
+        await flush();
+
+        expect(api.unlinkAgentInstruction).not.toHaveBeenCalled();
+    });
+
+    it('unbinds exactly that one (agent, instruction) pair on confirm', async () => {
+        mount();
+        await clickAsync(unlinkBtn(10));
+        await clickAsync(byTestId('instruction-unbind-confirm-btn'));
+        await flush();
+
+        expect(api.unlinkAgentInstruction)
+            .toHaveBeenCalledExactlyOnceWith(URI, TOKEN, 1, 10);
+    });
+
+    it('does not confuse two rows — it acts on the row it was opened from', async () => {
+        // Deliberately the SECOND row. `infoObject` carries the row, and the classic
+        // way to get this wrong is to read `myInstructions[0]` (or the last-hovered
+        // row) instead of the clicked one — which is indistinguishable from correct
+        // for as long as every confirm in the file happens to be fired on row 10.
+        mount();
+        await clickAsync(unlinkBtn(11));
+        await clickAsync(byTestId('instruction-unbind-confirm-btn'));
+        await flush();
+
+        expect(api.unlinkAgentInstruction)
+            .toHaveBeenCalledExactlyOnceWith(URI, TOKEN, 1, 11);
+    });
+
+    it('renders the binding it is closing on, not a blank, after the confirm', async () => {
+        // `useConfirmDialog` clears `infoObject` in the SAME pass that fires the
+        // callback, so on the next render the dialog's props are undefined while it
+        // is still fading out. Without the `lastShown` ref it returns null there and
+        // pops off the screen instead of transitioning. Nothing else notices: every
+        // other test in this file asserts on state BEFORE that render.
+        mount();
+        await clickAsync(unlinkBtn(11));
+        await clickAsync(byTestId('instruction-unbind-confirm-btn'));
+
+        const dialog = byTestId('instruction-unbind-dialog');
+        expect(dialog).not.toBeNull();
+        expect(dialog.textContent).toContain('Second Rule');
+    });
+
+    it('writes once and reports no error when confirm is clicked twice during the exit fade', async () => {
+        // The button stays mounted and clickable through MUI's ~195ms close, so the
+        // second click re-fires the effect with the already-cleared `{}` payload.
+        // The `if (row)` guard absorbs it.
+        //
+        // The call-count assertion ALONE cannot see that guard. Unlike ContextPage —
+        // where `performDelete(run.id)` derefs in the argument expression and throws
+        // out of the effect — `unlinkInstruction(row)` is async and derefs
+        // `instruction.id` inside its OWN try, so an unguarded second fire is caught
+        // by its own catch and lands in `reportInstructionError`. The visible damage
+        // is a false "Could not unlink the instruction" toast (plus a redundant cache
+        // invalidation) sitting on top of an unbind that in fact succeeded — and the
+        // API is still called exactly once either way. So the snackbar is what
+        // actually pins this.
+        mount();
+        await clickAsync(unlinkBtn(10));
+        const confirmBtn = byTestId('instruction-unbind-confirm-btn');
+        await clickAsync(confirmBtn);
+        await clickAsync(confirmBtn);
+        await flush();
+
+        expect(api.unlinkAgentInstruction)
+            .toHaveBeenCalledExactlyOnceWith(URI, TOKEN, 1, 10);
+        expect(useSnackBarStore.getState().open).toBe(false);
+    });
+
+    it('omits the slot warning when the junction row carries no sort_order', async () => {
+        // `sort_order` is nullable, and the card itself renders `#—` for it. A
+        // warning naming slot "#null" would be worse than no warning.
+        junctionData = [{ agent_fk: 1, instruction_fk: 10, sort_order: null }];
+        instructionsData = [{ ...INSTRUCTIONS[0] }];
+        mount();
+        await clickAsync(unlinkBtn(10));
+
+        expect(byTestId('instruction-unbind-dialog')).not.toBeNull();
+        expect(byTestId('instruction-unbind-slot-warning')).toBeNull();
+    });
+
+    it('invalidates the junction cache after the write, so the list resyncs', async () => {
+        // The unbind is pessimistic: nothing is applied locally, so the refetch IS
+        // the update. Skipping it leaves the card showing a binding that is gone.
+        mount();
+        const spy = vi.spyOn(queryClient, 'invalidateQueries');
+
+        await clickAsync(unlinkBtn(10));
+        await clickAsync(byTestId('instruction-unbind-confirm-btn'));
+        await flush();
+
+        const keys = spy.mock.calls.map(([arg]) => JSON.stringify(arg?.queryKey));
+        expect(keys).toContain(JSON.stringify(['agent_instructions', CREATOR]));
+    });
+});

--- a/src/Agents/__tests__/ContextPage.delete.test.jsx
+++ b/src/Agents/__tests__/ContextPage.delete.test.jsx
@@ -1,0 +1,407 @@
+// @vitest-environment jsdom
+//
+// Req #3071 — deleting a telemetry capture goes through a real dialog.
+//
+// This is the more dangerous of the two calls this requirement replaced. The
+// unbind is reversible by rebinding; a capture is a MEASUREMENT of a harness that
+// no longer exists, and its per-agent rows cascade away with the header. So the
+// assertions here are about more than "a dialog appeared":
+//
+//   * the write does not fire until the dialog is confirmed, and never on cancel;
+//   * the id deleted is the one the dialog was OPENED on, not whatever the picker
+//     happens to be showing when the confirm lands — the two diverge the moment a
+//     user changes the picker mid-dialog, and the page reads `activeRun` for
+//     everything else;
+//   * the dialog states the capture's SIZE, which the one-line picker cannot show
+//     and which `window.confirm` never did.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let runsData = [];
+let rowsByRun = {};
+// Flipped by the one test that needs the rows still in flight — the page falls
+// back to the run's stored `agent_count` for exactly that window.
+let rowsLoading = false;
+
+vi.mock('../../hooks/useDataQueries', () => ({
+    useAgentTelemetryRuns: () => ({ data: runsData, isLoading: false }),
+    useAgentTelemetryRowsByRun: (runId) => ({
+        data: rowsLoading ? undefined : (rowsByRun[runId] || []), isLoading: rowsLoading,
+    }),
+    agentTelemetryRunKeys: { all: (c) => ['agent_telemetry_runs', c] },
+}));
+
+vi.mock('../actions/contextApi', () => ({
+    deleteAgentTelemetryRun: vi.fn(),
+}));
+
+import ContextPage from '../ContextPage';
+import * as api from '../actions/contextApi';
+import AppContext from '../../Context/AppContext';
+import AuthContext from '../../Context/AuthContext';
+import { useSnackBarStore } from '../../stores/useSnackBarStore';
+
+const URI = 'http://test.local';
+const TOKEN = 'tok';
+const CREATOR = 'tester';
+
+// Two captures, newest first (the hook's own captured_at:desc order). Run 500 is
+// the default selection; 501 exists so "deletes the one it was opened on" has
+// something else to be wrong about.
+const RUNS = [
+    {
+        id: 500, label: 'Baseline', captured_at: '2026-07-20T10:00:00',
+        agent_count: 4, harness_version: '2.1.0', source_note: 'note five hundred',
+    },
+    {
+        id: 501, label: 'Earlier', captured_at: '2026-07-10T10:00:00',
+        agent_count: 2, harness_version: '2.0.0', source_note: null,
+    },
+];
+
+// Row counts deliberately DISAGREE with agent_count on run 500 (3 loaded vs 4
+// stored). The dialog is specified to report what is actually loaded and
+// rendered, so a version reading the stored column shows 4 and fails here.
+const ROWS = {
+    500: [
+        { id: 1, run_fk: 500, agent_name: 'Alpha', start_work_context_tokens: 10 },
+        { id: 2, run_fk: 500, agent_name: 'Bravo', start_work_context_tokens: 20 },
+        { id: 3, run_fk: 500, agent_name: 'Charlie', start_work_context_tokens: 30 },
+    ],
+    501: [
+        { id: 4, run_fk: 501, agent_name: 'Alpha', start_work_context_tokens: 11 },
+    ],
+};
+
+let container;
+let root;
+let queryClient;
+let bump;
+
+// `bump()` re-renders with whatever `runsData` now holds — a landed refetch.
+function Harness() {
+    const [, setTick] = useState(0);
+    bump = () => setTick(t => t + 1);
+    return <ContextPage />;
+}
+
+const mount = () => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: URI }}>
+                    <AuthContext.Provider value={{ idToken: TOKEN, profile: { userName: CREATOR } }}>
+                        <Harness />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+};
+
+beforeEach(() => {
+    // MUI's useMediaQuery falls back to `defaultMatches` when matchMedia is absent,
+    // which jsdom does not provide. Stubbed so the layout branch is deterministic
+    // rather than dependent on that fallback.
+    window.matchMedia = window.matchMedia || ((query) => ({
+        matches: false, media: query, onchange: null,
+        addListener: () => {}, removeListener: () => {},
+        addEventListener: () => {}, removeEventListener: () => {},
+        dispatchEvent: () => false,
+    }));
+
+    runsData = RUNS.map(r => ({ ...r }));
+    rowsByRun = { 500: [...ROWS[500]], 501: [...ROWS[501]] };
+    rowsLoading = false;
+
+    api.deleteAgentTelemetryRun.mockReset();
+    api.deleteAgentTelemetryRun.mockResolvedValue({});
+    useSnackBarStore.setState({ open: false, message: '' });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.body.innerHTML = '';
+});
+
+const byTestId = (id) => document.querySelector(`[data-testid="${id}"]`);
+
+const clickAsync = async (el) => { await act(async () => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+}); };
+
+const flush = async () => { await act(async () => {
+    await Promise.resolve(); await Promise.resolve();
+}); };
+
+describe('ContextPage — capture delete goes through a real dialog', () => {
+    it('opens the dialog rather than deleting on the spot', async () => {
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+
+        expect(api.deleteAgentTelemetryRun).not.toHaveBeenCalled();
+        expect(byTestId('telemetry-run-delete-dialog')).not.toBeNull();
+    });
+
+    it('names the capture and its date, so the confirm is about a specific run', async () => {
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+
+        const text = document.querySelector('.MuiDialog-container').textContent;
+        expect(text).toContain('Baseline');
+        expect(text).toContain('2026-07-20');
+    });
+
+    it('states how many per-agent rows cascade away with it', async () => {
+        // The picker renders a capture as one line, so its size — the thing being
+        // destroyed — is invisible without this. Three rows are loaded for run 500.
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+
+        expect(byTestId('telemetry-run-delete-rows').textContent).toContain('3');
+    });
+
+    it('explains WHY it is irreversible, not just that it is', async () => {
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+
+        const warning = byTestId('telemetry-run-delete-warning');
+        expect(warning).not.toBeNull();
+        expect(warning.textContent).toContain('agent-telemetry-run');
+    });
+
+    it('does not claim this is the last capture when another one exists', async () => {
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+
+        // Paired with the dialog-is-open assertion on purpose: `toBeNull()` alone
+        // would also pass if the dialog had never opened at all.
+        expect(byTestId('telemetry-run-delete-dialog')).not.toBeNull();
+        expect(byTestId('telemetry-run-delete-last')).toBeNull();
+    });
+
+    it('warns when it IS the last capture, because the page then goes empty', async () => {
+        runsData = [{ ...RUNS[0] }];
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+
+        expect(byTestId('telemetry-run-delete-last')).not.toBeNull();
+    });
+
+    it('retracts the last-capture claim when one arrives while the dialog is open', async () => {
+        // How many captures REMAIN is a fact about the LIST, not about the run being
+        // deleted — so unlike the run id it must NOT be snapshotted at open time. A
+        // frozen copy leaves the dialog asserting "It is the only capture stored"
+        // after that has stopped being true, which is a false statement made at
+        // exactly the moment the user is deciding.
+        runsData = [{ ...RUNS[0] }];
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+        expect(byTestId('telemetry-run-delete-last')).not.toBeNull();
+
+        await act(async () => {
+            runsData = [{ ...RUNS[0] }, { ...RUNS[1] }];
+            bump();
+        });
+
+        expect(byTestId('telemetry-run-delete-dialog')).not.toBeNull();
+        expect(byTestId('telemetry-run-delete-last')).toBeNull();
+    });
+
+    it('stops tracking the list once the question has been answered', async () => {
+        // The mirror of the test above, and the reason `remainingCount` is live only
+        // WHILE OPEN. After confirm the dialog is still fading, and the delete plus
+        // its refetch routinely beat MUI's ~195ms exit — a still-live count would
+        // rewrite the closing dialog to describe the world AFTER the decision,
+        // growing a "this is the only capture" line into the dialog that asked a
+        // question about the world before it.
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+        expect(byTestId('telemetry-run-delete-last')).toBeNull();   // two exist
+
+        await clickAsync(byTestId('telemetry-run-delete-confirm-btn'));
+        await act(async () => {
+            runsData = [{ ...RUNS[1] }];   // the refetch lands: one capture left
+            bump();
+        });
+
+        // Still mounted (fading), and still describing the decision that was made.
+        expect(byTestId('telemetry-run-delete-dialog')).not.toBeNull();
+        expect(byTestId('telemetry-run-delete-last')).toBeNull();
+    });
+
+    it('does not say "all 0 rows" for a header with no per-agent rows', async () => {
+        // Reachable: the run header and its rows are stored by separate MCP calls,
+        // so an aborted capture leaves a header with nothing under it.
+        rowsByRun[500] = [];
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+
+        const text = byTestId('telemetry-run-delete-rows').textContent;
+        expect(text).not.toMatch(/\b0\b/);
+        expect(text).toContain('no per-agent measurement rows');
+    });
+
+    it('deletes nothing when the dialog is cancelled', async () => {
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+        await clickAsync(byTestId('telemetry-run-delete-cancel-btn'));
+        await flush();
+
+        expect(api.deleteAgentTelemetryRun).not.toHaveBeenCalled();
+    });
+
+    it('deletes the selected capture on confirm', async () => {
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+        await clickAsync(byTestId('telemetry-run-delete-confirm-btn'));
+        await flush();
+
+        expect(api.deleteAgentTelemetryRun)
+            .toHaveBeenCalledExactlyOnceWith(URI, TOKEN, 500);
+    });
+
+    it('deletes the run the dialog was OPENED on, even if a refetch moves the selection', async () => {
+        // `activeRunId` is `selectedId ?? runsSorted[0].id`, and until the user
+        // touches the picker `selectedId` is null — so the active run is whatever
+        // sorts FIRST. A capture stored from another session (or the one the user
+        // just took) lands at the head of a captured_at:desc list and silently
+        // becomes `activeRun` under the open dialog.
+        //
+        // A confirm callback that re-read `activeRun` would then delete the capture
+        // that just arrived instead of the one named in the dialog — an
+        // irreplaceable measurement, destroyed with no wrong-looking click anywhere.
+        // The id travels in the payload precisely so that cannot happen.
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+        expect(document.querySelector('.MuiDialog-container').textContent)
+            .toContain('Baseline');
+
+        const ARRIVED = {
+            id: 502, label: 'Arrived Mid-Dialog', captured_at: '2026-07-25T10:00:00',
+            agent_count: 5, harness_version: '2.2.0', source_note: null,
+        };
+        rowsByRun[502] = [];
+        await act(async () => {
+            runsData = [ARRIVED, ...RUNS.map(r => ({ ...r }))];
+            bump();
+        });
+        // The selection really moved — without this the assertion below could pass
+        // for the wrong reason.
+        expect(byTestId('agent-context-run-picker').textContent)
+            .toContain('Arrived Mid-Dialog');
+
+        await clickAsync(byTestId('telemetry-run-delete-confirm-btn'));
+        await flush();
+
+        expect(api.deleteAgentTelemetryRun)
+            .toHaveBeenCalledExactlyOnceWith(URI, TOKEN, 500);
+    });
+
+    it('falls back to the stored agent_count while the rows are still in flight', async () => {
+        // The observed row count is preferred, but it does not exist yet on the
+        // frames before the rows query settles. `agent_count` on run 500 is 4, and
+        // the fixture's loaded rows are 3 — so this cannot pass by accident.
+        rowsLoading = true;
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+
+        expect(byTestId('telemetry-run-delete-rows').textContent).toContain('4');
+    });
+
+    it('renders the capture it is closing on, not a blank, after the confirm', async () => {
+        // `useConfirmDialog` clears `infoObject` in the SAME pass that fires the
+        // callback, so the dialog's `run` prop is undefined on the next render while
+        // it is still fading out. Without the `lastShown` ref it returns null there
+        // and pops off the screen mid-transition — invisible to every other test
+        // here, which all assert on state before that render.
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+        await clickAsync(byTestId('telemetry-run-delete-confirm-btn'));
+
+        const dialog = byTestId('telemetry-run-delete-dialog');
+        expect(dialog).not.toBeNull();
+        expect(dialog.textContent).toContain('Baseline');
+    });
+
+    it('deletes once when the confirm button is clicked twice during the exit fade', async () => {
+        // The button stays mounted and clickable through MUI's ~195ms close. The
+        // second click re-fires the effect with the already-cleared `{}` payload.
+        // Unguarded that is `undefined.id` raised inside a useEffect — it escapes to
+        // an error boundary rather than to the snackbar — and if it did not throw it
+        // would be a second DELETE of an irreplaceable measurement.
+        mount();
+        await clickAsync(byTestId('agent-context-delete-btn'));
+        const confirmBtn = byTestId('telemetry-run-delete-confirm-btn');
+        await clickAsync(confirmBtn);
+        await clickAsync(confirmBtn);
+        await flush();
+
+        expect(api.deleteAgentTelemetryRun)
+            .toHaveBeenCalledExactlyOnceWith(URI, TOKEN, 500);
+    });
+
+    it('clears an explicit selection that pointed at the run it just deleted', async () => {
+        // Otherwise `selectedId` keeps naming a row that no longer exists, and
+        // `activeRunId` resolves to it forever: the picker holds an out-of-range
+        // value and the table renders from a dead run instead of falling back to the
+        // newest surviving capture.
+        mount();
+        await act(async () => {
+            document.querySelector('.MuiSelect-select')
+                .dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+        });
+        await clickAsync(byTestId('agent-context-run-option-501'));
+        expect(byTestId('agent-context-run-picker').textContent).toContain('Earlier');
+
+        await clickAsync(byTestId('agent-context-delete-btn'));
+        await clickAsync(byTestId('telemetry-run-delete-confirm-btn'));
+        await flush();
+
+        expect(api.deleteAgentTelemetryRun)
+            .toHaveBeenCalledExactlyOnceWith(URI, TOKEN, 501);
+
+        // The refetch lands with 501 gone. The picker must fall back to the newest
+        // survivor rather than still pointing at the deleted row.
+        await act(async () => {
+            runsData = [{ ...RUNS[0] }];
+            bump();
+        });
+        expect(byTestId('agent-context-run-picker').textContent).toContain('Baseline');
+    });
+
+    it('invalidates the runs cache after the delete, so the picker resyncs', async () => {
+        mount();
+        const spy = vi.spyOn(queryClient, 'invalidateQueries');
+
+        await clickAsync(byTestId('agent-context-delete-btn'));
+        await clickAsync(byTestId('telemetry-run-delete-confirm-btn'));
+        await flush();
+
+        const keys = spy.mock.calls.map(([arg]) => JSON.stringify(arg?.queryKey));
+        expect(keys).toContain(JSON.stringify(['agent_telemetry_runs', CREATOR]));
+    });
+
+    it('surfaces a failed delete instead of swallowing it', async () => {
+        api.deleteAgentTelemetryRun.mockRejectedValue(new Error('boom'));
+        mount();
+
+        await clickAsync(byTestId('agent-context-delete-btn'));
+        await clickAsync(byTestId('telemetry-run-delete-confirm-btn'));
+        await flush();
+
+        expect(useSnackBarStore.getState().open).toBe(true);
+    });
+});

--- a/src/Agents/__tests__/noWindowConfirm.test.js
+++ b/src/Agents/__tests__/noWindowConfirm.test.js
@@ -1,0 +1,65 @@
+// Req #3071 — no `window.confirm` may return to /agents.
+//
+// This is a source scan rather than a behavioural test on purpose. Reqs #3063 and
+// #3071 each removed a `window.confirm` from this directory, and #3071 exists only
+// because #3063 left two behind — a per-call test can only pin the calls that
+// someone remembered to write a test for, and the failure mode here is a NEW
+// destructive action being added with the quick option.
+//
+// The cost of a regression is asymmetric and delayed. `window.confirm` blocks the
+// JS thread until a native dialog is answered, and Playwright auto-dismisses
+// nothing it was not told about — so the first E2E spec written against /agents
+// (none exists yet, see #3067) HANGS on it rather than failing with a readable
+// message. That is a debugging session, not a red test.
+//
+// Prose is skipped deliberately: the surrounding files discuss `window.confirm` at
+// length in their headers, and those explanations are worth keeping.
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const AGENTS_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// `__tests__` is skipped, and not just to spare this file from matching itself: a
+// test is ALLOWED to write `window.confirm` — stubbing or asserting on it is how
+// you would pin behaviour around one. The rule being enforced is about shipped
+// components, so the scan covers shipped components.
+const sourceFiles = (dir) => readdirSync(dir).flatMap((entry) => {
+    if (entry === '__tests__') return [];
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return sourceFiles(full);
+    return /\.jsx?$/.test(entry) ? [full] : [];
+});
+
+// A line is CODE unless it is a `//` line comment or a `*` block-comment
+// continuation. Good enough to separate the calls from the essays about them, and
+// it fails CLOSED: anything it cannot classify counts as code.
+const isCommentLine = (line) => {
+    const t = line.trim();
+    return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*');
+};
+
+describe('src/Agents — window.confirm stays gone', () => {
+    it('has no window.confirm call in any source line', () => {
+        const offenders = [];
+        for (const file of sourceFiles(AGENTS_DIR)) {
+            const lines = readFileSync(file, 'utf8').split('\n');
+            lines.forEach((line, i) => {
+                if (isCommentLine(line)) return;
+                if (/\bwindow\s*\.\s*confirm\s*\(/.test(line)) {
+                    offenders.push(`${relative(AGENTS_DIR, file)}:${i + 1}`);
+                }
+            });
+        }
+        expect(offenders).toEqual([]);
+    });
+
+    it('scans a real, non-empty set of files — so an empty pass means something', () => {
+        // A broken path would make the assertion above vacuously true forever.
+        const files = sourceFiles(AGENTS_DIR).map(f => relative(AGENTS_DIR, f));
+        expect(files).toContain('AgentDetail.jsx');
+        expect(files).toContain('ContextPage.jsx');
+    });
+});


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3071-replace-remaining-windowconfirm-1
- wip(Darwin): 2026-07-26T09:11:26Z
- chore: init swarm session feature/3071-replace-remaining-windowconfirm-1

## Files changed
```
 src/Agents/AgentDetail.jsx                       |  47 ++-
 src/Agents/ContextPage.jsx                       |  58 +++-
 src/Agents/InstructionUnbindDialog.jsx           |  13 +
 src/Agents/TelemetryRunDeleteDialog.jsx          | 155 +++++++++
 src/Agents/__tests__/AgentDetail.unbind.test.jsx | 292 ++++++++++++++++
 src/Agents/__tests__/ContextPage.delete.test.jsx | 407 +++++++++++++++++++++++
 src/Agents/__tests__/noWindowConfirm.test.js     |  65 ++++
 7 files changed, 1024 insertions(+), 13 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)