### PR TITLE
Per-document actual-token capture for architecture/autoload docs

### DIFF
--- a/src/Agents/ContextPage.jsx
+++ b/src/Agents/ContextPage.jsx
@@ -33,6 +33,15 @@
 // into Claude Code) — those cells render "n/a" or a footnote marker, matching
 // the artifact. The Docs cell renders in red when one or more architecture
 // documents failed to load for that agent.
+//
+// Docs Loaded drill-down (req #3096): when at least one document was loaded,
+// the cell is click-to-expand — a chevron toggles an inline detail <tr> right
+// below the agent's row, listing that run's per-document actual-token
+// breakdown (AgentDocsDetail). Deliberately NOT an MUI DataGrid (this page
+// already bypasses that convention to reproduce the artifact byte-for-byte,
+// see above) — the detail row reuses the same hand-rolled table CSS system
+// instead. Data is fetched lazily, only once a row is actually expanded
+// (useAgentTelemetryRowDocsByRow), never eagerly for every row on page load.
 
 import '../index.css';
 import { Fragment, useContext, useEffect, useMemo, useState } from 'react';
@@ -74,13 +83,14 @@ import AuthContext from '../Context/AuthContext';
 import GhostTextField from '../Components/GhostField/GhostTextField';
 import { formatDateTime } from '../utils/dateFormat';
 import {
-    useAgentTelemetryRuns, useAgentTelemetryRowsByRun, agentTelemetryRunKeys,
+    useAgentTelemetryRuns, useAgentTelemetryRowsByRun, useAgentTelemetryRowDocsByRow,
+    agentTelemetryRunKeys,
 } from '../hooks/useDataQueries';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
 import { deleteAgentTelemetryRun, updateAgentTelemetryRun } from './actions/contextApi';
 import {
-    NA as NA_TEXT, sortByColumn, naturalSortDir, DEFAULT_SORT_FIELD, DEFAULT_SORT_DIR,
+    NA as NA_TEXT, fmt, sortByColumn, naturalSortDir, DEFAULT_SORT_FIELD, DEFAULT_SORT_DIR,
     assignMarkers, computeCells, runDateLabel,
 } from './contextRenderUtils';
 import ContextDeleteDialog from './ContextDeleteDialog';
@@ -135,14 +145,59 @@ const TABLE_CSS = `
 .atc-root th.agent, .atc-root td.agent { text-align:left; position:sticky; left:0; background:var(--panel); font-weight:600; white-space:nowrap; box-shadow:1px 0 0 var(--line); }
 .atc-root thead th.agent { background:var(--head); }
 .atc-root tbody td { padding:8px 13px; border-bottom:1px solid var(--line); color:var(--ink); }
-.atc-root tbody tr:nth-of-type(even) td { background:var(--zebra); }
-.atc-root tbody tr:nth-of-type(even) td.agent { background:var(--zebra); }
+.atc-root tbody tr.even-row td { background:var(--zebra); }
+.atc-root tbody tr.even-row td.agent { background:var(--zebra); }
 .atc-root tbody tr:hover td, .atc-root tbody tr:hover td.agent { background:var(--accent-soft); }
 .atc-root .swc { font-weight:700; color:var(--accent); }
 .atc-root tr.primary td.agent { color:var(--accent); }
 .atc-root .fn { color:var(--muted); font-family:inherit; }
 .atc-root .docs-warn { color:var(--danger); font-weight:700; }
+.atc-root td.docs-clickable { cursor:pointer; text-decoration:underline dotted; text-underline-offset:3px; }
+.atc-root td.docs-clickable:hover { color:var(--accent); }
+.atc-root tr.doc-detail td { background:var(--zebra); padding:4px 13px 12px 13px; }
+.atc-root .doc-detail-table { width:100%; border-collapse:collapse; font-size:12.5px; margin-top:2px; }
+.atc-root .doc-detail-table td { padding:3px 10px; border:none; color:var(--muted); }
+.atc-root .doc-detail-table td.doc-path { font-family:var(--mono); color:var(--ink); }
+.atc-root .doc-detail-table td.doc-tokens { text-align:right; font-family:var(--mono); font-variant-numeric:tabular-nums; color:var(--ink); }
 `;
