### PR TITLE
Documents page becomes editable

### DIFF
--- a/src/Agents/AgentDetail.jsx
+++ b/src/Agents/AgentDetail.jsx
@@ -450,9 +450,19 @@ const AgentDetail = () => {
                                                   {...docTypeChipProps(row.doc_type)} />
                                         </TableCell>
                                         <TableCell>
+                                            {/* Drills through to the ROW, not just
+                                                the page (req #3051, the reverse of
+                                                the instruction pencil above).
+                                                /agents/documents is now the one
+                                                editor for a document's registry
+                                                fields and its relationships, so the
+                                                chip has to land on the card that
+                                                owns this link rather than at the
+                                                top of a 69-card grid. */}
                                             <Chip label={relationshipLabel(link.relationship)} size="small"
                                                   {...relationshipChipProps(link.relationship)}
-                                                  onClick={() => navigate('/agents/documents')}
+                                                  onClick={() => navigate(
+                                                      `/agents/documents#document-${row.id}`)}
                                                   clickable />
                                         </TableCell>
                                         <TableCell sx={{ maxWidth: 380 }}>

--- a/src/Agents/DocumentAgentChips.jsx
+++ b/src/Agents/DocumentAgentChips.jsx
@@ -1,0 +1,178 @@
+// Agent membership for one document row, edited in place (req #3051).
+//
+// The direct counterpart of InstructionAgentChips, and deliberately the same
+// gesture in both directions: bound agents render solid, one click on the ＋ chip
+// unfurls the REST of the roster inline as dashed ghost chips, clicking a ghost
+// chip binds it, and the ✕ on a solid one requests an unbind. The roster is
+// twelve architects — showing all of them is cheaper to read than any search
+// affordance, and it answers "who ISN'T linked?" without a click.
+//
+// TWO THINGS DIFFER FROM THE INSTRUCTION VERSION, both because a document link
+// carries more than membership:
+//
+//   1. THE OWNER IS NOT HERE. `owned` is DB-enforced unique per document and
+//      needs a transfer plan rather than a toggle, so it has its own row on the
+//      card and this component renders only the non-owner links. Mixing them
+//      would put two different kinds of write behind one identical-looking chip.
+//
+//   2. THE CHIP BODY OPENS AN EDITOR, not a drill-through. An instruction link is
+//      just membership, so its chip navigates. A document link additionally
+//      carries `relationship` roles and `notes`, and those need somewhere to be
+//      edited — so the body opens DocumentLinkPopover and the drill-through to
+//      the agent lives inside it, one click deeper. That is the honest trade: the
+//      information the chip is now hiding is the information the popover exists
+//      to show.
+//
+// Binding defaults to `referenced` with no role picker. Every one of the 32
+// non-owned links in production is exactly `referenced`; making the fast path
+// stop for a choice would tax the only case that actually happens. The popover is
+// there for the exceptions.
+//
+// PESSIMISTIC, like the instruction version and for the same reason: the bound
+// list is a useMemo over the whole `agent_documents` query, not a cache slice, so
+// an optimistic update would mean hand-patching the junction cache and
+// re-deriving from it — and a failed write would leave nothing to roll back.
+
+import { useState } from 'react';
+
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import AddIcon from '@mui/icons-material/Add';
+import CloseIcon from '@mui/icons-material/Close';
+import DoneAllIcon from '@mui/icons-material/DoneAll';
+
+import { relationshipChipProps, relationshipLabel } from './agentRegistryUtils';
+
+// Ghost chips read as "could be linked, isn't" — dashed and faded, so a glance
+// separates them from the real links without reading a single name.
+const ghostChipSx = {
+    borderStyle: 'dashed',
+    opacity: 0.55,
+    transition: 'opacity 150ms',
+    '&:hover': { opacity: 1 },
+};
+
+const DocumentAgentChips = ({
+    // Non-owner links for this document, each { agent_fk, relationship, notes, … }.
+    links = [],
+    agentIndex,
+    // Open agents this document could still link — the caller filters and sorts.
+    bindableAgents = [],
+    onBind,
+    onBindAll,
+    onRequestUnbind,
+    onOpenLink,
+    busy = false,
+    testIdPrefix,
+}) => {
+    const [paletteOpen, setPaletteOpen] = useState(false);
+
+    const bound = links
+        .map(l => ({ link: l, agent: agentIndex.get(l.agent_fk) }))
+        .filter(x => x.agent)
+        // Closed agents last: they never boot, so they never belong above an
+        // agent that does.
+        .sort((a, b) => (a.agent.closed ? 1 : 0) - (b.agent.closed ? 1 : 0)
+            || (a.agent.name || '').localeCompare(b.agent.name || ''));
+
+    return (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap', rowGap: 0.75 }}>
+            {bound.length === 0 && !paletteOpen && (
+                <Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
+                    No other agent references this —
+                </Typography>
+            )}
+
+            {bound.map(({ link, agent }) => (
+                <Tooltip
+                    key={agent.id}
+                    title={agent.closed
+                        ? `${agent.name} is closed — it never boots, so this link loads nothing. `
+                          + 'It is still real data a hard delete would cascade away.'
+                        : `${relationshipLabel(link.relationship)} — click to edit roles and notes`}
+                >
+                    <Chip
+                        label={`${agent.name} · ${relationshipLabel(link.relationship)}`}
+                        size="small"
+                        clickable
+                        {...relationshipChipProps(link.relationship)}
+                        // Deliberately NOT MUI's `disabled` for a closed agent:
+                        // that would kill both the editor and the ✕, and the link
+                        // still has to be removable — it is data a hard delete
+                        // would cascade. Muted styling instead.
+                        sx={agent.closed ? { opacity: 0.6 } : undefined}
+                        onClick={(e) => onOpenLink(link, agent, e.currentTarget)}
+                        onDelete={() => onRequestUnbind(link, agent)}
+                        // The canonical testid stays on EVERY chip regardless of
+                        // the agent's closed state — a test reaching for this link
+                        // should not have to know whether the agent happens to be
+                        // closed today.
+                        data-testid={`${testIdPrefix}-agent-${agent.id}`}
+                        data-agent-closed={agent.closed ? '1' : '0'}
+                    />
+                </Tooltip>
+            ))}
+
+            {paletteOpen && bindableAgents.map(agent => (
+                <Tooltip key={agent.id}
+                         title={`Not linked — click to add ${agent.name} as referenced`}>
+                    <Chip
+                        label={agent.name}
+                        size="small"
+                        clickable
+                        variant="outlined"
+                        sx={ghostChipSx}
+                        disabled={busy}
+                        onClick={() => onBind(agent.id)}
+                        data-testid={`${testIdPrefix}-bind-${agent.id}`}
+                    />
+                </Tooltip>
+            ))}
+
+            {/* Link-all sits with the palette, not on the resting card: it is only
+                meaningful once you can see WHICH agents it would link. Offered
+                from two upwards — at one remaining agent it is just that agent's
+                chip with a longer name. Additive and individually reversible, so
+                no confirmation; unlinking is the direction that gets a dialog. */}
+            {paletteOpen && bindableAgents.length > 1 && (
+                <Tooltip title={`Link all ${bindableAgents.length} remaining agents as referenced`}>
+                    <Chip
+                        size="small"
+                        variant="outlined"
+                        color="primary"
+                        icon={<DoneAllIcon fontSize="small" />}
+                        label={`link all ${bindableAgents.length}`}
+                        disabled={busy}
+                        onClick={() => onBindAll(bindableAgents)}
+                        data-testid={`${testIdPrefix}-agent-bind-all`}
+                    />
+                </Tooltip>
+            )}
+
+            {bindableAgents.length > 0 && (
+                <Tooltip title={paletteOpen
+                    ? 'Hide the unlinked agents'
+                    : `Show the ${bindableAgents.length} agents not linked to this`}>
+                    <Chip
+                        size="small"
+                        variant="outlined"
+                        color={paletteOpen ? 'primary' : 'default'}
+                        icon={paletteOpen
+                            ? <CloseIcon fontSize="small" />
+                            : <AddIcon fontSize="small" />}
+                        label={paletteOpen ? 'done' : bindableAgents.length}
+                        onClick={() => setPaletteOpen(v => !v)}
+                        data-testid={`${testIdPrefix}-agent-add`}
+                    />
+                </Tooltip>
+            )}
+
+            {busy && <CircularProgress size={14} sx={{ ml: 0.5 }} />}
+        </Box>
+    );
+};
+
+export default DocumentAgentChips;

--- a/src/Agents/DocumentDeleteDialog.jsx
+++ b/src/Agents/DocumentDeleteDialog.jsx
@@ -1,0 +1,179 @@
+// Close or delete one document REGISTRATION (req #3051).
+//
+// Modelled on InstructionDeleteDialog, which had already solved most of this
+// problem. Two things are genuinely different, and both are in the copy:
+//
+// 1. THIS DOES NOT DELETE A FILE, and that is the likeliest misconception on the
+//    page. `architecture_documents` stores a `location`, never content. Deleting
+//    the row leaves the file sitting on disk, fully intact — and nothing anywhere
+//    scans disk for unregistered files, so it becomes a file the registry will
+//    never notice again. That is precisely the silent ownership drift the registry
+//    was built to end, reintroduced by a delete button. The first line of the body
+//    says so before anything else.
+//
+// 2. THE OWNERSHIP ASSIGNMENT IS THE UNRECOVERABLE PART. `agent_documents`
+//    CASCADEs on `document_fk` (and it is the only table with an FK to
+//    `architecture_documents`, so the cascade is exactly the link set). Everything
+//    else about the row can be retyped from the file itself; who was responsible
+//    for it cannot. It exists nowhere else.
+//
+// TWO COUNTS, and they are a DIFFERENT pair from the instruction dialog's:
+//   * dataCount — every link. Junction rows destroyed, `notes` with them.
+//   * bootCount — open agents holding an AUTOLOAD link. Those are the agents that
+//     will boot without a document instruction #83 orders them to read in full.
+//     A `referenced` link going away is a soft loss; an `autoload` one is not.
+// Collapsing them would either understate the data loss or overstate the runtime
+// impact.
+//
+// Close is the primary path. It has the identical effect at boot — closed
+// documents drop out of every payload — but preserves the row and every link, so
+// it is reversible. Delete is for mistakes.
+
+import { useEffect, useState } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+const DocumentDeleteDialog = ({
+    open, onClose, onCloseDocument, onReopen, onDelete,
+    document: doc,
+    // [{ name, closed, autoload, owner }] — every linked agent, closed included.
+    linkedAgents = [],
+    busy = false,
+    // WHY the caller opened this: 'close' arrives from the Close menu item on a
+    // linked row, where the blast radius must be shown before the document drops
+    // out of those agents' payloads. A dialog titled "Delete …?" opened from a
+    // menu item labelled "Close document…" would be a lie.
+    intent = 'delete',
+}) => {
+    const [typed, setTyped] = useState('');
+
+    useEffect(() => { if (open) setTyped(''); }, [open, doc?.id]);
+
+    if (!doc) return null;
+
+    const dataCount = linkedAgents.length;
+    const bootCount = linkedAgents.filter(a => !a.closed && a.autoload).length;
+    const owner = linkedAgents.find(a => a.owner);
+
+    // Gated more tightly than the instruction dialog's `refCount >= 2`, because
+    // an autoload link is a silent runtime change on its own — one is enough.
+    const needsChallenge = dataCount >= 2 || bootCount >= 1;
+    const deleteEnabled = !busy && (!needsChallenge || typed.trim() === doc.name);
+
+    return (
+        <Dialog open={open} onClose={() => !busy && onClose()} maxWidth="sm" fullWidth
+                data-testid="documents-delete-dialog">
+            <DialogTitle>
+                {doc.closed
+                    ? `Reopen or delete the registration of “${doc.name}”?`
+                    : intent === 'close'
+                        ? `Close “${doc.name}”?`
+                        : `Delete the registration of “${doc.name}”?`}
+            </DialogTitle>
+            <DialogContent>
+                <Stack spacing={2} sx={{ mt: 1 }}>
+                    {/* First, before anything else. */}
+                    <Alert severity="info" data-testid="documents-delete-file-note">
+                        This removes the registry row, <strong>not the file</strong>.
+                        {doc.location ? <> <code>{doc.location}</code> stays on disk</> : ' The file stays on disk'}
+                        {' '}and nothing will record who owns it. Nothing scans disk for
+                        unregistered files, so it becomes invisible to the registry.
+                    </Alert>
+
+                    {!!doc.closed && (
+                        <Alert severity="info" data-testid="documents-delete-closed-note">
+                            This document is closed, so it already drops out of every boot payload.
+                            Reopening it restores it for {dataCount === 0
+                                ? 'any agent linked to it'
+                                : `${dataCount} linked agent${dataCount === 1 ? '' : 's'}`} at their
+                            next boot.
+                        </Alert>
+                    )}
+
+                    {dataCount > 0 ? (
+                        <>
+                            <Alert severity="error">
+                                {dataCount} agent link{dataCount === 1 ? '' : 's'} cascade away
+                                permanently, with their notes and no trace.
+                                {owner
+                                    ? ` That includes the ownership assignment held by ${owner.name}, which exists nowhere else.`
+                                    : ' This document has no owner to lose.'}
+                                {bootCount > 0
+                                    ? ` ${bootCount} open agent${bootCount === 1 ? '' : 's'} read${bootCount === 1 ? 's' : ''} this file in full at boot and would silently stop.`
+                                    : ' No open agent reads it at boot, so nothing changes at boot today.'}
+                            </Alert>
+                            <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                                {linkedAgents.map(a => (
+                                    <Chip key={a.name} size="small" color="error"
+                                          variant={a.owner ? 'filled' : 'outlined'}
+                                          label={[
+                                              a.name,
+                                              a.owner && 'owner',
+                                              a.autoload && 'autoload',
+                                              a.closed && 'closed',
+                                          ].filter(Boolean).join(' · ')} />
+                                ))}
+                            </Stack>
+                            <Typography variant="body2">
+                                <strong>Closing</strong> it instead has the same effect at boot —
+                                closed documents drop out of every payload — but keeps the row and
+                                every link, so it can be reopened.
+                            </Typography>
+                        </>
+                    ) : (
+                        <Typography variant="body2">
+                            No agent links this document, so deleting the registration affects
+                            nothing at boot.
+                        </Typography>
+                    )}
+
+                    {needsChallenge && (
+                        <TextField
+                            label={`Type "${doc.name}" to confirm deletion`}
+                            value={typed}
+                            onChange={e => setTyped(e.target.value)}
+                            size="small"
+                            inputProps={{
+                                style: { fontFamily: 'monospace' },
+                                'data-testid': 'document-delete-challenge-input',
+                            }}
+                        />
+                    )}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} disabled={busy}
+                        data-testid="document-delete-cancel-btn">Cancel</Button>
+                {doc.closed ? (
+                    <Button onClick={onReopen} variant="contained" disabled={busy}
+                            data-testid="document-delete-reopen-btn">
+                        Reopen
+                    </Button>
+                ) : (
+                    <Button onClick={onCloseDocument} variant="contained" disabled={busy}
+                            data-testid="document-delete-close-btn">
+                        {/* "instead" only makes sense when the user arrived wanting
+                            to delete. Coming from the Close menu item, this IS the
+                            action they asked for. */}
+                        {intent === 'close' || dataCount === 0 ? 'Close' : 'Close instead'}
+                    </Button>
+                )}
+                <Button onClick={onDelete} color="error" disabled={!deleteEnabled}
+                        data-testid="document-delete-confirm-btn">
+                    {busy ? 'Working…' : 'Delete permanently'}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default DocumentDeleteDialog;

--- a/src/Agents/DocumentLinkPopover.jsx
+++ b/src/Agents/DocumentLinkPopover.jsx
@@ -1,0 +1,251 @@
+// Edit ONE agent→document link: its roles and its notes (req #3051).
+//
+// WHY THIS ONE CONTROL HAS A SAVE BUTTON, when nothing else on the registry does.
+//
+// Darwin's shipped idiom for a short closed vocabulary is a chip row that writes
+// on click — RequirementDetail's Model / Effort / Machine chips, and the doc_type
+// chips on the card behind this popover. That is right THERE because each click
+// is a single-column PUT against a row with an `id`: non-destructive, and undone
+// by clicking the previous chip.
+//
+// `agent_documents` has NO `id` column, so Lambda-Rest cannot PUT it. Every role
+// change is a DELETE of the whole row followed by a fresh INSERT. Ticking three
+// roles would therefore be three destroy-and-recreate cycles for one logical
+// edit, each opening a window in which the link does not exist, and each able to
+// drop `notes` or `sort_order` if any single one of them is wired wrong. Staging
+// the whole set behind one Save collapses that to one cycle — the same reasoning
+// that made `bindAllAgents` a single bulk POST instead of a loop of binds.
+//
+// This is a deliberate, reasoned departure from the no-Save-button rule, not an
+// oversight. Do not "fix" it into commit-on-click.
+//
+// `owned` is NOT offered here. Ownership is DB-enforced unique per document, it
+// needs a transfer plan rather than a toggle, and it has its own row on the card.
+// One fact, one editor.
+
+import { useEffect, useState } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
+import Link from '@mui/material/Link';
+import Popover from '@mui/material/Popover';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+
+import {
+    parseRoles, serializeRoles, relationshipChipProps,
+    relationshipSetError, relationshipSetHint,
+    documentNotesError, charLength, DOCUMENT_NOTES_MAX,
+} from './agentRegistryUtils';
+
+// `owned` is handled by the card's owner row — see the header note.
+const EDITABLE_ROLES = ['curated', 'autoload', 'referenced'];
+
+const ROLE_HELP = {
+    curated: 'This agent keeps the document accurate, without owning it.',
+    autoload: 'This agent reads the file IN FULL at every boot — a real context cost.',
+    referenced: 'This agent may consult the document. Nothing is loaded automatically.',
+};
+
+const DocumentLinkPopover = ({
+    open,
+    anchorEl,
+    onClose,
+    document: doc,
+    agent,
+    link,
+    onSave,
+    onOpenAgent,
+    busy = false,
+}) => {
+    const [roles, setRoles] = useState([]);
+    const [notes, setNotes] = useState('');
+
+    // Re-seed whenever the popover is opened onto a (possibly different) link.
+    // Keyed on the link identity as well as `open` so reopening the same popover
+    // after an external refetch shows the stored values, not the last draft.
+    useEffect(() => {
+        if (!open) return;
+        setRoles(parseRoles(link?.relationship).filter(r => r !== 'owned'));
+        setNotes(link?.notes || '');
+    }, [open, link?.agent_fk, link?.document_fk, link?.relationship, link?.notes]);
+
+    if (!agent || !link) return null;
+
+    // `owned` is not editable here but it is still ON the link, and it must
+    // survive the save — dropping it would silently un-own the document from a
+    // control that never mentioned ownership.
+    const keepsOwned = parseRoles(link.relationship).includes('owned');
+    const nextRoles = keepsOwned ? ['owned', ...roles] : roles;
+
+    const roleError = relationshipSetError(nextRoles);
+    const roleHint = relationshipSetHint(nextRoles);
+    const notesError = documentNotesError(notes);
+    const notesLength = charLength(notes);
+
+    const gainsAutoload = roles.includes('autoload')
+        && !parseRoles(link.relationship).includes('autoload');
+
+    const dirty = serializeRoles(nextRoles) !== serializeRoles(link.relationship)
+        || (notes || '') !== (link.notes || '');
+
+    const toggleRole = (role) => setRoles(prev => (
+        prev.includes(role) ? prev.filter(r => r !== role) : [...prev, role]));
+
+    const save = () => {
+        if (roleError || notesError || !dirty) return;
+        onSave({
+            ...link,
+            relationship: serializeRoles(nextRoles),
+            notes: notes.trim() || null,
+            // Carried through UNTOUCHED. This is the agent's per-agent document
+            // order and it belongs to AgentDetail; a re-POST that omitted it would
+            // write NULL over it from a control that has nothing to do with order.
+            sort_order: link.sort_order,
+        });
+    };
+
+    return (
+        <Popover
+            open={open}
+            anchorEl={anchorEl}
+            onClose={onClose}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+            slotProps={{ paper: {
+                sx: { p: 2, width: 380, maxWidth: '95vw' },
+                'data-testid': `document-link-popover-${doc?.id}-${agent.id}`,
+            } }}
+        >
+            <Stack spacing={1.5}>
+                <Box>
+                    <Link
+                        component="button"
+                        type="button"
+                        underline="hover"
+                        onClick={() => onOpenAgent(agent.id)}
+                        sx={{ fontWeight: 500 }}
+                    >
+                        {agent.name}
+                    </Link>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                        Relationship to {doc?.name}
+                    </Typography>
+                </Box>
+
+                <Divider />
+
+                {keepsOwned && (
+                    <Alert severity="info" sx={{ py: 0 }}>
+                        This agent <strong>owns</strong> the document. Ownership is edited on the
+                        card&apos;s Owner row; it is preserved by anything you do here.
+                    </Alert>
+                )}
+
+                <Box>
+                    <Typography variant="caption" color="text.secondary"
+                                sx={{ display: 'block', mb: 0.5 }}>
+                        Roles
+                    </Typography>
+                    <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                        {EDITABLE_ROLES.map(role => {
+                            const on = roles.includes(role);
+                            // `owned` supersedes `referenced` (instruction #83), so
+                            // the combination is blocked by relationshipSetError.
+                            // Offering a chip that can only ever produce an error
+                            // is worse than not offering it — disable it and say
+                            // why in the tooltip.
+                            const blockedByOwnership = keepsOwned && role === 'referenced';
+                            const chip = (
+                                <Chip
+                                    key={role}
+                                    label={role}
+                                    size="small"
+                                    clickable={!blockedByOwnership}
+                                    disabled={busy || blockedByOwnership}
+                                    onClick={blockedByOwnership ? undefined : () => toggleRole(role)}
+                                    {...(on
+                                        ? relationshipChipProps(role)
+                                        : { variant: 'outlined', sx: { opacity: 0.55 } })}
+                                    data-testid={`document-link-role-${doc?.id}-${agent.id}-${role}`}
+                                />
+                            );
+                            return blockedByOwnership ? (
+                                <Tooltip key={role}
+                                         title="The owner already outranks a reference — release ownership first">
+                                    {/* A disabled MUI Chip swallows pointer events,
+                                        so the Tooltip needs a real element to hang
+                                        off. */}
+                                    <span>{chip}</span>
+                                </Tooltip>
+                            ) : chip;
+                        })}
+                    </Stack>
+                    <Typography variant="caption" color="text.secondary"
+                                sx={{ display: 'block', mt: 0.5 }}>
+                        {roles.length === 1 ? ROLE_HELP[roles[0]] : 'Pick one or more.'}
+                    </Typography>
+                </Box>
+
+                {/* Autoload is the only role with a runtime COST, so it is the only
+                    one that gets a warning. Advisory, never a block: there is no
+                    context budget anywhere in the system to measure this against,
+                    and a block would be inventing a limit nobody set. Deliberately
+                    no token estimate either — the file's size is on disk and the
+                    browser cannot see it, so any number here would be made up. */}
+                {gainsAutoload && (
+                    <Alert severity="warning" sx={{ py: 0 }}
+                           data-testid={`document-link-autoload-warning-${doc?.id}-${agent.id}`}>
+                        {agent.name} will read this file <strong>in full at every boot</strong>,
+                        adding its whole contents to that agent&apos;s context.
+                    </Alert>
+                )}
+
+                {roleError && <Alert severity="error" sx={{ py: 0 }}>{roleError}</Alert>}
+                {!roleError && roleHint && (
+                    <Alert severity="info" sx={{ py: 0 }}>{roleHint}</Alert>
+                )}
+
+                <TextField
+                    label="Notes"
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                    multiline
+                    maxRows={4}
+                    fullWidth
+                    size="small"
+                    error={!!notesError}
+                    helperText={notesError
+                        || `${notesLength} / ${DOCUMENT_NOTES_MAX} characters`}
+                    inputProps={{
+                        maxLength: DOCUMENT_NOTES_MAX,
+                        'data-testid': `document-link-notes-${doc?.id}-${agent.id}`,
+                    }}
+                />
+
+                <Stack direction="row" spacing={1} justifyContent="flex-end">
+                    <Button size="small" onClick={onClose} disabled={busy}
+                            data-testid={`document-link-cancel-${doc?.id}-${agent.id}`}>
+                        Cancel
+                    </Button>
+                    <Button
+                        size="small"
+                        variant="contained"
+                        onClick={save}
+                        disabled={busy || !dirty || !!roleError || !!notesError}
+                        data-testid={`document-link-save-${doc?.id}-${agent.id}`}
+                    >
+                        {busy ? 'Saving…' : 'Save'}
+                    </Button>
+                </Stack>
+            </Stack>
+        </Popover>
+    );
+};
+
+export default DocumentLinkPopover;

--- a/src/Agents/DocumentLocationDialog.jsx
+++ b/src/Agents/DocumentLocationDialog.jsx
@@ -1,0 +1,114 @@
+// Confirm changing a document's `location` when agents read it at boot (req #3051).
+//
+// WHY THIS FIELD, AND ONLY THIS FIELD, GETS A DIALOG.
+//
+// `location` looks like a caption and is the most dangerous editable value on the
+// page. It is not read by any code — it is read by the AGENT. Instruction #83,
+// bound to all twelve architects, orders each of them to read every `autoload`
+// document "from its `location` in full, byte 1 to byte n" before starting work.
+// The executor is an LLM, not a function, so nothing type-checks the path and
+// nothing fails loudly: an agent handed a wrong location boots without knowledge
+// it was told to have and reports itself green. The only detector in the system
+// is the context-telemetry harness, and that walks `autoload_documents` only.
+//
+// Contrast `name`, which LOOKS like the load-bearing one because it is UNIQUE and
+// documented as "the idempotent-seed key". It is not: there is no seed script in
+// the repo (verified — nothing under `scripts/` references either document
+// table), and `get_architecture_document_by_name` has no caller outside the MCP
+// test suite. A rename is prose, exactly as req #3068 found for instruction
+// names. So the intuition about which of the two fields is risky is backwards,
+// and the UI corrects for it here rather than treating both as ordinary text.
+//
+// The dialog is GRADUATED, not unconditional: a document no agent autoloads has
+// no boot to break, and ceremony with nothing to disclose trains people to click
+// past ceremony that does. The page checks for autoload readers before opening
+// this at all.
+//
+// The browser cannot verify the path exists — it has no filesystem. So this
+// dialog does not pretend to validate. It names who is affected and says plainly
+// that nothing checks the value, which is the honest disclosure.
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+const pathSx = {
+    fontFamily: 'monospace',
+    fontSize: '0.8125rem',
+    wordBreak: 'break-all',
+};
+
+const DocumentLocationDialog = ({ open, setOpen, setConfirmed, info }) => {
+    // Same closing-frame guard as the other dialogs here — see
+    // InstructionUnbindDialog's note. The page holds the last real value.
+    if (!info?.document) return null;
+
+    const { document: doc, next, readers = [] } = info;
+
+    const cancel = () => setOpen(false);
+    const confirm = () => { setConfirmed(true); setOpen(false); };
+
+    return (
+        <Dialog open={open} onClose={cancel} maxWidth="sm" fullWidth
+                data-testid="documents-location-dialog">
+            <DialogTitle>Change where “{doc.name}” is read from?</DialogTitle>
+            <DialogContent>
+                <Stack spacing={2} sx={{ mt: 1 }}>
+                    <Box>
+                        <Typography variant="caption" color="text.secondary">Currently</Typography>
+                        <Typography sx={pathSx} data-testid="documents-location-old">
+                            {doc.location || '— not set —'}
+                        </Typography>
+                    </Box>
+                    <Box>
+                        <Typography variant="caption" color="text.secondary">Changing to</Typography>
+                        <Typography sx={{ ...pathSx, color: 'primary.main' }}
+                                    data-testid="documents-location-new">
+                            {next || '— cleared —'}
+                        </Typography>
+                    </Box>
+
+                    <Alert severity="warning" data-testid="documents-location-warning">
+                        {readers.length === 1
+                            ? '1 agent reads this file'
+                            : `${readers.length} agents read this file`} in full at every boot.
+                        <strong> Nothing validates this path.</strong> If it is wrong they will boot
+                        without the knowledge and report themselves healthy — the failure is silent
+                        at the point it happens and only shows up as an agent that quietly does not
+                        know something.
+                    </Alert>
+
+                    <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                        {readers.map(a => (
+                            <Chip key={a.id} size="small" color="warning" variant="outlined"
+                                  label={a.name}
+                                  data-testid={`documents-location-reader-${a.id}`} />
+                        ))}
+                    </Stack>
+
+                    <DialogContentText>
+                        Registering a path does not create the file. Make sure it already exists at
+                        the new location on <code>main</code>.
+                    </DialogContentText>
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={cancel} data-testid="documents-location-cancel-btn">Cancel</Button>
+                <Button onClick={confirm} variant="contained" color="warning"
+                        data-testid="documents-location-confirm-btn">
+                    Change the path
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default DocumentLocationDialog;

--- a/src/Agents/DocumentOwnerDialog.jsx
+++ b/src/Agents/DocumentOwnerDialog.jsx
@@ -1,0 +1,199 @@
+// Confirm an ownership change on one document — transfer or release (req #3051).
+//
+// This dialog exists because the user is authorizing a NON-ATOMIC SEQUENCE, and
+// the sequence is forced. `uq_agent_documents_owner` is a UNIQUE key over a
+// virtual column that equals `document_fk` exactly when the relationship SET
+// contains `owned`, so the incoming claim is rejected while the incumbent still
+// holds it. Release must come first. There is no ordering that avoids a window in
+// which the document is unowned — only its length and its recoverability are in
+// our control, and the honest thing is to say so before the user commits rather
+// than after it goes wrong.
+//
+// PARENT-OWNS-STATE, the house pattern (InstructionUnbindDialog, TaskDeleteDialog,
+// RecurringDeleteDialog): this component holds no action logic. It sets
+// `confirmed` and closes; `useConfirmDialog`'s effect in the page runs the plan.
+// Keeping the write in the page is what lets it own the serialized membership
+// queue and the error resync.
+//
+// WHY OWNERSHIP CAN BE RELEASED AT ALL, with no successor. Three reasons, and the
+// first one settles it: the state already exists in the data — document #69
+// `memory/pipeline-plan-tracking.md` carries only `referenced` links and is
+// genuinely unowned. A UI that cannot reach a state it must render cannot round-
+// trip its own data. Second, every transfer passes through the unowned state
+// anyway, so it is structurally reachable. Third, and this is the registry's
+// whole thesis: it exists to make unowned documents VISIBLE, not impossible.
+// Ownership that lived only in prose "drifted silently and nobody notices"
+// (agents-registry.md) — the red chip and the accounting line are the mechanism.
+// Forbidding the state would only push people into naming a fake owner, which is
+// drift again, wearing a badge.
+
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormLabel from '@mui/material/FormLabel';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+
+import { parseRoles, relationshipLabel } from './agentRegistryUtils';
+
+const DocumentOwnerDialog = ({
+    open, setOpen, setConfirmed,
+    info,                       // { document, fromAgent, fromLink, toAgent, toLink }
+    keepOutgoing, setKeepOutgoing,
+}) => {
+    // `useConfirmDialog` resets `infoObject` to its default in the SAME effect
+    // pass that fires the confirm callback, so `info` goes empty the instant the
+    // user clicks. `open` is what controls visibility; rendering null here would
+    // rip the dialog out mid-close and skip its exit transition. The page holds
+    // the last real value for us — see `lastOwnerInfo` there.
+    if (!info?.document) return null;
+
+    const { document: doc, fromAgent, fromLink, toAgent, toLink } = info;
+    const isTransfer = !!toAgent;
+
+    // Does the outgoing owner's link survive on its own roles? An `owned,autoload`
+    // owner becomes plain `autoload` and the question does not arise. An
+    // owner-ONLY link has nothing left, and then the choice below is real: park it
+    // at `referenced`, or drop it. Parking is the default because the link's
+    // `notes` die with it, and 87 of the 100 live links carry one.
+    const outgoingRemaining = fromLink
+        ? parseRoles(fromLink.relationship).filter(r => r !== 'owned')
+        : [];
+    const outgoingWouldVanish = !!fromLink && outgoingRemaining.length === 0;
+
+    // Claiming ownership never adds `autoload` on its own — `planOwnerTransfer`
+    // merges only `owned` into whatever the incoming agent already had. So the
+    // only autoload fact worth stating is whether it ALREADY reads the file.
+    const incomingAutoloads = toLink
+        ? parseRoles(toLink.relationship).includes('autoload')
+        : false;
+
+    const cancel = () => setOpen(false);
+    const confirm = () => { setConfirmed(true); setOpen(false); };
+
+    return (
+        <Dialog open={open} onClose={cancel} maxWidth="sm" fullWidth
+                data-testid="documents-owner-dialog">
+            <DialogTitle>
+                {isTransfer
+                    ? `Transfer ownership of “${doc.name}”?`
+                    : `Release ownership of “${doc.name}”?`}
+            </DialogTitle>
+            <DialogContent>
+                <Stack spacing={2} sx={{ mt: 1 }}>
+                    <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+                        <Chip size="small" color="primary" variant="filled"
+                              label={fromAgent?.name || 'unowned'} />
+                        <ArrowForwardIcon fontSize="small" sx={{ opacity: 0.6 }} />
+                        {isTransfer
+                            ? <Chip size="small" color="primary" variant="outlined"
+                                    label={toAgent.name} />
+                            : <Chip size="small" color="error" variant="outlined" label="unowned" />}
+                    </Stack>
+
+                    {/* The mechanism, stated plainly. The user is not authorizing
+                        "make B the owner" — they are authorizing two writes that
+                        cannot be reordered and are not a transaction. */}
+                    <Alert severity="warning" data-testid="documents-owner-window-warning">
+                        {isTransfer ? (
+                            <>
+                                This is <strong>two writes</strong>: {fromAgent?.name} is released
+                                first, then {toAgent.name} claims it. The database allows only one
+                                owner per document, so the order cannot be reversed. If the second
+                                write fails, the document is left <strong>unowned</strong> and this
+                                card will say so in red.
+                            </>
+                        ) : (
+                            <>
+                                No agent will be the named responsible party for this file. Unowned
+                                documents are exactly what this registry exists to surface — it will
+                                show in red until someone claims it.
+                            </>
+                        )}
+                    </Alert>
+
+                    {fromLink && !outgoingWouldVanish && (
+                        <DialogContentText>
+                            {fromAgent?.name} keeps its other role
+                            {outgoingRemaining.length === 1 ? '' : 's'} on this document
+                            (<strong>{outgoingRemaining.join(', ')}</strong>)
+                            {outgoingRemaining.includes('autoload')
+                                ? ' — it still reads the file in full at every boot.'
+                                : '.'}
+                        </DialogContentText>
+                    )}
+
+                    {outgoingWouldVanish && (
+                        <FormControl>
+                            <FormLabel sx={{ fontSize: '0.875rem' }}>
+                                {fromAgent?.name} has no other role on this document
+                            </FormLabel>
+                            <RadioGroup
+                                value={keepOutgoing ? 'keep' : 'remove'}
+                                onChange={(e) => setKeepOutgoing(e.target.value === 'keep')}
+                            >
+                                <FormControlLabel
+                                    value="keep"
+                                    control={<Radio size="small"
+                                                    inputProps={{ 'data-testid': 'documents-owner-keep' }} />}
+                                    label={`Keep ${fromAgent?.name} linked as referenced`}
+                                />
+                                <FormControlLabel
+                                    value="remove"
+                                    control={<Radio size="small"
+                                                    inputProps={{ 'data-testid': 'documents-owner-remove' }} />}
+                                    label="Remove the link entirely"
+                                />
+                            </RadioGroup>
+                            {!keepOutgoing && fromLink?.notes && (
+                                <Typography variant="caption" color="warning.main">
+                                    Removing it also discards this link&apos;s notes:
+                                    “{fromLink.notes}”
+                                </Typography>
+                            )}
+                        </FormControl>
+                    )}
+
+                    {isTransfer && toLink && (
+                        <DialogContentText>
+                            {toAgent.name} already links this document as{' '}
+                            <strong>{relationshipLabel(toLink.relationship)}</strong>; ownership is
+                            added to what it has, and its notes are kept.
+                            {incomingAutoloads
+                                ? ' It already reads the file in full at boot.'
+                                : ' It does not read the file at boot — add autoload afterwards if it should.'}
+                        </DialogContentText>
+                    )}
+
+                    {isTransfer && !toLink && (
+                        <DialogContentText>
+                            {toAgent.name} has no link to this document yet, so a new one is created
+                            carrying <strong>owned</strong>. Add <code>autoload</code> afterwards if
+                            it should read the file at boot.
+                        </DialogContentText>
+                    )}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={cancel} data-testid="documents-owner-cancel-btn">Cancel</Button>
+                <Button onClick={confirm} variant="contained"
+                        color={isTransfer ? 'primary' : 'error'}
+                        data-testid="documents-owner-confirm-btn">
+                    {isTransfer ? 'Transfer ownership' : 'Release ownership'}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default DocumentOwnerDialog;

--- a/src/Agents/DocumentUnbindDialog.jsx
+++ b/src/Agents/DocumentUnbindDialog.jsx
@@ -1,0 +1,97 @@
+// Confirm removing one agent→document link (req #3051).
+//
+// Peer to InstructionUnbindDialog, and a real dialog rather than a
+// `window.confirm` for the reasons that one records: `window.confirm` is
+// unthemed, unstyleable, and invisible to a Playwright run that has not
+// registered a handler.
+//
+// PARENT-OWNS-STATE: this component sets `confirmed` and closes. The page runs
+// the write, through the same serialized queue as every other membership change.
+//
+// What this dialog has to say that the instruction one does not: whether the link
+// being removed is an AUTOLOAD link. Unbinding a `referenced` document is a soft
+// loss — the agent could have consulted the file and now will not think to. But
+// instruction #83 orders every agent to read its `autoload` documents in full
+// before starting work, so removing an autoload link silently changes what that
+// agent knows at its next boot, and nothing anywhere reports it. That is the one
+// consequence a user cannot see from the chip, so it is the one that gets an
+// Alert.
+
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import { isAutoload, relationshipLabel } from './agentRegistryUtils';
+
+const DocumentUnbindDialog = ({ open, setOpen, setConfirmed, info }) => {
+    // See InstructionUnbindDialog: `useConfirmDialog` clears `infoObject` in the
+    // same effect pass that fires the callback, and `open` controls visibility.
+    // The page holds the last real value so the closing frames have something to
+    // render.
+    if (!info?.document || !info?.agent) return null;
+
+    const { document: doc, agent, link } = info;
+    const autoload = isAutoload(link?.relationship);
+
+    const cancel = () => setOpen(false);
+    const confirm = () => { setConfirmed(true); setOpen(false); };
+
+    return (
+        <Dialog open={open} onClose={cancel} maxWidth="sm" fullWidth
+                data-testid="documents-unbind-dialog">
+            <DialogTitle>Unlink {agent.name} from “{doc.name}”?</DialogTitle>
+            <DialogContent>
+                <Stack spacing={2} sx={{ mt: 1 }}>
+                    <Stack direction="row" spacing={0.5} alignItems="center" flexWrap="wrap" useFlexGap>
+                        <Chip size="small" variant="outlined" label={doc.name} />
+                        <Chip size="small" color="error" variant="outlined"
+                              label={agent.closed ? `${agent.name} (closed)` : agent.name} />
+                        <Chip size="small" variant="outlined"
+                              label={relationshipLabel(link?.relationship)} />
+                    </Stack>
+
+                    {autoload ? (
+                        <Alert severity="warning" data-testid="documents-unbind-autoload-warning">
+                            {agent.name} currently reads this file <strong>in full at every
+                            boot</strong>. After this it will not, and nothing will report the
+                            change — the agent simply starts work without knowledge it used to have.
+                        </Alert>
+                    ) : (
+                        <DialogContentText>
+                            {agent.name} stops referencing this document at its next boot. Nothing
+                            was being loaded automatically, so no knowledge is lost.
+                        </DialogContentText>
+                    )}
+
+                    <DialogContentText>
+                        The document row itself survives, and every other agent linked to it keeps
+                        its link. Only this one relationship is removed.
+                    </DialogContentText>
+
+                    {link?.notes && (
+                        <Typography variant="body2" color="warning.main"
+                                    data-testid="documents-unbind-notes-warning">
+                            This link&apos;s notes are discarded with it: “{link.notes}”
+                        </Typography>
+                    )}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={cancel} data-testid="documents-unbind-cancel-btn">Cancel</Button>
+                <Button onClick={confirm} color="error" variant="contained"
+                        data-testid="documents-unbind-confirm-btn">
+                    Unlink
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default DocumentUnbindDialog;

--- a/src/Agents/DocumentsPage.jsx
+++ b/src/Agents/DocumentsPage.jsx
@@ -1,4 +1,5 @@
-// /agents/documents — THE architecture-document registry (req #2998).
+// /agents/documents — THE architecture-document registry (req #2998,
+// editable req #3051).
 //
 // One row per document, with the reverse-link direction of /agents/:id: there the
 // question is "what does this agent own?"; here it is "who owns this file?" —
@@ -8,37 +9,150 @@
 // At most one `owned` link may exist per document; that is enforced by a UNIQUE
 // key on a VIRTUAL generated column, not by convention. A row rendering without
 // an owner chip therefore means genuinely unowned, not a UI gap.
+//
+// ---------------------------------------------------------------------------
+// REQ #3051 — EVERY FACET OF A DOCUMENT IS NOW EDITABLE, EXCEPT THE DOCUMENT.
+// ---------------------------------------------------------------------------
+//
+// In scope: every column of `architecture_documents` worth editing, and every
+// column of the `agent_documents` links. Out of scope, permanently: the FILE
+// CONTENTS. This registry stores a `location` and a `url`, never content; the
+// browser has no filesystem; and the OpenInNew link out to GitHub or the rendered
+// site is the whole content affordance. Also out: `creator_fk` / `create_ts` /
+// `update_ts` (server-owned), `architecture_documents.sort_order` (see below),
+// and `agent_documents.sort_order` (owned by AgentDetail — this page carries it
+// through every write untouched, and never sets it except on a brand-new link).
+//
+// CARDS, NOT A TABLE, and not merely to match /agents/instructions. The thing
+// being edited on each row is a variable-height set of agent relationships — one
+// document carries twelve links today, and the edit affordance unfurls the rest
+// of the roster as ghost chips. A DataGrid is fixed-row-height by house rule, so
+// it structurally cannot host that. Per-link `notes` has nowhere to live in a
+// document-per-row table either, and 87 of the 100 live links carry one.
+//
+// WHICH FIELD IS DANGEROUS IS COUNTER-INTUITIVE, and the UI is shaped around it:
+//
+//   * `location` LOOKS like a caption and is the riskiest value on the page.
+//     Instruction #83 orders all twelve architects to read every `autoload`
+//     document from its `location` in full before starting work. The executor is
+//     an LLM, so nothing type-checks the path and nothing fails loudly — a wrong
+//     one means the agent boots without knowledge it was told to have and reports
+//     itself green. Editing it therefore goes through DocumentLocationDialog
+//     whenever any agent autoloads the document.
+//
+//   * `name` LOOKS load-bearing — it is UNIQUE and the registry docs call it "the
+//     idempotent-seed key" — and is not. Verified for this requirement: nothing
+//     under `scripts/` references either document table, so there is no seed to
+//     re-run and no duplicate-row hazard, and `get_architecture_document_by_name`
+//     has no caller outside the MCP test suite. A rename is prose, exactly as
+//     req #3068 concluded for instruction names. So it is an ordinary
+//     commit-on-blur heading.
+//
+// `architecture_documents.sort_order` IS NOT EDITABLE and is not merely omitted:
+// the column is incoherent (thirteen rows share the value 1, one is NULL) and
+// nothing reads it — the boot payload orders by relationship rank then the
+// junction's own `sort_order`, and this page has always re-sorted by name. The
+// server-side default sort was its last consumer, so `devopsQueries` now asks for
+// `name:asc` and the browse-sort control below replaces it. That is deliberately
+// the same sequence req #3063 ran before migration 072 dropped
+// `instructions.sort_order`; a follow-on requirement measures and drops this one.
+//
+// ONE PUT PER FIELD, CARRYING ONLY THAT FIELD. `rest_put.py` builds its SET
+// clause from the body's keys and has no version column, so a whole-row PUT would
+// silently revert whatever another tab had just changed. Each ghost field writes
+// its own column and nothing else.
+//
+// THE JUNCTION IS THE OPPOSITE: EVERY COLUMN, EVERY TIME. `agent_documents` has
+// no `id`, so Lambda-Rest cannot PUT it and a role change is a DELETE plus a
+// fresh INSERT. An INSERT that omits `notes` or `sort_order` does not leave them
+// alone — it writes NULL over them. That asymmetry is the likeliest silent defect
+// in this area, so it is handled in exactly one place (`linkRow` in
+// documentsApi.js) rather than at each call site.
 
 import '../index.css';
-import { useContext, useMemo } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
-import Link from '@mui/material/Link';
-import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
-import Table from '@mui/material/Table';
-import TableHead from '@mui/material/TableHead';
-import TableBody from '@mui/material/TableBody';
-import TableRow from '@mui/material/TableRow';
-import TableCell from '@mui/material/TableCell';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import ListSubheader from '@mui/material/ListSubheader';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import AddIcon from '@mui/icons-material/Add';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import CloseIcon from '@mui/icons-material/Close';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import SettingsIcon from '@mui/icons-material/Settings';
+import UnarchiveIcon from '@mui/icons-material/Unarchive';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
 
+import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
+import GhostTextField from '../Components/GhostField/GhostTextField';
 import {
     useArchitectureDocuments, useAgents, useAgentDocuments,
+    architectureDocumentKeys, agentDocumentKeys,
 } from '../hooks/useDataQueries';
+import { useConfirmDialog } from '../hooks/useConfirmDialog';
+import { useViewPreference } from '../hooks/useViewPreference';
+import { useSnackBarStore } from '../stores/useSnackBarStore';
 import {
-    byId, linksByDocument, relationshipChipProps, relationshipLabel,
-    docTypeChipProps, documentHref, hasRole,
+    byId, linksByAgent, linksByDocument, documentOwnerLink,
+    relationshipChipProps, docTypeChipProps, documentHref,
+    hasRole, isAutoload,
+    nextDocumentSortOrder, planOwnerTransfer, restErrorMessage,
+    documentNameError, documentLocationError, documentUrlError, docTypeError,
+    DOC_TYPES, DOCUMENT_NAME_MAX, DOCUMENT_LOCATION_MAX, DOCUMENT_URL_MAX,
 } from './agentRegistryUtils';
+import {
+    createArchitectureDocument, updateArchitectureDocument,
+    deleteArchitectureDocument, linkAgentDocument, linkAgentDocuments,
+    applyLinkPlan, setAgentDocumentLink, LinkRollbackError,
+} from './actions/documentsApi';
+import {
+    SORT_MODES, SORT_STORAGE_KEY, readStoredSort, compareDocumentRows,
+} from './documentSort';
+import DocumentAgentChips from './DocumentAgentChips';
+import DocumentLinkPopover from './DocumentLinkPopover';
+import DocumentOwnerDialog from './DocumentOwnerDialog';
+import DocumentUnbindDialog from './DocumentUnbindDialog';
+import DocumentDeleteDialog from './DocumentDeleteDialog';
+import DocumentLocationDialog from './DocumentLocationDialog';
+
+// Matches InstructionsPage: CardContent adds a 24px bottom pad to its last child
+// on top of its own 16px, so both are pinned to `p: 2` to keep the two registry
+// pages' card interiors identical.
+const CARD_CONTENT_SX = { p: 2, '&:last-child': { pb: 2 } };
+
+// Thrown by the location field to make GhostTextField revert while the
+// confirmation dialog decides. Nothing failed, so nothing is reported — see
+// `commitLocation`.
+class LocationNeedsConfirmation extends Error {}
 
 const DocumentsPage = () => {
     const navigate = useNavigate();
-    const { profile } = useContext(AuthContext);
+    const { profile, idToken } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
+    const queryClient = useQueryClient();
+    const showError = useSnackBarStore(s => s.showError);
     const isMobile = useMediaQuery('(max-width:899px)');
     const creatorFk = profile?.userName;
 
@@ -46,112 +160,1373 @@ const DocumentsPage = () => {
     const { data: agents } = useAgents(creatorFk);
     const { data: agentDocs } = useAgentDocuments(creatorFk);
 
+    // EVERY destructive decision on this page reads the junction. It decides
+    // whether closing a row goes straight through or via the dialog, it drives
+    // the delete dialog's agent list and its typed-name challenge, and it is the
+    // entire owner column. An UNRESOLVED junction query makes every document look
+    // unowned — so a document twelve architects reference would delete with no
+    // challenge and a dialog claiming zero blast radius.
+    //
+    // `isLoading` covers only `useArchitectureDocuments`, and `fetchEntity` maps
+    // 404 to [] but RETHROWS every other status — so a 500 on /agent_documents
+    // leaves this undefined permanently, not briefly. Treat missing relationship
+    // data as a hard stop, not as "no relationships".
+    const relationshipsReady = !!agents && !!agentDocs;
+
+    const [showClosed, setShowClosed] = useState(false);
+    const [showUnownedOnly, setShowUnownedOnly] = useState(false);
+    const [view, setView] = useViewPreference('darwin-documents-view', 'cards');
+    // Cards is the only view built; Table is a later requirement. A 'table' value
+    // can still be sitting in this browser's storage, and an unmatched
+    // ToggleButtonGroup value selects nothing — the toggle would render with no
+    // active state. Same normalization InstructionsPage carries.
+    const activeView = view === 'table' ? 'cards' : view;
+
+    const [sortMode, setSortMode] = useState(readStoredSort);
+    const [sortDesc, setSortDesc] = useState(
+        () => SORT_MODES.find(m => m.value === readStoredSort())?.defaultDesc ?? false);
+    const [sortAnchor, setSortAnchor] = useState(null);
+
+    const [deleteTarget, setDeleteTarget] = useState(null);
+    const [dialogIntent, setDialogIntent] = useState('delete');
+    // Per-card options menu. Stores the ROW ID plus the anchor element, never the
+    // row object: a refetch can land while the menu is open (every chip click
+    // invalidates these queries), and a snapshotted row would make the
+    // graduated-close decision from a stale link count.
+    const [menuAnchor, setMenuAnchor] = useState(null);
+    const [busy, setBusy] = useState(false);
+    // Membership writes are pessimistic and scoped to one card, so the spinner is
+    // too. A SET rather than a single id: two cards can legitimately be mid-write,
+    // and a single id would let the first to finish clear the second's spinner.
+    const [membershipBusyIds, setMembershipBusyIds] = useState(() => new Set());
+    // `${rowId}:${field}` -> error message, for rows holding a blocked value.
+    const [fieldErrors, setFieldErrors] = useState({});
+    // Which non-owner link is being edited, and where to anchor its popover.
+    const [linkEditor, setLinkEditor] = useState(null);
+    // Owner-row roster palettes, by document id.
+    const [ownerPaletteId, setOwnerPaletteId] = useState(null);
+    // Persistent per-document notice that a transfer left the document unowned.
+    // Keyed by id and rendered ONLY while the card really is unowned, so a resync
+    // that reveals a different owner retires it without any extra bookkeeping.
+    const [ownerAlerts, setOwnerAlerts] = useState({});
+    const [keepOutgoing, setKeepOutgoing] = useState(true);
+
+    // Template-row drafts. All CONTROLLED, so clearing them after a successful
+    // create empties the fields even while one still holds focus.
+    const [draftName, setDraftName] = useState('');
+    const [draftLocation, setDraftLocation] = useState('');
+    const [draftUrl, setDraftUrl] = useState('');
+    const [draftType, setDraftType] = useState('markdown');
+    const [creating, setCreating] = useState(false);
+    const templateNameRef = useRef(null);
+
+    // AgentDetail's relationship chip drills through to `#document-<id>`. A
+    // client-side route change does not make the browser honour a hash, so the
+    // scroll is explicit — and it waits for the rows, which do not exist on the
+    // first render after the navigation.
+    //
+    // ONCE PER HASH, and only once the row is actually on screen. The dependency
+    // list has to include the data, but every field save refetches and hands back
+    // a new `documents` identity — so without the latch, saving anything would
+    // smooth-scroll the viewport back to the drill-through target for as long as
+    // the hash sat in the URL.
+    const scrolledToHash = useRef(null);
+    useEffect(() => {
+        if (isLoading) return;
+        const hash = window.location.hash;
+        if (!hash || scrolledToHash.current === hash) return;
+
+        // The target may be a CLOSED row, which the list filters out by default —
+        // then the drill-through would land on nothing at all and look broken.
+        const targetId = Number(hash.replace('#document-', ''));
+        if (Number.isFinite(targetId) && !showClosed
+            && (documents || []).some(d => d.id === targetId && d.closed)) {
+            setShowClosed(true);
+            return;                        // re-runs once the row is rendered
+        }
+
+        const el = document.getElementById(hash.slice(1));
+        if (!el) return;
+        scrolledToHash.current = hash;
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, [isLoading, documents, showClosed]);
+
+    // Only the MODE persists. Direction resets to the mode's natural end on
+    // reload, so a user who flipped to "fewest agents" once does not silently come
+    // back tomorrow to a page that buries its own headline rows.
+    useEffect(() => {
+        try { localStorage.setItem(SORT_STORAGE_KEY, sortMode); } catch { /* private mode */ }
+    }, [sortMode]);
+
+    // CategoryCard's shipped idiom: picking the ACTIVE mode flips its direction
+    // and keeps the menu open so the arrow change is visible; picking a new mode
+    // adopts that mode's natural direction and closes.
+    const chooseSort = (value, defaultDesc) => {
+        if (sortMode === value) { setSortDesc(d => !d); return; }
+        setSortMode(value);
+        setSortDesc(defaultDesc);
+        setSortAnchor(null);
+    };
+
     const agentIndex = useMemo(() => byId(agents || []), [agents]);
     const byDocument = useMemo(() => linksByDocument(agentDocs || []), [agentDocs]);
+    // NOTE: there is deliberately no render-time `linksByAgent` memo here. Every
+    // consumer of it computes per-agent slots INSIDE a queued write, from
+    // `freshAgentDocuments()` — a render-time index would be exactly the stale
+    // snapshot those thunks exist to avoid.
 
-    const rows = useMemo(() => {
+    const openAgents = useMemo(
+        () => (agents || []).filter(a => !a.closed)
+            .sort((a, b) => (a.name || '').localeCompare(b.name || '')),
+        [agents]);
+
+    const hasClosed = useMemo(
+        () => (documents || []).some(d => d.closed), [documents]);
+
+    // Every document, decorated with its links and its owner. Built over the FULL
+    // catalog (not the filtered view) so the accounting line and the filter
+    // predicates read from one place.
+    const allRows = useMemo(() => {
         if (!documents) return [];
-        return documents
-            .filter(d => !d.closed)
-            .map(d => {
-                const links = byDocument.get(d.id) || [];
-                return {
-                    ...d,
-                    links,
-                    owner: links.find(l => hasRole(l.relationship, 'owned')) || null,
-                };
-            })
-            .sort((a, b) => a.name.localeCompare(b.name));
-    }, [documents, byDocument]);
+        return documents.map(d => {
+            const links = byDocument.get(d.id) || [];
+            const owner = documentOwnerLink(links);
+            return {
+                ...d,
+                links,
+                owner,
+                ownerName: owner ? (agentIndex.get(owner.agent_fk)?.name || '') : '',
+                others: links.filter(l => !hasRole(l.relationship, 'owned')),
+            };
+        });
+    }, [documents, byDocument, agentIndex]);
 
-    const unowned = rows.filter(r => !r.owner).length;
+    const hasUnowned = useMemo(
+        () => allRows.some(r => !r.closed && !r.owner), [allRows]);
 
-    if (isLoading || !documents) {
-        return <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }}><CircularProgress /></Box>;
+    const rows = useMemo(() => allRows
+        .filter(r => (showClosed || !r.closed) && (!showUnownedOnly || !r.owner))
+        .sort(compareDocumentRows(sortMode, sortDesc)),
+    [allRows, showClosed, showUnownedOnly, sortMode, sortDesc]);
+
+    // A row edit touches no junction row, so it invalidates the row query only.
+    const invalidateRows = () => queryClient.invalidateQueries(
+        { queryKey: architectureDocumentKeys.all(creatorFk) });
+
+    // A link edit changes the junction AND the owner chip / accounting line
+    // derived from it, so both caches go.
+    const invalidateAll = () => Promise.all([
+        invalidateRows(),
+        queryClient.invalidateQueries({ queryKey: agentDocumentKeys.all(creatorFk) }),
+    ]);
+
+    // ---------- per-field row edits ----------
+
+    const noteFieldError = (rowId, field) => (error) => setFieldErrors(prev => {
+        const key = `${rowId}:${field}`;
+        if (!error) {
+            if (!(key in prev)) return prev;
+            const next = { ...prev };
+            delete next[key];
+            return next;
+        }
+        if (prev[key] === error) return prev;
+        return { ...prev, [key]: error };
+    });
+
+    const rowBlocked = (rowId) => Object.keys(fieldErrors)
+        .some(k => k.startsWith(`${rowId}:`));
+
+    /**
+     * Commit one column of one row. RETHROWS on failure so GhostTextField
+     * reverts — the field must never keep displaying a value the database
+     * rejected. The resync runs BEFORE the error is reported, because a display
+     * failure must not be able to skip it.
+     */
+    const commitField = (row, field, label) => async (raw) => {
+        // Nullable columns store NULL rather than '' when cleared: an empty
+        // string would make `documentHref` return a dead link instead of falling
+        // back to the constructed GitHub blob URL.
+        const nullable = field === 'location' || field === 'url';
+        const value = nullable ? ((raw || '').trim() || null) : raw;
+        try {
+            await updateArchitectureDocument(darwinUri, idToken, row.id, { [field]: value });
+            await invalidateRows();
+        } catch (err) {
+            await invalidateRows();
+            showError(err, restErrorMessage(err, `Could not save the ${label}`));
+            throw err;
+        }
+    };
+
+    /** Open agents that read this document in full at boot. */
+    const autoloadReaders = (row) => row.links
+        .filter(l => isAutoload(l.relationship))
+        .map(l => agentIndex.get(l.agent_fk))
+        .filter(a => a && !a.closed);
+
+    const locationConfirm = useConfirmDialog({
+        onConfirm: async ({ document: row, next }) => {
+            if (!row) return;
+            try {
+                await updateArchitectureDocument(darwinUri, idToken, row.id,
+                    { location: next });
+                await invalidateRows();
+            } catch (err) {
+                await invalidateRows();
+                showError(err, restErrorMessage(err, 'Could not save the location'));
+            }
+        },
+        defaultInfo: {},
+    });
+
+    /**
+     * `location` is the one field whose commit can be intercepted.
+     *
+     * See DocumentLocationDialog's header for why. Graduated: a document nothing
+     * autoloads has no boot to break, and ceremony with nothing to disclose trains
+     * people to click past ceremony that does.
+     *
+     * The throw is not an error report — it is how GhostTextField is told to put
+     * the STORED value back on screen, which is honest, because at that moment
+     * nothing has been written. Deliberately not routed through `commitField`,
+     * whose catch would surface a snackbar for a write that was merely deferred.
+     */
+    const commitLocation = (row) => async (raw) => {
+        const next = (raw || '').trim() || null;
+        if (next === (row.location || null)) return;
+        const readers = autoloadReaders(row);
+        if (readers.length === 0) {
+            await commitField(row, 'location', 'location')(raw);
+            return;
+        }
+        locationConfirm.openDialog({ document: row, next, readers });
+        throw new LocationNeedsConfirmation();
+    };
+
+    const setDocType = async (row, docType) => {
+        if (docType === row.doc_type) return;
+        const invalid = docTypeError(docType);
+        if (invalid) { showError(null, invalid); return; }
+        try {
+            await updateArchitectureDocument(darwinUri, idToken, row.id,
+                { doc_type: docType });
+            await invalidateRows();
+        } catch (err) {
+            await invalidateRows();
+            showError(err, restErrorMessage(err, 'Could not change the document type'));
+        }
+    };
+
+    // ---------- membership ----------
+
+    const markMembershipBusy = (rowId, on) => setMembershipBusyIds(prev => {
+        const next = new Set(prev);
+        if (on) next.add(rowId); else next.delete(rowId);
+        return next;
+    });
+
+    // The freshest junction rows, for work that runs LATER than the render that
+    // scheduled it. Read from the CACHE, not from a ref holding the last rendered
+    // value: the cache updates synchronously when a refetch resolves, whereas a
+    // ref only catches up once React has re-rendered, and nothing guarantees that
+    // has happened by the time the next queued task starts. The key is matched by
+    // PREFIX because the query factory appends a `{fields}` segment.
+    const agentDocsRef = useRef(agentDocs);
+    agentDocsRef.current = agentDocs;
+
+    const freshAgentDocuments = () => {
+        const entries = queryClient.getQueriesData(
+            { queryKey: agentDocumentKeys.all(creatorFk) });
+        for (const [, data] of entries) if (Array.isArray(data)) return data;
+        return agentDocsRef.current || [];
+    };
+
+    /**
+     * Membership writes run ONE AT A TIME across the whole page.
+     *
+     * Not for the user's benefit — for correctness, and more so here than on the
+     * instructions page. A new link's slot is max(existing)+1 for that agent,
+     * computed from the junction cache, so two concurrent writes would both read
+     * the pre-write cache and claim the same slot. Worse, ownership is
+     * DB-unique: two overlapping owner claims on one document race the unique
+     * key, and the loser's error is meaningless without an order to attribute it
+     * to.
+     *
+     * Serializing means the second write is planned only after the first one's
+     * refetch has landed, and slots are read at EXECUTION time.
+     */
+    const membershipQueue = useRef(Promise.resolve());
+
+    /**
+     * RESOLVES `{ ok }` — it never rejects.
+     *
+     * Deliberately not the rethrowing shape. Most callers here are fire-and-forget
+     * from a chip's onClick, so a rejecting promise nobody awaits is an unhandled
+     * rejection on every failed bind — and the one caller that DOES need to know
+     * (the ownership path, which must raise a standing notice when a transfer
+     * strands a document unowned) needs a verdict rather than an exception. A
+     * resolved verdict serves both without a `.catch()` at every call site, which
+     * is the kind of thing that gets forgotten at the fourth one.
+     */
+    const runMembership = (rowId, fn, fallback) => {
+        markMembershipBusy(rowId, true);
+        const task = membershipQueue.current.then(async () => {
+            try {
+                await fn();
+                await invalidateAll();
+                return { ok: true };
+            } catch (err) {
+                // Resync BEFORE reporting: a display failure must never be able to
+                // skip it, because the caches now disagree with the database.
+                await invalidateAll();
+                // A rollback failure outranks the error that caused it. "Your edit
+                // was rejected" and "a link you did not touch is now missing" are
+                // different things to tell a user, and the second one wins.
+                showError(err, err instanceof LinkRollbackError
+                    ? err.message
+                    : restErrorMessage(err, fallback));
+                return { ok: false, error: err };
+            } finally {
+                markMembershipBusy(rowId, false);
+            }
+        });
+        // The queue must survive a failed task, or one error would wedge every
+        // later write on the page. `task` cannot reject, but the guard stays: it
+        // costs nothing and it is what stops a future edit to the body above from
+        // silently wedging the page.
+        membershipQueue.current = task.catch(() => {});
+        return task;
+    };
+
+    /** Link an agent as `referenced` — the fast path, and the only one used by 32 of 32 live non-owner links. */
+    const bindAgent = (row, agentId) => runMembership(row.id,
+        () => linkAgentDocument(darwinUri, idToken, {
+            agent_fk: agentId,
+            document_fk: row.id,
+            relationship: ['referenced'],
+            notes: null,
+            sort_order: nextDocumentSortOrder(agentId,
+                linksByAgent(freshAgentDocuments())),
+        }),
+        `Could not link ${agentIndex.get(agentId)?.name || 'that agent'} to "${row.name}"`);
+
+    /**
+     * Link every remaining agent in ONE round trip.
+     *
+     * An array-body POST is a single multi-value INSERT — it either lands or it
+     * does not — where a loop of single binds is exactly the half-applied-set
+     * failure mode the one-chip-one-write rule exists to avoid.
+     *
+     * Slots are computed per agent from the SAME fresh snapshot, which is safe
+     * here where a loop would not be: every row targets a different `agent_fk`,
+     * so no two compete for one agent's next slot.
+     */
+    const bindAllAgents = (row, agentsToBind) => runMembership(row.id,
+        () => {
+            const fresh = freshAgentDocuments();
+            const links = linksByAgent(fresh);
+            // RE-FILTER at execution time, not just re-compute the slots. The list
+            // came from a click on a render that may be seconds old, and a link
+            // created meanwhile in another tab or by the MCP tool would put an
+            // already-present pair in the body. This is ONE multi-value INSERT,
+            // not an upsert, so a single composite-PK collision fails the WHOLE
+            // batch — none of them land, for a document that was already partly
+            // correct.
+            const alreadyLinked = new Set(fresh
+                .filter(l => l.document_fk === row.id)
+                .map(l => l.agent_fk));
+            const rowsToInsert = agentsToBind
+                .filter(a => !alreadyLinked.has(a.id))
+                .map(a => ({
+                    agent_fk: a.id,
+                    document_fk: row.id,
+                    relationship: ['referenced'],
+                    notes: null,
+                    sort_order: nextDocumentSortOrder(a.id, links),
+                }));
+            // linkAgentDocuments no-ops on an empty list, so a fully-raced click
+            // is a clean nothing rather than an error.
+            return linkAgentDocuments(darwinUri, idToken, rowsToInsert);
+        },
+        `Could not link the remaining agents to "${row.name}"`);
+
+    const unbindConfirm = useConfirmDialog({
+        onConfirm: ({ document: row, agent, link }) => {
+            if (!row || !link) return;
+            runMembership(row.id,
+                () => applyLinkPlan(darwinUri, idToken, [{
+                    agent_fk: link.agent_fk,
+                    document_fk: row.id,
+                    prev: link,
+                    next: null,
+                }]),
+                `Could not unlink ${agent?.name || 'that agent'} from "${row.name}"`);
+        },
+        defaultInfo: {},
+    });
+
+    /** Save the roles + notes staged in the link popover. */
+    const saveLink = (row, next) => {
+        const prev = row.links.find(
+            l => l.agent_fk === next.agent_fk && l.document_fk === row.id);
+        if (!prev) return;
+        setLinkEditor(null);
+        return runMembership(row.id,
+            () => setAgentDocumentLink(darwinUri, idToken, { prev, next }),
+            `Could not save the relationship for "${row.name}"`);
+    };
+
+    // ---------- ownership ----------
+
+    /**
+     * Run an ownership change.
+     *
+     * `buildSteps` is a THUNK, not a step list, so the plan is built when the
+     * queue reaches this write rather than when the chip was clicked. That matters
+     * for the same reason it matters on the bind path: a new link's `sort_order` is
+     * max+1 read from the junction cache, and a plan built at click time would read
+     * a cache that a previous queued write has since moved. It also means the plan
+     * sees the CURRENT owner, so a transfer queued behind another transfer of the
+     * same document releases whoever actually holds it.
+     *
+     * ROLLING BACK IS ATTEMPTED. `applyLinkPlan` unwinds in reverse order if a step
+     * fails — because in the case that genuinely strands a document (a transient
+     * failure on the claim) restoring the incumbent is exactly right, and is the
+     * only thing that repairs it.
+     *
+     * The case where a rollback would be WRONG — someone else claimed ownership in
+     * the window — takes care of itself rather than needing a special path: their
+     * claim makes our restore fail on the same unique key, the resync repaints the
+     * card with the real owner, and the standing alert below is then not rendered
+     * at all, because it is conditioned on the card STILL BEING UNOWNED rather than
+     * on what we believed happened. That is why the alert is keyed by document id
+     * and evaluated at render time instead of being a message we compose here.
+     */
+    const runOwnerChange = async ({ document: row, fromAgent, toAgent, buildSteps }) => {
+        if (!row) return;
+        const { ok } = await runMembership(row.id,
+            () => {
+                const steps = buildSteps();
+                if (!steps.length) return null;
+                return applyLinkPlan(darwinUri, idToken, steps);
+            },
+            toAgent
+                ? `Could not transfer "${row.name}" to ${toAgent.name}`
+                : `Could not release ownership of "${row.name}"`);
+
+        if (ok) {
+            setOwnerAlerts(prev => {
+                if (!(row.id in prev)) return prev;
+                const next = { ...prev };
+                delete next[row.id];
+                return next;
+            });
+            return;
+        }
+
+        // A TRANSFER that failed may have left the document unowned; a RELEASE that
+        // failed changed nothing. Only the first needs a standing notice.
+        if (toAgent) {
+            setOwnerAlerts(prev => ({
+                ...prev,
+                [row.id]: { from: fromAgent?.name, to: toAgent.name, toId: toAgent.id },
+            }));
+        }
+    };
+
+    /**
+     * The freshest view of one document's links, for a plan built at execution
+     * time. Reads the same cache `freshAgentDocuments` does, for the same reason.
+     */
+    const freshLinksFor = (documentId) => freshAgentDocuments()
+        .filter(l => l.document_fk === documentId);
+
+    const ownerConfirm = useConfirmDialog({
+        onConfirm: (info) => {
+            if (!info?.document) return;
+            // The radio's value is read HERE, at confirm time, not inside the
+            // thunk — it is the user's decision about this dialog and must not be
+            // re-read from state that the next dialog has already reset.
+            const keep = keepOutgoing;
+            runOwnerChange({
+                ...info,
+                buildSteps: () => {
+                    // Re-read the links at execution time: the incumbent may have
+                    // changed while this write sat in the queue, and releasing an
+                    // agent that no longer owns the document would delete a link
+                    // nobody asked to remove.
+                    const links = freshLinksFor(info.document.id);
+                    const fromLink = documentOwnerLink(links);
+                    const toLink = info.toAgent
+                        ? links.find(l => l.agent_fk === info.toAgent.id) || null
+                        : null;
+                    const steps = planOwnerTransfer({
+                        documentId: info.document.id,
+                        fromLink,
+                        toLink,
+                        toAgentId: info.toAgent?.id ?? null,
+                        keepOutgoing: keep,
+                    });
+                    // A brand-new link needs a slot; an existing one keeps its own.
+                    const claim = steps[steps.length - 1];
+                    if (info.toAgent && !toLink && claim?.next) {
+                        claim.next.sort_order = nextDocumentSortOrder(
+                            info.toAgent.id, linksByAgent(freshAgentDocuments()));
+                    }
+                    return steps;
+                },
+            });
+        },
+        defaultInfo: {},
+    });
+
+    // `useConfirmDialog` clears `infoObject` in the SAME effect pass that fires
+    // the callback, so these hold the last real value for the dialog's closing
+    // frames. `open` is what controls visibility.
+    const lastOwnerInfo = useRef(null);
+    if (ownerConfirm.infoObject?.document) lastOwnerInfo.current = ownerConfirm.infoObject;
+    const lastUnbindInfo = useRef(null);
+    if (unbindConfirm.infoObject?.document) lastUnbindInfo.current = unbindConfirm.infoObject;
+    const lastLocationInfo = useRef(null);
+    if (locationConfirm.infoObject?.document) lastLocationInfo.current = locationConfirm.infoObject;
+
+    const linkFor = (row, agentId) => row.links.find(l => l.agent_fk === agentId) || null;
+
+    const requestOwnerChange = (row, toAgent) => {
+        // Reset the radio each time: it is a per-decision choice, not a setting.
+        setKeepOutgoing(true);
+        setOwnerPaletteId(null);
+        ownerConfirm.openDialog({
+            document: row,
+            fromAgent: row.owner ? agentIndex.get(row.owner.agent_fk) : null,
+            fromLink: row.owner,
+            toAgent: toAgent || null,
+            toLink: toAgent ? linkFor(row, toAgent.id) : null,
+        });
+    };
+
+    /**
+     * Claiming an UNOWNED document needs no dialog.
+     *
+     * It is one write, it is additive, and it repairs a state the page renders in
+     * red. Ceremony belongs on the paths that can lose something — transfer (two
+     * writes, an unowned window) and release (creates the red state).
+     */
+    const claimOwnership = (row, agentId) => {
+        setOwnerPaletteId(null);
+        return runOwnerChange({
+            document: row,
+            toAgent: agentIndex.get(agentId),
+            buildSteps: () => {
+                const links = freshLinksFor(row.id);
+                // Re-read at execution time. If somebody claimed the document while
+                // this sat in the queue, `fromLink` is no longer null and the plan
+                // becomes a transfer — which the unique key would otherwise reject
+                // as a second owner.
+                const fromLink = documentOwnerLink(links);
+                const toLink = links.find(l => l.agent_fk === agentId) || null;
+                const steps = planOwnerTransfer({
+                    documentId: row.id,
+                    fromLink,
+                    toLink,
+                    toAgentId: agentId,
+                });
+                const claim = steps[steps.length - 1];
+                if (!toLink && claim?.next) {
+                    claim.next.sort_order = nextDocumentSortOrder(
+                        agentId, linksByAgent(freshAgentDocuments()));
+                }
+                return steps;
+            },
+        });
+    };
+
+    const retryOwnerClaim = (row) => {
+        const alert = ownerAlerts[row.id];
+        if (!alert) return;
+        return claimOwnership(row, alert.toId);
+    };
+
+    // ---------- create (template card) ----------
+
+    /**
+     * POST as soon as the required columns are filled and the name is free.
+     *
+     * Called on EVERY blur of either required field, not only when one changed —
+     * which is what makes a failed POST retryable by clicking back into a field
+     * and out again. It is idempotent by the guards below.
+     *
+     * `location` is required HERE even though the column is nullable: a
+     * registration with no path registers nothing anyone can find, and every one
+     * of the live rows has one. The UI is deliberately stricter than the schema.
+     *
+     * No `sort_order` is sent. The column is not driving anything the UI shows and
+     * inventing a slot would perpetuate the artifact this requirement is retiring.
+     *
+     * NO AGENT LINKS. The junction needs a document id, which does not exist until
+     * this returns — so a new card appears with a red `unowned` chip, which is
+     * itself the prompt to assign an owner. That ordering is what retires the
+     * two-phase create-then-link failure mode, where a successful POST followed by
+     * a failed link left a row owned by nobody and a dialog reporting an error.
+     */
+    const maybeCreate = async () => {
+        const name = draftName.trim();
+        const location = draftLocation.trim();
+        const url = draftUrl.trim();
+        if (creating || !name || !location) return;
+        if (documentNameError(name, documents || [], null)) return;
+        if (documentLocationError(location)) return;
+        if (documentUrlError(url)) return;
+        if (docTypeError(draftType)) return;
+
+        setCreating(true);
+        try {
+            await createArchitectureDocument(darwinUri, idToken, {
+                name, doc_type: draftType, location, url: url || null, creator_fk: creatorFk,
+            });
+            setDraftName('');
+            setDraftLocation('');
+            setDraftUrl('');
+            setDraftType('markdown');
+            await invalidateRows();
+            // Put the caret back in the blank template so a second row can be
+            // typed without reaching for the mouse — but ONLY if the user has not
+            // already moved on. This runs a full round trip after their blur, and
+            // stealing focus out of another row would fire that row's blur and
+            // commit whatever half-typed text was in it.
+            setTimeout(() => {
+                const active = window.document.activeElement;
+                const nobodyHasIt = !active || active === window.document.body;
+                if (nobodyHasIt) templateNameRef.current?.focus();
+            }, 0);
+        } catch (err) {
+            // Deliberately NOT rethrown: the draft must survive so the user can
+            // retry. Their next blur of either field calls this again.
+            await invalidateRows();
+            showError(err, restErrorMessage(err, 'Could not register the document'));
+        } finally {
+            setCreating(false);
+        }
+    };
+
+    // ---------- retire / delete ----------
+
+    const setClosedFlag = async (row, closed) => {
+        const target = row || deleteTarget;
+        if (!target) return;
+        setBusy(true);
+        try {
+            await updateArchitectureDocument(darwinUri, idToken, target.id, { closed });
+            await invalidateRows();
+            setDeleteTarget(null);
+        } catch (err) {
+            await invalidateRows();
+            showError(err, restErrorMessage(err,
+                closed ? 'Could not close the document' : 'Could not reopen the document'));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const closeMenu = () => setMenuAnchor(null);
+
+    /**
+     * CLOSE IS GRADUATED ON BLAST RADIUS, the same rule the instruction list uses.
+     *
+     * Closing drops the document out of every linked agent's boot payload, which
+     * is the exact silent unloading the delete dialog exists to make visible — so
+     * a LINKED row still goes through the dialog, where the agent chips are. An
+     * UNLINKED row has no blast radius at all, and ceremony with nothing to
+     * disclose trains people to click past ceremony that does. The trailing
+     * ellipsis on the menu label is what tells the two apart.
+     */
+    const menuCloseDocument = (row) => {
+        closeMenu();
+        if (row.links.length === 0) { setClosedFlag(row, 1); return; }
+        setDialogIntent('close');
+        setDeleteTarget(row);
+    };
+
+    const menuReopenDocument = (row) => { closeMenu(); setClosedFlag(row, 0); };
+
+    const menuDeleteDocument = (row) => {
+        closeMenu();
+        setDialogIntent('delete');
+        setDeleteTarget(row);
+    };
+
+    const handleDelete = async () => {
+        if (!deleteTarget) return;
+        setBusy(true);
+        try {
+            await deleteArchitectureDocument(darwinUri, idToken, deleteTarget.id);
+            // A hard delete CASCADEs the junction rows, so both caches are stale.
+            await invalidateAll();
+            setDeleteTarget(null);
+        } catch (err) {
+            await invalidateAll();
+            showError(err, restErrorMessage(err, 'Could not delete the document'));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    if (isLoading || !documents || !relationshipsReady) {
+        return (
+            <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }}>
+                {documents && !relationshipsReady ? (
+                    <Alert severity="error" data-testid="documents-relationships-error">
+                        The agent links could not be loaded, so this page cannot show who owns each
+                        document. Editing is disabled rather than shown without ownership — every
+                        row would render as unowned, and closing or deleting one from here would
+                        silently change what the linked agents read at boot. Reload to retry.
+                    </Alert>
+                ) : <CircularProgress />}
+            </Box>
+        );
     }
+
+    // Counted over the WHOLE catalog, not the filtered `rows` — an accounting line
+    // that changed when you toggled a view filter would not be an accounting line.
+    const openRows = allRows.filter(r => !r.closed);
+    const closedCount = allRows.length - openRows.length;
+    const unownedCount = openRows.filter(r => !r.owner).length;
+
+    const editorRow = linkEditor
+        ? rows.find(r => r.id === linkEditor.docId)
+            || allRows.find(r => r.id === linkEditor.docId)
+        : null;
 
     return (
         <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }}>
-            <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ mb: 0.5 }}>Architecture Documents</Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                {rows.length} registered documents
-                {unowned > 0
-                    ? ` · ${unowned} with no owner`
-                    : ' · every one has exactly one owner'}
+            {/* Canonical viewer header (req #3013, memory/view-switchable-pages.md).
+                Reading order is fixed for every viewer:
+                  [view toggle] [title, flex:1] [filters] [settings]
+                The toggle is the far-left anchor so the title starts at the same x
+                on every viewer page; the title's `flex: 1` IS the spacer — do not
+                add a second flexGrow Box. Filters sit beside the title because
+                they change WHAT is listed; the settings gear is pinned right. */}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5, flexWrap: 'wrap' }}>
+                {/* Cards only, and the group is kept at length 1 rather than
+                    dropped for a bare title — that is what preserves the far-left
+                    anchor and the title's x-position until a Table view ships.
+                    Following InstructionsPage's documented standing exception to
+                    V1: the user removed the disabled placeholder button there
+                    because a control you cannot act on reads as broken rather than
+                    as forthcoming. */}
+                <ToggleButtonGroup
+                    size="small"
+                    exclusive
+                    value={activeView}
+                    onChange={(_e, v) => setView(v)}
+                    sx={{ flexShrink: 0 }}
+                    data-testid="documents-view-toggle"
+                >
+                    <Tooltip title="Cards view">
+                        <ToggleButton value="cards" aria-label="cards view"
+                                      data-testid="view-toggle-cards">
+                            <ViewModuleIcon fontSize="small" />
+                        </ToggleButton>
+                    </Tooltip>
+                </ToggleButtonGroup>
+
+                <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ flex: 1 }}>
+                    Architecture Documents
+                </Typography>
+
+                {/* The highest-value filter on this page: it isolates exactly the
+                    drift the registry was built to catch. Rendered only when there
+                    is drift to isolate. */}
+                {hasUnowned && (
+                    <Tooltip title={showUnownedOnly
+                        ? 'Show every document'
+                        : 'Show only documents with no owner'}>
+                        <Chip
+                            label="Unowned"
+                            size="small"
+                            color={showUnownedOnly ? 'error' : 'default'}
+                            variant={showUnownedOnly ? 'filled' : 'outlined'}
+                            onClick={() => setShowUnownedOnly(v => !v)}
+                            sx={{ cursor: 'pointer', flexShrink: 0 }}
+                            data-testid="documents-show-unowned"
+                        />
+                    </Tooltip>
+                )}
+
+                {hasClosed && (
+                    <Tooltip title={showClosed ? 'Hide closed documents' : 'Show closed documents'}>
+                        <Chip
+                            label="Closed"
+                            size="small"
+                            color={showClosed ? 'primary' : 'default'}
+                            variant={showClosed ? 'filled' : 'outlined'}
+                            onClick={() => setShowClosed(v => !v)}
+                            sx={{ cursor: 'pointer', flexShrink: 0 }}
+                            data-testid="documents-show-closed"
+                        />
+                    </Tooltip>
+                )}
+
+                <Tooltip title="Sort & display settings">
+                    <IconButton size="small" onClick={(e) => setSortAnchor(e.currentTarget)}
+                                sx={{ flexShrink: 0 }}
+                                data-testid="documents-settings-button">
+                        <SettingsIcon fontSize="small" />
+                    </IconButton>
+                </Tooltip>
+                <Menu
+                    anchorEl={sortAnchor}
+                    open={!!sortAnchor}
+                    onClose={() => setSortAnchor(null)}
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                    transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                    slotProps={{ list: { 'data-testid': 'documents-sort-menu' } }}
+                >
+                    <ListSubheader disableSticky sx={{ lineHeight: '32px' }}>Sort by</ListSubheader>
+                    {SORT_MODES.map(({ value, label, icon: Icon, defaultDesc }) => {
+                        const active = sortMode === value;
+                        return (
+                            <MenuItem key={value} selected={active}
+                                      onClick={() => chooseSort(value, defaultDesc)}
+                                      data-testid={`documents-sort-${value}`}>
+                                <ListItemIcon><Icon fontSize="small" /></ListItemIcon>
+                                <ListItemText>{label}</ListItemText>
+                                {/* The arrow is the only affordance telling the user
+                                    that re-picking the active mode reverses it —
+                                    without it the second click looks broken. */}
+                                {active && (sortDesc
+                                    ? <ArrowDownwardIcon fontSize="small" sx={{ ml: 2, opacity: 0.7 }} />
+                                    : <ArrowUpwardIcon fontSize="small" sx={{ ml: 2, opacity: 0.7 }} />)}
+                            </MenuItem>
+                        );
+                    })}
+                </Menu>
+            </Box>
+
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}
+                        data-testid="documents-accounting">
+                {[
+                    `${openRows.length} registered document${openRows.length === 1 ? '' : 's'}`,
+                    unownedCount > 0
+                        ? `${unownedCount} with no owner`
+                        : 'every one has exactly one owner',
+                    closedCount > 0 && `${closedCount} closed`,
+                ].filter(Boolean).join(' · ')}
                 . At most one owner per document is enforced by the database.
             </Typography>
 
-            <Box sx={{ overflowX: 'auto' }}>
-                <Table size="small" data-testid="documents-registry">
-                    <TableHead>
-                        <TableRow>
-                            <TableCell>Document</TableCell>
-                            <TableCell>Type</TableCell>
-                            <TableCell>Owner</TableCell>
-                            <TableCell>Other agents</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {rows.map(doc => {
-                            const href = documentHref(doc);
-                            const others = doc.links.filter(l => !hasRole(l.relationship, 'owned'));
-                            return (
-                                <TableRow key={doc.id} data-testid={`document-row-${doc.id}`}>
-                                    <TableCell>
-                                        {href ? (
-                                            <Link href={href} target="_blank" rel="noopener noreferrer"
-                                                  underline="hover">
-                                                {doc.name} <OpenInNewIcon sx={{ fontSize: 12 }} />
-                                            </Link>
-                                        ) : doc.name}
-                                        <Typography variant="caption" color="text.secondary"
-                                                    sx={{ display: 'block' }}>
-                                            {doc.location}
-                                        </Typography>
-                                    </TableCell>
-                                    <TableCell>
-                                        <Chip label={doc.doc_type || '—'} size="small"
-                                              {...docTypeChipProps(doc.doc_type)} />
-                                    </TableCell>
-                                    <TableCell>
-                                        {doc.owner ? (
+            <Box
+                data-testid="documents-registry"
+                sx={{
+                    display: 'grid',
+                    gap: 2,
+                    alignItems: 'start',
+                    gridTemplateColumns: {
+                        xs: '1fr',
+                        lg: 'repeat(2, minmax(0, 1fr))',
+                        xl: 'repeat(3, minmax(0, 1fr))',
+                    },
+                }}
+            >
+                {rows.map(row => {
+                    const blocked = rowBlocked(row.id);
+                    const membershipBusy = membershipBusyIds.has(row.id);
+                    const href = documentHref(row);
+                    const ownerAgent = row.owner ? agentIndex.get(row.owner.agent_fk) : null;
+                    const linkedIds = new Set(row.links.map(l => l.agent_fk));
+                    const ownerAlert = ownerAlerts[row.id];
+
+                    return (
+                        <Card key={row.id} variant="outlined"
+                              id={`document-${row.id}`}
+                              sx={{
+                                  scrollMarginTop: 16,
+                                  ...(row.closed && { opacity: 0.55 }),
+                              }}
+                              data-testid={`document-row-${row.id}`}>
+                          <CardContent sx={CARD_CONTENT_SX}>
+                            {/* CARD HEADER, in the TaskCard / CategoryCard idiom:
+                                the record's identity as an always-editable
+                                BORDERLESS heading, with the actions to its right.
+                                The title alone drops its border and label — a
+                                heading IS the record's identity and is
+                                self-describing, so a label above it is a tautology;
+                                every other field on the card keeps outlined+label.
+
+                                THE OPEN-LINK ICON IS A REGRESSION GUARD, not
+                                decoration. The document NAME used to be the
+                                external link. Making it an editable heading would
+                                have silently removed the page's most-used
+                                affordance, so the drill-out moves here. */}
+                            <Box className="card-header" sx={{ mb: 1 }}>
+                                <GhostTextField
+                                    value={row.name}
+                                    required
+                                    // WRAPS but does not accept newlines. `commitOnEnter`
+                                    // DEFAULTS to `!multiline`, so adding `multiline`
+                                    // without keeping this explicit would silently turn
+                                    // Enter into a newline inside a name.
+                                    multiline
+                                    commitOnEnter
+                                    maxRows={2}
+                                    placeholder="Document name"
+                                    // MySQL 8's collation is NO PAD, so "  x  " and "x"
+                                    // are DIFFERENT rows under the unique key — a padded
+                                    // name would then block the clean one as a collision
+                                    // the user cannot see. Collapses newlines too: the
+                                    // field is `multiline` so a pasted two-line string
+                                    // would otherwise store an embedded \n.
+                                    normalize={(text) => text.replace(/\s+/g, ' ').trim()}
+                                    validate={(text) => documentNameError(text, documents, row.id)}
+                                    onCommit={commitField(row, 'name', 'document name')}
+                                    onErrorChange={noteFieldError(row.id, 'name')}
+                                    inputProps={{ maxLength: DOCUMENT_NAME_MAX }}
+                                    sx={{
+                                        fontSize: '1.4rem',
+                                        fontWeight: 500,
+                                        '& .MuiInputBase-input': {
+                                            fontSize: '1.4rem',
+                                            fontWeight: 500,
+                                        },
+                                    }}
+                                    testId={`document-name-input-${row.id}`}
+                                />
+                                {href && (
+                                    <Tooltip title="Open the document in a new tab">
+                                        <IconButton
+                                            size="small"
+                                            component="a"
+                                            href={href}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            sx={{ maxWidth: '25px', maxHeight: '25px' }}
+                                            data-testid={`document-open-link-${row.id}`}
+                                        >
+                                            <OpenInNewIcon fontSize="small" />
+                                        </IconButton>
+                                    </Tooltip>
+                                )}
+                                <Tooltip title="Document options">
+                                    <IconButton
+                                        size="small"
+                                        onClick={(e) => setMenuAnchor({ id: row.id, el: e.currentTarget })}
+                                        sx={{ maxWidth: '25px', maxHeight: '25px' }}
+                                        data-testid={`document-card-menu-${row.id}`}
+                                    >
+                                        <MoreVertIcon fontSize="small" />
+                                    </IconButton>
+                                </Tooltip>
+                                <Menu
+                                    anchorEl={menuAnchor?.el}
+                                    open={menuAnchor?.id === row.id}
+                                    onClose={closeMenu}
+                                    anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                                    transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                                    slotProps={{ list: { 'data-testid': `document-card-menu-popup-${row.id}` } }}
+                                >
+                                    {row.closed ? (
+                                        <MenuItem onClick={() => menuReopenDocument(row)}
+                                                  data-testid={`document-menu-reopen-${row.id}`}>
+                                            <ListItemIcon><UnarchiveIcon fontSize="small" /></ListItemIcon>
+                                            <ListItemText>Reopen document</ListItemText>
+                                        </MenuItem>
+                                    ) : (
+                                        <MenuItem onClick={() => menuCloseDocument(row)}
+                                                  data-testid={`document-menu-close-${row.id}`}>
+                                            <ListItemIcon><CloseIcon fontSize="small" /></ListItemIcon>
+                                            {/* Ellipsis = opens the dialog, because
+                                                this row is linked and the agents it
+                                                would unload from must be shown. */}
+                                            <ListItemText>
+                                                {row.links.length === 0
+                                                    ? 'Close document'
+                                                    : 'Close document…'}
+                                            </ListItemText>
+                                        </MenuItem>
+                                    )}
+                                    <Divider />
+                                    <MenuItem onClick={() => menuDeleteDocument(row)}
+                                              sx={{ color: 'error.main' }}
+                                              data-testid={`document-menu-delete-${row.id}`}>
+                                        <ListItemIcon>
+                                            <DeleteForeverIcon fontSize="small" sx={{ color: 'error.main' }} />
+                                        </ListItemIcon>
+                                        <ListItemText>Delete registration…</ListItemText>
+                                    </MenuItem>
+                                </Menu>
+                            </Box>
+
+                            {/* Type + accounting. The doc_type chips are Darwin's
+                                shipped in-place editor for a short closed
+                                vocabulary (RequirementDetail's Model / Effort /
+                                Machine): selected is filled, unselected is
+                                outlined and faded, one click writes.
+
+                                A CHIP ROW RATHER THAN A SELECT is a correctness
+                                choice, not a stylistic one. `doc_type` is
+                                VARCHAR(16) with no DB constraint and the MCP's
+                                VALID_DOC_TYPES never runs for a browser write — so
+                                the client is the only guard, and a chip row makes
+                                an illegal value structurally unreachable. Writing
+                                on click is safe here (unlike the link roles): it is
+                                a single-column PUT on a row that HAS an id, and it
+                                is undone by clicking the previous chip. */}
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5,
+                                       flexWrap: 'wrap', mb: 1 }}>
+                                {DOC_TYPES.map(t => {
+                                    const on = row.doc_type === t;
+                                    return (
+                                        <Chip
+                                            key={t}
+                                            label={t}
+                                            size="small"
+                                            clickable
+                                            onClick={() => setDocType(row, t)}
+                                            {...(on
+                                                ? docTypeChipProps(t)
+                                                : { variant: 'outlined', sx: { opacity: 0.55 } })}
+                                            data-testid={`document-type-${row.id}-${t}`}
+                                        />
+                                    );
+                                })}
+                                {/* A stored value outside the vocabulary can only
+                                    have come from outside this UI, and it would
+                                    otherwise render as three unselected chips with
+                                    no hint that anything is wrong. */}
+                                {row.doc_type && !DOC_TYPES.includes(row.doc_type) && (
+                                    <Chip label={`unknown: ${row.doc_type}`} size="small"
+                                          color="warning" variant="outlined"
+                                          data-testid={`document-type-unknown-${row.id}`} />
+                                )}
+                                <Box sx={{ flex: 1 }} />
+                                {/* `!!` is load-bearing: `closed` is a MySQL
+                                    TINYINT, so it arrives as the NUMBER 0, and
+                                    `0 && <Chip/>` evaluates to 0 — which React
+                                    renders as a literal "0". */}
+                                {!!row.closed && (
+                                    <Chip label="closed" size="small"
+                                          data-testid={`document-closed-${row.id}`} />
+                                )}
+                                {/* With no Save button, "blocked" has no natural
+                                    signal — without this chip the user navigates
+                                    away believing the value was written. */}
+                                {blocked && (
+                                    <Chip label="unsaved" size="small" color="error"
+                                          variant="outlined"
+                                          data-testid={`document-unsaved-${row.id}`} />
+                                )}
+                            </Box>
+
+                            {/* OWNER — its own row, above location and url, because
+                                "who owns this file?" is the question this page
+                                exists to answer. */}
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5,
+                                       flexWrap: 'wrap', rowGap: 0.75, mb: 1.5 }}>
+                                <Typography variant="caption" color="text.secondary"
+                                            sx={{ mr: 0.5 }}>
+                                    Owner
+                                </Typography>
+
+                                {ownerAgent ? (
+                                    <Tooltip title={`${ownerAgent.name} owns this document — click to open its page, ✕ to release`}>
+                                        <Chip
+                                            label={ownerAgent.closed
+                                                ? `${ownerAgent.name} (closed)`
+                                                : ownerAgent.name}
+                                            size="small"
+                                            clickable
+                                            {...relationshipChipProps('owned')}
+                                            onClick={() => navigate(`/agents/${ownerAgent.id}#documents`)}
+                                            onDelete={() => requestOwnerChange(row, null)}
+                                            data-testid={`document-owner-${row.id}`}
+                                            data-agent-closed={ownerAgent.closed ? '1' : '0'}
+                                        />
+                                    </Tooltip>
+                                ) : (
+                                    <Chip label="unowned" size="small" color="error"
+                                          variant="outlined"
+                                          data-testid={`document-unowned-${row.id}`} />
+                                )}
+
+                                {ownerPaletteId === row.id && openAgents
+                                    .filter(a => a.id !== row.owner?.agent_fk)
+                                    .map(a => (
+                                        <Tooltip key={a.id} title={row.owner
+                                            ? `Transfer ownership to ${a.name}`
+                                            : `Make ${a.name} the owner`}>
                                             <Chip
-                                                label={agentIndex.get(doc.owner.agent_fk)?.name || `#${doc.owner.agent_fk}`}
+                                                label={a.name}
                                                 size="small"
-                                                {...relationshipChipProps('owned')}
                                                 clickable
-                                                onClick={() => navigate(`/agents/${doc.owner.agent_fk}#documents`)}
-                                                data-testid={`document-owner-${doc.id}`}
+                                                variant="outlined"
+                                                sx={{ borderStyle: 'dashed', opacity: 0.55,
+                                                      '&:hover': { opacity: 1 } }}
+                                                disabled={membershipBusy}
+                                                onClick={() => (row.owner
+                                                    ? requestOwnerChange(row, a)
+                                                    : claimOwnership(row, a.id))}
+                                                data-testid={`document-owner-claim-${row.id}-${a.id}`}
                                             />
-                                        ) : (
-                                            <Chip label="unowned" size="small" color="error"
-                                                  variant="outlined"
-                                                  data-testid={`document-unowned-${doc.id}`} />
-                                        )}
-                                    </TableCell>
-                                    <TableCell>
-                                        <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
-                                            {others.length === 0
-                                                ? <Typography variant="caption" color="text.secondary">—</Typography>
-                                                : others.map(l => (
-                                                    <Chip
-                                                        key={`${l.agent_fk}-${l.document_fk}`}
-                                                        size="small"
-                                                        label={`${agentIndex.get(l.agent_fk)?.name || `#${l.agent_fk}`} · ${relationshipLabel(l.relationship)}`}
-                                                        {...relationshipChipProps(l.relationship)}
-                                                        clickable
-                                                        onClick={() => navigate(`/agents/${l.agent_fk}#documents`)}
-                                                        data-testid={`document-${doc.id}-agent-${l.agent_fk}`}
-                                                    />
-                                                ))}
-                                        </Stack>
-                                    </TableCell>
-                                </TableRow>
-                            );
-                        })}
-                    </TableBody>
-                </Table>
+                                        </Tooltip>
+                                    ))}
+
+                                <Tooltip title={ownerPaletteId === row.id
+                                    ? 'Hide the roster'
+                                    : (row.owner ? 'Transfer ownership' : 'Assign an owner')}>
+                                    <Chip
+                                        size="small"
+                                        variant="outlined"
+                                        color={ownerPaletteId === row.id ? 'primary' : 'default'}
+                                        icon={ownerPaletteId === row.id
+                                            ? <CloseIcon fontSize="small" />
+                                            : <AddIcon fontSize="small" />}
+                                        label={ownerPaletteId === row.id ? 'done' : 'assign'}
+                                        onClick={() => setOwnerPaletteId(
+                                            id => (id === row.id ? null : row.id))}
+                                        data-testid={`document-owner-add-${row.id}`}
+                                    />
+                                </Tooltip>
+                            </Box>
+
+                            {/* Rendered only while the card really IS unowned, so a
+                                resync that reveals somebody else took it retires
+                                this notice without any extra bookkeeping. A
+                                transient snackbar would be wrong here: the user may
+                                have looked away, and the document stays broken. */}
+                            {ownerAlert && !row.owner && (
+                                <Alert severity="error" sx={{ mb: 1.5, py: 0 }}
+                                       onClose={() => setOwnerAlerts(prev => {
+                                           const next = { ...prev };
+                                           delete next[row.id];
+                                           return next;
+                                       })}
+                                       action={(
+                                           <Chip size="small" color="error" variant="outlined"
+                                                 label={`Retry — give it to ${ownerAlert.to}`}
+                                                 onClick={() => retryOwnerClaim(row)}
+                                                 disabled={membershipBusy}
+                                                 data-testid={`document-owner-retry-${row.id}`} />
+                                       )}
+                                       data-testid={`document-owner-alert-${row.id}`}>
+                                    Ownership was released from {ownerAlert.from || 'the previous owner'},
+                                    but {ownerAlert.to} could not claim it. This document is currently
+                                    unowned.
+                                </Alert>
+                            )}
+
+                            <Box sx={{ mb: 1 }}>
+                                <GhostTextField
+                                    value={row.location || ''}
+                                    outlined
+                                    label="Location"
+                                    fullWidth
+                                    // `required` in the UI although the column is
+                                    // nullable: a registration with no path
+                                    // registers nothing anyone can find, and every
+                                    // live row has one. Deliberately stricter than
+                                    // the schema.
+                                    required
+                                    commitOnEnter
+                                    placeholder="memory/example.md"
+                                    normalize={(text) => text.trim()}
+                                    validate={documentLocationError}
+                                    hint={() => (autoloadReaders(row).length
+                                        ? `${autoloadReaders(row).length} agent${autoloadReaders(row).length === 1 ? '' : 's'} read this file in full at boot — a wrong path fails silently.`
+                                        : null)}
+                                    onCommit={commitLocation(row)}
+                                    onErrorChange={noteFieldError(row.id, 'location')}
+                                    inputProps={{ maxLength: DOCUMENT_LOCATION_MAX }}
+                                    sx={{ '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.8125rem' } }}
+                                    testId={`document-location-input-${row.id}`}
+                                />
+                            </Box>
+
+                            <Box sx={{ mb: 1.5 }}>
+                                <GhostTextField
+                                    value={row.url || ''}
+                                    outlined
+                                    label="URL"
+                                    fullWidth
+                                    commitOnEnter
+                                    placeholder="Blank falls back to the GitHub blob URL"
+                                    normalize={(text) => text.trim()}
+                                    validate={documentUrlError}
+                                    onCommit={commitField(row, 'url', 'URL')}
+                                    onErrorChange={noteFieldError(row.id, 'url')}
+                                    inputProps={{ maxLength: DOCUMENT_URL_MAX }}
+                                    sx={{ '& .MuiInputBase-input': { fontSize: '0.8125rem' } }}
+                                    testId={`document-url-input-${row.id}`}
+                                />
+                            </Box>
+
+                            <DocumentAgentChips
+                                links={row.others}
+                                agentIndex={agentIndex}
+                                bindableAgents={openAgents.filter(a => !linkedIds.has(a.id))}
+                                onBind={(agentId) => bindAgent(row, agentId)}
+                                onBindAll={(agentsToBind) => bindAllAgents(row, agentsToBind)}
+                                onRequestUnbind={(link, agent) => unbindConfirm.openDialog(
+                                    { document: row, agent, link })}
+                                onOpenLink={(link, agent, anchorEl) => setLinkEditor(
+                                    { docId: row.id, agentId: agent.id, anchorEl })}
+                                busy={membershipBusy}
+                                testIdPrefix={`document-${row.id}`}
+                            />
+                          </CardContent>
+                        </Card>
+                    );
+                })}
+
+                {/* The template card. Per instruction #41 an inline-editable list
+                    ends with a blank item the user fills in place — never an
+                    explicit add button. It carries no agent chips: membership needs
+                    a row id, so a new document is linked with its own chips once it
+                    exists, and it appears carrying the red `unowned` badge that
+                    prompts for an owner. */}
+                <Card variant="outlined" sx={{ borderStyle: 'dashed' }}
+                      data-testid="document-row-template">
+                  <CardContent sx={CARD_CONTENT_SX}>
+                    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 1 }}>
+                        <GhostTextField
+                            value={draftName}
+                            onChangeText={setDraftName}
+                            outlined
+                            label="Name"
+                            fullWidth
+                            commitOnEnter
+                            placeholder="New document name"
+                            validate={(text) => documentNameError(text, documents, null)}
+                            onCommit={maybeCreate}
+                            inputProps={{ maxLength: DOCUMENT_NAME_MAX }}
+                            inputRef={templateNameRef}
+                            testId="document-name-input-template"
+                        />
+                        {creating && <CircularProgress size={14} sx={{ mt: 1.5 }} />}
+                    </Box>
+
+                    <Stack direction="row" spacing={0.5} sx={{ mb: 1 }} flexWrap="wrap" useFlexGap>
+                        {DOC_TYPES.map(t => (
+                            <Chip
+                                key={t}
+                                label={t}
+                                size="small"
+                                clickable
+                                onClick={() => setDraftType(t)}
+                                {...(draftType === t
+                                    ? docTypeChipProps(t)
+                                    : { variant: 'outlined', sx: { opacity: 0.55 } })}
+                                data-testid={`document-type-template-${t}`}
+                            />
+                        ))}
+                    </Stack>
+
+                    <Box sx={{ mb: 1 }}>
+                        <GhostTextField
+                            value={draftLocation}
+                            onChangeText={setDraftLocation}
+                            outlined
+                            label="Location"
+                            fullWidth
+                            commitOnEnter
+                            placeholder="memory/new-document.md — the file must already exist"
+                            validate={documentLocationError}
+                            hint={(text) => (draftName.trim() && !text.trim()
+                                ? 'Fill both fields — the row is created when the second one is filled.'
+                                : null)}
+                            onCommit={maybeCreate}
+                            inputProps={{ maxLength: DOCUMENT_LOCATION_MAX }}
+                            sx={{ '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.8125rem' } }}
+                            testId="document-location-input-template"
+                        />
+                    </Box>
+
+                    <GhostTextField
+                        value={draftUrl}
+                        onChangeText={setDraftUrl}
+                        outlined
+                        label="URL (optional)"
+                        fullWidth
+                        commitOnEnter
+                        placeholder="Blank falls back to the GitHub blob URL"
+                        validate={documentUrlError}
+                        onCommit={maybeCreate}
+                        inputProps={{ maxLength: DOCUMENT_URL_MAX }}
+                        sx={{ '& .MuiInputBase-input': { fontSize: '0.8125rem' } }}
+                        testId="document-url-input-template"
+                    />
+                  </CardContent>
+                </Card>
             </Box>
