### PR TITLE
Map pymysql IntegrityError to HTTP 409 in Lambda-Rest

### DIFF
--- a/src/Agents/__tests__/agentRegistryUtils.test.js
+++ b/src/Agents/__tests__/agentRegistryUtils.test.js
@@ -214,32 +214,70 @@ describe('instructionNameTaken', () => {
     });
 });
 
+// req #3059 — Lambda-Rest now answers a constraint violation with 409 and a
+// structured body, so this reads fields instead of regexing pymysql prose.
+// call_rest_api splits the response: the object lands on `httpDetail`,
+// `httpMessage` stays the string the rest of the codebase interpolates.
 describe('restErrorMessage', () => {
-    const thrown = (httpMessage) => ({ httpStatus: { httpStatus: 500, httpMessage } });
+    const conflict = (errno, constraint, table = 'instructions') => ({
+        httpStatus: {
+            httpStatus: 409,
+            httpMessage: `HTTP PUT SQL FAILED: ${errno} ...`,
+            httpDetail: { error: 'CONFLICT', errno, constraint, table,
+                message: `HTTP PUT SQL FAILED: ${errno} ...` },
+        },
+    });
 
     it('maps a duplicate instruction name', () => {
-        const err = thrown("HTTP PUT SQL FAILED: 1062 Duplicate entry 'x' for key 'instructions.uq_instructions_name'");
-        expect(restErrorMessage(err, 'fallback')).toMatch(/already in use/);
+        expect(restErrorMessage(conflict(1062, 'uq_instructions_name'), 'fallback'))
+            .toMatch(/already in use/);
     });
 
     it('maps a duplicate agent link', () => {
-        const err = thrown("HTTP POST bulk failed: 1062 Duplicate entry '10-6' for key 'agent_instructions.PRIMARY'");
-        expect(restErrorMessage(err, 'fallback')).toMatch(/already bound/);
+        expect(restErrorMessage(
+            conflict(1062, 'PRIMARY', 'agent_instructions'), 'fallback'))
+            .toMatch(/already bound/);
     });
 
-    it('maps a foreign key failure', () => {
-        const err = thrown('HTTP POST bulk failed: 1452 Cannot add or update a child row: a foreign key constraint fails');
-        expect(restErrorMessage(err, 'fallback')).toMatch(/no longer exists/);
-    });
-
-    it('falls back for an unrecognised error', () => {
-        expect(restErrorMessage(thrown('HTTP PUT SQL FAILED: 2013 Lost connection'), 'fallback'))
+    it('does not claim "already bound" for a PRIMARY collision on another table', () => {
+        // `constraint` arrives unqualified, and every table has a PRIMARY — the
+        // table check is the only thing making that pair identifying.
+        expect(restErrorMessage(conflict(1062, 'PRIMARY', 'agent_documents'), 'fallback'))
             .toBe('fallback');
     });
 
-    it('falls back when the thrown value has no message at all', () => {
+    it('maps both foreign key errnos', () => {
+        expect(restErrorMessage(conflict(1452, 'agent_instructions_ibfk_1'), 'fallback'))
+            .toMatch(/no longer exists/);
+        expect(restErrorMessage(conflict(1451, 'agent_instructions_ibfk_2'), 'fallback'))
+            .toMatch(/no longer exists/);
+    });
+
+    it('falls back for a 409 carrying an errno it has no wording for', () => {
+        expect(restErrorMessage(conflict(1062, 'uq_something_else'), 'fallback'))
+            .toBe('fallback');
+    });
+
+    it('falls back for a 500 — the database really is broken', () => {
+        // The whole point of the 409: a 500 must NEVER render "that name is
+        // taken", however duplicate-shaped its message looks.
+        expect(restErrorMessage({ httpStatus: {
+            httpStatus: 500,
+            httpMessage: "HTTP PUT SQL FAILED: 1062 Duplicate entry 'x' for key "
+                + "'instructions.uq_instructions_name'",
+            httpDetail: null,
+        } }, 'fallback')).toBe('fallback');
+    });
+
+    it('falls back when the thrown value has no status at all', () => {
         expect(restErrorMessage(new Error('boom'), 'fallback')).toBe('fallback');
         expect(restErrorMessage(undefined, 'fallback')).toBe('fallback');
+    });
+
+    it('falls back on a 409 with no detail object rather than throwing', () => {
+        expect(restErrorMessage(
+            { httpStatus: { httpStatus: 409, httpMessage: 'CONFLICT', httpDetail: null } },
+            'fallback')).toBe('fallback');
     });
 });
 

--- a/src/Agents/actions/instructionsApi.js
+++ b/src/Agents/actions/instructionsApi.js
@@ -19,9 +19,10 @@
 //       Every junction insert here therefore sends an ARRAY body, which routes to
 //       _rest_post_bulk: no read-back, returns 201 {"inserted": N}.
 //
-// - Lambda-Rest emits no 409. A duplicate name or link is an HTTP 500 whose body
-//   carries the pymysql message; agentRegistryUtils.restErrorMessage maps the
-//   known ones to human text.
+// - A duplicate name or link is an HTTP 409 (req #3059) carrying a structured
+//   `{error, errno, constraint, table, message}` body. call_rest_api splits it:
+//   `httpStatus.httpDetail` holds the object (agentRegistryUtils.restErrorMessage
+//   reads it), `httpStatus.httpMessage` stays the string assertOk interpolates.
 //
 // - call_rest_api THROWS on any status outside 200/201/204 — including 404. A
 //   DELETE that matched nothing throws, so the 404-tolerant paths catch it

--- a/src/Agents/agentRegistryUtils.js
+++ b/src/Agents/agentRegistryUtils.js
@@ -355,24 +355,29 @@ export const instructionContentError = (content) => {
 /**
  * Turn a thrown call_rest_api rejection into something a human can act on.
  *
- * Lambda-Rest has no 409: a constraint violation arrives as HTTP 500 whose body
- * is the raw pymysql message (`"HTTP PUT SQL FAILED: 1062 Duplicate entry ..."`).
- * Matching on the message is the only way to tell "you picked a taken name" from
- * "the database is broken" — mapping IntegrityError to a real status code is
- * filed as its own requirement.
+ * Lambda-Rest answers a constraint violation with HTTP 409 and a structured body
+ * (req #3059): `{ error, errno, constraint, table, message }`. call_rest_api
+ * parks that object on `err.httpStatus.httpDetail`, so the constraint that
+ * actually failed is a field read — this used to regex the raw pymysql prose,
+ * which could not tell a taken name from a broken database.
+ *
+ * Anything that is NOT a 409 falls through to `fallback` on purpose: a 500 means
+ * the database is genuinely unhappy and "that name is taken" would be a lie.
+ *
+ * `constraint` arrives unqualified (`PRIMARY`, not `agent_instructions.PRIMARY`),
+ * so the junction check pairs it with `table` — every table has a PRIMARY.
  */
 export const restErrorMessage = (err, fallback) => {
-    const msg = typeof err?.httpStatus?.httpMessage === 'string'
-        ? err.httpStatus.httpMessage
-        : '';
+    if (err?.httpStatus?.httpStatus !== 409) return fallback;
+    const { errno, constraint, table } = err.httpStatus.httpDetail || {};
 
-    if (/Duplicate entry .* for key '.*uq_instructions_name'/i.test(msg)) {
+    if (errno === 1062 && constraint === 'uq_instructions_name') {
         return 'That instruction name is already in use (the existing row may be closed).';
     }
-    if (/Duplicate entry .* for key '.*agent_instructions\.PRIMARY'/i.test(msg)) {
+    if (errno === 1062 && constraint === 'PRIMARY' && table === 'agent_instructions') {
         return 'That instruction is already bound to this agent.';
     }
-    if (/foreign key constraint fails/i.test(msg)) {
+    if (errno === 1451 || errno === 1452) {
         return 'The agent or instruction no longer exists — reload the page and retry.';
     }
     return fallback;

--- a/src/RestApi/RestApi.jsx
+++ b/src/RestApi/RestApi.jsx
@@ -33,9 +33,13 @@ const call_rest_api = async (url, method, body, idToken) => {
     } catch (error) {
         const errorReturn = {
             data: {},
+            // httpDetail carried here too, even though a transport failure can
+            // never be a 409. A second httpStatus shape is exactly the drift
+            // that caused req #3049's TypeError-inside-a-catch.
             httpStatus: { httpMethod: fetchInit.method,
                                httpStatus: 503,
-                               httpMessage: 'SERVICE UNAVAILABLE',},
+                               httpMessage: 'SERVICE UNAVAILABLE',
+                               httpDetail: null,},
         };
         return errorReturn;
     };
@@ -59,6 +63,7 @@ const call_rest_api = async (url, method, body, idToken) => {
     var httpStatus = {httpMethod: fetchInit.method,
                       httpStatus: response.status,
                       httpMessage: '',
+                      httpDetail: null,
     };
 
     // Generate httpMessage based on HTTP status
@@ -71,7 +76,19 @@ const call_rest_api = async (url, method, body, idToken) => {
     } else {
         // there is some form of error, in which case the data returned
         // is actually the error message, unpleasant overload for now
-        httpStatus.httpMessage = data;
+        //
+        // A 409 CONFLICT body is a structured object (Lambda-Rest req #3059):
+        // {error, errno, constraint, table, message}. Every other error status
+        // sends a bare JSON string, and half a dozen callers interpolate
+        // httpMessage straight into text — so httpMessage STAYS a string and the
+        // object goes on httpDetail. agentRegistryUtils.restErrorMessage is the
+        // one consumer that wants the fields.
+        if (data && typeof data === 'object') {
+            httpStatus.httpDetail = data;
+            httpStatus.httpMessage = data.message || JSON.stringify(data);
+        } else {
+            httpStatus.httpMessage = data;
+        }
         data = null;
         // eslint-disable-next-line  no-throw-literal
         throw {data, httpStatus}

--- a/src/RestApi/__tests__/RestApi.test.js
+++ b/src/RestApi/__tests__/RestApi.test.js
@@ -1,0 +1,93 @@
+// req #3059 — how call_rest_api unpacks an error response.
+//
+// Lambda-Rest answers an integrity violation with 409 and a structured CONFLICT
+// OBJECT; every other error status still sends a bare JSON STRING. Six call
+// sites interpolate `httpStatus.httpMessage` straight into user-facing or log
+// text, so the split matters: httpMessage stays a string in both cases, and the
+// object is exposed separately on `httpDetail` for the one consumer that wants
+// the fields (agentRegistryUtils.restErrorMessage).
+//
+// Getting this wrong is quiet, not loud — the snackbar would read
+// "[object Object]" and nothing would throw.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import call_rest_api from '../RestApi';
+
+const CONFLICT = {
+    error: 'CONFLICT',
+    errno: 1062,
+    constraint: 'uq_instructions_name',
+    table: 'instructions',
+    message: "HTTP PUT SQL FAILED: 1062 Duplicate entry 'x' for key "
+        + "'instructions.uq_instructions_name'",
+};
+
+/** Stub `fetch` with one canned response. `body` is the PARSED JSON. */
+const respondWith = (status, body) => {
+    global.fetch = vi.fn().mockResolvedValue({
+        status,
+        json: async () => body,
+    });
+};
+
+afterEach(() => { vi.restoreAllMocks(); delete global.fetch; });
+
+describe('call_rest_api error unpacking', () => {
+
+    it('splits a 409 CONFLICT object into httpDetail plus a string httpMessage', async () => {
+        respondWith(409, CONFLICT);
+
+        const err = await call_rest_api('/darwin/instructions', 'PUT', [{ id: 1 }])
+            .then(() => null, e => e);
+
+        expect(err.httpStatus.httpStatus).toBe(409);
+        expect(err.httpStatus.httpDetail).toEqual(CONFLICT);
+        expect(err.httpStatus.httpMessage).toBe(CONFLICT.message);
+        expect(typeof err.httpStatus.httpMessage).toBe('string');
+    });
+
+    it('leaves a plain-string error body exactly as it was', async () => {
+        // The 500 contract is unchanged — nothing about it may shift.
+        respondWith(500, 'HTTP PUT SQL FAILED: 1054 Unknown column');
+
+        const err = await call_rest_api('/darwin/instructions', 'PUT', [{ id: 1 }])
+            .then(() => null, e => e);
+
+        expect(err.httpStatus.httpMessage).toBe('HTTP PUT SQL FAILED: 1054 Unknown column');
+        expect(err.httpStatus.httpDetail).toBeNull();
+    });
+
+    it('falls back to the serialized object when a structured body has no message', async () => {
+        // Defensive: an object body with nothing to read must not silently
+        // become the string "undefined" in a snackbar.
+        respondWith(409, { error: 'CONFLICT', errno: 1451 });
+
+        const err = await call_rest_api('/darwin/areas', 'DELETE', { id: 1 })
+            .then(() => null, e => e);
+
+        expect(err.httpStatus.httpMessage).toBe('{"error":"CONFLICT","errno":1451}');
+        expect(err.httpStatus.httpDetail.errno).toBe(1451);
+    });
+
+    it('does not mistake a null body for a structured one', async () => {
+        // typeof null === 'object' — the guard that stops httpDetail becoming null
+        // by way of the object branch and httpMessage becoming "null".
+        respondWith(404, null);
+
+        const err = await call_rest_api('/darwin/areas', 'DELETE', { id: 1 })
+            .then(() => null, e => e);
+
+        expect(err.httpStatus.httpDetail).toBeNull();
+        expect(err.httpStatus.httpMessage).toBeNull();
+    });
+
+    it('leaves the success path untouched — no httpDetail, data returned', async () => {
+        respondWith(200, [{ id: 7 }]);
+
+        const r = await call_rest_api('/darwin/instructions', 'GET', null);
+
+        expect(r.data).toEqual([{ id: 7 }]);
+        expect(r.httpStatus.httpMessage).toBe('OK');
+        expect(r.httpStatus.httpDetail).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-07-26T10:01:53Z
- wip(Darwin): 2026-07-26T09:57:37Z
- chore: init swarm session feature/3059-map-pymysql-integrityerror-to-http-1

## Files changed
```
 src/Agents/__tests__/agentRegistryUtils.test.js | 69 ++++++++++++++----
 src/Agents/actions/instructionsApi.js           |  7 +-
 src/Agents/agentRegistryUtils.js                | 29 ++++----
 src/RestApi/RestApi.jsx                         | 21 +++++-
 src/RestApi/__tests__/RestApi.test.js           | 93 +++++++++++++++++++++++++
 5 files changed, 187 insertions(+), 32 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
Related PRs (req #3059, one change across three repos): BillWilliams79/DarwinAI-Config#645 · BillWilliams79/Darwin#843 · BillWilliams79/AWS-Lambda-REST-API#55