### PR TITLE
Ground-truth breakdown of the Claude Code base token figure

### DIFF
--- a/src/Agents/ContextPage.jsx
+++ b/src/Agents/ContextPage.jsx
@@ -94,6 +94,11 @@ const GLOSSARY = [
     ['Units', <>All values are <strong>actual tokens</strong> (real tokenizer, from transcript usage deltas), except <strong>Boot time</strong> which is milliseconds.</>],
     ['Boot time', <>Latency of the <code>darwin://agents/&lt;Name&gt;</code> boot call, measured <strong>sequentially</strong> (one boot at a time; parallel launch inflates it ~2&times;).</>],
     ['Claude Code', <>The Claude Code system prompt: harness instructions + tool schemas + skills listing + MCP listing. Equals Initial context minus CLAUDE.md and the charter stub.</>],
+    ['System Prompt', <>Ground-truth breakdown (req #3095): the harness instructions piece of Claude Code, read directly from Claude Code's own <code>/context</code> command.</>],
+    ['System Tools', <>Ground-truth breakdown: the built-in tool-schema piece of Claude Code (Read, Write, Bash, etc.), read directly from <code>/context</code>.</>],
+    ['MCP Tools', <>Ground-truth breakdown: the MCP tools/resources listing piece of Claude Code, read directly from <code>/context</code>.</>],
+    ['Skills', <>Ground-truth breakdown: the available-skills listing piece of Claude Code, read directly from <code>/context</code>.</>],
+    ['Custom Agents', <>Ground-truth breakdown: the other-custom-agent listing piece of Claude Code, read directly from <code>/context</code>.</>],
     ['CLAUDE.md', <>The project instruction file, loaded into every session.</>],
     ['Agent File', <>The agent's <code>.claude/agents/*.md</code> file, loaded as its system prompt.</>],
     ['Agent MCP Payload', <>Context added by the boot call — identity row, binding instructions, and document pointers (not document contents).</>],
@@ -326,12 +331,15 @@ const ContextPage = () => {
         <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }} data-testid="agent-context-page">
             <style>{TABLE_CSS}</style>
 
-            {/* maxWidth matches the atc-root Box below so the trailing icons here
-                right-align with the telemetry table's actual right edge, not the
-                full (possibly much wider) page — req #3065. mb matches the
-                atc-root Box's own flex `gap` (34px) so the gap above the capture
-                picker equals the gap below it (picker -> Description). */}
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: '34px', flexWrap: 'wrap', gap: 2, maxWidth: 1120 }}>
+            {/* No maxWidth (req #3095 follow-up) — the table now has 14 columns and
+                needs the full content-area width before its own horizontal scrollbar
+                (.atc-scroll) should ever engage; a fixed cap here forced that scrollbar
+                well before the viewport ran out of room. This Box and the atc-root Box
+                below both stretch to the same (unconstrained) width, so the trailing
+                icons here still right-align with the table's actual right edge. mb
+                matches the atc-root Box's own flex `gap` (34px) so the gap above the
+                capture picker equals the gap below it (picker -> Description). */}
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: '34px', flexWrap: 'wrap', gap: 2 }}>
                 <ToggleButtonGroup
                     size="small"
                     exclusive