+
+            <DocumentLinkPopover
+                open={!!linkEditor}
+                anchorEl={linkEditor?.anchorEl}
+                onClose={() => setLinkEditor(null)}
+                document={editorRow}
+                agent={linkEditor ? agentIndex.get(linkEditor.agentId) : null}
+                link={editorRow && linkEditor
+                    ? editorRow.links.find(l => l.agent_fk === linkEditor.agentId)
+                    : null}
+                onSave={(next) => saveLink(editorRow, next)}
+                onOpenAgent={(agentId) => navigate(`/agents/${agentId}#documents`)}
+                busy={editorRow ? membershipBusyIds.has(editorRow.id) : false}
+            />
+
+            <DocumentOwnerDialog
+                open={ownerConfirm.dialogOpen}
+                setOpen={ownerConfirm.setDialogOpen}
+                setConfirmed={ownerConfirm.setConfirmed}
+                info={ownerConfirm.infoObject?.document
+                    ? ownerConfirm.infoObject
+                    : lastOwnerInfo.current}
+                keepOutgoing={keepOutgoing}
+                setKeepOutgoing={setKeepOutgoing}
+            />
+
+            <DocumentUnbindDialog
+                open={unbindConfirm.dialogOpen}
+                setOpen={unbindConfirm.setDialogOpen}
+                setConfirmed={unbindConfirm.setConfirmed}
+                info={unbindConfirm.infoObject?.document
+                    ? unbindConfirm.infoObject
+                    : lastUnbindInfo.current}
+            />
+
+            <DocumentLocationDialog
+                open={locationConfirm.dialogOpen}
+                setOpen={locationConfirm.setDialogOpen}
+                setConfirmed={locationConfirm.setConfirmed}
+                info={locationConfirm.infoObject?.document
+                    ? locationConfirm.infoObject
+                    : lastLocationInfo.current}
+            />
+
+            <DocumentDeleteDialog
+                open={!!deleteTarget}
+                onClose={() => { setDeleteTarget(null); setDialogIntent('delete'); }}
+                onCloseDocument={() => setClosedFlag(deleteTarget, 1)}
+                onReopen={() => setClosedFlag(deleteTarget, 0)}
+                onDelete={handleDelete}
+                intent={dialogIntent}
+                document={deleteTarget}
+                // EVERY link, including closed agents' — a hard delete cascades all
+                // of them away, so all of them belong in the warning. The dialog
+                // counts the open autoload ones separately for the "reads it at
+                // boot" wording; data loss and boot impact are different questions.
+                linkedAgents={deleteTarget
+                    ? (byDocument.get(deleteTarget.id) || [])
+                        .map(l => ({ agent: agentIndex.get(l.agent_fk), link: l }))
+                        .filter(x => x.agent)
+                        .map(({ agent, link }) => ({
+                            name: agent.name,
+                            closed: !!agent.closed,
+                            autoload: isAutoload(link.relationship),
+                            owner: hasRole(link.relationship, 'owned'),
+                        }))
+                    : []}
+                busy={busy}
+            />
         </Box>
     );
 };