+
+// req #3096 — the per-document breakdown for one agent row's Docs Loaded cell.
+// Only ever mounted while its row is expanded (see `expandedDocRows` below), so
+// the fetch is lazy by construction — no `enabled` gate needed, the query simply
+// does not exist in the tree until the user asks for it.
+const AgentDocsDetail = ({ rowId }) => {
+    const { data: docs, isLoading } = useAgentTelemetryRowDocsByRow(rowId);
+    const sorted = useMemo(() => {
+        return [...(docs || [])].sort((a, b) => {
+            const as = a.sort_order ?? Number.MAX_SAFE_INTEGER;
+            const bs = b.sort_order ?? Number.MAX_SAFE_INTEGER;
+            return (as - bs) || (a.id - b.id);
+        });
+    }, [docs]);
+    return (
+        <tr className="doc-detail" data-testid={`agent-context-docs-detail-${rowId}`}>
+            <td className="agent" />
+            <td colSpan={8}>
+                {isLoading ? (
+                    <CircularProgress size={14} />
+                ) : sorted.length === 0 ? (
+                    <span className="fn">No per-document breakdown captured for this run.</span>
+                ) : (
+                    <table className="doc-detail-table" data-testid={`agent-context-docs-grid-${rowId}`}>
+                        <tbody>
+                            {sorted.map((d) => (
+                                <tr key={d.id} data-testid={`agent-context-docs-detail-item-${rowId}-${d.id}`}>
+                                    <td className="doc-path">{d.doc_path}</td>
+                                    <td className="doc-tokens">{fmt(d.actual_tokens)}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </td>
+        </tr>
+    );
+};
 
 const ContextPage = () => {
     const { profile, idToken } = useContext(AuthContext);
@@ -167,6 +222,14 @@ const ContextPage = () => {
     const [captureAnchor, setCaptureAnchor] = useState(null);
     const [sortField, setSortField] = useState(DEFAULT_SORT_FIELD);
     const [sortDir, setSortDir] = useState(DEFAULT_SORT_DIR);
+    // req #3096 — which agent rows currently show their per-document breakdown.
+    // Multiple rows may be expanded at once (comparing agents is a natural use).
+    const [expandedDocRows, setExpandedDocRows] = useState(() => new Set());
+    const toggleDocsExpanded = (rowId) => setExpandedDocRows((prev) => {
+        const next = new Set(prev);
+        if (next.has(rowId)) next.delete(rowId); else next.add(rowId);
+        return next;
+    });
     const runsSorted = useMemo(() => runs || [], [runs]);
     // Self-healing: if `selectedId` points at a run that no longer exists in
     // `runsSorted` (e.g. deleted from another tab/session — a background
@@ -590,38 +653,63 @@ const ContextPage = () => {
                                 {rowsLoading ? (
                                     <tr><td className="agent"><CircularProgress size={16} /></td>
                                         <td colSpan={8} /></tr>
-                                ) : rendered.list.map((r) => {
+                                ) : rendered.list.map((r, idx) => {
                                     const c = computeCells(r, rendered.markerByText);
                                     // A cell string that equals the n/a sentinel renders muted.
                                     const cell = (text) => (text === NA_TEXT
                                         ? <span className="fn">n/a</span> : text);
+                                    const isExpanded = expandedDocRows.has(r.id);
+                                    // req #3096: zebra striping is keyed off this JS index, not
+                                    // CSS `nth-of-type`, because the optional detail <tr> below
+                                    // is a real sibling in the same <tbody> — nth-of-type counts
+                                    // it as an element, so expanding any row would shift every
+                                    // later row's parity and visibly reshuffle stripes on a
+                                    // read-only inspection action.
+                                    const rowClasses = [
+                                        c.isPrimary ? 'primary' : null,
+                                        idx % 2 === 1 ? 'even-row' : null,
+                                    ].filter(Boolean).join(' ') || undefined;
                                     return (
-                                        <tr key={r.id} className={c.isPrimary ? 'primary' : undefined}
-                                            data-testid={`agent-context-row-${r.id}`}>
-                                            <td className="agent">{r.agent_name}</td>
-                                            <td className="num">{cell(c.bootMs)}</td>
-                                            <td className="num">
-                                                {cell(c.ccBase)}
-                                                {c.ccBaseMarker && <span className="fn">{c.ccBaseMarker}</span>}
-                                            </td>
-                                            <td className="num">{cell(c.claudeMd)}</td>
-                                            <td className="num">
-                                                {c.stub.kind === 'value'
-                                                    ? c.stub.text
-                                                    : (
-                                                        <span className="fn">
-                                                            {c.stub.kind === 'marker'
-                                                                ? <>Not Captured{c.stub.text}</> : 'n/a'}
-                                                        </span>
+                                        <Fragment key={r.id}>
+                                            <tr className={rowClasses}
+                                                data-testid={`agent-context-row-${r.id}`}>
+                                                <td className="agent">{r.agent_name}</td>
+                                                <td className="num">{cell(c.bootMs)}</td>
+                                                <td className="num">
+                                                    {cell(c.ccBase)}
+                                                    {c.ccBaseMarker && <span className="fn">{c.ccBaseMarker}</span>}
+                                                </td>
+                                                <td className="num">{cell(c.claudeMd)}</td>
+                                                <td className="num">
+                                                    {c.stub.kind === 'value'
+                                                        ? c.stub.text
+                                                        : (
+                                                            <span className="fn">
+                                                                {c.stub.kind === 'marker'
+                                                                    ? <>Not Captured{c.stub.text}</> : 'n/a'}
+                                                            </span>
+                                                        )}
+                                                </td>
+                                                <td className="num">{cell(c.bootPayload)}</td>
+                                                <td className="num">{cell(c.autoload)}</td>
+                                                <td className={`mid${c.docsIncomplete ? ' docs-warn' : ''}${c.docsClickable ? ' docs-clickable' : ''}`}
+                                                    onClick={c.docsClickable ? () => toggleDocsExpanded(r.id) : undefined}
+                                                    data-testid={`agent-context-docs-cell-${r.id}`}>
+                                                    {cell(c.docs)}
+                                                    {c.docsClickable && (
+                                                        <ArrowDropDownIcon
+                                                            fontSize="small"
+                                                            sx={{
+                                                                verticalAlign: 'middle', ml: '-2px',
+                                                                transform: isExpanded ? 'rotate(180deg)' : 'none',
+                                                            }}
+                                                        />
                                                     )}
-                                            </td>
-                                            <td className="num">{cell(c.bootPayload)}</td>
-                                            <td className="num">{cell(c.autoload)}</td>
-                                            <td className={`mid${c.docsIncomplete ? ' docs-warn' : ''}`}>
-                                                {cell(c.docs)}
-                                            </td>
-                                            <td className="num swc">{c.swc}</td>
-                                        </tr>
+                                                </td>
+                                                <td className="num swc">{c.swc}</td>
+                                            </tr>
+                                            {isExpanded && <AgentDocsDetail rowId={r.id} />}
+                                        </Fragment>
                                     );
                                 })}
                             </tbody>

--- a/src/Agents/__tests__/contextRenderUtils.test.js
+++ b/src/Agents/__tests__/contextRenderUtils.test.js
@@ -138,6 +138,7 @@ describe('computeCells — architect (all present)', () => {
         expect(c.autoload).toBe('6,768');
         expect(c.docs).toBe('4 / 4');
         expect(c.docsIncomplete).toBe(false);
+        expect(c.docsClickable).toBe(true);
         expect(c.swc).toBe('38,996');
         expect(c.isPrimary).toBe(false);
     });
@@ -153,6 +154,7 @@ describe('computeCells — reviewer (bundled stub)', () => {
         expect(c.stub).toEqual({ kind: 'marker', text: '†' });
         expect(c.docs).toBe('0 / 1');
         expect(c.docsIncomplete).toBe(true);
+        expect(c.docsClickable).toBe(false);
         expect(c.swc).toBe('19,651');
     });
 });
@@ -171,6 +173,7 @@ describe('computeCells — primary (no boot/autoload phase)', () => {
         expect(c.autoload).toBe(NA);
         expect(c.docs).toBe(NA);
         expect(c.docsIncomplete).toBe(false);
+        expect(c.docsClickable).toBe(false);
         expect(c.swc).toBe('34,559');
     });
 });
@@ -191,5 +194,22 @@ describe('computeCells — docsIncomplete edge cases', () => {
         const c = computeCells(architect({ docs_loaded: 3, docs_expected: null }), m);
         expect(c.docs).toBe(NA);
         expect(c.docsIncomplete).toBe(false);
+    });
+});
+
+describe('computeCells — docsClickable edge cases (req #3096)', () => {
+    const m = new Map();
+    it('0 docs_loaded is inert — nothing to drill into', () => {
+        const c = computeCells(architect({ docs_loaded: 0, docs_expected: 0 }), m);
+        expect(c.docsClickable).toBe(false);
+    });
+    it('null docs_loaded (n/a, e.g. PrimaryAI) is inert', () => {
+        const c = computeCells(architect({ docs_loaded: null, docs_expected: null }), m);
+        expect(c.docsClickable).toBe(false);
+    });
+    it('at least one doc loaded is clickable, even if incomplete vs. expected', () => {
+        const c = computeCells(architect({ docs_loaded: 1, docs_expected: 4 }), m);
+        expect(c.docsIncomplete).toBe(true);
+        expect(c.docsClickable).toBe(true);
     });
 });

--- a/src/Agents/contextRenderUtils.js
+++ b/src/Agents/contextRenderUtils.js
@@ -142,6 +142,11 @@ export function computeCells(row, markerByText) {
         docsIncomplete: (row.docs_loaded !== null && row.docs_loaded !== undefined
                && row.docs_expected !== null && row.docs_expected !== undefined)
             ? row.docs_loaded < row.docs_expected : false,
+        // req #3096 — the Docs Loaded cell becomes a click-to-expand drill-down
+        // trigger only when there is at least one document to show. Zero count
+        // (0 loaded, or docs_loaded unknown/n/a) stays inert — same "zero count
+        // = inert" rule as the anchor-chip pattern (memory/detail-page-interlinking.md).
+        docsClickable: !!row.docs_loaded && row.docs_loaded > 0,
         swc: fmt(row.start_work_context_tokens),   // always present — bold teal
     };
 }

--- a/src/hooks/factory/devopsQueries.js
+++ b/src/hooks/factory/devopsQueries.js
@@ -308,3 +308,15 @@ export const agentTelemetryRows = createEntityQueries({
         { field: 'run_fk', as: 'run', creatorScoped: false },
     ],
 });
+
+// Per-document actual-token breakdown (req #3096), one level under
+// agent_telemetry_rows. Fetched lazily per row (only while its drill-down is
+// expanded) via useAgentTelemetryRowDocsByRow — never eagerly for a whole run.
+export const agentTelemetryRowDocs = createEntityQueries({
+    entity: 'agent_telemetry_row_docs',
+    defaultFields: 'id,row_fk,doc_path,actual_tokens,sort_order,creator_fk',
+    fieldsInKey: true,
+    foreignKeys: [
+        { field: 'row_fk', as: 'row', creatorScoped: false },
+    ],
+});

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -3,7 +3,7 @@ import { useContext } from 'react';
 import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
 import { domainKeys, areaKeys, taskKeys, projectKeys, categoryKeys, requirementKeys, priorityCardOrderKeys, recurringTaskKeys, mapRunKeys, mapRouteKeys, mapCoordinateKeys, mapViewKeys, mapPartnerKeys, mapRunPartnerKeys, featureKeys, testCaseKeys, featureTestCaseKeys, testPlanKeys, testPlanCaseKeys, testRunKeys, testResultKeys, customerKeys, buildProjectKeys, branchKeys, buildKeys, customerReleaseKeys } from './useQueryKeys';
-import { devServers, sessions, swarmStarts, swarmStartSessions, swarmUndos, swarmCompletes, swarmCompleteSessions, machines, agents, instructions, architectureDocuments, agentDocuments, agentInstructions, agentTelemetryRuns, agentTelemetryRows } from './factory/devopsQueries';
+import { devServers, sessions, swarmStarts, swarmStartSessions, swarmUndos, swarmCompletes, swarmCompleteSessions, machines, agents, instructions, architectureDocuments, agentDocuments, agentInstructions, agentTelemetryRuns, agentTelemetryRows, agentTelemetryRowDocs } from './factory/devopsQueries';
 // `fetchEntity` is shared with the factory so both layers handle REST errors
 // identically (req #2593).
 import { fetchEntity } from './factory/createEntityQueries';
@@ -764,3 +764,9 @@ export const useAgentTelemetryRun       = agentTelemetryRuns.useById;
 export const agentTelemetryRunKeys      = agentTelemetryRuns.keys;
 export const useAgentTelemetryRowsByRun = agentTelemetryRows.useByRun;
 export const agentTelemetryRowKeys      = agentTelemetryRows.keys;
+// Req #3096 — per-document breakdown. ContextPage.jsx achieves laziness by only
+// mounting the consumer component while a row is expanded (conditional mount, not
+// a conditional hook call) rather than passing an `enabled` option here — either
+// approach works, but a future caller reusing this hook can pick whichever fits.
+export const useAgentTelemetryRowDocsByRow = agentTelemetryRowDocs.useByRow;
+export const agentTelemetryRowDocKeys      = agentTelemetryRowDocs.keys;


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3096-per-document-actual-token-capture-1
- wip(Darwin): 2026-07-26T12:40:07Z
- chore: init swarm session feature/3096-per-document-actual-token-capture-1

## Files changed
```
 src/Agents/ContextPage.jsx                      | 148 +++++++++++++++++++-----
 src/Agents/__tests__/contextRenderUtils.test.js |  20 ++++
 src/Agents/contextRenderUtils.js                |   5 +
 src/hooks/factory/devopsQueries.js              |  12 ++
 src/hooks/useDataQueries.js                     |   8 +-
 5 files changed, 162 insertions(+), 31 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)