@@ -369,7 +377,7 @@ const ContextPage = () => {
                     No telemetry captures recorded yet.
                 </Typography>
             ) : (
-                <Box className="atc-root" sx={{ ...vars, display: 'flex', flexDirection: 'column', gap: '34px', maxWidth: 1120 }}>
+                <Box className="atc-root" sx={{ ...vars, display: 'flex', flexDirection: 'column', gap: '34px' }}>
                     {/* Capture control is the first element of the render window
                         (req #3065) — above the Description, which is itself above
                         the table. A Button rather than a <Select> so the dropdown
@@ -552,6 +560,7 @@ const ContextPage = () => {
                                         Boot time<br />(ms){sortArrow('boot_time_ms')}
                                     </th>
                                     <th className="grp" colSpan={3}>FIXED OVERHEAD</th>
+                                    <th className="grp" colSpan={5}>CC BASE BREAKDOWN</th>
                                     <th className="grp" colSpan={3}>Loaded per-agent</th>
                                     <th className="num sortable" rowSpan={2}
                                         onClick={() => handleSort('start_work_context_tokens')}
@@ -572,6 +581,26 @@ const ContextPage = () => {
                                         data-testid="agent-context-sort-charter_stub_tokens">
                                         Agent File{sortArrow('charter_stub_tokens')}
                                     </th>
+                                    <th className="num sortable" onClick={() => handleSort('system_prompt_tokens')}
+                                        data-testid="agent-context-sort-system_prompt_tokens">
+                                        System<br />Prompt{sortArrow('system_prompt_tokens')}
+                                    </th>
+                                    <th className="num sortable" onClick={() => handleSort('system_tools_tokens')}
+                                        data-testid="agent-context-sort-system_tools_tokens">
+                                        System<br />Tools{sortArrow('system_tools_tokens')}
+                                    </th>
+                                    <th className="num sortable" onClick={() => handleSort('mcp_tools_tokens')}
+                                        data-testid="agent-context-sort-mcp_tools_tokens">
+                                        MCP<br />Tools{sortArrow('mcp_tools_tokens')}
+                                    </th>
+                                    <th className="num sortable" onClick={() => handleSort('skills_tokens')}
+                                        data-testid="agent-context-sort-skills_tokens">
+                                        Skills{sortArrow('skills_tokens')}
+                                    </th>
+                                    <th className="num sortable" onClick={() => handleSort('custom_agents_tokens')}
+                                        data-testid="agent-context-sort-custom_agents_tokens">
+                                        Custom<br />Agents{sortArrow('custom_agents_tokens')}
+                                    </th>
                                     <th className="num sortable" onClick={() => handleSort('boot_payload_tokens')}
                                         data-testid="agent-context-sort-boot_payload_tokens">
                                         Agent MCP Payload{sortArrow('boot_payload_tokens')}
@@ -589,7 +618,7 @@ const ContextPage = () => {
                             <tbody>
                                 {rowsLoading ? (
                                     <tr><td className="agent"><CircularProgress size={16} /></td>
-                                        <td colSpan={8} /></tr>
+                                        <td colSpan={13} /></tr>
                                 ) : rendered.list.map((r) => {
                                     const c = computeCells(r, rendered.markerByText);
                                     // A cell string that equals the n/a sentinel renders muted.
@@ -615,6 +644,11 @@ const ContextPage = () => {
                                                         </span>
                                                     )}
                                             </td>
+                                            <td className="num">{cell(c.systemPrompt)}</td>
+                                            <td className="num">{cell(c.systemTools)}</td>
+                                            <td className="num">{cell(c.mcpTools)}</td>
+                                            <td className="num">{cell(c.skills)}</td>
+                                            <td className="num">{cell(c.customAgents)}</td>
                                             <td className="num">{cell(c.bootPayload)}</td>
                                             <td className="num">{cell(c.autoload)}</td>
                                             <td className={`mid${c.docsIncomplete ? ' docs-warn' : ''}`}>
@@ -627,6 +661,22 @@ const ContextPage = () => {
                             </tbody>
                         </table>
                     </div>
+
+                    {/* Per-row footnotes (the *, †, … markers on individual cells — e.g. why a
+                        row's charter stub or boot/autoload phase shows n/a) render as a legend
+                        directly below the table, not inside the column-definition Glossary
+                        dialog — they explain THIS capture's specific rows, not the table's fixed
+                        column vocabulary, and a reader should be able to see them without an
+                        extra click. */}
+                    {rendered.markerByText.size > 0 && (
+                        <Box data-testid="agent-context-footnotes" sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                            {[...rendered.markerByText.entries()].map(([text, mark]) => (
+                                <Typography key={mark} variant="caption" color="text.secondary">
+                                    <strong>{mark}</strong> {text}
+                                </Typography>
+                            ))}
+                        </Box>
+                    )}
                 </Box>
             )}
 