--- a/src/Agents/DocumentsPage.jsx
+++ b/src/Agents/DocumentsPage.jsx
@@ -1036,6 +1036,12 @@ const DocumentsPage = () => {
                     const ownerAgent = row.owner ? agentIndex.get(row.owner.agent_fk) : null;
                     const linkedIds = new Set(row.links.map(l => l.agent_fk));
                     const ownerAlert = ownerAlerts[row.id];
+                    // Computed ONCE per row: it drives both the location field's
+                    // standing caption and the decision to route that field's
+                    // commit through the confirmation dialog, and calling it from
+                    // inside a `hint` callback would re-walk the links on every
+                    // keystroke.
+                    const readers = autoloadReaders(row);
 
                     return (
                         <Card key={row.id} variant="outlined"
@@ -1331,8 +1337,12 @@ const DocumentsPage = () => {
                                     placeholder="memory/example.md"
                                     normalize={(text) => text.trim()}
                                     validate={documentLocationError}
-                                    hint={() => (autoloadReaders(row).length
-                                        ? `${autoloadReaders(row).length} agent${autoloadReaders(row).length === 1 ? '' : 's'} read this file in full at boot — a wrong path fails silently.`
+                                    // A STANDING caption, not an on-focus one: the
+                                    // fact that agents execute this path is true
+                                    // whether or not anyone is editing it, and it
+                                    // is the reason the commit is gated.
+                                    hint={() => (readers.length
+                                        ? `${readers.length} agent${readers.length === 1 ? '' : 's'} read this file in full at boot — a wrong path fails silently.`
                                         : null)}
                                     onCommit={commitLocation(row)}
                                     onErrorChange={noteFieldError(row.id, 'location')}

--- a/src/Agents/__tests__/DocumentsPage.test.jsx
+++ b/src/Agents/__tests__/DocumentsPage.test.jsx
@@ -1,0 +1,975 @@
+// @vitest-environment jsdom
+//
+// Req #3051 — the WIRING of the editable document card.
+//
+// documentRegistryUtils.test.js pins the pure validators and the ownership
+// planner; documentsApi.test.js pins the REST wire format and the rollback.
+// Neither can see the layer between them, which is where this page's real risk
+// lives: whether the card hands the right arguments to the right action at the
+// right moment.
+//
+// What is only observable HERE:
+//
+//   * THE relationshipsReady HARD STOP. `isLoading` covers only the document
+//     query, and `fetchEntity` rethrows every non-404 — so a 500 on
+//     /agent_documents leaves the junction undefined PERMANENTLY. Every document
+//     would then render as unowned, and a delete dialog would claim zero blast
+//     radius for a document twelve architects read. Both halves are green in
+//     isolation while the page happily renders a lie.
+//   * THE LOCATION CONFIRM GATE. `location` is the most dangerous field on the
+//     page (instruction #83 makes agents execute it at boot, and nothing validates
+//     it), so its commit is intercepted when the document has autoload readers and
+//     written directly when it has none. The graduation is the whole design; a
+//     version that always wrote, or always asked, passes every other test.
+//   * ONE PUT PER FIELD, carrying only that field. rest_put.py is a blind UPDATE
+//     with no version column, so a body with an extra key silently reverts another
+//     tab's edit. Only the page decides what goes in the body.
+//   * THE GRADUATED CLOSE, read from the LIVE row's link count.
+//   * The five data-testids that shipped with the read-only table. They moved from
+//     <tr>/<Table> to <Card>/grid <Box>; the SELECTORS are the contract.
+//
+// Mounted harness with raw react-dom + act — the house pattern (there is no
+// @testing-library in this repo), copied from InstructionsPage.test.jsx. The
+// action module is mocked so assertions are about ARGUMENTS; the data hooks are
+// mocked so a "refetch" is a controlled re-render.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const navigateSpy = vi.fn();
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigateSpy }));
+
+// Module-level query data — mutate then `bump()` to simulate a refetch landing.
+let documentsData = [];
+let agentsData = [];
+let junctionData = [];
+let junctionUndefined = false;
+
+vi.mock('../../hooks/useDataQueries', () => ({
+    useArchitectureDocuments: () => ({ data: documentsData, isLoading: false }),
+    useAgents: () => ({ data: agentsData }),
+    useAgentDocuments: () => ({ data: junctionUndefined ? undefined : junctionData }),
+    architectureDocumentKeys: { all: (c) => ['architecture_documents', c] },
+    agentDocumentKeys: { all: (c) => ['agent_documents', c] },
+}));
+
+vi.mock('../actions/documentsApi', () => ({
+    createArchitectureDocument: vi.fn(),
+    updateArchitectureDocument: vi.fn(),
+    deleteArchitectureDocument: vi.fn(),
+    linkAgentDocument: vi.fn(),
+    linkAgentDocuments: vi.fn(),
+    unlinkAgentDocument: vi.fn(),
+    applyLinkPlan: vi.fn(),
+    setAgentDocumentLink: vi.fn(),
+    // A real class, because the page tests errors with `instanceof`.
+    LinkRollbackError: class LinkRollbackError extends Error {},
+}));
+
+import DocumentsPage from '../DocumentsPage';
+import * as api from '../actions/documentsApi';
+import AppContext from '../../Context/AppContext';
+import AuthContext from '../../Context/AuthContext';
+import { useSnackBarStore } from '../../stores/useSnackBarStore';
+
+const URI = 'http://test.local';
+const TOKEN = 'tok';
+const CREATOR = 'tester';
+
+// ---------------------------------------------------------------------------
+// Fixture.
+//
+//   doc 20 — owned by Alpha with `autoload`, plus a `referenced` link from Bravo.
+//            The AUTOLOAD reader is what makes it the location-confirm case, and
+//            two links is what triggers the delete challenge.
+//   doc 21 — UNOWNED and unlinked: the other side of every graduated branch, and
+//            the state the registry exists to surface.
+//   doc 22 — owned by Bravo with NO autoload link, so its location writes直接.
+//            (Also proves the confirm gate is per-document, not per-page.)
+// ---------------------------------------------------------------------------
+const AGENTS = [
+    { id: 1, name: 'Alpha', closed: 0 },
+    { id: 2, name: 'Bravo', closed: 0 },
+    { id: 3, name: 'Charlie', closed: 0 },
+];
+const DOCUMENTS = [
+    { id: 20, name: 'Owned Doc', doc_type: 'markdown', location: 'memory/owned.md',
+      url: null, closed: 0, sort_order: 1, update_ts: '2026-07-02T00:00:00' },
+    { id: 21, name: 'Orphan Doc', doc_type: 'markdown', location: 'memory/orphan.md',
+      url: null, closed: 0, sort_order: 1, update_ts: '2026-07-01T00:00:00' },
+    { id: 22, name: 'Quiet Doc', doc_type: 'html', location: 'docs/quiet.html',
+      url: 'https://example.test/quiet', closed: 0, sort_order: 2, update_ts: null },
+];
+const JUNCTION = [
+    { agent_fk: 1, document_fk: 20, relationship: 'owned,autoload', notes: 'Alpha owns it', sort_order: 1 },
+    { agent_fk: 2, document_fk: 20, relationship: 'referenced', notes: null, sort_order: 4 },
+    { agent_fk: 2, document_fk: 22, relationship: 'owned', notes: null, sort_order: 2 },
+];
+
+let container;
+let root;
+let queryClient;
+let bump;
+
+function Harness() {
+    const [, setTick] = useState(0);
+    bump = () => setTick(t => t + 1);
+    return <DocumentsPage />;
+}
+
+// The REAL cache key the junction query lives under. `agentDocuments` is declared
+// `fieldsInKey: true` in devopsQueries, so the factory appends a `{ fields }`
+// segment — the page's key factory returns only the PREFIX, which is why
+// `freshAgentDocuments` must use `getQueriesData` (prefix match) rather than
+// `getQueryData` (exact). Seeding the FULL key is what keeps that load-bearing:
+// against the bare prefix an exact lookup would find it too, and the test would
+// pass while production fell through to the stale ref.
+const JUNCTION_KEY = ['agent_documents', CREATOR,
+    { fields: 'agent_fk,document_fk,relationship,notes,sort_order' }];
+
+const mount = () => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(JUNCTION_KEY, junctionData);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: URI }}>
+                    <AuthContext.Provider value={{ idToken: TOKEN, profile: { userName: CREATOR } }}>
+                        <Harness />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+};
+
+beforeEach(() => {
+    // A stored sort mode would reorder the cards and break any position-based
+    // read; the page default (Owner, asc) is what these tests assume.
+    localStorage.clear();
+    sessionStorage.clear();
+    junctionUndefined = false;
+    documentsData = DOCUMENTS.map(d => ({ ...d }));
+    agentsData = AGENTS.map(a => ({ ...a }));
+    junctionData = JUNCTION.map(l => ({ ...l }));
+    for (const [name, fn] of Object.entries(api)) {
+        if (typeof fn?.mockReset !== 'function') continue;   // skip the error class
+        fn.mockReset();
+        fn.mockResolvedValue(name === 'unlinkAgentDocument' ? true : {});
+    }
+    api.applyLinkPlan.mockResolvedValue({ applied: 1 });
+    navigateSpy.mockReset();
+    useSnackBarStore.setState({ open: false, message: '' });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.body.innerHTML = '';
+});
+
+// ---------------------------------------------------------------------------
+// DOM helpers. Menus, dialogs and popovers render into portals on document.body,
+// so every lookup is document-wide rather than container-scoped.
+// ---------------------------------------------------------------------------
+const byTestId = (id) => document.querySelector(`[data-testid="${id}"]`);
+
+const click = (el) => act(() => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+});
+
+const clickAsync = async (el) => { await act(async () => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+}); };
+
+// A controlled React input ignores `el.value = x`; the write has to go through the
+// native setter so React's change tracking sees it.
+const typeInto = (el, value) => act(() => {
+    const proto = el instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, 'value').set.call(el, value);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+});
+
+const focus = (el) => act(() => el.focus());
+const blur = async (el) => { await act(async () => { el.blur(); }); };
+const flush = async () => { await act(async () => {
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+}); };
+
+const editField = async (testId, value) => {
+    const el = byTestId(testId);
+    focus(el);
+    typeInto(el, value);
+    await blur(el);
+    await flush();
+};
+
+const openRowMenu = (rowId) => click(byTestId(`document-card-menu-${rowId}`));
+
+const putBodies = () => api.updateArchitectureDocument.mock.calls.map(
+    ([, , id, fields]) => ({ id, fields }));
+
+// ===========================================================================
+
+describe('DocumentsPage — the relationshipsReady hard stop', () => {
+    it('refuses to render the registry when the junction query is unresolved', () => {
+        // Every document would otherwise render as unowned — indistinguishable from
+        // genuine drift — and a delete dialog would report zero blast radius for a
+        // document several architects read in full at boot.
+        junctionUndefined = true;
+        mount();
+
+        expect(byTestId('documents-relationships-error')).toBeTruthy();
+        expect(byTestId('documents-registry')).toBeNull();
+        expect(byTestId('document-row-20')).toBeNull();
+    });
+
+    it('says WHY editing is disabled rather than just failing', () => {
+        junctionUndefined = true;
+        mount();
+        const text = byTestId('documents-relationships-error').textContent;
+        expect(text).toMatch(/who owns each document/i);
+        expect(text).toMatch(/Reload/i);
+    });
+
+    it('renders the registry once the junction resolves', () => {
+        mount();
+        expect(byTestId('documents-relationships-error')).toBeNull();
+        expect(byTestId('documents-registry')).toBeTruthy();
+    });
+});
+
+describe('DocumentsPage — the testids that shipped with the read-only table', () => {
+    // These five are the standing contract. They moved from <tr>/<Table> to
+    // <Card>/grid <Box>; a test reaching for them should not have to care.
+    it('still resolves all five', () => {
+        mount();
+        expect(byTestId('documents-registry')).toBeTruthy();
+        expect(byTestId('document-row-20')).toBeTruthy();
+        expect(byTestId('document-owner-20')).toBeTruthy();
+        expect(byTestId('document-unowned-21')).toBeTruthy();
+        expect(byTestId('document-20-agent-2')).toBeTruthy();
+    });
+
+    it('names the owning agent on the owner chip, not its id', () => {
+        mount();
+        expect(byTestId('document-owner-20').textContent).toMatch(/Alpha/);
+    });
+
+    it('marks a genuinely unowned document, and does NOT give it an owner chip', () => {
+        mount();
+        expect(byTestId('document-unowned-21')).toBeTruthy();
+        expect(byTestId('document-owner-21')).toBeNull();
+    });
+
+    it('keeps the owner OUT of the other-agents chip row — one fact, one place', () => {
+        // Alpha owns doc 20, so it must not also appear as an ordinary link chip.
+        mount();
+        expect(byTestId('document-20-agent-2')).toBeTruthy();    // Bravo, referenced
+        expect(byTestId('document-20-agent-1')).toBeNull();      // Alpha, the owner
+    });
+});
+
+describe('DocumentsPage — one PUT per field, carrying only that field', () => {
+    it('writes ONLY the edited column', async () => {
+        // rest_put.py builds its SET clause from the body's keys and has no version
+        // column, so an extra key silently reverts a concurrent edit to it.
+        mount();
+        await editField('document-name-input-20', 'Renamed Doc');
+
+        expect(putBodies()).toHaveLength(1);
+        const [{ id, fields }] = putBodies();
+        expect(id).toBe(20);
+        expect(Object.keys(fields)).toEqual(['name']);
+        expect(fields.name).toBe('Renamed Doc');
+    });
+
+    it('normalizes a name before storing it — NO PAD collation makes padding a distinct row', async () => {
+        mount();
+        await editField('document-name-input-20', '  Padded   Name  ');
+        expect(putBodies()[0].fields.name).toBe('Padded Name');
+    });
+
+    it('stores an emptied URL as NULL, not as an empty string', async () => {
+        // '' would make documentHref return a dead link instead of falling back to
+        // the constructed GitHub blob URL.
+        mount();
+        await editField('document-url-input-22', '');
+        expect(putBodies()[0].fields).toEqual({ url: null });
+    });
+
+    it('does NOT write a name the validator rejects, and flags the card unsaved', async () => {
+        mount();
+        // 'Orphan Doc' is doc 21's name and the unique key does not exclude closed
+        // rows, so this is a collision the user cannot see the cause of.
+        await editField('document-name-input-20', 'Orphan Doc');
+
+        expect(api.updateArchitectureDocument).not.toHaveBeenCalled();
+        // With no Save button, this chip is the ONLY signal the value was not written.
+        expect(byTestId('document-unsaved-20')).toBeTruthy();
+    });
+
+    it('does NOT write a url with a dangerous scheme', async () => {
+        // documentHref's result goes straight into an anchor href.
+        mount();
+        await editField('document-url-input-22', 'javascript:alert(1)');
+        expect(api.updateArchitectureDocument).not.toHaveBeenCalled();
+        expect(byTestId('document-unsaved-22')).toBeTruthy();
+    });
+});
+
+describe('DocumentsPage — doc_type is a constrained chip row', () => {
+    it('offers exactly the three registry types', () => {
+        mount();
+        for (const t of ['markdown', 'html', 'text']) {
+            expect(byTestId(`document-type-20-${t}`), t).toBeTruthy();
+        }
+    });
+
+    it('writes immediately on click — a single-column PUT on a row that has an id', async () => {
+        mount();
+        await clickAsync(byTestId('document-type-20-html'));
+        expect(putBodies()).toEqual([{ id: 20, fields: { doc_type: 'html' } }]);
+    });
+
+    it('does not write when the already-selected type is clicked again', async () => {
+        mount();
+        await clickAsync(byTestId('document-type-20-markdown'));
+        expect(api.updateArchitectureDocument).not.toHaveBeenCalled();
+    });
+
+    it('surfaces a stored value outside the vocabulary instead of hiding it', () => {
+        // The column is VARCHAR(16), not an ENUM, and the MCP's VALID_DOC_TYPES
+        // never runs for a browser write — so a bad value CAN be in there, and
+        // three unselected chips would give no hint that anything was wrong.
+        documentsData = documentsData.map(
+            d => (d.id === 20 ? { ...d, doc_type: 'mrkdown' } : d));
+        mount();
+        expect(byTestId('document-type-unknown-20')).toBeTruthy();
+        expect(byTestId('document-type-unknown-20').textContent).toMatch(/mrkdown/);
+    });
+});
+
+describe('DocumentsPage — the location confirm gate', () => {
+    it('ASKS before writing when an open agent autoloads the document', async () => {
+        // Instruction #83 makes agents read this path in full at boot and nothing
+        // validates it, so a wrong value fails silently at their next boot.
+        mount();
+        await editField('document-location-input-20', 'memory/moved.md');
+
+        expect(byTestId('documents-location-dialog')).toBeTruthy();
+        expect(api.updateArchitectureDocument).not.toHaveBeenCalled();
+    });
+
+    it('shows the old path, the new path, and names the reader agents', async () => {
+        mount();
+        await editField('document-location-input-20', 'memory/moved.md');
+
+        expect(byTestId('documents-location-old').textContent).toBe('memory/owned.md');
+        expect(byTestId('documents-location-new').textContent).toBe('memory/moved.md');
+        expect(byTestId('documents-location-reader-1')).toBeTruthy();   // Alpha
+        expect(byTestId('documents-location-warning').textContent)
+            .toMatch(/Nothing validates this path/i);
+    });
+
+    it('reverts the field to the STORED value while the dialog is open', async () => {
+        // Nothing has been written, so showing the new value would be a lie.
+        mount();
+        await editField('document-location-input-20', 'memory/moved.md');
+        expect(byTestId('document-location-input-20').value).toBe('memory/owned.md');
+    });
+
+    it('writes once the change is confirmed', async () => {
+        mount();
+        await editField('document-location-input-20', 'memory/moved.md');
+        await clickAsync(byTestId('documents-location-confirm-btn'));
+        await flush();
+
+        expect(putBodies()).toEqual([{ id: 20, fields: { location: 'memory/moved.md' } }]);
+    });
+
+    it('writes NOTHING when the change is cancelled', async () => {
+        mount();
+        await editField('document-location-input-20', 'memory/moved.md');
+        await clickAsync(byTestId('documents-location-cancel-btn'));
+        await flush();
+
+        expect(api.updateArchitectureDocument).not.toHaveBeenCalled();
+        expect(byTestId('document-location-input-20').value).toBe('memory/owned.md');
+    });
+
+    it('does NOT ask when no agent autoloads the document — ceremony needs something to disclose', async () => {
+        // Doc 22 is owned but not autoloaded by anyone. Ceremony with nothing to
+        // disclose trains people to click past ceremony that does.
+        mount();
+        await editField('document-location-input-22', 'docs/moved.html');
+
+        expect(byTestId('documents-location-dialog')).toBeNull();
+        expect(putBodies()).toEqual([{ id: 22, fields: { location: 'docs/moved.html' } }]);
+    });
+
+    it('does NOT ask for a document with no links at all', async () => {
+        mount();
+        await editField('document-location-input-21', 'memory/renamed.md');
+        expect(byTestId('documents-location-dialog')).toBeNull();
+        expect(putBodies()).toEqual([{ id: 21, fields: { location: 'memory/renamed.md' } }]);
+    });
+
+    it('does not write an invalid path, and does not open the dialog for one either', async () => {
+        mount();
+        await editField('document-location-input-20', '/memory/absolute.md');
+        expect(byTestId('documents-location-dialog')).toBeNull();
+        expect(api.updateArchitectureDocument).not.toHaveBeenCalled();
+        expect(byTestId('document-unsaved-20')).toBeTruthy();
+    });
+});
+
+describe('DocumentsPage — the graduated close decision', () => {
+    it('closes an UNLINKED document immediately, with no dialog', async () => {
+        mount();
+        openRowMenu(21);
+
+        // No ellipsis: the label itself is the promise that nothing else happens.
+        expect(byTestId('document-menu-close-21').textContent).toBe('Close document');
+
+        await clickAsync(byTestId('document-menu-close-21'));
+        await flush();
+
+        expect(putBodies()).toEqual([{ id: 21, fields: { closed: 1 } }]);
+        expect(byTestId('documents-delete-dialog')).toBeNull();
+    });
+
+    it('routes a LINKED document through the dialog, writing nothing yet', async () => {
+        mount();
+        openRowMenu(20);
+
+        expect(byTestId('document-menu-close-20').textContent).toBe('Close document…');
+
+        await clickAsync(byTestId('document-menu-close-20'));
+        await flush();
+
+        expect(api.updateArchitectureDocument).not.toHaveBeenCalled();
+        expect(byTestId('documents-delete-dialog')).toBeTruthy();
+    });
+
+    it('titles the dialog by the INTENT it was opened with', async () => {
+        // A dialog headed "Delete …?" opened from a menu item labelled "Close" is a
+        // lie about what the primary button will do.
+        mount();
+        openRowMenu(20);
+        await clickAsync(byTestId('document-menu-close-20'));
+        expect(document.body.textContent).toMatch(/Close “Owned Doc”\?/);
+    });
+});
+
+describe('DocumentsPage — the delete dialog discloses what a delete really costs', () => {
+    const openDelete = async (id) => {
+        openRowMenu(id);
+        await clickAsync(byTestId(`document-menu-delete-${id}`));
+        await flush();
+    };
+
+    it('states FIRST that the file on disk survives', async () => {
+        // The likeliest misconception on the page: this deletes a registration, and
+        // nothing scans disk for unregistered files afterwards.
+        mount();
+        await openDelete(20);
+
+        const note = byTestId('documents-delete-file-note');
+        expect(note).toBeTruthy();
+        expect(note.textContent).toMatch(/not the file/i);
+        expect(note.textContent).toMatch(/memory\/owned\.md/);
+    });
+
+    it('names the owner as unrecoverable, separately from the other links', async () => {
+        mount();
+        await openDelete(20);
+        expect(document.body.textContent).toMatch(/ownership assignment held by Alpha/);
+        expect(document.body.textContent).toMatch(/exists nowhere else/);
+    });
+
+    it('counts BOOT impact separately from data loss', async () => {
+        // Two links cascade away (data), but only the autoload one changes what an
+        // agent knows at boot. Collapsing the two would misstate one of them.
+        mount();
+        await openDelete(20);
+        expect(document.body.textContent).toMatch(/2 agent links cascade away/);
+        expect(document.body.textContent).toMatch(/1 open agent reads this file in full at boot/);
+    });
+
+    it('challenges the delete when the document is autoloaded', async () => {
+        mount();
+        await openDelete(20);
+        expect(byTestId('document-delete-challenge-input')).toBeTruthy();
+        expect(byTestId('document-delete-confirm-btn').disabled).toBe(true);
+    });
+
+    it('enables the delete only once the name is typed EXACTLY', async () => {
+        mount();
+        await openDelete(20);
+
+        typeInto(byTestId('document-delete-challenge-input'), 'Owned Do');
+        expect(byTestId('document-delete-confirm-btn').disabled).toBe(true);
+
+        typeInto(byTestId('document-delete-challenge-input'), 'Owned Doc');
+        expect(byTestId('document-delete-confirm-btn').disabled).toBe(false);
+
+        await clickAsync(byTestId('document-delete-confirm-btn'));
+        await flush();
+        expect(api.deleteArchitectureDocument).toHaveBeenCalledWith(URI, TOKEN, 20);
+    });
+
+    it('does NOT challenge an unlinked document — nothing to disclose', async () => {
+        mount();
+        await openDelete(21);
+        expect(byTestId('document-delete-challenge-input')).toBeNull();
+        expect(byTestId('document-delete-confirm-btn').disabled).toBe(false);
+        expect(document.body.textContent).toMatch(/affects nothing at boot/);
+    });
+
+    it('offers Close as the primary path', async () => {
+        mount();
+        await openDelete(20);
+        expect(byTestId('document-delete-close-btn').textContent).toBe('Close instead');
+    });
+});
+
+describe('DocumentsPage — ownership', () => {
+    const openOwnerPalette = (id) => click(byTestId(`document-owner-add-${id}`));
+
+    it('CLAIMS an unowned document with no dialog — additive, and it repairs a red state', async () => {
+        mount();
+        openOwnerPalette(21);
+        await clickAsync(byTestId('document-owner-claim-21-1'));
+        await flush();
+
+        expect(byTestId('documents-owner-dialog')).toBeNull();
+        expect(api.applyLinkPlan).toHaveBeenCalledTimes(1);
+
+        const [, , steps] = api.applyLinkPlan.mock.calls[0];
+        expect(steps).toHaveLength(1);
+        expect(steps[0].prev).toBeNull();
+        expect(steps[0].agent_fk).toBe(1);
+        expect(steps[0].next.relationship).toBe('owned');
+        // A brand-new link needs a slot, computed from the cache at write time.
+        expect(steps[0].next.sort_order).toBe(2);      // Alpha's max is 1
+    });
+
+    it('ASKS before a TRANSFER — two non-atomic writes with an unowned window', async () => {
+        mount();
+        openOwnerPalette(20);
+        await clickAsync(byTestId('document-owner-claim-20-3'));   // Alpha -> Charlie
+        await flush();
+
+        expect(byTestId('documents-owner-dialog')).toBeTruthy();
+        expect(api.applyLinkPlan).not.toHaveBeenCalled();
+        expect(byTestId('documents-owner-window-warning').textContent)
+            .toMatch(/two writes/i);
+    });
+
+    it('releases BEFORE it claims, and demotes rather than unlinking the incumbent', async () => {
+        mount();
+        openOwnerPalette(20);
+        await clickAsync(byTestId('document-owner-claim-20-3'));
+        await clickAsync(byTestId('documents-owner-confirm-btn'));
+        await flush();
+
+        const [, , steps] = api.applyLinkPlan.mock.calls[0];
+        expect(steps).toHaveLength(2);
+        // Release first — the unique key rejects a second owner.
+        expect(steps[0].agent_fk).toBe(1);
+        expect(steps[0].next.relationship).toBe('autoload');   // keeps its other role
+        expect(steps[0].next.notes).toBe('Alpha owns it');     // and its notes
+        expect(steps[0].next.sort_order).toBe(1);              // and its slot
+        // Then claim.
+        expect(steps[1].agent_fk).toBe(3);
+        expect(steps[1].next.relationship).toBe('owned');
+    });
+
+    it('ASKS before a RELEASE with no successor, and creates the unowned state on confirm', async () => {
+        mount();
+        await clickAsync(byTestId('document-owner-20').querySelector('.MuiChip-deleteIcon'));
+        await flush();
+
+        expect(byTestId('documents-owner-dialog')).toBeTruthy();
+        expect(document.body.textContent).toMatch(/Release ownership/);
+
+        await clickAsync(byTestId('documents-owner-confirm-btn'));
+        await flush();
+
+        const [, , steps] = api.applyLinkPlan.mock.calls[0];
+        expect(steps).toHaveLength(1);
+        expect(steps[0].next.relationship).toBe('autoload');
+    });
+
+    it('raises a STANDING notice when a transfer leaves the document unowned', async () => {
+        // A transient snackbar would be wrong: the user may have looked away, and
+        // the document stays broken until someone acts.
+        api.applyLinkPlan.mockRejectedValue(
+            Object.assign(new Error('boom'), { httpStatus: { httpStatus: 500 } }));
+        mount();
+
+        openOwnerPalette(20);
+        await clickAsync(byTestId('document-owner-claim-20-3'));
+        await clickAsync(byTestId('documents-owner-confirm-btn'));
+        await flush();
+
+        // The junction is unchanged in the fixture, so doc 20 still HAS an owner —
+        // and the alert is conditioned on the card actually being unowned, so it
+        // must stay hidden rather than contradict the chip beside it.
+        expect(byTestId('document-owner-alert-20')).toBeNull();
+    });
+
+    it('renders the standing notice only while the card really IS unowned', async () => {
+        api.applyLinkPlan.mockRejectedValue(
+            Object.assign(new Error('boom'), { httpStatus: { httpStatus: 500 } }));
+        // Simulate the genuinely-stranded case: the release landed, the claim did
+        // not, so the refetch shows no owner.
+        junctionData = junctionData.filter(l => !(l.document_fk === 20 && l.agent_fk === 1));
+        mount();
+
+        openOwnerPalette(20);
+        await clickAsync(byTestId('document-owner-claim-20-3'));
+        await flush();
+
+        // Doc 20 is now unowned in the data, so this is a CLAIM (no dialog).
+        expect(byTestId('document-owner-alert-20')).toBeTruthy();
+        expect(byTestId('document-owner-retry-20')).toBeTruthy();
+        expect(byTestId('document-owner-alert-20').textContent).toMatch(/currently\s+unowned/);
+    });
+});
+
+describe('DocumentsPage — non-owner links', () => {
+    it('links a new agent as `referenced` in one write, with a fresh slot', async () => {
+        // All 32 live non-owner links are plain `referenced`, so the fast path must
+        // not stop for a role choice.
+        mount();
+        click(byTestId('document-20-agent-add'));
+        await clickAsync(byTestId('document-20-bind-3'));
+        await flush();
+
+        expect(api.linkAgentDocument).toHaveBeenCalledTimes(1);
+        const [, , link] = api.linkAgentDocument.mock.calls[0];
+        expect(link).toMatchObject({
+            agent_fk: 3, document_fk: 20, relationship: ['referenced'], notes: null,
+        });
+        expect(link.sort_order).toBe(1);      // Charlie has no links yet
+    });
+
+    it('links ALL remaining agents in ONE array-body call, each with its own slot', async () => {
+        // A loop would be the half-applied-set failure mode; one multi-value INSERT
+        // either lands or does not.
+        mount();
+        click(byTestId('document-21-agent-add'));
+        await clickAsync(byTestId('document-21-agent-bind-all'));
+        await flush();
+
+        expect(api.linkAgentDocuments).toHaveBeenCalledTimes(1);
+        const [, , rows] = api.linkAgentDocuments.mock.calls[0];
+        expect(rows.map(r => r.agent_fk).sort()).toEqual([1, 2, 3]);
+        // Per-agent slots, not one shared value: Alpha's max is 1, Bravo's is 4,
+        // Charlie has none.
+        const slots = Object.fromEntries(rows.map(r => [r.agent_fk, r.sort_order]));
+        expect(slots).toEqual({ 1: 2, 2: 5, 3: 1 });
+    });
+
+    it('confirms before unlinking, and warns when the link is an AUTOLOAD one', async () => {
+        // Doc 22's owner link is not autoload; doc 20's Bravo link is `referenced`.
+        // Use doc 20 + Alpha via the owner row? No — Alpha is the owner. Bravo's
+        // referenced link is the non-autoload case.
+        mount();
+        await clickAsync(byTestId('document-20-agent-2').querySelector('.MuiChip-deleteIcon'));
+        await flush();
+
+        expect(byTestId('documents-unbind-dialog')).toBeTruthy();
+        // `referenced`, so no knowledge is lost and there is no autoload warning.
+        expect(byTestId('documents-unbind-autoload-warning')).toBeNull();
+        expect(api.applyLinkPlan).not.toHaveBeenCalled();
+
+        await clickAsync(byTestId('documents-unbind-confirm-btn'));
+        await flush();
+
+        const [, , steps] = api.applyLinkPlan.mock.calls[0];
+        expect(steps).toEqual([{
+            agent_fk: 2, document_fk: 20,
+            prev: expect.objectContaining({ agent_fk: 2, relationship: 'referenced' }),
+            next: null,
+        }]);
+    });
+
+    it('opens the role/notes editor from the chip body', async () => {
+        mount();
+        await clickAsync(byTestId('document-20-agent-2'));
+        await flush();
+
+        expect(byTestId('document-link-popover-20-2')).toBeTruthy();
+        // `owned` is not offered here — it lives on the owner row.
+        expect(byTestId('document-link-role-20-2-referenced')).toBeTruthy();
+        expect(byTestId('document-link-role-20-2-autoload')).toBeTruthy();
+        expect(byTestId('document-link-role-20-2-owned')).toBeNull();
+    });
+
+    it('stages role changes behind Save rather than writing per click', async () => {
+        // No PUT on this table, so each role change is a DELETE + re-INSERT. Three
+        // clicks would be three destroy-and-recreate cycles for one logical edit.
+        mount();
+        await clickAsync(byTestId('document-20-agent-2'));
+        await clickAsync(byTestId('document-link-role-20-2-autoload'));
+        await flush();
+
+        expect(api.setAgentDocumentLink).not.toHaveBeenCalled();
+
+        await clickAsync(byTestId('document-link-save-20-2'));
+        await flush();
+
+        expect(api.setAgentDocumentLink).toHaveBeenCalledTimes(1);
+        const [, , { prev, next }] = api.setAgentDocumentLink.mock.calls[0];
+        expect(prev.relationship).toBe('referenced');
+        expect(next.relationship).toBe('autoload,referenced');
+        // The agent's per-agent document order belongs to AgentDetail and must
+        // survive a role edit made here.
+        expect(next.sort_order).toBe(4);
+    });
+
+    it('warns when a role edit newly adds autoload', async () => {
+        mount();
+        await clickAsync(byTestId('document-20-agent-2'));
+        await clickAsync(byTestId('document-link-role-20-2-autoload'));
+        await flush();
+        expect(byTestId('document-link-autoload-warning-20-2').textContent)
+            .toMatch(/in full at every boot/);
+    });
+
+    it('disables Save when every role has been unticked', async () => {
+        // An empty SET is a legal value for a NOT NULL SET column, so the database
+        // would accept it and the link would stop meaning anything.
+        mount();
+        await clickAsync(byTestId('document-20-agent-2'));
+        await clickAsync(byTestId('document-link-role-20-2-referenced'));
+        await flush();
+
+        expect(byTestId('document-link-save-20-2').disabled).toBe(true);
+        expect(document.body.textContent).toMatch(/at least one role/);
+    });
+});
+
+describe('DocumentsPage — the template card creates in place', () => {
+    it('waits for BOTH required columns before posting', async () => {
+        mount();
+        await editField('document-name-input-template', 'Brand New');
+        expect(api.createArchitectureDocument).not.toHaveBeenCalled();
+
+        await editField('document-location-input-template', 'memory/brand-new.md');
+        expect(api.createArchitectureDocument).toHaveBeenCalledTimes(1);
+    });
+
+    it('posts the registry defaults and the creator, and NO sort_order', async () => {
+        // The column is incoherent and being retired; inventing a slot would
+        // perpetuate the artifact.
+        mount();
+        await editField('document-name-input-template', 'Brand New');
+        await editField('document-location-input-template', 'memory/brand-new.md');
+
+        const [, , body] = api.createArchitectureDocument.mock.calls[0];
+        expect(body).toEqual({
+            name: 'Brand New',
+            doc_type: 'markdown',
+            location: 'memory/brand-new.md',
+            url: null,
+            creator_fk: CREATOR,
+        });
+        expect(body).not.toHaveProperty('sort_order');
+    });
+
+    it('creates NO agent links — the junction needs an id that does not exist yet', async () => {
+        // This ordering is what retires the two-phase create-then-link failure
+        // mode, where a successful POST followed by a failed link left a row owned
+        // by nobody and a dialog reporting an error.
+        mount();
+        await editField('document-name-input-template', 'Brand New');
+        await editField('document-location-input-template', 'memory/brand-new.md');
+
+        expect(api.linkAgentDocument).not.toHaveBeenCalled();
+        expect(api.linkAgentDocuments).not.toHaveBeenCalled();
+        expect(api.applyLinkPlan).not.toHaveBeenCalled();
+    });
+
+    it('honours a type chosen on the template', async () => {
+        mount();
+        await clickAsync(byTestId('document-type-template-html'));
+        await editField('document-name-input-template', 'Brand New');
+        await editField('document-location-input-template', 'docs/new.html');
+        expect(api.createArchitectureDocument.mock.calls[0][2].doc_type).toBe('html');
+    });
+
+    it('posts ONCE, not twice, when both fields are blurred in turn', async () => {
+        mount();
+        await editField('document-name-input-template', 'Brand New');
+        await editField('document-location-input-template', 'memory/brand-new.md');
+        // Re-blurring the first field must not create a second row.
+        await editField('document-name-input-template', 'Brand New');
+        expect(api.createArchitectureDocument).toHaveBeenCalledTimes(1);
+    });
+
+    it('empties the draft after a successful create, so the next row inherits nothing', async () => {
+        mount();
+        await editField('document-name-input-template', 'Brand New');
+        await editField('document-location-input-template', 'memory/brand-new.md');
+        await flush();
+
+        expect(byTestId('document-name-input-template').value).toBe('');
+        expect(byTestId('document-location-input-template').value).toBe('');
+    });
+
+    it('KEEPS the draft when the create fails, so the next blur retries it', async () => {
+        api.createArchitectureDocument.mockRejectedValue(
+            Object.assign(new Error('boom'), { httpStatus: { httpStatus: 500 } }));
+        mount();
+        await editField('document-name-input-template', 'Brand New');
+        await editField('document-location-input-template', 'memory/brand-new.md');
+        await flush();
+
+        expect(byTestId('document-name-input-template').value).toBe('Brand New');
+
+        api.createArchitectureDocument.mockResolvedValue({});
+        await editField('document-location-input-template', 'memory/brand-new.md');
+        expect(api.createArchitectureDocument).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not post a name that collides with an existing document', async () => {
+        mount();
+        await editField('document-name-input-template', 'Owned Doc');
+        await editField('document-location-input-template', 'memory/whatever.md');
+        expect(api.createArchitectureDocument).not.toHaveBeenCalled();
+    });
+});
+
+describe('DocumentsPage — the viewer header', () => {
+    it('counts the WHOLE catalog, not the filtered rows', () => {
+        mount();
+        const text = byTestId('documents-accounting').textContent;
+        expect(text).toMatch(/3 registered documents/);
+        expect(text).toMatch(/1 with no owner/);
+    });
+
+    it('offers the Unowned filter only when there IS drift to isolate', () => {
+        mount();
+        expect(byTestId('documents-show-unowned')).toBeTruthy();
+    });
+
+    it('hides the Unowned filter when every document has an owner', () => {
+        documentsData = documentsData.filter(d => d.id !== 21);
+        mount();
+        expect(byTestId('documents-show-unowned')).toBeNull();
+    });
+
+    it('filters to unowned rows without changing the accounting line', async () => {
+        mount();
+        await clickAsync(byTestId('documents-show-unowned'));
+
+        expect(byTestId('document-row-21')).toBeTruthy();
+        expect(byTestId('document-row-20')).toBeNull();
+        // V7: a count that changed when you toggled a filter would not be an
+        // accounting line.
+        expect(byTestId('documents-accounting').textContent).toMatch(/3 registered documents/);
+    });
+
+    it('hides the Closed filter until a closed row exists', () => {
+        mount();
+        expect(byTestId('documents-show-closed')).toBeNull();
+
+        act(() => root.unmount());
+        documentsData = documentsData.map(d => (d.id === 21 ? { ...d, closed: 1 } : d));
+        root = createRoot(container);
+        mount();
+        expect(byTestId('documents-show-closed')).toBeTruthy();
+    });
+
+    it('keeps sort behind the gear, not in a chip row (V4)', () => {
+        mount();
+        click(byTestId('documents-settings-button'));
+        expect(byTestId('documents-sort-menu')).toBeTruthy();
+        expect(byTestId('documents-sort-owner')).toBeTruthy();
+    });
+
+    it('reverses when the ACTIVE mode is picked again, and stays open to show it', async () => {
+        mount();
+        click(byTestId('documents-settings-button'));
+        await clickAsync(byTestId('documents-sort-owner'));
+        // The arrow is the only affordance saying a second click reverses it, so
+        // the menu must remain open.
+        expect(byTestId('documents-sort-menu')).toBeTruthy();
+    });
+
+    it('renders the view toggle even with a single view, to hold the title anchor', () => {
+        mount();
+        expect(byTestId('documents-view-toggle')).toBeTruthy();
+        expect(byTestId('view-toggle-cards')).toBeTruthy();
+    });
+});
+
+describe('DocumentsPage — closed rows', () => {
+    it('renders a closed chip as a CHIP, never as a literal 0', () => {
+        // `closed` is a MySQL TINYINT, so it arrives as the number 0 and
+        // `0 && <Chip/>` renders "0".
+        documentsData = documentsData.map(d => (d.id === 21 ? { ...d, closed: 1 } : d));
+        mount();
+        click(byTestId('documents-show-closed'));
+        expect(byTestId('document-closed-21')).toBeTruthy();
+        expect(byTestId('document-row-20').textContent).not.toMatch(/^0/);
+    });
+
+    it('hides closed rows by default and offers Reopen rather than Close', async () => {
+        documentsData = documentsData.map(d => (d.id === 21 ? { ...d, closed: 1 } : d));
+        mount();
+        expect(byTestId('document-row-21')).toBeNull();
+
+        await clickAsync(byTestId('documents-show-closed'));
+        openRowMenu(21);
+        expect(byTestId('document-menu-reopen-21')).toBeTruthy();
+        expect(byTestId('document-menu-close-21')).toBeNull();
+
+        await clickAsync(byTestId('document-menu-reopen-21'));
+        await flush();
+        expect(putBodies()).toEqual([{ id: 21, fields: { closed: 0 } }]);
+    });
+});
+
+describe('DocumentsPage — drill-through', () => {
+    it('sends the owner chip to that agent\'s documents section', async () => {
+        mount();
+        await clickAsync(byTestId('document-owner-20'));
+        expect(navigateSpy).toHaveBeenCalledWith('/agents/1#documents');
+    });
+
+    it('links out to the document itself, since the name is now an editable heading', () => {
+        // The name used to BE the external link; making it editable would have
+        // silently removed the page's most-used affordance.
+        const link = byTestId('document-open-link-20');
+        expect(link).toBeNull();     // not yet mounted
+        mount();
+        const el = byTestId('document-open-link-20');
+        expect(el).toBeTruthy();
+        expect(el.getAttribute('href'))
+            .toBe('https://github.com/BillWilliams79/DarwinAI-Config/blob/main/memory/owned.md');
+        expect(el.getAttribute('target')).toBe('_blank');
+        expect(el.getAttribute('rel')).toMatch(/noopener/);
+    });
+
+    it('prefers a stored url over the constructed blob url', () => {
+        mount();
+        expect(byTestId('document-open-link-22').getAttribute('href'))
+            .toBe('https://example.test/quiet');
+    });
+});

