### PR TITLE
Junction POST returns 500 after committing the row (breaks Features linking UI)

### DIFF
--- a/src/Agents/__tests__/instructionsApi.test.js
+++ b/src/Agents/__tests__/instructionsApi.test.js
@@ -3,10 +3,14 @@
 // agentRegistryUtils.test.js covers the PURE planning helpers. This file covers
 // the part that actually talks to the network, where the risk lives:
 //
-//   * `agent_instructions` has no `id` column, so a SINGLE-OBJECT POST commits
-//     the row and THEN returns 500 (rest_post.py re-reads `WHERE id = ...`).
-//     Every insert must therefore use an array body. Locked in Lambda-Rest by
-//     tests/test_agent_instructions.py; locked on the client side here.
+//   * `agent_instructions` has no `id` column, so every insert uses an ARRAY
+//     body — one multi-value INSERT for N links instead of N round trips. It
+//     began as a workaround: a single-object POST used to commit the row and
+//     THEN return 500, because rest_post.py re-read it with `WHERE id = ...`.
+//     Req #3057 fixed that (it now returns 201 with no body), so the array
+//     body is a choice rather than a necessity — but it is still the right
+//     choice, and it is what the assertions below lock. Lambda-Rest side:
+//     tests/test_agent_instructions.py.
 //   * A load-order change is DELETE + re-POST across two non-atomic Lambda
 //     invocations under autocommit. The restore-on-failure path is the only
 //     thing standing between a failed write and an agent booting without its

--- a/src/Agents/actions/instructionsApi.js
+++ b/src/Agents/actions/instructionsApi.js
@@ -13,11 +13,14 @@
 // - `agent_instructions` has a composite PK and NO `id` column. Two consequences:
 //     * PUT is impossible (rest_put.py requires `id`) — a load-order change is a
 //       DELETE + re-POST, never an update.
-//     * A SINGLE-OBJECT POST COMMITS THE ROW AND THEN RETURNS 500. rest_post.py
-//       re-reads the new row with `WHERE id = ...`, which raises 1054 on a table
-//       with no id column — after the INSERT has already committed (autocommit).
-//       Every junction insert here therefore sends an ARRAY body, which routes to
-//       _rest_post_bulk: no read-back, returns 201 {"inserted": N}.
+//     * Every junction insert here sends an ARRAY body, routing to
+//       _rest_post_bulk: one multi-value INSERT, no read-back, 201
+//       {"inserted": N}. That started as a workaround — a single-object POST
+//       used to commit the row and then return 500, because rest_post.py's
+//       `WHERE id = ...` read-back raised 1054 on an id-less table after the
+//       INSERT had already committed. Req #3057 fixed that (single-object POST
+//       now returns 201 with no body), so the array body is no longer forced.
+//       It stays because it is still one round trip for N links instead of N.
 //
 // - Lambda-Rest emits no 409. A duplicate name or link is an HTTP 500 whose body
 //   carries the pymysql message; agentRegistryUtils.restErrorMessage maps the

--- a/src/Features/actions/validationApi.js
+++ b/src/Features/actions/validationApi.js
@@ -12,7 +12,12 @@
 //
 // REST status handling:
 // - POST on content tables returns 200 + the inserted row
-// - POST on junction tables returns 201 without body (no LAST_INSERT_ID possible)
+// - POST on junction tables returns 201 without body — rest_post.py reads the new
+//   row back with `WHERE id=<LAST_INSERT_ID()>`, which an id-less table cannot
+//   answer, so it skips the read-back. This was NOT true until req #3057: the
+//   read-back raised MySQL 1054 and the gateway returned 500 for a row that had
+//   already committed, so every link/add/reorder below threw on success. Anything
+//   here that needs the stored row must GET it by composite key.
 // - PUT returns 204 on success
 // - DELETE returns 200 on success, 404 if no rows matched
 
@@ -72,7 +77,8 @@ export async function deleteTestCase(darwinUri, idToken, id) {
 export async function linkFeatureTestCase(darwinUri, idToken, feature_fk, test_case_fk) {
     const r = await call_rest_api(`${darwinUri}/feature_test_cases`, 'POST',
         { feature_fk, test_case_fk }, idToken);
-    // Junction tables return 201 without body (no id column to read back).
+    // 201 with an empty body — no id column to read back (req #3057). The
+    // returned data is '' by design; callers use it only as a success signal.
     return assertOk(r, 'linkFeatureTestCase');
 }
 


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3057-junction-post-returns-500-after-1
- wip(Darwin): 2026-07-26T09:10:23Z
- chore: init swarm session feature/3057-junction-post-returns-500-after-1

## Files changed
```
 src/Agents/__tests__/instructionsApi.test.js | 12 ++++++++----
 src/Agents/actions/instructionsApi.js        | 13 ++++++++-----
 src/Features/actions/validationApi.js        | 10 ++++++++--
 3 files changed, 24 insertions(+), 11 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)