@@ -648,12 +698,6 @@ const ContextPage = () => {
                             <Fragment key={term}>
                                 <Typography variant="subtitle2">{term}</Typography>
                                 <Typography variant="body2" color="text.secondary">{def}</Typography>
-                            </Fragment>
-                        ))}
-                        {[...rendered.markerByText.entries()].map(([text, mark]) => (
-                            <Fragment key={mark}>
-                                <Typography variant="subtitle2">{mark}</Typography>
-                                <Typography variant="body2" color="text.secondary">{text}</Typography>
                             </Fragment>
                         ))}
                     </Box>

--- a/src/Agents/__tests__/ContextPage.test.jsx
+++ b/src/Agents/__tests__/ContextPage.test.jsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+//
+// Req #3095 gap-coverage pass — ContextPage.jsx had NO component-level test at
+// all before this file (a pre-existing gap unrelated to req #3095, named in the
+// test-architect's report; this file only closes the slice that req #3095's own
+// change touches, not a full page rewrite of coverage).
+//
+// contextRenderUtils.test.js already pins computeCells()/sortByColumn() as pure
+// functions for the five new ground-truth breakdown columns (system_prompt_tokens
+// / system_tools_tokens / mcp_tools_tokens / skills_tokens / custom_agents_tokens).
+// What THOSE tests cannot see is whether the page actually wires them into the
+// table: the new "CC BASE BREAKDOWN" group header, the five sortable <th>s with
+// their data-testids, and the five <td>s rendering real values vs "n/a" per row.
+//
+// Mounted harness with raw react-dom + act — the house pattern (there is no
+// @testing-library in this repo). Unlike DocumentsPage.test.jsx / InstructionsPage
+// .test.jsx, this harness does NOT call localStorage.clear()/sessionStorage.clear()
+// in beforeEach — ContextPage doesn't read either, and (per the test-architect's
+// gap analysis) those two calls are the proximate cause of the pre-existing
+// unrelated failure in those other two files, not something to reproduce here.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// Module-level query data the mocked hooks read from — set per test.
+let runsData = [];
+let rowsData = [];
+
+vi.mock('../../hooks/useDataQueries', () => ({
+    useAgentTelemetryRuns: () => ({ data: runsData, isLoading: false }),
+    useAgentTelemetryRowsByRun: () => ({ data: rowsData, isLoading: false }),
+    agentTelemetryRunKeys: { all: (c) => ['agent_telemetry_runs', c] },
+}));
+
+vi.mock('../actions/contextApi', () => ({
+    deleteAgentTelemetryRun: vi.fn(),
+    updateAgentTelemetryRun: vi.fn(),
+}));
+
+import ContextPage from '../ContextPage';
+import AppContext from '../../Context/AppContext';
+import AuthContext from '../../Context/AuthContext';
+
+const URI = 'http://test.local';
+const TOKEN = 'tok';
+const CREATOR = 'tester';
+
+const RUN = { id: 1, label: 'baseline capture', captured_at: '2026-07-26T00:00:00',
+    harness_version: 'cc-x', source_note: null };
+
+// One row WITH the full ground-truth breakdown captured, one WITHOUT — the two
+// shapes the report route actually produces (a re-captured agent vs. an older
+// run's row that predates req #3095 and simply has NULL in all five columns).
+const ROW_WITH_BREAKDOWN = {
+    id: 10, agent_name: 'Frontend Architect', role: 'architect', session_kind: 'subagent',
+    boot_time_ms: 400, cc_base_tokens: 70082,
+    system_prompt_tokens: 9260, system_tools_tokens: 36500, mcp_tools_tokens: 21400,
+    skills_tokens: 2000, custom_agents_tokens: 922,
+    claude_md_tokens: 10033, charter_stub_tokens: 1821, boot_payload_tokens: 4973,
+    autoload_tokens: 6768, docs_loaded: 4, docs_expected: 4,
+    start_work_context_tokens: 92714, footnote: null, sort_order: 1,
+};
+const ROW_WITHOUT_BREAKDOWN = {
+    id: 11, agent_name: 'Legacy Agent', role: 'architect', session_kind: 'subagent',
+    boot_time_ms: 300, cc_base_tokens: 15000,
+    system_prompt_tokens: null, system_tools_tokens: null, mcp_tools_tokens: null,
+    skills_tokens: null, custom_agents_tokens: null,
+    claude_md_tokens: 10033, charter_stub_tokens: 1500, boot_payload_tokens: 4000,
+    autoload_tokens: 5000, docs_loaded: 2, docs_expected: 2,
+    start_work_context_tokens: 30000, footnote: null, sort_order: 2,
+};
+
+let container;
+let root;
+
+function mount() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: URI }}>
+                    <AuthContext.Provider value={{ idToken: TOKEN, profile: { userName: CREATOR } }}>
+                        <ContextPage />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+}
+
+beforeEach(() => {
+    runsData = [RUN];
+    rowsData = [ROW_WITH_BREAKDOWN, ROW_WITHOUT_BREAKDOWN];
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.body.innerHTML = '';
+});
+
+describe('ContextPage — CC BASE BREAKDOWN columns (req #3095)', () => {
+    it('renders the group header spanning all five breakdown columns', () => {
+        mount();
+        const groupHeaders = [...container.querySelectorAll('th.grp')]
+            .map(th => th.textContent);
+        expect(groupHeaders).toContain('CC BASE BREAKDOWN');
+    });
+
+    it('renders all five sortable column headers with their data-testids', () => {
+        mount();
+        for (const field of ['system_prompt_tokens', 'system_tools_tokens',
+            'mcp_tools_tokens', 'skills_tokens', 'custom_agents_tokens']) {
+            const th = container.querySelector(`[data-testid="agent-context-sort-${field}"]`);
+            expect(th, `missing header for ${field}`).not.toBeNull();
+        }
+    });
+
+    it('formats real values for a row whose breakdown was captured', () => {
+        mount();
+        const row = container.querySelector('[data-testid="agent-context-row-10"]');
+        expect(row).not.toBeNull();
+        const cells = [...row.querySelectorAll('td.num')].map(td => td.textContent);
+        expect(cells).toContain('9,260');
+        expect(cells).toContain('36,500');
+        expect(cells).toContain('21,400');
+        expect(cells).toContain('2,000');
+        expect(cells).toContain('922');
+    });
+
+    it('renders n/a for a row whose breakdown was never captured', () => {
+        mount();
+        const row = container.querySelector('[data-testid="agent-context-row-11"]');
+        expect(row).not.toBeNull();
+        // The five breakdown <td>s sit between cc_base_tokens and claude_md_tokens;
+        // count how many "n/a" markers this row shows overall and confirm it's at
+        // least 5 (the five breakdown cells), without depending on exact column
+        // position, which is already pinned by the header-order test above.
+        const naCount = [...row.querySelectorAll('td .fn')]
+            .filter(el => el.textContent === 'n/a').length;
+        expect(naCount).toBeGreaterThanOrEqual(5);
+    });
+
+    it('clicking the System Prompt header sorts the table by that column', () => {
+        mount();
+        const th = container.querySelector('[data-testid="agent-context-sort-system_prompt_tokens"]');
+        act(() => { th.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+        // Descending is the natural direction for a numeric column — row 10
+        // (9260) outranks row 11 (null, sorted last), so it must render FIRST.
+        const rows = [...container.querySelectorAll('tbody tr[data-testid^="agent-context-row-"]')];
+        expect(rows[0].getAttribute('data-testid')).toBe('agent-context-row-10');
+    });
+
+    it('the glossary lists all five breakdown terms', () => {
+        mount();
+        act(() => {
+            container.querySelector('[data-testid="agent-context-glossary-btn"]')
+                .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+        const text = document.body.textContent;
+        for (const term of ['System Prompt', 'System Tools', 'MCP Tools', 'Skills', 'Custom Agents']) {
+            expect(text).toContain(term);
+        }
+    });
+});

--- a/src/Agents/__tests__/contextRenderUtils.test.js
+++ b/src/Agents/__tests__/contextRenderUtils.test.js
@@ -175,6 +175,53 @@ describe('computeCells — primary (no boot/autoload phase)', () => {
     });
 });
 
+describe('naturalSortDir — ground-truth breakdown columns (req #3095)', () => {
+    it('defaults each breakdown column to descending, same as any other numeric column', () => {
+        expect(naturalSortDir('system_prompt_tokens')).toBe('desc');
+        expect(naturalSortDir('system_tools_tokens')).toBe('desc');
+        expect(naturalSortDir('mcp_tools_tokens')).toBe('desc');
+        expect(naturalSortDir('skills_tokens')).toBe('desc');
+        expect(naturalSortDir('custom_agents_tokens')).toBe('desc');
+    });
+});
+
+describe('sortByColumn — ground-truth breakdown columns (req #3095)', () => {
+    it('sorts by system_tools_tokens, NULLs last', () => {
+        const rows = [
+            architect({ id: 1, system_tools_tokens: 36500 }),
+            architect({ id: 2, system_tools_tokens: null }),
+            architect({ id: 3, system_tools_tokens: 12000 }),
+        ];
+        expect(sortByColumn(rows, 'system_tools_tokens', 'desc').map(r => r.id))
+            .toEqual([1, 3, 2]);
+    });
+});
+
+describe('computeCells — ground-truth breakdown (req #3095)', () => {
+    it('formats all five breakdown cells when present', () => {
+        const row = architect({
+            system_prompt_tokens: 926, system_tools_tokens: 36500,
+            mcp_tools_tokens: 21400, skills_tokens: 2000, custom_agents_tokens: 922,
+        });
+        const c = computeCells(row, new Map());
+        expect(c.systemPrompt).toBe('926');
+        expect(c.systemTools).toBe('36,500');
+        expect(c.mcpTools).toBe('21,400');
+        expect(c.skills).toBe('2,000');
+        expect(c.customAgents).toBe('922');
+    });
+    it('renders n/a for a row whose breakdown was never captured', () => {
+        // architect() fixture doesn't set the five breakdown fields at all —
+        // the same "not yet measured" shape as an existing historical run row.
+        const c = computeCells(architect(), new Map());
+        expect(c.systemPrompt).toBe(NA);
+        expect(c.systemTools).toBe(NA);
+        expect(c.mcpTools).toBe(NA);
+        expect(c.skills).toBe(NA);
+        expect(c.customAgents).toBe(NA);
+    });
+});
+
 describe('computeCells — docsIncomplete edge cases', () => {
     const m = new Map();
     it('0/0 is not incomplete — nothing was owed', () => {

--- a/src/Agents/contextRenderUtils.js
+++ b/src/Agents/contextRenderUtils.js
@@ -22,6 +22,11 @@ const SORT_COLUMNS = {
     agent_name: { type: 'string', get: (r) => r.agent_name },
     boot_time_ms: { type: 'number', get: (r) => r.boot_time_ms },
     cc_base_tokens: { type: 'number', get: (r) => r.cc_base_tokens },
+    system_prompt_tokens: { type: 'number', get: (r) => r.system_prompt_tokens },
+    system_tools_tokens: { type: 'number', get: (r) => r.system_tools_tokens },
+    mcp_tools_tokens: { type: 'number', get: (r) => r.mcp_tools_tokens },
+    skills_tokens: { type: 'number', get: (r) => r.skills_tokens },
+    custom_agents_tokens: { type: 'number', get: (r) => r.custom_agents_tokens },
     claude_md_tokens: { type: 'number', get: (r) => r.claude_md_tokens },
     charter_stub_tokens: { type: 'number', get: (r) => r.charter_stub_tokens },
     boot_payload_tokens: { type: 'number', get: (r) => r.boot_payload_tokens },
@@ -123,6 +128,14 @@ export function computeCells(row, markerByText) {
         bootMs: num(row.boot_time_ms),
         ccBase: num(row.cc_base_tokens),
         ccBaseMarker: marker,                      // superscript appended to CC base
+        // Ground-truth CC-base breakdown (req #3095) — each independently nullable;
+        // a row without a captured breakdown renders "n/a" in all five, same as any
+        // other not-yet-measured cell on this page.
+        systemPrompt: num(row.system_prompt_tokens),
+        systemTools: num(row.system_tools_tokens),
+        mcpTools: num(row.mcp_tools_tokens),
+        skills: num(row.skills_tokens),
+        customAgents: num(row.custom_agents_tokens),
         claudeMd: num(row.claude_md_tokens),
         // Charter stub: a real number when present; the footnote marker when the
         // agent BUNDLES its stub into CC base (reviewer); otherwise n/a (primary).

--- a/src/hooks/__tests__/createEntityQueriesOpsUrl.test.js
+++ b/src/hooks/__tests__/createEntityQueriesOpsUrl.test.js
@@ -168,4 +168,28 @@ describe('createEntityQueries — wired devops blocks follow dev/prod split (req
         const url = callRestApiMock.mock.calls[0][0];
         expect(url).toContain(`${TEST_DARWIN_URI}/swarm_start_sessions`);
     });
+
+    // Req #3095 — the ground-truth CC-base breakdown added five columns to
+    // agent_telemetry_rows. The report route reads them by NAME through this
+    // factory's `fields=` projection (see agent-context-telemetry.md's
+    // ContextPage.jsx consumer); a typo'd or dropped column name here would
+    // silently omit that data from every fetch with no error anywhere, since
+    // Lambda-Rest's generic GET simply returns fewer columns for an unknown
+    // field rather than 400ing. This locks the five names into the projection.
+    it('agentTelemetryRows.useByRun projects the five ground-truth breakdown columns (req #3095)', async () => {
+        const { agentTelemetryRows } = await import('../factory/devopsQueries');
+        agentTelemetryRows.useByRun(1);
+        const url = callRestApiMock.mock.calls[0][0];
+        const fieldsMatch = /[?&]fields=([^&]+)/.exec(url);
+        expect(fieldsMatch).not.toBeNull();
+        const projected = fieldsMatch[1].split(',');
+        for (const breakdown of ['system_prompt_tokens', 'system_tools_tokens',
+            'mcp_tools_tokens', 'skills_tokens', 'custom_agents_tokens']) {
+            expect(projected).toContain(breakdown);
+        }
+        // Sanity: the pre-existing columns the table already rendered are untouched.
+        for (const existing of ['cc_base_tokens', 'claude_md_tokens', 'start_work_context_tokens']) {
+            expect(projected).toContain(existing);
+        }
+    });
 });

--- a/src/hooks/factory/devopsQueries.js
+++ b/src/hooks/factory/devopsQueries.js
@@ -300,6 +300,8 @@ export const agentTelemetryRows = createEntityQueries({
     entity: 'agent_telemetry_rows',
     defaultFields:
         'id,run_fk,agent_name,role,session_kind,boot_time_ms,cc_base_tokens,' +
+        'system_prompt_tokens,system_tools_tokens,mcp_tools_tokens,skills_tokens,' +
+        'custom_agents_tokens,' +
         'claude_md_tokens,charter_stub_tokens,boot_payload_tokens,autoload_tokens,' +
         'docs_loaded,docs_expected,start_work_context_tokens,footnote,sort_order,' +
         'creator_fk',


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-07-27T01:54:41Z
- wip(Darwin): 2026-07-27T01:50:48Z
- chore: init swarm session feature/3095-ground-truth-breakdown-of-the-1

## Files changed
```
 src/Agents/ContextPage.jsx                         |  72 +++++++--
 src/Agents/__tests__/ContextPage.test.jsx          | 178 +++++++++++++++++++++
 src/Agents/__tests__/contextRenderUtils.test.js    |  47 ++++++
 src/Agents/contextRenderUtils.js                   |  13 ++
 .../__tests__/createEntityQueriesOpsUrl.test.js    |  24 +++
 src/hooks/factory/devopsQueries.js                 |   2 +
 6 files changed, 322 insertions(+), 14 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)