--- a/src/Agents/__tests__/documentRegistryUtils.test.js
+++ b/src/Agents/__tests__/documentRegistryUtils.test.js
@@ -17,7 +17,7 @@ import {
     documentNameTaken, documentNameError, documentLocationError,
     documentUrlError, documentNotesError, docTypeError,
     documentOwnerLink, nextDocumentSortOrder, planOwnerTransfer,
-    charLength, restErrorMessage, relationshipLabel,
+    charLength, restErrorMessage, relationshipLabel, documentHref,
     DOCUMENT_NAME_MAX, DOCUMENT_LOCATION_MAX, DOCUMENT_URL_MAX, DOCUMENT_NOTES_MAX,
 } from '../agentRegistryUtils';
 
@@ -262,6 +262,56 @@ describe('documentUrlError guards a stored-href sink', () => {
     it('rejects over the column width', () => {
         expect(documentUrlError(`https://x.test/${'a'.repeat(DOCUMENT_URL_MAX)}`))
             .toMatch(/Too long/);
+    });
+});
+
+describe('documentHref refuses a dangerous scheme AT THE RENDER BOUNDARY', () => {
+    // documentUrlError guards this UI's writes, but it is not the only writer:
+    // the MCP daemon's update_architecture_document accepts `url` with no scheme
+    // check, and rows predate both. Rendering is where the harm happens — every
+    // consumer feeds this into an anchor href, and React does not sanitize a
+    // javascript: URL, it only warns in development.
+    const BLOB = 'https://github.com/BillWilliams79/DarwinAI-Config/blob/main/memory/a.md';
+
+    it('falls back to the blob URL for javascript:, rather than returning it', () => {
+        expect(documentHref({ url: 'javascript:alert(1)', location: 'memory/a.md' })).toBe(BLOB);
+    });
+
+    it('falls back for data: and file: too', () => {
+        expect(documentHref({ url: 'data:text/html,<script>', location: 'memory/a.md' })).toBe(BLOB);
+        expect(documentHref({ url: 'file:///etc/passwd', location: 'memory/a.md' })).toBe(BLOB);
+    });
+
+    it('is not fooled by case or leading whitespace', () => {
+        expect(documentHref({ url: '  JaVaScRiPt:alert(1)', location: 'memory/a.md' })).toBe(BLOB);
+    });
+
+    it('FALLS THROUGH rather than going dead — one bad column must not remove the link', () => {
+        // Returning null would silently strip the page's most-used affordance.
+        expect(documentHref({ url: 'javascript:alert(1)', location: 'memory/a.md' }))
+            .not.toBeNull();
+    });
+
+    it('returns null only when there is genuinely nowhere to go', () => {
+        expect(documentHref({ url: 'javascript:alert(1)', location: null })).toBeNull();
+        expect(documentHref({})).toBeNull();
+        expect(documentHref(null)).toBeNull();
+    });
+
+    it('still honours a legitimate stored url', () => {
+        expect(documentHref({ url: 'https://example.test/a', location: 'memory/a.md' }))
+            .toBe('https://example.test/a');
+        expect(documentHref({ url: 'http://example.test/a', location: 'memory/a.md' }))
+            .toBe('http://example.test/a');
+    });
+
+    it('allows a protocol-relative and a root-relative url', () => {
+        expect(documentHref({ url: '//example.test/a' })).toBe('//example.test/a');
+        expect(documentHref({ url: '/docs/a.html' })).toBe('/docs/a.html');
+    });
+
+    it('constructs the blob URL from location when url is absent', () => {
+        expect(documentHref({ location: 'memory/a.md' })).toBe(BLOB);
     });
 });
 

--- a/src/Agents/__tests__/documentRegistryUtils.test.js
+++ b/src/Agents/__tests__/documentRegistryUtils.test.js
@@ -1,0 +1,584 @@
+// Req #3051 — the pure helpers behind the editable documents registry.
+//
+// Its own file rather than more cases in agentRegistryUtils.test.js: that file is
+// already the instruction-side contract, and the two sets of validators differ in
+// ways that matter (characters vs bytes, SET vs scalar). Keeping them apart stops
+// a reader assuming a rule proven for one applies to the other.
+//
+// Everything here is a pure function, which is the whole reason these tests are
+// worth more than their length: each one encodes a database behaviour that fails
+// SILENTLY in production, so a unit test is the only place the failure is ever
+// loud.
+
+import { describe, it, expect } from 'vitest';
+
+import {
+    parseRoles, serializeRoles, relationshipSetError, relationshipSetHint,
+    documentNameTaken, documentNameError, documentLocationError,
+    documentUrlError, documentNotesError, docTypeError,
+    documentOwnerLink, nextDocumentSortOrder, planOwnerTransfer,
+    charLength, restErrorMessage, relationshipLabel,
+    DOCUMENT_NAME_MAX, DOCUMENT_LOCATION_MAX, DOCUMENT_URL_MAX, DOCUMENT_NOTES_MAX,
+} from '../agentRegistryUtils';
+
+// ---------------------------------------------------------------------------
+// serializeRoles — the single highest-consequence helper in the change.
+//
+// `agent_documents.relationship` is a MySQL SET and RDS runs a NON-STRICT
+// sql_mode, so a member MySQL does not recognise does not raise: the whole
+// assignment stores as ''. A link with an empty SET is not owned, not autoloaded
+// and not referenced — it renders as a bland dash and a document silently loses
+// its owner. A single space is enough to cause it.
+// ---------------------------------------------------------------------------
+
+describe('serializeRoles (req #3051)', () => {
+    it('joins with a BARE comma — a space would empty the SET', () => {
+        expect(serializeRoles(['owned', 'autoload'])).toBe('owned,autoload');
+        expect(serializeRoles(['owned', 'autoload'])).not.toMatch(/\s/);
+    });
+
+    it('emits precedence order regardless of input order, so equal sets store identically', () => {
+        expect(serializeRoles(['autoload', 'owned'])).toBe('owned,autoload');
+        expect(serializeRoles(['owned', 'autoload'])).toBe('owned,autoload');
+        expect(serializeRoles(['referenced', 'curated'])).toBe('curated,referenced');
+    });
+
+    it('drops members MySQL would not recognise rather than passing them through', () => {
+        // Passing 'onwed' through would store '' — losing the three GOOD roles
+        // alongside the typo. Dropping it keeps the rest.
+        expect(serializeRoles(['owned', 'onwed', 'autoload'])).toBe('owned,autoload');
+    });
+
+    it('de-duplicates', () => {
+        expect(serializeRoles(['owned', 'owned', 'autoload'])).toBe('owned,autoload');
+    });
+
+    it('trims members, so a hand-split string cannot smuggle in a space', () => {
+        expect(serializeRoles([' owned', 'autoload '])).toBe('owned,autoload');
+    });
+
+    it('survives a round trip through relationshipLabel, which is DISPLAY-only', () => {
+        // This is the exact bug the helper exists to prevent: relationshipLabel
+        // joins with ", " for humans, and sending its output to the API stores ''.
+        const label = relationshipLabel('owned,autoload');
+        expect(label).toBe('owned, autoload');            // display form has a space
+        expect(serializeRoles(label)).toBe('owned,autoload');   // wire form does not
+        expect(serializeRoles(label)).not.toMatch(/\s/);
+    });
+
+    it('accepts a stored SET string as well as an array', () => {
+        expect(serializeRoles('owned,autoload')).toBe('owned,autoload');
+    });
+
+    it('returns an empty string for an empty or fully-unknown set', () => {
+        expect(serializeRoles([])).toBe('');
+        expect(serializeRoles(['nonsense'])).toBe('');
+    });
+
+    it('is the exact inverse of parseRoles', () => {
+        for (const stored of ['owned', 'referenced', 'owned,autoload', 'curated,referenced']) {
+            expect(serializeRoles(parseRoles(stored))).toBe(stored);
+        }
+    });
+});
+
+describe('relationshipSetError', () => {
+    it('rejects an EMPTY set — a NOT NULL SET accepts \'\', so the DB would not', () => {
+        // There is no stored value to fall back to either: the roles ARE the link.
+        expect(relationshipSetError([])).toMatch(/at least one role/);
+    });
+
+    it('rejects an unknown member by name', () => {
+        expect(relationshipSetError(['owned', 'onwed'])).toMatch(/onwed/);
+    });
+
+    it('blocks owned + referenced as self-referential', () => {
+        // Instruction #83 makes an owned document outrank a referenced one, so a
+        // link carrying both makes the precedence rule refer to itself.
+        expect(relationshipSetError(['owned', 'referenced'])).toMatch(/cannot be both/);
+    });
+
+    it('allows every combination production actually uses', () => {
+        expect(relationshipSetError(['owned', 'autoload'])).toBeNull();
+        expect(relationshipSetError(['referenced'])).toBeNull();
+        expect(relationshipSetError(['owned'])).toBeNull();
+        expect(relationshipSetError(['curated', 'referenced'])).toBeNull();
+        expect(relationshipSetError(['autoload'])).toBeNull();
+    });
+});
+
+describe('relationshipSetHint', () => {
+    it('flags owned + curated as redundant WITHOUT blocking it', () => {
+        expect(relationshipSetHint(['owned', 'curated'])).toMatch(/Redundant/);
+        expect(relationshipSetError(['owned', 'curated'])).toBeNull();
+    });
+
+    it('says nothing about an ordinary set', () => {
+        expect(relationshipSetHint(['owned', 'autoload'])).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Length validation — CHARACTERS, not UTF-16 units.
+// ---------------------------------------------------------------------------
+
+describe('charLength counts what MySQL counts', () => {
+    it('counts an astral character as ONE, where String.length counts two', () => {
+        const emoji = '😀';
+        expect(emoji.length).toBe(2);        // UTF-16 code units
+        expect(charLength(emoji)).toBe(1);   // utf8mb4 characters
+    });
+
+    it('treats null and undefined as empty', () => {
+        expect(charLength(null)).toBe(0);
+        expect(charLength(undefined)).toBe(0);
+    });
+});
+
+describe('documentNameError measures the column the way MySQL does', () => {
+    it('accepts a name of exactly the column width in CHARACTERS', () => {
+        const name = '😀'.repeat(DOCUMENT_NAME_MAX);       // 256 chars, 512 units
+        expect(charLength(name)).toBe(DOCUMENT_NAME_MAX);
+        expect(documentNameError(name, [])).toBeNull();
+    });
+
+    it('rejects one character over', () => {
+        const name = '😀'.repeat(DOCUMENT_NAME_MAX + 1);
+        expect(documentNameError(name, [])).toMatch(/Too long/);
+    });
+
+    it('does NOT reject a legal name whose String.length is over the limit', () => {
+        // The bug this pins: `.length` on 200 emoji is 400, which a naive check
+        // would reject even though MySQL stores it happily.
+        const name = '😀'.repeat(200);
+        expect(name.length).toBeGreaterThan(DOCUMENT_NAME_MAX);
+        expect(documentNameError(name, [])).toBeNull();
+    });
+
+    it('treats an empty name as "abandon the edit", not as an error', () => {
+        // `name` is NOT NULL, so an in-place field reverts. Reporting it would
+        // leave a red field the user can only clear by retyping what was there.
+        expect(documentNameError('   ', [])).toBeNull();
+    });
+});
+
+describe('documentNameTaken', () => {
+    // uq_architecture_documents_name does NOT exclude closed rows, so the check
+    // must run against the UNFILTERED catalog — colliding with an invisible
+    // closed row is the confusing failure this prevents.
+    const catalog = [
+        { id: 1, name: 'Agents Registry', closed: 0 },
+        { id: 2, name: 'Retired Notes', closed: 1 },
+    ];
+
+    it('matches case-insensitively, as the server collation does', () => {
+        expect(documentNameTaken('agents registry', catalog)).toBe(true);
+    });
+
+    it('matches on the trimmed value — MySQL 8 collation is NO PAD', () => {
+        expect(documentNameTaken('  Agents Registry  ', catalog)).toBe(true);
+    });
+
+    it('collides with a CLOSED row, which the page hides by default', () => {
+        expect(documentNameTaken('Retired Notes', catalog)).toBe(true);
+        expect(documentNameError('Retired Notes', catalog)).toMatch(/may be closed/);
+    });
+
+    it('does not collide a row with itself', () => {
+        expect(documentNameTaken('Agents Registry', catalog, 1)).toBe(false);
+    });
+
+    it('allows a genuinely new name', () => {
+        expect(documentNameTaken('Brand New Doc', catalog)).toBe(false);
+    });
+});
+
+describe('documentLocationError', () => {
+    it('accepts a repo-relative path', () => {
+        expect(documentLocationError('memory/agents-registry.md')).toBeNull();
+    });
+
+    it('accepts empty — the column is nullable and `url` may carry the link', () => {
+        expect(documentLocationError('')).toBeNull();
+        expect(documentLocationError(null)).toBeNull();
+    });
+
+    it('rejects a leading slash', () => {
+        // documentHref interpolates this into a GitHub blob URL, where an absolute
+        // path produces a double slash and a 404.
+        expect(documentLocationError('/memory/foo.md')).toMatch(/no leading slash/);
+    });
+
+    it('rejects a .. segment', () => {
+        expect(documentLocationError('memory/../../etc/passwd')).toMatch(/cannot be resolved/);
+    });
+
+    it('rejects embedded whitespace — the commonest silent typo', () => {
+        expect(documentLocationError('memory/ foo.md')).toMatch(/whitespace/);
+    });
+
+    it('rejects over the column width, in characters', () => {
+        expect(documentLocationError('a'.repeat(DOCUMENT_LOCATION_MAX + 1)))
+            .toMatch(/Too long/);
+        expect(documentLocationError('a'.repeat(DOCUMENT_LOCATION_MAX))).toBeNull();
+    });
+});
+
+describe('documentUrlError guards a stored-href sink', () => {
+    // `documentHref` returns `url` verbatim and the page renders it straight into
+    // an anchor href. While the column was read-only that was inert — the only
+    // writer was a seed. Making it editable turns it into a stored-script sink.
+    it('rejects javascript:', () => {
+        expect(documentUrlError('javascript:alert(1)')).toMatch(/Only http and https/);
+    });
+
+    it('rejects data:', () => {
+        expect(documentUrlError('data:text/html;base64,PHNjcmlwdD4='))
+            .toMatch(/Only http and https/);
+    });
+
+    it('rejects an unexpected novel scheme by DEFAULT, rather than blocklisting', () => {
+        expect(documentUrlError('vbscript:msgbox(1)')).toMatch(/Only http and https/);
+        expect(documentUrlError('file:///etc/passwd')).toMatch(/Only http and https/);
+    });
+
+    it('is not fooled by case or leading whitespace', () => {
+        expect(documentUrlError('  JavaScript:alert(1)')).toMatch(/Only http and https/);
+    });
+
+    it('allows http and https', () => {
+        expect(documentUrlError('https://github.com/x/y/blob/main/a.md')).toBeNull();
+        expect(documentUrlError('http://example.test/a')).toBeNull();
+    });
+
+    it('allows a scheme-less relative path — same-origin and harmless', () => {
+        expect(documentUrlError('/docs/a.html')).toBeNull();
+    });
+
+    it('allows empty — NULL is a real value that falls back to the blob URL', () => {
+        expect(documentUrlError('')).toBeNull();
+    });
+
+    it('rejects over the column width', () => {
+        expect(documentUrlError(`https://x.test/${'a'.repeat(DOCUMENT_URL_MAX)}`))
+            .toMatch(/Too long/);
+    });
+});
+
+describe('documentNotesError', () => {
+    it('accepts up to the column width and rejects beyond it', () => {
+        expect(documentNotesError('a'.repeat(DOCUMENT_NOTES_MAX))).toBeNull();
+        expect(documentNotesError('a'.repeat(DOCUMENT_NOTES_MAX + 1))).toMatch(/Too long/);
+    });
+
+    it('accepts empty', () => {
+        expect(documentNotesError('')).toBeNull();
+    });
+});
+
+describe('docTypeError is the ONLY guard on doc_type', () => {
+    // The column is VARCHAR(16), not an ENUM, and VALID_DOC_TYPES lives only in
+    // the MCP daemon — which a browser write never passes through. A typo would
+    // store fine and render as an ordinary chip.
+    it('accepts the three registry types', () => {
+        expect(docTypeError('markdown')).toBeNull();
+        expect(docTypeError('html')).toBeNull();
+        expect(docTypeError('text')).toBeNull();
+    });
+
+    it('rejects a near-miss typo', () => {
+        expect(docTypeError('mrkdown')).toMatch(/Unknown document type/);
+    });
+
+    it('rejects empty and undefined', () => {
+        expect(docTypeError('')).toMatch(/Unknown document type/);
+        expect(docTypeError(undefined)).toMatch(/Unknown document type/);
+    });
+});
+
+describe('documentOwnerLink', () => {
+    it('finds the link carrying `owned` among several roles', () => {
+        const links = [
+            { agent_fk: 1, relationship: 'referenced' },
+            { agent_fk: 2, relationship: 'owned,autoload' },
+        ];
+        expect(documentOwnerLink(links).agent_fk).toBe(2);
+    });
+
+    it('returns null for a genuinely unowned document', () => {
+        expect(documentOwnerLink([{ agent_fk: 1, relationship: 'referenced' }])).toBeNull();
+    });
+
+    it('returns null for a link whose SET was silently emptied', () => {
+        // The '' corruption state. It must read as unowned rather than as owned,
+        // because that is what the database actually holds.
+        expect(documentOwnerLink([{ agent_fk: 1, relationship: '' }])).toBeNull();
+    });
+});
+
+describe('nextDocumentSortOrder', () => {
+    const links = new Map([[7, [{ sort_order: 1 }, { sort_order: 4 }]]]);
+
+    it('is max + 1', () => {
+        expect(nextDocumentSortOrder(7, links)).toBe(5);
+    });
+
+    it('is 1-indexed for an agent with no links yet', () => {
+        expect(nextDocumentSortOrder(99, links)).toBe(1);
+    });
+
+    it('ignores NULL slots rather than treating them as zero', () => {
+        const withNulls = new Map([[7, [{ sort_order: null }, { sort_order: 2 }]]]);
+        expect(nextDocumentSortOrder(7, withNulls)).toBe(3);
+    });
+
+    it('is 1 when every stored slot is NULL', () => {
+        expect(nextDocumentSortOrder(7, new Map([[7, [{ sort_order: null }]]]))).toBe(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// planOwnerTransfer — the only multi-write action on the page.
+// ---------------------------------------------------------------------------
+
+describe('planOwnerTransfer', () => {
+    const owner = {
+        agent_fk: 2, document_fk: 10, relationship: 'owned,autoload',
+        notes: 'why agent 2 owns it', sort_order: 3,
+    };
+    const ownerOnly = {
+        agent_fk: 2, document_fk: 10, relationship: 'owned',
+        notes: 'sole role', sort_order: 3,
+    };
+
+    it('releases BEFORE it claims — the unique key forces the order', () => {
+        // uq_agent_documents_owner rejects the incoming claim while the incumbent
+        // still holds `owned`, so a claim-first plan could never commit.
+        const steps = planOwnerTransfer({
+            documentId: 10, fromLink: owner, toLink: null, toAgentId: 5,
+        });
+        expect(steps).toHaveLength(2);
+        expect(steps[0].agent_fk).toBe(2);      // release
+        expect(steps[1].agent_fk).toBe(5);      // claim
+    });
+
+    it('DEMOTES a multi-role incumbent rather than unlinking it', () => {
+        // An owned,autoload owner very likely still reads the file at boot.
+        // Dropping the link would be a second change nobody asked for.
+        const [release] = planOwnerTransfer({
+            documentId: 10, fromLink: owner, toLink: null, toAgentId: 5,
+        });
+        expect(release.next).not.toBeNull();
+        expect(release.next.relationship).toBe('autoload');
+    });
+
+    it('PRESERVES notes and sort_order verbatim on the demoted link', () => {
+        // There is no PUT on this table, so the release is a DELETE and a fresh
+        // INSERT. An INSERT that omits these does not leave them alone — it writes
+        // NULL over them. This is the quietest way to lose data on the page.
+        const [release] = planOwnerTransfer({
+            documentId: 10, fromLink: owner, toLink: null, toAgentId: 5,
+        });
+        expect(release.next.notes).toBe('why agent 2 owns it');
+        expect(release.next.sort_order).toBe(3);
+    });
+
+    it('parks an owner-ONLY link at referenced when keepOutgoing is true', () => {
+        // Its notes die with the link otherwise, and 87 of 100 live links carry one.
+        const [release] = planOwnerTransfer({
+            documentId: 10, fromLink: ownerOnly, toLink: null, toAgentId: 5,
+            keepOutgoing: true,
+        });
+        expect(release.next.relationship).toBe('referenced');
+        expect(release.next.notes).toBe('sole role');
+        expect(release.next.sort_order).toBe(3);
+    });
+
+    it('removes an owner-ONLY link entirely when keepOutgoing is false', () => {
+        const [release] = planOwnerTransfer({
+            documentId: 10, fromLink: ownerOnly, toLink: null, toAgentId: 5,
+            keepOutgoing: false,
+        });
+        expect(release.next).toBeNull();
+        expect(release.prev).toBe(ownerOnly);   // still rollback-able
+    });
+
+    it('REPLACES referenced when claiming, rather than stacking with it', () => {
+        // The defect this pins: a blind union produced 'owned,referenced', which
+        // relationshipSetError blocks — so the planner built a role set the
+        // codebase itself rejects. All 32 live non-owner links are plain
+        // `referenced`, making this the commonest transfer target of all.
+        const toLink = {
+            agent_fk: 5, document_fk: 10, relationship: 'referenced',
+            notes: 'agent 5 consults it', sort_order: 9,
+        };
+        const steps = planOwnerTransfer({
+            documentId: 10, fromLink: owner, toLink, toAgentId: 5,
+        });
+        const claim = steps[1];
+        expect(claim.next.relationship).toBe('owned');
+        expect(claim.next.notes).toBe('agent 5 consults it');
+        expect(claim.next.sort_order).toBe(9);
+    });
+
+    it('MERGES autoload and curated when claiming — they are orthogonal to ownership', () => {
+        const auto = {
+            agent_fk: 5, document_fk: 10, relationship: 'autoload', notes: null, sort_order: 2,
+        };
+        expect(planOwnerTransfer({
+            documentId: 10, fromLink: null, toLink: auto, toAgentId: 5,
+        })[0].next.relationship).toBe('owned,autoload');
+
+        const curated = {
+            agent_fk: 5, document_fk: 10, relationship: 'curated,referenced',
+            notes: null, sort_order: 2,
+        };
+        expect(planOwnerTransfer({
+            documentId: 10, fromLink: null, toLink: curated, toAgentId: 5,
+        })[0].next.relationship).toBe('owned,curated');
+    });
+
+    it('creates a bare `owned` link when the incoming agent has none', () => {
+        const steps = planOwnerTransfer({
+            documentId: 10, fromLink: null, toLink: null, toAgentId: 5,
+        });
+        expect(steps).toHaveLength(1);
+        expect(steps[0].prev).toBeNull();
+        expect(steps[0].next.relationship).toBe('owned');
+        expect(steps[0].next.document_fk).toBe(10);
+    });
+
+    it('plans a RELEASE with no successor as a single step', () => {
+        const steps = planOwnerTransfer({
+            documentId: 10, fromLink: owner, toLink: null, toAgentId: null,
+        });
+        expect(steps).toHaveLength(1);
+        expect(steps[0].next.relationship).toBe('autoload');
+    });
+
+    it('plans nothing at all when there is neither an incumbent nor a successor', () => {
+        expect(planOwnerTransfer({ documentId: 10 })).toEqual([]);
+    });
+
+    // THE COMPOSITION TEST. This is the one that would have caught the
+    // owned+referenced defect, and it is worth more than any individual case
+    // above: it asserts the planner and the validator cannot disagree.
+    it('never emits a role set its own validator would reject', () => {
+        const incumbents = [null, owner, ownerOnly, {
+            agent_fk: 2, document_fk: 10, relationship: 'owned,curated',
+            notes: null, sort_order: 1,
+        }];
+        const incoming = [null,
+            { agent_fk: 5, document_fk: 10, relationship: 'referenced', notes: null, sort_order: 1 },
+            { agent_fk: 5, document_fk: 10, relationship: 'autoload', notes: null, sort_order: 1 },
+            { agent_fk: 5, document_fk: 10, relationship: 'curated', notes: null, sort_order: 1 },
+            { agent_fk: 5, document_fk: 10, relationship: 'autoload,referenced', notes: null, sort_order: 1 },
+        ];
+
+        for (const fromLink of incumbents) {
+            for (const toLink of incoming) {
+                for (const toAgentId of [null, 5]) {
+                    for (const keepOutgoing of [true, false]) {
+                        const steps = planOwnerTransfer({
+                            documentId: 10, fromLink, toLink, toAgentId, keepOutgoing,
+                        });
+                        for (const step of steps) {
+                            if (!step.next) continue;   // an unlink has no set to validate
+                            const roles = parseRoles(step.next.relationship);
+                            expect(
+                                relationshipSetError(roles),
+                                `rejected set "${step.next.relationship}" from `
+                                + `from=${fromLink?.relationship ?? 'none'} `
+                                + `to=${toLink?.relationship ?? 'none'} `
+                                + `toAgentId=${toAgentId} keepOutgoing=${keepOutgoing}`,
+                            ).toBeNull();
+                            // And it must never be the silently-empty SET.
+                            expect(step.next.relationship).not.toBe('');
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    it('produces at most ONE owned link across the whole plan', () => {
+        // Two `owned` steps would be rejected by the unique key at the second one,
+        // leaving the plan half-applied.
+        const steps = planOwnerTransfer({
+            documentId: 10, fromLink: owner, toLink: null, toAgentId: 5,
+        });
+        const ownedSteps = steps.filter(
+            s => s.next && parseRoles(s.next.relationship).includes('owned'));
+        expect(ownedSteps).toHaveLength(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// restErrorMessage — Lambda-Rest has no 409, so the pymysql text is the only
+// signal distinguishing "you picked a taken name" from "the database is broken".
+// ---------------------------------------------------------------------------
+
+describe('restErrorMessage — the document keys (req #3051)', () => {
+    const thrown = (httpMessage) => ({ httpStatus: { httpStatus: 500, httpMessage } });
+
+    it('maps a duplicate document name and mentions the closed-row trap', () => {
+        const err = thrown("HTTP POST failed: 1062 Duplicate entry 'Agents Registry' "
+            + "for key 'architecture_documents.uq_architecture_documents_name'");
+        expect(restErrorMessage(err, 'fallback')).toMatch(/already exists/);
+        expect(restErrorMessage(err, 'fallback')).toMatch(/may be closed/);
+    });
+
+    it('maps a second ownership claim to advice, not to a raw constraint name', () => {
+        const err = thrown("HTTP POST bulk failed: 1062 Duplicate entry '42' "
+            + "for key 'agent_documents.uq_agent_documents_owner'");
+        expect(restErrorMessage(err, 'fallback')).toMatch(/already owns this document/);
+    });
+
+    it('maps a duplicate document link', () => {
+        const err = thrown("HTTP POST bulk failed: 1062 Duplicate entry '6-31' "
+            + "for key 'agent_documents.PRIMARY'");
+        expect(restErrorMessage(err, 'fallback')).toMatch(/already linked to this agent/);
+    });
+
+    // THE COLLISION THIS PINS: agent_instructions.PRIMARY and
+    // agent_documents.PRIMARY both end in `.PRIMARY`, so an unqualified pattern
+    // would report the wrong entity — telling a user about an instruction when a
+    // document link failed, or the reverse.
+    it('does not confuse the two junctions\' PRIMARY keys', () => {
+        const docErr = thrown("HTTP POST bulk failed: 1062 Duplicate entry '6-31' "
+            + "for key 'agent_documents.PRIMARY'");
+        const instrErr = thrown("HTTP POST bulk failed: 1062 Duplicate entry '10-6' "
+            + "for key 'agent_instructions.PRIMARY'");
+
+        expect(restErrorMessage(docErr, 'fallback')).toMatch(/document/);
+        expect(restErrorMessage(docErr, 'fallback')).not.toMatch(/instruction/);
+        expect(restErrorMessage(instrErr, 'fallback')).toMatch(/instruction/);
+        expect(restErrorMessage(instrErr, 'fallback')).not.toMatch(/document/);
+    });
+
+    it('matches regardless of the table qualifier, so darwin and darwin_dev both work', () => {
+        // The `.*` prefix on every pattern is what makes this true; hardcoding a
+        // table name would silently stop matching in the other database.
+        const bare = thrown("HTTP PUT SQL FAILED: 1062 Duplicate entry 'x' "
+            + "for key 'uq_architecture_documents_name'");
+        expect(restErrorMessage(bare, 'fallback')).toMatch(/already exists/);
+    });
+
+    it('still maps the instruction keys it mapped before', () => {
+        expect(restErrorMessage(thrown(
+            "HTTP PUT SQL FAILED: 1062 Duplicate entry 'x' for key 'instructions.uq_instructions_name'",
+        ), 'fallback')).toMatch(/already in use/);
+    });
+
+    it('mentions documents in the foreign-key message now that this page can hit it', () => {
+        const err = thrown('HTTP POST bulk failed: 1452 Cannot add or update a child row: '
+            + 'a foreign key constraint fails');
+        expect(restErrorMessage(err, 'fallback')).toMatch(/document/);
+    });
+
+    it('falls back for anything unrecognised', () => {
+        expect(restErrorMessage(thrown('HTTP PUT SQL FAILED: 2013 Lost connection'), 'fb'))
+            .toBe('fb');
+        expect(restErrorMessage(undefined, 'fb')).toBe('fb');
+    });
+});

--- a/src/Agents/__tests__/documentSort.test.js
+++ b/src/Agents/__tests__/documentSort.test.js
@@ -1,0 +1,249 @@
+// Req #3051 — the browse-list sort vocabulary for /agents/documents.
+//
+// Tested here rather than through the page for the reason the module exists at
+// all: keeping the comparator out of the component file keeps that file in React
+// Fast Refresh, and it lets these run without pulling MUI into the test
+// environment. The comparator carries two STRUCTURAL rules that outrank the
+// user's chosen sort, and the interesting property of the second one is that it is
+// scoped to a single mode — so most of this file is about where the rules do NOT
+// apply.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+    DEFAULT_SORT_MODE, SORT_MODES, SORT_ASC, SORT_STORAGE_KEY,
+    lastTouched, ownerName, readStoredSort, compareDocumentRows,
+} from '../documentSort';
+
+/**
+ * A decorated row in the shape DocumentsPage builds: the document columns plus
+ * `links`, `owner` (the junction row carrying `owned`, or null) and `ownerName`.
+ */
+const row = (name, { owner = null, links = [], closed = 0, update_ts = null,
+    create_ts = '2026-01-01T00:00:00' } = {}) => ({
+    id: name.length * 7,
+    name,
+    closed,
+    links,
+    owner: owner ? { agent_fk: 1, relationship: 'owned' } : null,
+    ownerName: owner || '',
+    update_ts,
+    create_ts,
+});
+
+const sorted = (rows, mode, desc) =>
+    [...rows].sort(compareDocumentRows(mode, desc)).map(r => r.name);
+
+describe('the sort vocabulary', () => {
+    it('defaults to OWNER, the question the page exists to answer', () => {
+        // Not a convenience: /agents/documents exists because "who owns this file?"
+        // had no answer before the registry, so the owner axis leads unless the
+        // user asks otherwise.
+        expect(DEFAULT_SORT_MODE).toBe('owner');
+        expect(SORT_MODES.some(m => m.value === DEFAULT_SORT_MODE)).toBe(true);
+    });
+
+    it('has a comparator for every advertised mode', () => {
+        // A mode in the menu with no comparator would silently fall back to the
+        // default and the menu would lie about what it did.
+        for (const { value } of SORT_MODES) {
+            expect(SORT_ASC[value], `no comparator for "${value}"`).toBeTypeOf('function');
+        }
+    });
+
+    it('gives each mode the useful end of its own axis as the default direction', () => {
+        const byValue = Object.fromEntries(SORT_MODES.map(m => [m.value, m.defaultDesc]));
+        expect(byValue.name).toBe(false);      // A→Z
+        expect(byValue.owner).toBe(false);     // A→Z by owner
+        expect(byValue.agents).toBe(true);     // most-referenced first
+        expect(byValue.date).toBe(true);       // newest first
+    });
+});
+
+describe('lastTouched', () => {
+    it('falls back to create_ts when update_ts is NULL', () => {
+        // update_ts is NULL until a row is first edited. Without the fallback every
+        // never-touched document sorts as if it were from 1970 and "Last updated"
+        // is meaningless — which is most of the catalog.
+        const r = row('A', { update_ts: null, create_ts: '2026-05-05T00:00:00' });
+        expect(lastTouched(r)).toBe(Date.parse('2026-05-05T00:00:00'));
+    });
+
+    it('prefers update_ts when present', () => {
+        const r = row('A', { update_ts: '2026-07-07T00:00:00', create_ts: '2026-01-01T00:00:00' });
+        expect(lastTouched(r)).toBe(Date.parse('2026-07-07T00:00:00'));
+    });
+
+    it('is 0 for a row with neither, rather than NaN', () => {
+        // NaN comparisons are always false, which makes a sort non-deterministic.
+        expect(lastTouched({ })).toBe(0);
+    });
+});
+
+describe('ownerName', () => {
+    it('is the empty string for an unowned document, never undefined', () => {
+        // localeCompare on undefined throws; the empty string sorts predictably.
+        expect(ownerName(row('A'))).toBe('');
+        expect(ownerName({})).toBe('');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Structural rule 1 — CLOSED LAST, everywhere.
+// ---------------------------------------------------------------------------
+
+describe('closed documents sort last in EVERY mode and BOTH directions', () => {
+    // A closed document is in no agent's boot payload, so it never belongs above a
+    // live one — not even when it would sort first alphabetically.
+    const rows = [
+        row('Aardvark', { closed: 1, owner: 'Aaa Architect' }),
+        row('Zebra', { owner: 'Zzz Architect' }),
+    ];
+
+    for (const { value } of SORT_MODES) {
+        for (const desc of [false, true]) {
+            it(`holds in ${value} / ${desc ? 'desc' : 'asc'}`, () => {
+                expect(sorted(rows, value, desc)).toEqual(['Zebra', 'Aardvark']);
+            });
+        }
+    }
+
+    it('outranks even the unowned pin', () => {
+        // A closed UNOWNED row must not be dragged to the top by rule 2 — it is
+        // still in nobody's payload.
+        const mixed = [
+            row('ClosedUnowned', { closed: 1 }),
+            row('OpenOwned', { owner: 'Some Architect' }),
+        ];
+        expect(sorted(mixed, 'owner', false)).toEqual(['OpenOwned', 'ClosedUnowned']);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Structural rule 2 — UNOWNED FIRST, in `owner` mode ONLY.
+// ---------------------------------------------------------------------------
+
+describe('unowned documents pin to the top in OWNER mode', () => {
+    const rows = [
+        row('Bravo', { owner: 'Aaa Architect' }),
+        row('Alpha'),                                   // unowned
+        row('Charlie', { owner: 'Zzz Architect' }),
+    ];
+
+    it('leads in owner/asc — the drift the registry exists to surface', () => {
+        expect(sorted(rows, 'owner', false)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    });
+
+    it('STILL leads in owner/desc — the pin is not multiplied by direction', () => {
+        // Reversing the owner axis must not bury the rows the page is for.
+        expect(sorted(rows, 'owner', true)).toEqual(['Alpha', 'Charlie', 'Bravo']);
+    });
+
+    it('keeps several unowned rows together, name-ordered among themselves', () => {
+        const many = [
+            row('Zulu'), row('Alpha'), row('Mike', { owner: 'Someone' }),
+        ];
+        expect(sorted(many, 'owner', false)).toEqual(['Alpha', 'Zulu', 'Mike']);
+    });
+});
+
+describe('the unowned pin does NOT leak into any other mode', () => {
+    // An alphabetical list that is not alphabetical reads as a bug rather than as
+    // emphasis, which is why this rule is scoped to the one axis it belongs to.
+    const rows = [
+        row('Alpha', { owner: 'Someone' }),
+        row('Bravo'),                                   // unowned
+        row('Charlie', { owner: 'Someone' }),
+    ];
+
+    it('name mode stays strictly alphabetical', () => {
+        expect(sorted(rows, 'name', false)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+        expect(sorted(rows, 'name', true)).toEqual(['Charlie', 'Bravo', 'Alpha']);
+    });
+
+    it('agents mode ranks purely by link count', () => {
+        const byCount = [
+            row('One', { links: [{}] , owner: 'Someone' }),
+            row('Three', { links: [{}, {}, {}] }),        // unowned, but most-linked
+            row('Two', { links: [{}, {}], owner: 'Someone' }),
+        ];
+        expect(sorted(byCount, 'agents', true)).toEqual(['Three', 'Two', 'One']);
+        expect(sorted(byCount, 'agents', false)).toEqual(['One', 'Two', 'Three']);
+    });
+
+    it('date mode ranks purely by recency', () => {
+        const byDate = [
+            row('Old', { owner: 'Someone', update_ts: '2026-01-01T00:00:00' }),
+            row('New', { update_ts: '2026-07-01T00:00:00' }),   // unowned, newest
+        ];
+        expect(sorted(byDate, 'date', true)).toEqual(['New', 'Old']);
+        expect(sorted(byDate, 'date', false)).toEqual(['Old', 'New']);
+    });
+});
+
+describe('the sort is TOTAL, so the list never shuffles between renders', () => {
+    it('breaks ties on name, which carries a UNIQUE key', () => {
+        const tied = [
+            row('Charlie', { links: [{}] , owner: 'Same Architect' }),
+            row('Alpha', { links: [{}], owner: 'Same Architect' }),
+            row('Bravo', { links: [{}], owner: 'Same Architect' }),
+        ];
+        // Identical on every primary axis — only the tiebreak decides.
+        expect(sorted(tied, 'owner', false)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+        expect(sorted(tied, 'agents', true)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+        expect(sorted(tied, 'date', true)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    });
+
+    it('is stable across repeated sorts of an already-sorted list', () => {
+        const rows = [row('B', { owner: 'X' }), row('A'), row('C', { owner: 'Y' })];
+        const once = sorted(rows, 'owner', false);
+        const twice = [...rows].sort(compareDocumentRows('owner', false))
+            .sort(compareDocumentRows('owner', false)).map(r => r.name);
+        expect(twice).toEqual(once);
+    });
+
+    it('falls back to the default comparator for an unknown mode', () => {
+        // Reachable from a stale localStorage value written by an older build.
+        expect(sorted([row('B', { owner: 'X' }), row('A')], 'nonsense', false))
+            .toEqual(['A', 'B']);
+    });
+});
+
+describe('readStoredSort', () => {
+    const realStorage = globalThis.localStorage;
+
+    afterEach(() => {
+        Object.defineProperty(globalThis, 'localStorage',
+            { value: realStorage, configurable: true, writable: true });
+    });
+
+    const stubStorage = (getItem) => Object.defineProperty(globalThis, 'localStorage',
+        { value: { getItem, setItem: vi.fn() }, configurable: true, writable: true });
+
+    it('returns a stored mode that is still in the vocabulary', () => {
+        stubStorage(() => 'name');
+        expect(readStoredSort()).toBe('name');
+    });
+
+    it('falls back to the default for a mode that no longer exists', () => {
+        // Protects against a value written before a mode was renamed or removed —
+        // an unmatched mode would otherwise select nothing.
+        stubStorage(() => 'by-vibes');
+        expect(readStoredSort()).toBe(DEFAULT_SORT_MODE);
+    });
+
+    it('falls back when nothing is stored', () => {
+        stubStorage(() => null);
+        expect(readStoredSort()).toBe(DEFAULT_SORT_MODE);
+    });
+
+    it('survives localStorage throwing — Safari private mode', () => {
+        stubStorage(() => { throw new Error('SecurityError'); });
+        expect(readStoredSort()).toBe(DEFAULT_SORT_MODE);
+    });
+
+    it('uses a page-specific storage key, not the instructions one', () => {
+        expect(SORT_STORAGE_KEY).toBe('darwin-documents-sort');
+        expect(SORT_STORAGE_KEY).not.toBe('darwin-instructions-sort');
+    });
+});

--- a/src/Agents/__tests__/documentsApi.test.js
+++ b/src/Agents/__tests__/documentsApi.test.js
@@ -1,0 +1,471 @@
+// Req #3051 — the REST mutation layer for the editable documents registry.
+//
+// documentRegistryUtils.test.js covers the pure PLANNING helpers. This file
+// covers the part that talks to the network, where the risk lives:
+//
+//   * `agent_documents` has no `id` column, so a SINGLE-OBJECT POST commits the
+//     row and THEN returns 500 (rest_post.py re-reads `WHERE id = ...`, raising
+//     1054 after the INSERT has already committed under autocommit). Every insert
+//     must use an array body.
+//   * With no PUT available, a role change is a DELETE plus a fresh INSERT across
+//     two non-atomic Lambda invocations. The rollback is the only thing standing
+//     between a rejected edit and a link vanishing from an agent that was told to
+//     read the file at boot — and it is unreachable from an integration test.
+//   * A re-INSERT that omits `notes` or `sort_order` does not leave them alone. It
+//     writes NULL over them. Silently.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../RestApi/RestApi', () => ({ default: vi.fn() }));
+
+import call_rest_api from '../../RestApi/RestApi';
+import {
+    createArchitectureDocument, updateArchitectureDocument,
+    deleteArchitectureDocument,
+    linkAgentDocument, linkAgentDocuments, unlinkAgentDocument,
+    applyLinkPlan, setAgentDocumentLink, LinkRollbackError,
+} from '../actions/documentsApi';
+
+const URI = 'https://api.test/darwin_dev';
+const TOKEN = 'id-token';
+
+const ok = (status = 200, data = null) =>
+    ({ data, httpStatus: { httpStatus: status, httpMessage: 'OK' } });
+
+// call_rest_api rejects with a bare object (`throw {data, httpStatus}`), not an
+// Error — the 404-tolerant paths read that shape directly.
+const rejectWith = (status, httpMessage = '') =>
+    Promise.reject({ data: null, httpStatus: { httpStatus: status, httpMessage } });
+
+const calls = () => call_rest_api.mock.calls.map(
+    ([url, method, body]) => ({ table: url.split('/').pop(), method, body }));
+
+beforeEach(() => {
+    call_rest_api.mockReset();
+    call_rest_api.mockResolvedValue(ok(201, { inserted: 1 }));
+});
+
+// ---------------------------------------------------------------------------
+// architecture_documents — the table that HAS an id.
+// ---------------------------------------------------------------------------
+
+describe('architecture_documents writes', () => {
+    it('creates with a single-object POST — this table has an id, so read-back works', () => {
+        return createArchitectureDocument(URI, TOKEN, {
+            name: 'New Doc', location: 'memory/new.md', creator_fk: 'user-1',
+        }).then(() => {
+            const [c] = calls();
+            expect(c.table).toBe('architecture_documents');
+            expect(c.method).toBe('POST');
+            expect(Array.isArray(c.body)).toBe(false);
+            expect(c.body.doc_type).toBe('markdown');       // registry default
+            expect(c.body.url).toBeNull();
+            expect(c.body.closed).toBe(0);
+            expect(c.body.creator_fk).toBe('user-1');
+        });
+    });
+
+    it('PUTs an array body carrying ONLY the fields it was given', async () => {
+        // rest_put.py builds its SET clause from the body's keys and has no version
+        // column, so including an unchanged field would silently revert whatever
+        // another tab had just written to it.
+        await updateArchitectureDocument(URI, TOKEN, 12, { location: 'memory/moved.md' });
+
+        const [c] = calls();
+        expect(c.method).toBe('PUT');
+        expect(c.body).toEqual([{ id: 12, location: 'memory/moved.md' }]);
+        expect(Object.keys(c.body[0])).toEqual(['id', 'location']);
+    });
+
+    it('passes an explicit null through, which Lambda-Rest maps to SQL NULL', async () => {
+        await updateArchitectureDocument(URI, TOKEN, 12, { url: null });
+        expect(calls()[0].body).toEqual([{ id: 12, url: null }]);
+    });
+
+    it('deletes by id', async () => {
+        await deleteArchitectureDocument(URI, TOKEN, 12);
+        const [c] = calls();
+        expect(c.method).toBe('DELETE');
+        expect(c.body).toEqual({ id: 12 });
+    });
+
+    it('throws an error CARRYING httpStatus, which every consumer destructures', async () => {
+        // showError reads err.httpStatus.httpStatus from inside a catch block; an
+        // error without it throws a TypeError there and kills the resync that
+        // catch block exists to perform.
+        call_rest_api.mockResolvedValue(
+            { data: null, httpStatus: { httpStatus: 500, httpMessage: 'boom' } });
+        await expect(updateArchitectureDocument(URI, TOKEN, 1, { name: 'x' }))
+            .rejects.toMatchObject({ httpStatus: { httpStatus: 500 } });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// agent_documents — the id-less junction.
+// ---------------------------------------------------------------------------
+
+describe('junction inserts never use the single-object POST path', () => {
+    it('sends an ARRAY body even for one link', async () => {
+        await linkAgentDocument(URI, TOKEN, {
+            agent_fk: 7, document_fk: 42, relationship: ['referenced'], sort_order: 3,
+        });
+
+        const [c] = calls();
+        expect(c.table).toBe('agent_documents');
+        expect(c.method).toBe('POST');
+        expect(Array.isArray(c.body)).toBe(true);
+        expect(c.body).toHaveLength(1);
+    });
+
+    it('serializes the SET with NO SPACES — a space stores \'\' under non-strict mode', async () => {
+        await linkAgentDocument(URI, TOKEN, {
+            agent_fk: 7, document_fk: 42, relationship: ['autoload', 'owned'],
+        });
+        expect(calls()[0].body[0].relationship).toBe('owned,autoload');
+        expect(calls()[0].body[0].relationship).not.toMatch(/\s/);
+    });
+
+    it('canonicalizes at the WIRE BOUNDARY, so a bad caller cannot bypass it', async () => {
+        // Passing relationshipLabel's display output ("owned, autoload") is the
+        // exact mistake that empties the SET. It is normalized here regardless.
+        await linkAgentDocument(URI, TOKEN, {
+            agent_fk: 7, document_fk: 42, relationship: 'owned, autoload',
+        });
+        expect(calls()[0].body[0].relationship).toBe('owned,autoload');
+    });
+
+    it('carries notes and sort_order rather than defaulting them away', async () => {
+        await linkAgentDocument(URI, TOKEN, {
+            agent_fk: 7, document_fk: 42, relationship: ['owned'],
+            notes: 'because', sort_order: 5,
+        });
+        expect(calls()[0].body[0]).toMatchObject({ notes: 'because', sort_order: 5 });
+    });
+
+    it('never writes the VIRTUAL owned_document_fk column', async () => {
+        await linkAgentDocument(URI, TOKEN, {
+            agent_fk: 7, document_fk: 42, relationship: ['owned'],
+            owned_document_fk: 42,          // a caller mistakenly passing it
+        });
+        expect(calls()[0].body[0]).not.toHaveProperty('owned_document_fk');
+    });
+
+    it('normalizes every row to the SAME key set', async () => {
+        // _rest_post_bulk builds ONE multi-value INSERT from the FIRST item's key
+        // list and then reads item[k] on every later item, so a row missing a key
+        // raises KeyError inside the Lambda and a row with extra keys drops them.
+        await linkAgentDocuments(URI, TOKEN, [
+            { agent_fk: 1, document_fk: 42, relationship: ['owned'], notes: 'a', sort_order: 1 },
+            { agent_fk: 2, document_fk: 42, relationship: ['referenced'] },
+        ]);
+        const [a, b] = calls()[0].body;
+        expect(Object.keys(a)).toEqual(Object.keys(b));
+        expect(b.notes).toBeNull();
+        expect(b.sort_order).toBeNull();
+    });
+
+    it('coerces a non-finite sort_order to null rather than sending NaN', async () => {
+        await linkAgentDocuments(URI, TOKEN, [
+            { agent_fk: 1, document_fk: 42, relationship: ['owned'], sort_order: undefined },
+        ]);
+        expect(calls()[0].body[0].sort_order).toBeNull();
+    });
+
+    it('no-ops on an empty list, so a fully-raced click is a clean nothing', async () => {
+        await linkAgentDocuments(URI, TOKEN, []);
+        expect(call_rest_api).not.toHaveBeenCalled();
+    });
+});
+
+describe('unlinkAgentDocument tolerates an already-absent link', () => {
+    it('returns true when a row was really removed', async () => {
+        call_rest_api.mockResolvedValue(ok(204));
+        await expect(unlinkAgentDocument(URI, TOKEN, 7, 42)).resolves.toBe(true);
+    });
+
+    it('returns FALSE on 404 — already gone is the desired end state', async () => {
+        call_rest_api.mockImplementation(() => rejectWith(404, 'NOT FOUND'));
+        await expect(unlinkAgentDocument(URI, TOKEN, 7, 42)).resolves.toBe(false);
+    });
+
+    it('rethrows anything that is not a 404', async () => {
+        call_rest_api.mockImplementation(() => rejectWith(500, 'SQL FAILED'));
+        await expect(unlinkAgentDocument(URI, TOKEN, 7, 42)).rejects.toBeTruthy();
+    });
+
+    it('deletes by the COMPOSITE key — there is no id to delete by', async () => {
+        call_rest_api.mockResolvedValue(ok(204));
+        await unlinkAgentDocument(URI, TOKEN, 7, 42);
+        expect(calls()[0].body).toEqual({ agent_fk: 7, document_fk: 42 });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// applyLinkPlan — the rollback. The reason this module exists.
+// ---------------------------------------------------------------------------
+
+const link = (agent_fk, relationship, extra = {}) => ({
+    agent_fk, document_fk: 10, relationship, notes: null, sort_order: 1, ...extra,
+});
+
+/**
+ * Drive call_rest_api by (method, table) so a test can fail exactly one call.
+ * `fail(n)` fails the nth matching call, 1-indexed.
+ */
+const scriptCalls = (script) => {
+    let i = 0;
+    call_rest_api.mockImplementation((url, method) => {
+        i += 1;
+        const verdict = script(i, method);
+        if (verdict === 'fail') return rejectWith(500, 'SQL FAILED');
+        if (verdict === '404') return rejectWith(404, 'NOT FOUND');
+        return Promise.resolve(ok(method === 'DELETE' ? 204 : 201));
+    });
+};
+
+describe('applyLinkPlan — the happy paths', () => {
+    it('re-classifies as DELETE then array-POST, in that order', async () => {
+        const prev = link(2, 'referenced', { notes: 'keep me', sort_order: 4 });
+        await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10, prev, next: { ...prev, relationship: 'curated' },
+        }]);
+
+        const c = calls();
+        expect(c.map(x => x.method)).toEqual(['DELETE', 'POST']);
+        expect(c[1].body[0]).toMatchObject({
+            relationship: 'curated', notes: 'keep me', sort_order: 4,
+        });
+    });
+
+    it('creates with NO leading DELETE when prev is null', async () => {
+        await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 5, document_fk: 10, prev: null, next: link(5, 'owned'),
+        }]);
+        expect(calls().map(x => x.method)).toEqual(['POST']);
+    });
+
+    it('unlinks with NO trailing POST when next is null', async () => {
+        await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10, prev: link(2, 'referenced'), next: null,
+        }]);
+        expect(calls().map(x => x.method)).toEqual(['DELETE']);
+    });
+
+    it('runs steps in the order given — release before claim', async () => {
+        await applyLinkPlan(URI, TOKEN, [
+            { agent_fk: 2, document_fk: 10, prev: link(2, 'owned,autoload'),
+              next: link(2, 'autoload') },
+            { agent_fk: 5, document_fk: 10, prev: null, next: link(5, 'owned') },
+        ]);
+        const c = calls();
+        expect(c.map(x => x.method)).toEqual(['DELETE', 'POST', 'POST']);
+        expect(c[1].body[0].agent_fk).toBe(2);
+        expect(c[2].body[0].agent_fk).toBe(5);
+    });
+
+    it('no-ops on an empty plan', async () => {
+        await expect(applyLinkPlan(URI, TOKEN, [])).resolves.toBeNull();
+        expect(call_rest_api).not.toHaveBeenCalled();
+    });
+});
+
+describe('applyLinkPlan — rollback', () => {
+    it('restores step 1 when step 2 fails — the ownership-transfer failure mode', async () => {
+        // Release agent 2, then agent 5 claims and is rejected. Without the
+        // rollback the document is left permanently unowned.
+        const prev = link(2, 'owned,autoload', { notes: 'why 2 owns it', sort_order: 3 });
+        scriptCalls((i, method) => (i === 3 && method === 'POST' ? 'fail' : 'ok'));
+
+        await expect(applyLinkPlan(URI, TOKEN, [
+            { agent_fk: 2, document_fk: 10, prev, next: { ...prev, relationship: 'autoload' } },
+            { agent_fk: 5, document_fk: 10, prev: null, next: link(5, 'owned') },
+        ])).rejects.toBeTruthy();
+
+        const c = calls();
+        // 1 DELETE(2) 2 POST(2 as autoload) 3 POST(5 owned) FAILS
+        // rollback, reverse order: step2 wrote nothing durable -> DELETE(5),
+        // then step1: DELETE(2 autoload) + POST(2 at its ORIGINAL roles)
+        expect(c).toHaveLength(6);
+        const restore = c[c.length - 1];
+        expect(restore.method).toBe('POST');
+        expect(restore.body[0]).toMatchObject({
+            agent_fk: 2,
+            relationship: 'owned,autoload',      // the ORIGINAL, not the demoted value
+            notes: 'why 2 owns it',
+            sort_order: 3,
+        });
+    });
+
+    it('rolls back creates by DELETING them in REVERSE order, posting nothing', async () => {
+        scriptCalls((i) => (i === 2 ? 'fail' : 'ok'));
+
+        await expect(applyLinkPlan(URI, TOKEN, [
+            { agent_fk: 5, document_fk: 10, prev: null, next: link(5, 'referenced') },
+            { agent_fk: 6, document_fk: 10, prev: null, next: link(6, 'referenced') },
+        ])).rejects.toBeTruthy();
+
+        const c = calls();
+        expect(c.map(x => x.method)).toEqual(['POST', 'POST', 'DELETE', 'DELETE']);
+
+        // Reverse order: the FAILED step is cleaned up first. Its own write is
+        // attempted-not-confirmed, and the DELETE is issued anyway — a lost
+        // response after a committed INSERT would otherwise leave the row behind,
+        // and the delete is 404-tolerant so trying costs nothing.
+        expect(c[2].body).toEqual({ agent_fk: 6, document_fk: 10 });
+        expect(c[3].body).toEqual({ agent_fk: 5, document_fk: 10 });
+
+        // Nothing is RESTORED, because neither step removed anything: `prev` was
+        // null on both. Recreating a row that never existed is its own corruption.
+        expect(c.filter(x => x.method === 'POST')).toHaveLength(2);
+    });
+
+    it('does NOT resurrect a link whose prev turned out to be already absent', async () => {
+        // Recreating a row that did not exist is its own corruption. The DELETE
+        // returns 404, so the step records deleted:false and the rollback skips
+        // the restore.
+        scriptCalls((i, method) => {
+            if (i === 1 && method === 'DELETE') return '404';   // prev already gone
+            if (i === 2 && method === 'POST') return 'fail';    // our write fails
+            return 'ok';
+        });
+
+        await expect(applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10,
+            prev: link(2, 'referenced'), next: link(2, 'curated'),
+        }])).rejects.toBeTruthy();
+
+        const c = calls();
+        // DELETE(404), POST(fail), then rollback removes what we wrote — and
+        // crucially does NOT post `prev` back.
+        expect(c.filter(x => x.method === 'POST')).toHaveLength(1);
+        expect(c[c.length - 1].method).toBe('DELETE');
+    });
+
+    it('propagates the ORIGINAL error when the rollback succeeds', async () => {
+        // Nothing was lost, so "your edit was rejected" is the right headline.
+        scriptCalls((i, method) => (i === 2 && method === 'POST' ? 'fail' : 'ok'));
+
+        await expect(applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10,
+            prev: link(2, 'referenced'), next: link(2, 'curated'),
+        }])).rejects.not.toBeInstanceOf(LinkRollbackError);
+    });
+
+    it('raises LinkRollbackError when the RESTORE itself fails', async () => {
+        // Now a link the user never asked to remove really is missing, and that
+        // outranks the error that caused it. This is the case the MCP daemon gets
+        // wrong: it logs "the link is now MISSING" and re-raises the original
+        // conflict, so the user is told about ownership while data has vanished.
+        scriptCalls((i, method) => {
+            if (i === 1 && method === 'DELETE') return 'ok';    // prev removed
+            if (i === 2 && method === 'POST') return 'fail';    // our write fails
+            if (i === 3 && method === 'DELETE') return 'ok';    // undo our write
+            if (i === 4 && method === 'POST') return 'fail';    // restore FAILS
+            return 'ok';
+        });
+
+        const prev = link(2, 'owned,autoload');
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10, prev, next: { ...prev, relationship: 'autoload' },
+        }]).catch(e => e);
+
+        expect(err).toBeInstanceOf(LinkRollbackError);
+        expect(err.message).toMatch(/could not be restored/);
+        expect(err.message).toMatch(/Reload the page/);
+        expect(err.lost).toHaveLength(1);
+        expect(err.lost[0].prev).toBe(prev);
+        expect(err.cause).toBeTruthy();
+        // It must still carry httpStatus, or showError throws inside the catch
+        // block that is trying to report it.
+        expect(err.httpStatus).toBeTruthy();
+    });
+
+    it('keeps unwinding after one restore fails, rather than stranding the rest', async () => {
+        // Three relinks. The third one's INSERT fails, and then the FIRST restore
+        // the rollback attempts (step 3's, since it unwinds in reverse) ALSO fails.
+        // Steps 2 and 1 must still be restored — a second failure must not strand
+        // rows that could still be put back.
+        //
+        // Call order, by index:
+        //   1 DEL(2)  2 POST(2)   step1 ok
+        //   3 DEL(3)  4 POST(3)   step2 ok
+        //   5 DEL(4)  6 POST(4)   step3 — POST FAILS
+        //   7 DEL(4)  8 POST(4)   rollback step3 — RESTORE FAILS  -> lost
+        //   9 DEL(3) 10 POST(3)   rollback step2 — restored
+        //  11 DEL(2) 12 POST(2)   rollback step1 — restored
+        scriptCalls((i) => ((i === 6 || i === 8) ? 'fail' : 'ok'));
+
+        const prevs = { 2: link(2, 'referenced'), 3: link(3, 'referenced'), 4: link(4, 'referenced') };
+        const err = await applyLinkPlan(URI, TOKEN, [2, 3, 4].map(id => ({
+            agent_fk: id, document_fk: 10, prev: prevs[id], next: link(id, 'curated'),
+        }))).catch(e => e);
+
+        expect(err).toBeInstanceOf(LinkRollbackError);
+        // Exactly ONE step was unrecoverable, not all three.
+        expect(err.lost).toHaveLength(1);
+        expect(err.lost[0].agent_fk).toBe(4);
+
+        // Steps 2 and 1 were restored to their ORIGINAL roles after the failure.
+        const restores = calls()
+            .filter(c => c.method === 'POST' && c.body[0].relationship === 'referenced')
+            .map(c => c.body[0].agent_fk);
+        expect(restores).toContain(3);
+        expect(restores).toContain(2);
+    });
+
+    it('restores prev when the re-INSERT fails on a SINGLE relink', async () => {
+        // The regression this pins, and the reason `applied` is recorded before the
+        // insert rather than after it: the DELETE has already committed by the time
+        // the INSERT fails, so a rollback that never saw this step would leave the
+        // link permanently missing — the exact silent loss this module exists to
+        // prevent, and the commonest shape of it.
+        scriptCalls((i, method) => (i === 2 && method === 'POST' ? 'fail' : 'ok'));
+
+        const prev = link(2, 'owned,autoload', { notes: 'why', sort_order: 6 });
+        await expect(applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10, prev, next: { ...prev, relationship: 'autoload' },
+        }])).rejects.toBeTruthy();
+
+        const restore = calls().at(-1);
+        expect(restore.method).toBe('POST');
+        expect(restore.body[0]).toMatchObject({
+            agent_fk: 2, relationship: 'owned,autoload', notes: 'why', sort_order: 6,
+        });
+    });
+
+    it('does not report a loss when the only failed step wrote nothing', async () => {
+        // A pure unlink that fails has removed nothing and written nothing.
+        scriptCalls(() => 'fail');
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10, prev: link(2, 'referenced'), next: null,
+        }]).catch(e => e);
+        expect(err).not.toBeInstanceOf(LinkRollbackError);
+    });
+});
+
+describe('setAgentDocumentLink', () => {
+    it('is a one-step plan, so it inherits the rollback', async () => {
+        const prev = link(2, 'referenced', { notes: 'n', sort_order: 8 });
+        await setAgentDocumentLink(URI, TOKEN, {
+            prev, next: { ...prev, relationship: 'curated,referenced' },
+        });
+
+        const c = calls();
+        expect(c.map(x => x.method)).toEqual(['DELETE', 'POST']);
+        expect(c[1].body[0]).toMatchObject({
+            agent_fk: 2, document_fk: 10,
+            relationship: 'curated,referenced', notes: 'n', sort_order: 8,
+        });
+    });
+
+    it('preserves sort_order through a role-only edit', async () => {
+        // The likeliest silent defect in this area: sort_order is the agent's
+        // per-agent document order, owned by AgentDetail. A re-POST that dropped it
+        // would reset that order from a control that has nothing to do with it.
+        const prev = link(2, 'autoload', { sort_order: 12 });
+        await setAgentDocumentLink(URI, TOKEN, {
+            prev, next: { ...prev, relationship: 'autoload,referenced' },
+        });
+        expect(calls()[1].body[0].sort_order).toBe(12);
+    });
+});

--- a/src/Agents/actions/documentsApi.js
+++ b/src/Agents/actions/documentsApi.js
@@ -238,29 +238,48 @@ export async function applyLinkPlan(darwinUri, idToken, steps) {
         const deleted = step.prev
             ? await unlinkAgentDocument(darwinUri, idToken, step.agent_fk, step.document_fk)
             : false;
+
+        // RECORDED BEFORE THE INSERT IS ATTEMPTED, and that ordering is the whole
+        // point. A relink is DELETE-then-INSERT; if the INSERT fails, the DELETE
+        // has ALREADY committed (autocommit, separate Lambda invocation) and is
+        // precisely what has to be undone. Pushing after the insert — the obvious
+        // way to write this — means the one step that most needs a rollback is the
+        // only step the rollback never sees, and the link is silently gone.
+        //
+        // `deleted` records what ACTUALLY happened rather than what was intended:
+        // a `prev` that turned out to be already absent (404) must never be
+        // resurrected, because recreating a row that did not exist is its own
+        // corruption.
+        const record = { ...step, deleted, attemptedWrite: false };
+        applied.push(record);
+
         if (step.next) {
+            // Flagged BEFORE the await for the same reason: the write may commit
+            // and the response still fail (a flake after the INSERT landed), and
+            // the rollback has to assume it might be there.
+            record.attemptedWrite = true;
             await linkAgentDocument(darwinUri, idToken, {
                 ...step.next,
                 agent_fk: step.agent_fk,
                 document_fk: step.document_fk,
             });
         }
-        // Record what we ACTUALLY did, not what we intended: a `prev` that turned
-        // out to be already absent must not be resurrected by the rollback.
-        applied.push({ ...step, deleted });
     };
 
     const rollback = async () => {
         const lost = [];
         for (const step of [...applied].reverse()) {
             try {
-                // Remove whatever this step wrote, then put back whatever it
-                // genuinely removed. Both halves are conditional so a create-only
-                // step is undone by a delete and nothing else.
-                if (step.next) {
+                // Remove whatever this step may have written. Unconditionally
+                // attempted whenever a write was STARTED, not only when it was
+                // observed to succeed — `unlinkAgentDocument` tolerates a 404, so
+                // trying costs nothing, while skipping it would leave a committed
+                // row behind whenever a response was lost after the INSERT landed.
+                if (step.attemptedWrite) {
                     await unlinkAgentDocument(darwinUri, idToken,
                         step.agent_fk, step.document_fk);
                 }
+                // Then put back whatever it genuinely removed.
                 if (step.deleted && step.prev) {
                     await linkAgentDocument(darwinUri, idToken, {
                         ...step.prev,
@@ -269,8 +288,10 @@ export async function applyLinkPlan(darwinUri, idToken, steps) {
                     });
                 }
             } catch {
-                // Keep unwinding the rest — a second failure must not strand
-                // steps that could still be undone.
+                // Keep unwinding the rest — a second failure must not strand steps
+                // that could still be undone. Only a step that had a row to
+                // restore counts as LOST; one that merely failed to have its own
+                // write cleaned up has not cost the user anything they had.
                 if (step.deleted && step.prev) lost.push(step);
             }
         }

--- a/src/Agents/actions/documentsApi.js
+++ b/src/Agents/actions/documentsApi.js
@@ -1,0 +1,313 @@
+// Mutation utilities for the architecture-document registry (req #3051).
+//
+// Peer to instructionsApi.js, and deliberately the same shape: all mutations go
+// through call_rest_api, callers own TanStack Query invalidation, and nothing
+// here touches React.
+//
+// REST contracts that shape this file — verified against Lambda-Rest's source,
+// not assumed:
+//
+// - `architecture_documents` IS in Lambda-Rest CREATOR_FK_TABLES (auth_utils.py),
+//   so POST overwrites any client-supplied creator_fk with the authenticated
+//   Cognito sub, and PUT / DELETE are scoped to it. We still send creator_fk on
+//   create: it is NOT NULL with an FK to profiles.
+//
+// - `agent_documents` is NOT, and correctly so — it has no creator_fk column, and
+//   adding it to the set would emit `WHERE creator_fk = %s` against a column that
+//   does not exist. Its only gate is the API Gateway Cognito authorizer.
+//
+// - `agent_documents` has a composite PK and NO `id` column. Two consequences,
+//   identical to `agent_instructions`:
+//     * PUT is impossible (rest_put.py requires `id`) — changing a link's
+//       relationship or notes is a DELETE + re-POST, never an update.
+//     * A SINGLE-OBJECT POST COMMITS THE ROW AND THEN RETURNS 500 (rest_post.py
+//       re-reads with `WHERE id = ...`, raising 1054 after the INSERT has already
+//       committed under autocommit). Every junction insert here therefore sends an
+//       ARRAY body, which routes to _rest_post_bulk: no read-back, 201.
+//
+// - A PUT body carries ONLY the columns that changed. rest_put.py builds its SET
+//   clause from the body's keys and has no version column, so a whole-row PUT
+//   silently reverts a concurrent edit to any field it happens to include.
+//
+// - Lambda-Rest emits no 409. A duplicate name, a duplicate link, or a second
+//   ownership claim is an HTTP 500 whose body carries the pymysql message;
+//   agentRegistryUtils.restErrorMessage maps the known ones to human text.
+//
+// - The string "NULL" and JSON null both become SQL NULL (rest_put.py:32,
+//   rest_post.py:26 and :140). We send JSON null, matching instructionsApi.
+//
+// - call_rest_api THROWS on any status outside 200/201/204 — including 404 — so
+//   the 404-tolerant paths catch it explicitly rather than testing the status.
+
+import call_rest_api from '../../RestApi/RestApi';
+import { serializeRoles } from '../agentRegistryUtils';
+
+const isOk = (status) => status === 200 || status === 201 || status === 204;
+
+/**
+ * Same helper as instructionsApi's, and duplicated for the same reason that one
+ * is duplicated from validationApi: coupling two registries through a ten-line
+ * function is worse than the ten lines. The thrown error CARRIES `httpStatus`,
+ * which every consumer downstream reads — `isNotFound`, `restErrorMessage`, and
+ * `useSnackBarStore.showError` all destructure it, and showError would throw a
+ * TypeError from inside a catch block without it, killing the resync that catch
+ * block exists to perform.
+ */
+function assertOk(result, action) {
+    const status = result?.httpStatus?.httpStatus;
+    if (!isOk(status)) {
+        const httpStatus = result?.httpStatus
+            || { httpStatus: 0, httpMessage: 'unknown' };
+        const msg = httpStatus.httpMessage || 'unknown';
+        throw Object.assign(
+            new Error(`${action} failed: HTTP ${status} ${msg}`), { httpStatus });
+    }
+    return result.data;
+}
+
+const isNotFound = (err) => err?.httpStatus?.httpStatus === 404;
+
+// ----- architecture_documents -----
+
+/**
+ * Register a document. `name` is UNIQUE and the key does NOT exclude closed
+ * rows, so the caller must pre-check against the unfiltered catalog —
+ * `documentNameError` does that.
+ *
+ * A row is created with NO agent links: the junction needs a document id, which
+ * does not exist until this returns. That ordering is deliberate and is what
+ * retires the two-phase create-then-link failure mode, where a successful POST
+ * followed by a failed link leaves a row owned by nobody and a dialog reporting
+ * an error. A new row is simply unowned until someone claims it — a state the
+ * registry already models and renders in red.
+ */
+export async function createArchitectureDocument(darwinUri, idToken,
+    { name, doc_type = 'markdown', location = null, url = null, closed = 0, creator_fk }) {
+    const r = await call_rest_api(`${darwinUri}/architecture_documents`, 'POST',
+        { name, doc_type, location, url, closed, creator_fk }, idToken);
+    return assertOk(r, 'createArchitectureDocument');
+}
+
+/** Partial update — `fields` must carry ONLY the columns that changed. */
+export async function updateArchitectureDocument(darwinUri, idToken, id, fields) {
+    const r = await call_rest_api(`${darwinUri}/architecture_documents`, 'PUT',
+        [{ id, ...fields }], idToken);
+    return assertOk(r, 'updateArchitectureDocument');
+}
+
+/**
+ * Hard delete of the REGISTRATION — never the file on disk.
+ *
+ * `agent_documents` CASCADEs on `document_fk`, so this silently strips every
+ * agent link including the ownership assignment, which is the one fact the
+ * registry holds that cannot be reconstructed from the filesystem. Callers must
+ * have shown that blast radius first. Closing (`{ closed: 1 }`) is the reversible
+ * path and has the identical effect at boot.
+ */
+export async function deleteArchitectureDocument(darwinUri, idToken, id) {
+    const r = await call_rest_api(`${darwinUri}/architecture_documents`, 'DELETE',
+        { id }, idToken);
+    return assertOk(r, 'deleteArchitectureDocument');
+}
+
+// ----- agent_documents (junction — array-body POST, composite-key DELETE) -----
+
+/**
+ * Normalize one link to the exact key set the bulk INSERT needs.
+ *
+ * `_rest_post_bulk` builds ONE multi-value INSERT from the FIRST item's key
+ * list, so a row missing a key would silently take its neighbour's value. Every
+ * row therefore goes through here.
+ *
+ * `relationship` is passed through `serializeRoles`, which is not cosmetic: this
+ * is a MySQL SET under a non-strict sql_mode, so any member it does not
+ * recognise — including one with a leading space from a naive `roles.join(', ')`
+ * or from `relationshipLabel`, which is DISPLAY-only — makes the WHOLE assignment
+ * store as `''`. The link would then carry no roles at all: not owned, not
+ * autoloaded, rendered as a bland dash. Canonicalizing at the wire boundary is
+ * the one place that catches it no matter which caller got it wrong.
+ *
+ * `notes` and `sort_order` are carried through EXPLICITLY rather than defaulted
+ * away. There is no PUT on this table, so every role change is a DELETE and a
+ * fresh INSERT; an INSERT that omits a column writes NULL over it rather than
+ * leaving it alone. Dropping `sort_order` here would silently reset an agent's
+ * document order every time anyone edited a role.
+ *
+ * `owned_document_fk` is a VIRTUAL generated column and is never written.
+ */
+const linkRow = ({ agent_fk, document_fk, relationship, notes = null, sort_order = null }) => ({
+    agent_fk,
+    document_fk,
+    relationship: serializeRoles(relationship),
+    notes: notes || null,
+    sort_order: Number.isFinite(sort_order) ? sort_order : null,
+});
+
+/** Create several links in ONE round trip (one atomic multi-value INSERT). */
+export async function linkAgentDocuments(darwinUri, idToken, rows) {
+    if (!rows.length) return null;
+    const r = await call_rest_api(`${darwinUri}/agent_documents`, 'POST',
+        rows.map(linkRow), idToken);
+    return assertOk(r, 'linkAgentDocuments');
+}
+
+/** Create one link. Still an array body — see the header note on id-less POST. */
+export async function linkAgentDocument(darwinUri, idToken, link) {
+    return linkAgentDocuments(darwinUri, idToken, [link]);
+}
+
+/**
+ * Remove one link. Tolerates an already-absent row.
+ *
+ * Returns true when a row was actually removed, false when it was already gone.
+ * The rollback below needs that distinction: recreating a row that never existed
+ * is its own corruption, so only genuinely-deleted rows are ever restored.
+ */
+export async function unlinkAgentDocument(darwinUri, idToken, agent_fk, document_fk) {
+    try {
+        const r = await call_rest_api(`${darwinUri}/agent_documents`, 'DELETE',
+            { agent_fk, document_fk }, idToken);
+        assertOk(r, 'unlinkAgentDocument');
+        return true;
+    } catch (err) {
+        if (isNotFound(err)) return false;   // already gone — the desired end state
+        throw err;
+    }
+}
+
+/**
+ * Error thrown when a rollback could not put the database back.
+ *
+ * Its own type because the caller must treat it differently from an ordinary
+ * failure: an ordinary failure means "nothing changed, try again", while this
+ * means "a link you did not ask to remove is now missing". The UI has to say so
+ * out loud and force a refetch rather than reporting the original conflict and
+ * leaving a stale, wrong screen up.
+ *
+ * This is the one place this module deliberately DIVERGES from the MCP daemon.
+ * `darwin-mcp/services/agents.py::link_agent_document` catches a failed restore,
+ * logs "the link is now MISSING", and then re-raises the ORIGINAL owner conflict
+ * — so the user is told "someone else owns this" while a link has silently
+ * vanished. That is a real defect on that path; reproducing it here would just
+ * give it a second home.
+ */
+export class LinkRollbackError extends Error {
+    constructor(message, { cause, lost } = {}) {
+        super(message);
+        this.name = 'LinkRollbackError';
+        this.cause = cause;
+        // The links that could not be restored, so the caller can name them.
+        this.lost = lost || [];
+        // Carried through so restErrorMessage / showError still work on it.
+        this.httpStatus = cause?.httpStatus;
+    }
+}
+
+/**
+ * Apply an ordered plan of junction writes, rolling back on failure.
+ *
+ * A "step" is one (agent, document) pair moving from `prev` to `next`:
+ *
+ *   { agent_fk, document_fk, prev: link | null, next: link | null }
+ *
+ *   prev=null, next=link   → create
+ *   prev=link, next=link   → re-classify (DELETE + POST, because there is no PUT)
+ *   prev=link, next=null   → unlink
+ *
+ * WHY A PLAN AND NOT A SEQUENCE OF CALLS. Ownership transfer is intrinsically two
+ * steps and their ORDER IS FORCED: `uq_agent_documents_owner` rejects the
+ * incoming claim while the incumbent still holds `owned`, so the incumbent must
+ * be dropped first. There is no ordering that avoids a window in which the
+ * document is unowned — only the length of that window and whether it is
+ * recoverable are in our control. Nothing here is atomic (each call is a separate
+ * Lambda invocation under autocommit), so recoverability is the whole job.
+ *
+ * On failure every applied step is undone in REVERSE order, restoring exactly
+ * what was there. Steps that were never reached are left alone. If the rollback
+ * itself fails, a LinkRollbackError is thrown naming what could not be put back —
+ * the original error is attached as `cause`, but it is no longer the headline,
+ * because "your edit was rejected" and "a link is now missing" are different
+ * things to tell a user and the second one outranks the first.
+ */
+export async function applyLinkPlan(darwinUri, idToken, steps) {
+    if (!steps.length) return null;
+
+    const applied = [];   // steps that completed, newest last
+
+    const runStep = async (step) => {
+        const deleted = step.prev
+            ? await unlinkAgentDocument(darwinUri, idToken, step.agent_fk, step.document_fk)
+            : false;
+        if (step.next) {
+            await linkAgentDocument(darwinUri, idToken, {
+                ...step.next,
+                agent_fk: step.agent_fk,
+                document_fk: step.document_fk,
+            });
+        }
+        // Record what we ACTUALLY did, not what we intended: a `prev` that turned
+        // out to be already absent must not be resurrected by the rollback.
+        applied.push({ ...step, deleted });
+    };
+
+    const rollback = async () => {
+        const lost = [];
+        for (const step of [...applied].reverse()) {
+            try {
+                // Remove whatever this step wrote, then put back whatever it
+                // genuinely removed. Both halves are conditional so a create-only
+                // step is undone by a delete and nothing else.
+                if (step.next) {
+                    await unlinkAgentDocument(darwinUri, idToken,
+                        step.agent_fk, step.document_fk);
+                }
+                if (step.deleted && step.prev) {
+                    await linkAgentDocument(darwinUri, idToken, {
+                        ...step.prev,
+                        agent_fk: step.agent_fk,
+                        document_fk: step.document_fk,
+                    });
+                }
+            } catch {
+                // Keep unwinding the rest — a second failure must not strand
+                // steps that could still be undone.
+                if (step.deleted && step.prev) lost.push(step);
+            }
+        }
+        return lost;
+    };
+
+    try {
+        for (const step of steps) await runStep(step);
+        return { applied: applied.length };
+    } catch (err) {
+        const lost = await rollback();
+        if (lost.length) {
+            throw new LinkRollbackError(
+                'The change was rejected AND the previous links could not be restored — '
+                + `${lost.length} agent link${lost.length === 1 ? ' is' : 's are'} now missing. `
+                + 'Reload the page to see the real state.',
+                { cause: err, lost });
+        }
+        throw err;
+    }
+}
+
+/**
+ * Re-classify one existing link — change its roles and/or notes.
+ * A single-step plan, so it inherits the rollback above.
+ */
+export async function setAgentDocumentLink(darwinUri, idToken, { prev, next }) {
+    return applyLinkPlan(darwinUri, idToken, [{
+        agent_fk: prev.agent_fk,
+        document_fk: prev.document_fk,
+        prev,
+        next,
+    }]);
+}
+
+// The ownership-transfer PLANNER lives in agentRegistryUtils as
+// `planOwnerTransfer`, next to the role helpers it is built from and away from
+// anything that touches the network. This module executes plans; it does not
+// build them. Same split as `planInstructionSwap` (utils) versus
+// `setAgentInstructionOrder` (api).

--- a/src/Agents/agentRegistryUtils.js
+++ b/src/Agents/agentRegistryUtils.js
@@ -25,6 +25,27 @@ export const parseRoles = (rel) => {
 export const hasRole = (rel, role) => parseRoles(rel).includes(role);
 export const isAutoload = (rel) => hasRole(rel, 'autoload');
 
+/**
+ * The INVERSE of `parseRoles`: roles -> the exact string the database stores.
+ *
+ * Deliberately named as `parseRoles`' pair and defined next to it, because the
+ * one thing that must never happen on this junction is a round trip through
+ * `relationshipLabel`. That helper joins with `", "` for DISPLAY; the space makes
+ * `" autoload"` a member no SET recognises, and under the non-strict sql_mode
+ * this database runs, an unrecognised member does not raise — the WHOLE
+ * assignment stores as `''`. The link then carries no roles at all: not owned,
+ * not autoloaded, rendered as an unremarkable dash. A document silently loses its
+ * owner and an agent silently stops reading a file it was told to read in full.
+ *
+ * So: bare comma, no space, unknown members dropped, output in precedence order
+ * so two links with the same roles always store byte-identical strings.
+ */
+export const serializeRoles = (roles = []) => {
+    const list = Array.isArray(roles) ? roles : parseRoles(roles);
+    const present = new Set(list.map(r => (r || '').trim()));
+    return RELATIONSHIP_ORDER.filter(r => present.has(r)).join(',');
+};
+
 // The highest-precedence role present — drives single-chip styling and sorting.
 export const primaryRole = (rel) => parseRoles(rel)[0] || null;
 
@@ -352,6 +373,334 @@ export const instructionContentError = (content) => {
     return null;
 };
 
+// ---------------------------------------------------------------------------
+// Field validation for edit-in-place DOCUMENT rows (req #3051).
+//
+// Same contract as the instruction validators above — a pure function per field
+// returning an error string or null — and the same reason for existing: the RDS
+// sql_mode is NOT strict, so the database silently TRUNCATES an over-long value
+// and silently CLAMPS an out-of-range integer instead of rejecting it. The client
+// is the only guard.
+//
+// TWO WAYS THIS DIFFERS FROM THE INSTRUCTION SIDE, both verified against
+// DarwinSQL/schema.sql rather than assumed:
+//
+//   1. EVERY editable document column is a VARCHAR, not a TEXT. MySQL measures a
+//      VARCHAR in CHARACTERS and a TEXT in BYTES — so `contentByteLength` (right
+//      for instructions.content) is the WRONG measure here, and so is JS
+//      `String.length`, which counts UTF-16 code units and reads an emoji as 2
+//      where MySQL counts 1. Rejecting a legal name is as much a defect as
+//      accepting an illegal one. See `charLength`.
+//
+//   2. `doc_type` LOOKS like an enum and is not: the column is VARCHAR(16) with a
+//      default, and VALID_DOC_TYPES is enforced only inside the MCP daemon
+//      (darwin-mcp/services/agents.py). A browser POST of "mrkdown" is accepted,
+//      stored, and then renders as an ordinary chip — nothing anywhere catches it.
+//      That is why the UI offers a fixed choice rather than a free-text field, and
+//      why this validator exists behind it.
+// ---------------------------------------------------------------------------
+
+// VARCHAR widths, from DarwinSQL/schema.sql.
+export const DOCUMENT_NAME_MAX = 256;       // NOT NULL, UNIQUE
+export const DOCUMENT_LOCATION_MAX = 512;   // nullable
+export const DOCUMENT_URL_MAX = 1024;       // nullable
+export const DOCUMENT_NOTES_MAX = 512;      // agent_documents.notes, nullable
+
+/** The only three values the registry recognises (MCP `VALID_DOC_TYPES`). */
+export const DOC_TYPES = ['markdown', 'html', 'text'];
+
+/**
+ * Length as MySQL counts it for a utf8mb4 VARCHAR: CODE POINTS.
+ *
+ * `'x'.length` counts UTF-16 code units, so any astral character (an emoji, and
+ * plenty of CJK extensions) counts double and a legal value would be rejected.
+ * Spreading the string iterates code points, which is what utf8mb4 stores one
+ * character per.
+ */
+export const charLength = (text) => [...(text || '')].length;
+
+/**
+ * Is this document name already taken?
+ *
+ * `architecture_documents.name` carries UNIQUE `uq_architecture_documents_name`,
+ * and — exactly like the instruction key — it does NOT exclude closed rows. The
+ * check must therefore run against the UNFILTERED catalog: the page hides closed
+ * rows by default, so colliding with one is a rejection the user cannot see the
+ * cause of. Compared case-insensitively on the trimmed value, matching the
+ * server's default utf8mb4 collation.
+ */
+export const documentNameTaken = (name, documents = [], selfId = null) => {
+    const candidate = (name || '').trim().toLowerCase();
+    if (!candidate) return false;
+    return documents.some(
+        d => d.id !== selfId && (d.name || '').trim().toLowerCase() === candidate);
+};
+
+/**
+ * Verdict for a pending document `name`.
+ *
+ * Empty is NOT an error, for the same reason as `instructionNameError`: the
+ * column is NOT NULL, so an in-place field treats empty as "abandon the edit" and
+ * reverts. Reporting it would leave a red field the user can only clear by
+ * retyping what was already there.
+ */
+export const documentNameError = (name, documents = [], selfId = null) => {
+    const trimmed = (name || '').trim();
+    if (!trimmed) return null;
+    const len = charLength(trimmed);
+    if (len > DOCUMENT_NAME_MAX) {
+        return `Too long: ${len} of ${DOCUMENT_NAME_MAX} characters. `
+            + 'The database would truncate it silently.';
+    }
+    if (documentNameTaken(trimmed, documents, selfId)) {
+        return `A document named "${trimmed}" already exists (it may be closed).`;
+    }
+    return null;
+};
+
+/**
+ * Verdict for `location` — the repo-relative path of the file this row registers.
+ *
+ * THIS IS THE MOST DANGEROUS FIELD ON THE PAGE, which is the opposite of how it
+ * looks. `name` is UNIQUE and reads like a key, but nothing in production
+ * resolves a document by name (`get_architecture_document_by_name` exists and has
+ * no caller outside the MCP test suite). `location` reads like a caption and is
+ * live, executed data: instruction #83 orders all 12 agents to read every
+ * `autoload` document "from its `location` in full, byte 1 to byte n" before
+ * starting work. The executor is an LLM, not a function, so nothing type-checks
+ * it — a wrong path means the agent boots without knowledge it was told to have
+ * and reports itself green. The only detector is the context-telemetry harness,
+ * and that walks `autoload_documents` only.
+ *
+ * The client cannot verify a path exists — the browser has no filesystem. So
+ * validation here is limited to shapes that are definitely wrong, and the real
+ * guard is the confirmation the page requires before writing this field on a
+ * document any agent autoloads.
+ *
+ * Empty is not an error: the column is nullable, and a row with only a `url` is
+ * legal (`documentHref` prefers `url` anyway).
+ */
+export const documentLocationError = (location) => {
+    const trimmed = (location || '').trim();
+    if (!trimmed) return null;
+    const len = charLength(trimmed);
+    if (len > DOCUMENT_LOCATION_MAX) {
+        return `Too long: ${len} of ${DOCUMENT_LOCATION_MAX} characters. `
+            + 'The database would truncate it silently.';
+    }
+    // `documentHref` interpolates this straight into a GitHub blob URL when `url`
+    // is absent, and every one of the 69 live rows is repo-relative.
+    if (trimmed.startsWith('/')) {
+        return 'Repo-relative path, with no leading slash (e.g. "memory/foo.md").';
+    }
+    if (trimmed.includes('..')) {
+        return 'A path segment of ".." cannot be resolved from the repo root.';
+    }
+    if (/\s/.test(trimmed)) {
+        return 'A path with whitespace in it will not resolve — check for a stray space.';
+    }
+    return null;
+};
+
+/**
+ * Verdict for `url`.
+ *
+ * Length is the boring half. The SCHEME check is the real one: `documentHref`
+ * returns `doc.url` verbatim and the page renders it straight into an anchor
+ * `href`. While the column was read-only that was inert — the only writer was a
+ * seed script. Making the field editable turns it into a stored-href sink, so a
+ * `javascript:` (or `data:`) value would be a script that runs on click, stored
+ * in the database, for every viewer. Restricting the scheme to http/https is the
+ * cheapest correct guard and costs nothing real: every one of the 69 live rows is
+ * an https GitHub-blob or site URL.
+ *
+ * A path with no scheme is allowed through — `documentHref` prefers `url` when
+ * present, and a relative href is same-origin and harmless.
+ */
+export const documentUrlError = (url) => {
+    const trimmed = (url || '').trim();
+    if (!trimmed) return null;
+    const len = charLength(trimmed);
+    if (len > DOCUMENT_URL_MAX) {
+        return `Too long: ${len} of ${DOCUMENT_URL_MAX} characters. `
+            + 'The database would truncate it silently.';
+    }
+    // Only a value that actually carries a scheme is scheme-checked; anything
+    // else is a relative path. The pattern matches the RFC 3986 shape rather than
+    // hunting for "javascript:" so a novel scheme is refused by default.
+    const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(trimmed);
+    if (scheme && !/^https?$/i.test(scheme[1])) {
+        return `Only http and https links are allowed here (this is "${scheme[1]}:"). `
+            + 'The registry renders this value straight into a link.';
+    }
+    return null;
+};
+
+/** Verdict for a link's `notes` — free prose about why an agent holds a role. */
+export const documentNotesError = (notes) => {
+    const len = charLength(notes || '');
+    if (len > DOCUMENT_NOTES_MAX) {
+        return `Too long: ${len} of ${DOCUMENT_NOTES_MAX} characters. `
+            + 'The database would truncate it silently.';
+    }
+    return null;
+};
+
+/** Verdict for `doc_type`. The column is free text; this is the only guard. */
+export const docTypeError = (docType) => (
+    DOC_TYPES.includes(docType)
+        ? null
+        : `Unknown document type "${docType}". Must be one of: ${DOC_TYPES.join(', ')}.`);
+
+/**
+ * Verdict for a pending role set. Error string, or null when writable.
+ *
+ * An EMPTY set is an error here rather than a revert, and that is deliberate —
+ * the opposite call from the text fields above. `relationship` is NOT NULL, but
+ * `''` is a perfectly legal value for a NOT NULL SET column, so the database
+ * would accept it and the link would simply stop meaning anything. There is no
+ * stored value to fall back to either: the roles ARE the link.
+ */
+export const relationshipSetError = (roles = []) => {
+    const list = Array.isArray(roles) ? roles : parseRoles(roles);
+    const unknown = list.filter(r => !RELATIONSHIP_ORDER.includes((r || '').trim()));
+    if (unknown.length) {
+        return `Unknown relationship${unknown.length === 1 ? '' : 's'}: `
+            + `${unknown.join(', ')}. Must be one of: ${RELATIONSHIP_ORDER.join(', ')}.`;
+    }
+    if (!serializeRoles(list)) {
+        return 'A link must carry at least one role — remove the link instead.';
+    }
+    // Instruction #83 makes an `owned` or `curated` document outrank a
+    // `referenced` one. A link carrying both ends of that comparison makes the
+    // precedence rule refer to itself, so it is a hard block rather than a hint.
+    if (list.includes('owned') && list.includes('referenced')) {
+        return 'A link cannot be both owned and referenced — owning already outranks referencing.';
+    }
+    return null;
+};
+
+/**
+ * Advisory for a role set — never blocks. Owning a document already carries the
+ * duty to keep it accurate (instruction #83), so `curated` on top of `owned`
+ * states the same thing twice rather than contradicting it.
+ */
+export const relationshipSetHint = (roles = []) => {
+    const list = Array.isArray(roles) ? roles : parseRoles(roles);
+    if (list.includes('owned') && list.includes('curated')) {
+        return 'Redundant: owning a document already carries the duty to keep it accurate.';
+    }
+    return null;
+};
+
+/**
+ * Which agent currently holds `owned` on this document, if any.
+ * Returns the junction link, not the agent row.
+ */
+export const documentOwnerLink = (links = []) =>
+    links.find(l => hasRole(l.relationship, 'owned')) || null;
+
+/**
+ * Next free slot in an agent's per-agent DOCUMENT order — max + 1, 1-indexed.
+ *
+ * Peer to `nextInstructionSortOrder`. `agent_documents.sort_order` is a tiebreak
+ * WITHIN a relationship rank (`list_documents_for_agent` orders by rank, then
+ * this, then name), so it matters less than the instruction one — but a new link
+ * landing on NULL still sorts last regardless of its role, which is wrong for a
+ * document an agent just took ownership of.
+ */
+export const nextDocumentSortOrder = (agentId, docLinks) => {
+    const links = docLinks.get(agentId) || [];
+    const orders = links.map(l => l.sort_order).filter(o => Number.isFinite(o));
+    return orders.length ? Math.max(...orders) + 1 : 1;
+};
+
+/**
+ * Plan the writes that move `owned` on one document from one agent to another.
+ *
+ * PURE — it issues nothing. That is the point: ownership transfer is the one
+ * multi-write action on this page, the dialog has to describe the exact writes
+ * before the user authorizes them, and the whole thing has to be testable without
+ * a network.
+ *
+ * THE ORDER IS FORCED, NOT CHOSEN. `uq_agent_documents_owner` is a UNIQUE key
+ * over a VIRTUAL column that equals `document_fk` exactly when the SET contains
+ * `owned`. So the incoming claim is rejected while the incumbent still holds it:
+ * release must come first, and the window in which the document is unowned is
+ * structural. Only its LENGTH and its RECOVERABILITY are in our control — hence
+ * `prev` on every step, which is what `applyLinkPlan` rolls back with.
+ *
+ * The incumbent KEEPS its other roles. An `owned,autoload` owner handing over
+ * ownership becomes plain `autoload` — it very likely still reads the file at
+ * boot, and silently dropping that would be a second change nobody asked for.
+ * When `owned` was its ONLY role there is no link left to demote to, so
+ * `keepOutgoing` decides between removing the link and parking it at
+ * `referenced`. Parking is the default the dialog offers, because the link's
+ * `notes` die with it and 87 of the 100 live links carry one.
+ *
+ * @param documentId   the document being transferred
+ * @param fromLink     the incumbent owner's link, or null when unowned
+ * @param toLink       the incoming owner's existing link, or null
+ * @param toAgentId    the incoming owner, or null to RELEASE without a successor
+ * @param keepOutgoing when the outgoing link would be left roleless, park it at
+ *                     `referenced` instead of deleting it
+ * @returns ordered steps of `{ agent_fk, document_fk, prev, next }`
+ */
+export const planOwnerTransfer = ({
+    documentId, fromLink = null, toLink = null, toAgentId = null, keepOutgoing = true,
+}) => {
+    const steps = [];
+
+    if (fromLink) {
+        const remaining = parseRoles(fromLink.relationship).filter(r => r !== 'owned');
+        const nextRoles = remaining.length
+            ? serializeRoles(remaining)
+            : (keepOutgoing ? 'referenced' : '');
+        steps.push({
+            agent_fk: fromLink.agent_fk,
+            document_fk: documentId,
+            prev: fromLink,
+            // EVERY column of the row is carried forward. There is no PUT on this
+            // table, so a "role change" is a DELETE and a fresh INSERT — and an
+            // INSERT that omits `notes` or `sort_order` does not leave them alone,
+            // it writes NULL over them. That is the quietest way to lose data on
+            // this page.
+            next: nextRoles
+                ? { ...fromLink, relationship: nextRoles }
+                : null,
+        });
+    }
+
+    if (toAgentId != null) {
+        // `owned` SUPERSEDES `referenced`; it does not stack with it. Instruction
+        // #83 makes an owned document outrank a referenced one, so a link carrying
+        // both makes that precedence rule refer to itself — which is exactly why
+        // `relationshipSetError` blocks the combination. A blind union would
+        // therefore have produced a set this codebase itself rejects: claiming
+        // ownership of a document you currently merely reference (the single
+        // commonest transfer target, since all 32 non-owner links are plain
+        // `referenced`) would build an invalid plan. Drop `referenced` on the way
+        // in. `autoload` and `curated` are orthogonal to ownership and are kept.
+        const merged = serializeRoles([
+            ...parseRoles(toLink?.relationship).filter(r => r !== 'referenced'),
+            'owned',
+        ]);
+        steps.push({
+            agent_fk: toAgentId,
+            document_fk: documentId,
+            prev: toLink,
+            next: {
+                ...(toLink || {}),
+                agent_fk: toAgentId,
+                document_fk: documentId,
+                relationship: merged,
+            },
+        });
+    }
+
+    return steps;
+};
+
 /**
  * Turn a thrown call_rest_api rejection into something a human can act on.
  *
@@ -360,6 +709,12 @@ export const instructionContentError = (content) => {
  * Matching on the message is the only way to tell "you picked a taken name" from
  * "the database is broken" — mapping IntegrityError to a real status code is
  * filed as its own requirement.
+ *
+ * EVERY key pattern keeps its `.*` table prefix rather than hardcoding one. That
+ * is what makes the same regex match against `darwin` and `darwin_dev`, whose
+ * messages carry different table qualifiers. And every `PRIMARY` pattern MUST be
+ * table-qualified: `agent_instructions.PRIMARY` and `agent_documents.PRIMARY`
+ * both end in `.PRIMARY`, so a bare match would report the wrong entity.
  */
 export const restErrorMessage = (err, fallback) => {
     const msg = typeof err?.httpStatus?.httpMessage === 'string'
@@ -372,8 +727,21 @@ export const restErrorMessage = (err, fallback) => {
     if (/Duplicate entry .* for key '.*agent_instructions\.PRIMARY'/i.test(msg)) {
         return 'That instruction is already bound to this agent.';
     }
+    // req #3051 — the documents registry's three keys.
+    if (/Duplicate entry .* for key '.*uq_architecture_documents_name'/i.test(msg)) {
+        return 'A document with that name already exists (the existing row may be closed).';
+    }
+    // The unique key is over the VIRTUAL `owned_document_fk`, so this fires only
+    // on a SECOND ownership claim — never on an ordinary link.
+    if (/Duplicate entry .* for key '.*uq_agent_documents_owner'/i.test(msg)) {
+        return 'Another agent already owns this document — at most one owner per document. '
+            + 'Use "curated" for a second architect, or hand ownership over from the current owner.';
+    }
+    if (/Duplicate entry .* for key '.*agent_documents\.PRIMARY'/i.test(msg)) {
+        return 'That document is already linked to this agent.';
+    }
     if (/foreign key constraint fails/i.test(msg)) {
-        return 'The agent or instruction no longer exists — reload the page and retry.';
+        return 'The agent, instruction or document no longer exists — reload the page and retry.';
     }
     return fallback;
 };

--- a/src/Agents/agentRegistryUtils.js
+++ b/src/Agents/agentRegistryUtils.js
@@ -110,9 +110,38 @@ export const docTypeChipProps = (t) =>
  * actually wants. Falling back to a constructed blob URL keeps a hand-inserted
  * row (one created through the MCP tool without a url) clickable rather than
  * dead.
+ *
+ * THE SCHEME IS CHECKED HERE, AT THE RENDER BOUNDARY, and not only in
+ * `documentUrlError` on the way in (req #3051). Two reasons the input validator
+ * is not sufficient on its own:
+ *
+ *   1. This UI is not the only writer. `update_architecture_document` in the MCP
+ *      daemon accepts `url` with no scheme validation at all, and rows predate
+ *      both. A value already in the database has never been past
+ *      `documentUrlError`.
+ *   2. Rendering is where the harm happens. Every consumer feeds this result
+ *      straight into an anchor `href` — DocumentsPage's open-link button and
+ *      AgentDetail's document link — and React does NOT sanitize a
+ *      `javascript:` URL, it only warns in development. So a stored one would be
+ *      a script that runs on click, for every viewer, in production.
+ *
+ * A rejected scheme FALLS THROUGH to the constructed blob URL rather than
+ * returning null: the row still links somewhere true, and the document does not
+ * silently lose its only affordance because one column is malformed.
  */
+const SAFE_HREF_SCHEME = /^(https?:)?\/\//i;
+
+const isSafeHref = (url) => {
+    const trimmed = (url || '').trim();
+    if (!trimmed) return false;
+    // A value carrying no scheme at all is a relative path: same-origin, inert.
+    const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(trimmed);
+    if (!scheme) return true;
+    return SAFE_HREF_SCHEME.test(trimmed) || /^https?:$/i.test(scheme[1] + ':');
+};
+
 export const documentHref = (doc) => {
-    if (doc?.url) return doc.url;
+    if (doc?.url && isSafeHref(doc.url)) return doc.url;
     if (!doc?.location) return null;
     return `https://github.com/BillWilliams79/DarwinAI-Config/blob/main/${doc.location}`;
 };

--- a/src/Agents/documentSort.js
+++ b/src/Agents/documentSort.js
@@ -1,0 +1,94 @@
+import GroupsIcon from '@mui/icons-material/Groups';
+import PersonIcon from '@mui/icons-material/Person';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import SortByAlphaIcon from '@mui/icons-material/SortByAlpha';
+
+// Browse-list sort vocabulary for /agents/documents (req #3051).
+//
+// Its own module rather than exports from DocumentsPage.jsx, for the two reasons
+// instructionSort.js gives and that apply verbatim here: mixing non-component
+// exports into a component file drops that file out of React Fast Refresh, so
+// every edit forces a full browser reload during development; and it lets vitest
+// exercise the comparator without pulling MUI into the test environment.
+//
+// This control also has a second job. `architecture_documents.sort_order` is
+// incoherent — 13 rows share the value 1, one is NULL, and the range is 1..16 —
+// and the page has always discarded it by re-sorting on name. The server default
+// sort was the column's last consumer, so retiring it here (devopsQueries now
+// asks for `name:asc`) is what makes the follow-on migration that drops the
+// column a one-line change. Exactly the move req #3063 made before migration 072
+// dropped `instructions.sort_order`.
+
+// The page default. Named once, here, so nothing infers it from array order.
+//
+// OWNER, not name, and that is not a convenience: this page exists to answer
+// "who owns this file?", which is the question that had no answer before the
+// registry existed and the reason ownership drifted silently for years. The
+// owner axis leads unless the user asks otherwise.
+export const DEFAULT_SORT_MODE = 'owner';
+
+export const SORT_MODES = [
+    { value: 'owner',  label: 'Owner',        icon: PersonIcon,      defaultDesc: false },
+    { value: 'name',   label: 'Name',         icon: SortByAlphaIcon, defaultDesc: false },
+    { value: 'agents', label: 'Agent Count',  icon: GroupsIcon,      defaultDesc: true  },
+    { value: 'date',   label: 'Last updated', icon: ScheduleIcon,    defaultDesc: true  },
+];
+
+// `update_ts` is NULL until a row is first edited, so an unedited row falls back
+// to its creation time — otherwise every never-touched document sorts as if it
+// were from 1970 and the "newest" list is meaningless.
+export const lastTouched = (d) => Date.parse(d.update_ts || d.create_ts || '') || 0;
+
+/** The owning agent's name, or '' when the document is unowned. */
+export const ownerName = (d) => d.ownerName || '';
+
+// Comparators are written ASCENDING and multiplied by the direction, so a mode
+// and its reverse can never disagree about ties.
+export const SORT_ASC = {
+    // Unowned rows are handled by the pin below, not here, so this only ever
+    // compares two rows that both have an owner (or two that both do not).
+    owner:  (a, b) => ownerName(a).localeCompare(ownerName(b)),
+    name:   (a, b) => (a.name || '').localeCompare(b.name || ''),
+    agents: (a, b) => a.links.length - b.links.length,
+    date:   (a, b) => lastTouched(a) - lastTouched(b),
+};
+
+// Cross-tab (localStorage), unlike the per-tab VIEW preference: a sort is a
+// standing preference about the catalog, not about this tab's task.
+export const SORT_STORAGE_KEY = 'darwin-documents-sort';
+export const readStoredSort = () => {
+    try {
+        const stored = localStorage.getItem(SORT_STORAGE_KEY);
+        return SORT_MODES.some(m => m.value === stored) ? stored : DEFAULT_SORT_MODE;
+    } catch { return DEFAULT_SORT_MODE; }   // Safari private mode
+};
+
+/**
+ * The full row comparator.
+ *
+ * TWO structural rules outrank the user's chosen sort, and they are deliberately
+ * different in scope:
+ *
+ * 1. CLOSED LAST, in every mode and both directions. A closed document is in no
+ *    agent's boot payload, so it never belongs above a live one — not even when
+ *    it would sort first alphabetically. Same rule as the instruction list.
+ *
+ * 2. UNOWNED FIRST, in the `owner` mode ONLY, in both directions. An unowned
+ *    document is the drift this registry exists to surface, so when the user is
+ *    reading by owner it leads. It is scoped to that one mode on purpose: pinning
+ *    it in `name` mode would produce an alphabetical list that is not
+ *    alphabetical, which reads as a bug rather than as emphasis.
+ *
+ * Name is the stable tiebreak, and a total one: `architecture_documents.name`
+ * carries a UNIQUE key, so no two rows can tie and the order never shuffles
+ * between renders.
+ */
+export const compareDocumentRows = (mode, desc) => {
+    const dir = desc ? -1 : 1;
+    const primary = SORT_ASC[mode] || SORT_ASC[DEFAULT_SORT_MODE];
+    return (a, b) =>
+        (a.closed ? 1 : 0) - (b.closed ? 1 : 0)
+        || (mode === 'owner' ? (a.owner ? 1 : 0) - (b.owner ? 1 : 0) : 0)
+        || dir * primary(a, b)
+        || (a.name || '').localeCompare(b.name || '');
+};

--- a/src/hooks/factory/devopsQueries.js
+++ b/src/hooks/factory/devopsQueries.js
@@ -234,7 +234,21 @@ export const architectureDocuments = createEntityQueries({
     defaultFields:
         'id,name,doc_type,location,url,closed,sort_order,creator_fk,create_ts,update_ts',
     fieldsInKey: true,
-    defaultSort: 'sort_order:asc',
+    // `name:asc`, not `sort_order:asc` (req #3051). This was the LAST consumer of
+    // `architecture_documents.sort_order`, and that column is incoherent: thirteen
+    // rows share the value 1, one is NULL, and nothing reads it — the agent boot
+    // payload orders by relationship rank then the JUNCTION's `sort_order`, and
+    // /agents/documents has always discarded it by re-sorting client-side. Since
+    // that page now ships an explicit browse-sort control (documentSort.js), the
+    // server sort only needs to be deterministic, and `name` is UNIQUE so it is
+    // total. Retiring the last reader here is what makes the follow-on migration
+    // that drops the column a one-line change — deliberately the same sequence
+    // req #3063 ran before migration 072 dropped `instructions.sort_order`.
+    //
+    // `sort_order` stays in `defaultFields` on purpose: the column still exists,
+    // and a projection that omitted it would make the eventual drop invisible to
+    // anything reading these rows.
+    defaultSort: 'name:asc',
 });
 
 export const agentDocuments = createEntityQueries({


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-07-26T10:39:35Z
- fix(3051): refuse a dangerous url scheme at the RENDER boundary, not only on input
- test(3051): cover the editable documents registry — and fix the rollback defect it found
- wip(3051): make the architecture-document registry editable
- chore: init swarm session feature/3051-documents-page-becomes-editable-1

## Files changed
```
 src/Agents/AgentDetail.jsx                         |   12 +-
 src/Agents/DocumentAgentChips.jsx                  |  178 +++
 src/Agents/DocumentDeleteDialog.jsx                |  179 +++
 src/Agents/DocumentLinkPopover.jsx                 |  251 ++++
 src/Agents/DocumentLocationDialog.jsx              |  114 ++
 src/Agents/DocumentOwnerDialog.jsx                 |  199 +++
 src/Agents/DocumentUnbindDialog.jsx                |   97 ++
 src/Agents/DocumentsPage.jsx                       | 1589 ++++++++++++++++++--
 src/Agents/__tests__/DocumentsPage.test.jsx        |  975 ++++++++++++
 src/Agents/__tests__/agentRegistryUtils.test.js    |   12 +-
 src/Agents/__tests__/documentRegistryUtils.test.js |  657 ++++++++
 src/Agents/__tests__/documentSort.test.js          |  249 +++
 src/Agents/__tests__/documentsApi.test.js          |  471 ++++++
 src/Agents/actions/documentsApi.js                 |  340 +++++
 src/Agents/agentRegistryUtils.js                   |  407 ++++-
 src/Agents/documentSort.js                         |   94 ++
 src/hooks/factory/devopsQueries.js                 |   16 +-
 17 files changed, 5726 insertions(+), 114 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Related PRs: BillWilliams79/DarwinAI-Config#647