### PR TITLE
Instructions Table View — hardened generic edit-in-place table pattern

### DIFF
--- a/src/Agents/AgentsPage.jsx
+++ b/src/Agents/AgentsPage.jsx
@@ -4,9 +4,24 @@
 // identity (name, model/effort pin, overview) plus anchor-chip counts that drill
 // into the matching anchored section of /agents/:id — the req #2494 interlinking
 // grammar used by requirements <-> sessions.
+//
+// Req #3067 converted the hand-rolled header to the shared ViewerHeader and fixed
+// three pieces of drift this page had accumulated as the codebase's oldest viewer:
+//   1. It was the SINGLE file using TableRowsIcon for a table toggle; TableChartIcon
+//      is canon (view-switchable-pages.md § C R3) and is what ten other files use.
+//   2. Its view-preference key was `agents-view`, violating V8's
+//      `darwin-<feature>-view` shape. Changed with no migration shim: anyone who had
+//      selected Table is reset to Cards exactly once, which is cheaper than a
+//      compatibility branch that would live forever.
+//   3. It filtered closed agents out of its own list UNCONDITIONALLY, with no count
+//      and no way to reveal them — so a user looking at twelve rows could not tell
+//      whether that was all of them. That is precisely the drift V7's accounting
+//      line exists to make legible, and both sibling /agents/* pages already fixed
+//      it. The line and its Closed chip arrive together on purpose: an accounting
+//      line that names a hidden set with no way to see it is worse than silence.
 
 import '../index.css';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Box from '@mui/material/Box';
@@ -15,16 +30,17 @@ import CardContent from '@mui/material/CardContent';
 import CardActionArea from '@mui/material/CardActionArea';
 import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
-import ToggleButton from '@mui/material/ToggleButton';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
-import TableRowsIcon from '@mui/icons-material/TableRows';
+import TableChartIcon from '@mui/icons-material/TableChart';
 import { DataGrid, GridToolbar } from '@mui/x-data-grid';
 
 import AuthContext from '../Context/AuthContext';
+import ViewerHeader from '../Components/ViewerHeader/ViewerHeader';
+import { normalizeView } from '../Components/ViewerHeader/normalizeView';
 import {
     useAgents, useAgentDocuments, useAgentInstructions,
 } from '../hooks/useDataQueries';
@@ -35,11 +51,18 @@ import {
     agentModelChipProps, agentModelLabel,
 } from './agentRegistryUtils';
 
+const VIEWS = [
+    { value: 'cards', label: 'Cards view', icon: ViewModuleIcon },
+    { value: 'table', label: 'Table view', icon: TableChartIcon },
+];
+
 const AgentsPage = () => {
     const { profile } = useContext(AuthContext);
     const navigate = useNavigate();
     const isMobile = useMediaQuery('(max-width:899px)');
-    const [view, setView] = useViewPreference('agents-view', 'cards');
+    const [view, setView] = useViewPreference('darwin-agents-view', 'cards');
+    const activeView = normalizeView(view, VIEWS);
+    const [showClosed, setShowClosed] = useState(false);
 
     const creatorFk = profile?.userName;
     const { data: agents, isLoading } = useAgents(creatorFk);
@@ -53,11 +76,16 @@ const AgentsPage = () => {
     const rows = useMemo(() => {
         if (!agents) return [];
         return agents
-            .filter(a => !a.closed)
+            .filter(a => showClosed || !a.closed)
             .map(a => ({ ...a, ...agentCounts(a.id, instrLinks, docLinks) }))
-            .sort((a, b) =>
-                (a.sort_order ?? Infinity) - (b.sort_order ?? Infinity) || a.id - b.id);
-    }, [agents, instrLinks, docLinks]);
+            // Closed agents last regardless of catalog order: a closed agent never
+            // boots, so it never belongs above one that does.
+            .sort((a, b) => (a.closed ? 1 : 0) - (b.closed ? 1 : 0)
+                || (a.sort_order ?? Infinity) - (b.sort_order ?? Infinity)
+                || a.id - b.id);
+    }, [agents, instrLinks, docLinks, showClosed]);
+
+    const hasClosed = useMemo(() => (agents || []).some(a => a.closed), [agents]);
 
     // Drill-through: land on the detail page with the relevant section anchored.
     const openAgent = (id, hash = '') => navigate(`/agents/${id}${hash}`);
@@ -98,6 +126,10 @@ const AgentsPage = () => {
             description: 'Documents tagged autoload — read in full at boot',
         },
         { field: 'file_name', headerName: 'Stub', width: 200 },
+        // Only reachable once the Closed filter is on, but the column is always
+        // present: a row list that can contain closed rows and cannot say which
+        // they are is the drift the accounting line was added to stop.
+        { field: 'closed', headerName: 'Closed', width: 90, type: 'boolean' },
         { field: 'overview', headerName: 'Overview', flex: 1, minWidth: 260 },
     ], []);
 
@@ -107,34 +139,50 @@ const AgentsPage = () => {
         );
     }
 
+    // V7 — counted over the WHOLE registry, never the filtered rows.
+    const openCount = agents.filter(a => !a.closed).length;
+    const closedCount = agents.length - openCount;
+
     return (
         <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }}>
-            {/* Canonical viewer header (req #3013): the view toggle is the stable
-                far-left anchor, the title follows with `flex: 1` — mirrors Requirements
-                and the other viewers. The Instructions/Documents links that used to sit
-                here moved to the AGENTS navbar group. */}
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, flexWrap: 'wrap', gap: 1 }}>
-                <ToggleButtonGroup
-                    size="small"
-                    exclusive
-                    value={view}
-                    onChange={(_e, v) => setView(v)}
-                    sx={{ flexShrink: 0 }}
-                    data-testid="agents-view-toggle"
-                >
-                    <ToggleButton value="cards" aria-label="cards view">
-                        <ViewModuleIcon fontSize="small" />
-                    </ToggleButton>
-                    <ToggleButton value="table" aria-label="table view">
-                        <TableRowsIcon fontSize="small" />
-                    </ToggleButton>
-                </ToggleButtonGroup>
-                <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ flex: 1 }}>Agents</Typography>
-            </Box>
+            {/* The Instructions/Documents links that used to sit here moved to the
+                AGENTS navbar group. */}
+            <ViewerHeader
+                title="Agents"
+                views={VIEWS}
+                view={activeView}
+                onViewChange={setView}
+                testIdPrefix="agents"
+                filters={hasClosed && (
+                    <Tooltip title={showClosed ? 'Hide closed agents' : 'Show closed agents'}>
+                        <Chip
+                            label="Closed"
+                            size="small"
+                            color={showClosed ? 'primary' : 'default'}
+                            variant={showClosed ? 'filled' : 'outlined'}
+                            onClick={() => setShowClosed(v => !v)}
+                            sx={{ cursor: 'pointer', flexShrink: 0 }}
+                            data-testid="agents-show-closed"
+                        />
+                    </Tooltip>
+                )}
+                accounting={[
+                    `${openCount} agent${openCount === 1 ? '' : 's'}`,
+                    closedCount > 0 && `${closedCount} closed`,
+                ].filter(Boolean).join(' · ')}
+            />
 
             {rows.length === 0 ? (
-                <Typography color="text.secondary" sx={{ p: 2 }}>No agents registered</Typography>
-            ) : view === 'table' ? (
+                <Typography color="text.secondary" sx={{ p: 2 }}>
+                    {/* "No agents registered" would contradict the accounting line
+                        directly above it when every agent is closed and the filter is
+                        off — it reads `0 agents · 12 closed`, so there plainly ARE
+                        agents. Say which of the two situations this is. */}
+                    {closedCount > 0
+                        ? 'No open agents — turn on the Closed filter to see the retired ones'
+                        : 'No agents registered'}
+                </Typography>
+            ) : activeView === 'table' ? (
                 <Box sx={{ width: '100%' }} data-testid="agents-datagrid">
                     <DataGrid
                         autoHeight
@@ -150,7 +198,14 @@ const AgentsPage = () => {
                         pageSizeOptions={[10, 25, 50, 100]}
                         disableRowSelectionOnClick
                         density="compact"
-                        sx={{ '& .MuiDataGrid-row': { cursor: 'pointer' } }}
+                        // Closed rows carry `opacity: 0.55` in the card view; without
+                        // this the Closed column would be the table's only signal,
+                        // and the two views would disagree about how retired reads.
+                        getRowClassName={(p) => (p.row.closed ? 'agent-row--closed' : '')}
+                        sx={{
+                            '& .MuiDataGrid-row': { cursor: 'pointer' },
+                            '& .agent-row--closed .MuiDataGrid-cell': { opacity: 0.55 },
+                        }}
                     />
                 </Box>
             ) : (
@@ -167,7 +222,9 @@ const AgentsPage = () => {
                     }}
                 >
                     {rows.map(a => (
-                        <Card key={a.id} variant="outlined" data-testid={`agent-card-${a.id}`}>
+                        <Card key={a.id} variant="outlined"
+                              sx={a.closed ? { opacity: 0.55 } : undefined}
+                              data-testid={`agent-card-${a.id}`}>
                             <CardActionArea onClick={() => openAgent(a.id)}>
                                 <CardContent>
                                     <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1, mb: 1 }}>
@@ -176,6 +233,14 @@ const AgentsPage = () => {
                                             {a.name}
                                         </Typography>
                                         <Stack direction="row" spacing={0.5}>
+                                            {/* `!!` is load-bearing: `closed` is a MySQL
+                                                TINYINT, so it arrives as the NUMBER 0, and
+                                                `0 && <Chip/>` evaluates to 0 — which React
+                                                renders as a literal "0" beside the chips. */}
+                                            {!!a.closed && (
+                                                <Chip label="closed" size="small"
+                                                      data-testid={`agent-closed-${a.id}`} />
+                                            )}
                                             <Chip label={agentModelLabel(a.ai_model)} size="small"
                                                   {...agentModelChipProps(a.ai_model)} />
                                             <Chip label={effortLabel(a.effort)} size="small"

--- a/src/Agents/DocumentsPage.jsx
+++ b/src/Agents/DocumentsPage.jsx
@@ -84,12 +84,9 @@ import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import ListSubheader from '@mui/material/ListSubheader';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
-import ToggleButton from '@mui/material/ToggleButton';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -100,7 +97,6 @@ import CloseIcon from '@mui/icons-material/Close';
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import SettingsIcon from '@mui/icons-material/Settings';
 import UnarchiveIcon from '@mui/icons-material/Unarchive';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 
@@ -113,6 +109,8 @@ import {
 } from '../hooks/useDataQueries';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { useViewPreference } from '../hooks/useViewPreference';
+import ViewerHeader from '../Components/ViewerHeader/ViewerHeader';
+import { normalizeView } from '../Components/ViewerHeader/normalizeView';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
 import {
     byId, linksByAgent, linksByDocument, documentOwnerLink,
@@ -147,6 +145,15 @@ const CARD_CONTENT_SX = { p: 2, '&:last-child': { pb: 2 } };
 // `commitLocation`.
 class LocationNeedsConfirmation extends Error {}
 
+// One entry, deliberately. `ViewerHeader` always renders the ToggleButtonGroup even
+// at length 1, and that is what preserves the far-left anchor and the title's
+// x-position against the other viewers until a Table view for this page ships. It
+// is NOT a placeholder for a disabled button — see the standing exception in
+// memory/darwin-viewer-pages.md.
+const VIEWS = [
+    { value: 'cards', label: 'Cards view', icon: ViewModuleIcon },
+];
+
 const DocumentsPage = () => {
     const navigate = useNavigate();
     const { profile, idToken } = useContext(AuthContext);
@@ -176,16 +183,17 @@ const DocumentsPage = () => {
     const [showClosed, setShowClosed] = useState(false);
     const [showUnownedOnly, setShowUnownedOnly] = useState(false);
     const [view, setView] = useViewPreference('darwin-documents-view', 'cards');
-    // Cards is the only view built; Table is a later requirement. A 'table' value
-    // can still be sitting in this browser's storage, and an unmatched
-    // ToggleButtonGroup value selects nothing — the toggle would render with no
-    // active state. Same normalization InstructionsPage carries.
-    const activeView = view === 'table' ? 'cards' : view;
+    // Cards is the only view built here; a Table view for this page is a later
+    // requirement. The normalization is no longer hand-rolled — `normalizeView` is
+    // the generic form, and it does the same job for the same reason: a 'table'
+    // value can still be sitting in this browser's storage, and an unmatched
+    // ToggleButtonGroup value selects nothing, so the toggle would render with no
+    // active state at all.
+    const activeView = normalizeView(view, VIEWS);
 
     const [sortMode, setSortMode] = useState(readStoredSort);
     const [sortDesc, setSortDesc] = useState(
         () => SORT_MODES.find(m => m.value === readStoredSort())?.defaultDesc ?? false);
-    const [sortAnchor, setSortAnchor] = useState(null);
 
     const [deleteTarget, setDeleteTarget] = useState(null);
     const [dialogIntent, setDialogIntent] = useState('delete');
@@ -261,11 +269,13 @@ const DocumentsPage = () => {
     // CategoryCard's shipped idiom: picking the ACTIVE mode flips its direction
     // and keeps the menu open so the arrow change is visible; picking a new mode
     // adopts that mode's natural direction and closes.
-    const chooseSort = (value, defaultDesc) => {
+    const chooseSort = (value, defaultDesc, close) => {
         if (sortMode === value) { setSortDesc(d => !d); return; }
         setSortMode(value);
         setSortDesc(defaultDesc);
-        setSortAnchor(null);
+        // `close` is handed in by ViewerHeader, which owns the menu anchor. It is
+        // deliberately not called on the direction-flip path above.
+        close?.();
     };
 
     const agentIndex = useMemo(() => byId(agents || []), [agents]);
@@ -900,121 +910,78 @@ const DocumentsPage = () => {
 
     return (
         <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }}>
-            {/* Canonical viewer header (req #3013, memory/view-switchable-pages.md).
-                Reading order is fixed for every viewer:
-                  [view toggle] [title, flex:1] [filters] [settings]
-                The toggle is the far-left anchor so the title starts at the same x
-                on every viewer page; the title's `flex: 1` IS the spacer — do not
-                add a second flexGrow Box. Filters sit beside the title because
-                they change WHAT is listed; the settings gear is pinned right. */}
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5, flexWrap: 'wrap' }}>
-                {/* Cards only, and the group is kept at length 1 rather than
-                    dropped for a bare title — that is what preserves the far-left
-                    anchor and the title's x-position until a Table view ships.
-                    Following InstructionsPage's documented standing exception to
-                    V1: the user removed the disabled placeholder button there
-                    because a control you cannot act on reads as broken rather than
-                    as forthcoming. */}
-                <ToggleButtonGroup
-                    size="small"
-                    exclusive
-                    value={activeView}
-                    onChange={(_e, v) => setView(v)}
-                    sx={{ flexShrink: 0 }}
-                    data-testid="documents-view-toggle"
-                >
-                    <Tooltip title="Cards view">
-                        <ToggleButton value="cards" aria-label="cards view"
-                                      data-testid="view-toggle-cards">
-                            <ViewModuleIcon fontSize="small" />
-                        </ToggleButton>
-                    </Tooltip>
-                </ToggleButtonGroup>
-
-                <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ flex: 1 }}>
-                    Architecture Documents
-                </Typography>
-
-                {/* The highest-value filter on this page: it isolates exactly the
-                    drift the registry was built to catch. Rendered only when there
-                    is drift to isolate. */}
-                {hasUnowned && (
-                    <Tooltip title={showUnownedOnly
-                        ? 'Show every document'
-                        : 'Show only documents with no owner'}>
-                        <Chip
-                            label="Unowned"
-                            size="small"
-                            color={showUnownedOnly ? 'error' : 'default'}
-                            variant={showUnownedOnly ? 'filled' : 'outlined'}
-                            onClick={() => setShowUnownedOnly(v => !v)}
-                            sx={{ cursor: 'pointer', flexShrink: 0 }}
-                            data-testid="documents-show-unowned"
-                        />
-                    </Tooltip>
-                )}
-
-                {hasClosed && (
-                    <Tooltip title={showClosed ? 'Hide closed documents' : 'Show closed documents'}>
-                        <Chip
-                            label="Closed"
-                            size="small"
-                            color={showClosed ? 'primary' : 'default'}
-                            variant={showClosed ? 'filled' : 'outlined'}
-                            onClick={() => setShowClosed(v => !v)}
-                            sx={{ cursor: 'pointer', flexShrink: 0 }}
-                            data-testid="documents-show-closed"
-                        />
-                    </Tooltip>
-                )}
-
-                <Tooltip title="Sort & display settings">
-                    <IconButton size="small" onClick={(e) => setSortAnchor(e.currentTarget)}
-                                sx={{ flexShrink: 0 }}
-                                data-testid="documents-settings-button">
-                        <SettingsIcon fontSize="small" />
-                    </IconButton>
-                </Tooltip>
-                <Menu
-                    anchorEl={sortAnchor}
-                    open={!!sortAnchor}
-                    onClose={() => setSortAnchor(null)}
-                    anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-                    transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-                    slotProps={{ list: { 'data-testid': 'documents-sort-menu' } }}
-                >
-                    <ListSubheader disableSticky sx={{ lineHeight: '32px' }}>Sort by</ListSubheader>
-                    {SORT_MODES.map(({ value, label, icon: Icon, defaultDesc }) => {
-                        const active = sortMode === value;
-                        return (
-                            <MenuItem key={value} selected={active}
-                                      onClick={() => chooseSort(value, defaultDesc)}
-                                      data-testid={`documents-sort-${value}`}>
-                                <ListItemIcon><Icon fontSize="small" /></ListItemIcon>
-                                <ListItemText>{label}</ListItemText>
-                                {/* The arrow is the only affordance telling the user
-                                    that re-picking the active mode reverses it —
-                                    without it the second click looks broken. */}
-                                {active && (sortDesc
-                                    ? <ArrowDownwardIcon fontSize="small" sx={{ ml: 2, opacity: 0.7 }} />
-                                    : <ArrowUpwardIcon fontSize="small" sx={{ ml: 2, opacity: 0.7 }} />)}
-                            </MenuItem>
-                        );
-                    })}
-                </Menu>
-            </Box>
-
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}
-                        data-testid="documents-accounting">
-                {[
-                    `${openRows.length} registered document${openRows.length === 1 ? '' : 's'}`,
-                    unownedCount > 0
-                        ? `${unownedCount} with no owner`
-                        : 'every one has exactly one owner',
-                    closedCount > 0 && `${closedCount} closed`,
-                ].filter(Boolean).join(' · ')}
-                . At most one owner per document is enforced by the database.
-            </Typography>
+            {/* The canonical viewer header, now the shared component
+                (Components/ViewerHeader, req #3067). This page was the third
+                hand-rolled copy of it. */}
+            <ViewerHeader
+                title="Architecture Documents"
+                views={VIEWS}
+                view={activeView}
+                onViewChange={setView}
+                testIdPrefix="documents"
+                filters={<>
+                    {/* The highest-value filter on this page: it isolates exactly
+                        the drift the registry was built to catch. Rendered only when
+                        there is drift to isolate. */}
+                    {hasUnowned && (
+                        <Tooltip title={showUnownedOnly
+                            ? 'Show every document'
+                            : 'Show only documents with no owner'}>
+                            <Chip
+                                label="Unowned"
+                                size="small"
+                                color={showUnownedOnly ? 'error' : 'default'}
+                                variant={showUnownedOnly ? 'filled' : 'outlined'}
+                                onClick={() => setShowUnownedOnly(v => !v)}
+                                sx={{ cursor: 'pointer', flexShrink: 0 }}
+                                data-testid="documents-show-unowned"
+                            />
+                        </Tooltip>
+                    )}
+                    {hasClosed && (
+                        <Tooltip title={showClosed ? 'Hide closed documents' : 'Show closed documents'}>
+                            <Chip
+                                label="Closed"
+                                size="small"
+                                color={showClosed ? 'primary' : 'default'}
+                                variant={showClosed ? 'filled' : 'outlined'}
+                                onClick={() => setShowClosed(v => !v)}
+                                sx={{ cursor: 'pointer', flexShrink: 0 }}
+                                data-testid="documents-show-closed"
+                            />
+                        </Tooltip>
+                    )}
+                </>}
+                settingsItems={[{
+                    id: 'sort',
+                    heading: 'Sort by',
+                    items: SORT_MODES.map(({ value, label, icon: Icon, defaultDesc }) => ({
+                        id: value,
+                        label,
+                        icon: <Icon fontSize="small" />,
+                        selected: sortMode === value,
+                        // The arrow is the only affordance telling the user that
+                        // re-picking the active mode reverses it — without it the
+                        // second click looks broken.
+                        trailing: sortMode === value
+                            ? (sortDesc
+                                ? <ArrowDownwardIcon fontSize="small" sx={{ ml: 2, opacity: 0.7 }} />
+                                : <ArrowUpwardIcon fontSize="small" sx={{ ml: 2, opacity: 0.7 }} />)
+                            : null,
+                        onClick: (close) => chooseSort(value, defaultDesc, close),
+                    })),
+                }]}
+                accounting={<>
+                    {[
+                        `${openRows.length} registered document${openRows.length === 1 ? '' : 's'}`,
+                        unownedCount > 0
+                            ? `${unownedCount} with no owner`
+                            : 'every one has exactly one owner',
+                        closedCount > 0 && `${closedCount} closed`,
+                    ].filter(Boolean).join(' · ')}
+                    . At most one owner per document is enforced by the database.
+                </>}
+            />
 
             <Box
                 data-testid="documents-registry"

--- a/src/Agents/InstructionAgentChips.jsx
+++ b/src/Agents/InstructionAgentChips.jsx
@@ -42,11 +42,29 @@
 //     For a non-atomic write that is worth more than the latency it costs; the
 //     round trip is one call and its result is simply the chip going solid.
 
-import { useState } from 'react';
+// THE COMPACT VARIANT (req #3067). The table view needs this same control inside a
+// 92px grid row, where an inline palette of twelve ghost chips cannot fit. Rather
+// than write a second membership control — which would be a second answer to the
+// question "what does one click do?" — `variant="compact"` keeps every behaviour and
+// changes only the assembly: bound chips on one non-wrapping line, and the palette
+// moved into a Popover.
+//
+// The three chip GROUPS are built once and laid out twice. The first cut had the
+// compact variant render THIS COMPONENT recursively inside the Popover, which is
+// tidier to describe and wrong in practice: the bound chips and the toggle would
+// then exist in both the row and the popover simultaneously, duplicating the exact
+// data-testids both views' assertions reach for. Sharing the groups gets the same
+// "one implementation, two presentations" property with no duplicate DOM.
+//
+// Untouched by the variant, because they are the part that matters: one chip is one
+// write, the page's serialized pessimistic queue, and the drill-through.
+
+import { useEffect, useState } from 'react';
 
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
+import Popover from '@mui/material/Popover';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
@@ -75,8 +93,34 @@ const InstructionAgentChips = ({
     onOpenAgent,
     busy = false,
     testIdPrefix,
+    // 'inline' — the card: the palette unfurls in place, below the bound chips.
+    // 'compact' — a DataGrid cell: one non-wrapping line, palette in a Popover.
+    variant = 'inline',
 }) => {
     const [paletteOpen, setPaletteOpen] = useState(false);
+    // The compact variant's Popover anchor, captured from the toggle chip's own
+    // `e.currentTarget` — the house idiom (SwarmView, InstructionsPage's sort menu)
+    // rather than a forwarded ref through Tooltip's cloned child.
+    const [paletteAnchor, setPaletteAnchor] = useState(null);
+    const compact = variant === 'compact';
+
+    const togglePalette = (e) => {
+        setPaletteAnchor(e.currentTarget);
+        setPaletteOpen(v => !v);
+    };
+
+    // BINDING THE LAST AGENT MUST CLOSE THE PALETTE, not merely hide it.
+    //
+    // The toggle chip IS the Popover's anchor, and it unmounts when nothing is left
+    // to bind. Gating only the Popover's `open` on `bindableAgents.length` masks the
+    // symptom at that instant and re-arms it: unbind anyone afterwards, a new toggle
+    // chip mounts, `paletteOpen` is still true, and the palette REOPENS BY ITSELF —
+    // anchored to the detached original chip, so MUI clamps it to the top-left of
+    // the viewport, far from the row it belongs to. Clearing the state is the fix;
+    // the `open` guard stays as belt and braces for the frame in between.
+    useEffect(() => {
+        if (bindableAgents.length === 0) setPaletteOpen(false);
+    }, [bindableAgents.length]);
 
     const bound = boundAgentIds
         .map(id => agentIndex.get(id))
@@ -97,106 +141,176 @@ const InstructionAgentChips = ({
     // feedback at all.
     const requestUnbind = (agent) => onRequestUnbind(agent, slotOf?.(agent.id));
 
+    // ---- the three chip groups, built once, laid out twice ----
+
+    const emptyNote = bound.length === 0 && (compact || !paletteOpen) ? (
+        <Typography key="empty" variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
+            {/* The row has no space for the card's fuller phrasing, and in a
+                table the adjacent count column already says "0". */}
+            {compact ? 'not bound' : 'No agent loads this yet —'}
+        </Typography>
+    ) : null;
+
+    const boundChips = bound.map(agent => {
+        const slot = slotOf?.(agent.id);
+        const orderNote = Number.isFinite(slot)
+            ? `Loads at #${slot} in ${agent.name}'s order — reorder on that agent's page.`
+            : `${agent.name} loads this at boot — set its position on that agent's page.`;
+        return (
+            <Tooltip
+                key={agent.id}
+                title={agent.closed
+                    ? `${agent.name} is closed — it never boots, so this binding loads nothing. `
+                      + 'It is still real data a hard delete would cascade away.'
+                    : orderNote}
+            >
+                <Chip
+                    label={agent.closed ? `${agent.name} (closed)` : agent.name}
+                    size="small"
+                    clickable
+                    // Deliberately NOT MUI's `disabled` for a closed agent:
+                    // that would kill both the drill-through and the ✕, and
+                    // the binding still has to be removable — it is data a
+                    // hard delete would cascade. Muted styling instead.
+                    variant={agent.closed ? 'outlined' : 'filled'}
+                    sx={{
+                        ...(agent.closed && { opacity: 0.6 }),
+                        // In a grid row the chips must not shrink into ellipsised
+                        // stubs; the row scrolls the overflow away instead and the
+                        // palette popover is where the full roster is legible.
+                        ...(compact && { flexShrink: 0, maxWidth: 160 }),
+                    }}
+                    onClick={() => onOpenAgent(agent.id)}
+                    onDelete={() => requestUnbind(agent)}
+                    // The canonical testid stays on EVERY chip regardless of
+                    // the agent's closed state. A test reaching for this
+                    // binding should not have to know whether the agent
+                    // happens to be closed today; closedness is exposed
+                    // through the label and the attribute below instead.
+                    data-testid={`${testIdPrefix}-agent-${agent.id}`}
+                    data-agent-closed={agent.closed ? '1' : '0'}
+                />
+            </Tooltip>
+        );
+    });
+
+    const paletteChips = bindableAgents.map(agent => (
+        <Tooltip key={agent.id} title={`Not bound — click to bind ${agent.name}`}>
+            <Chip
+                label={agent.name}
+                size="small"
+                clickable
+                variant="outlined"
+                sx={ghostChipSx}
+                disabled={busy}
+                onClick={() => onBind(agent.id)}
+                data-testid={`${testIdPrefix}-bind-${agent.id}`}
+            />
+        </Tooltip>
+    ));
+
+    // Bind-all sits with the palette, not on the resting card: it is only
+    // meaningful once you can see WHICH agents it would bind. Offered from two
+    // upwards — at one remaining agent it is just that agent's chip with a longer
+    // name. Additive and individually reversible, so no confirmation; unbinding is
+    // the direction that gets a dialog.
+    const bindAllChip = bindableAgents.length > 1 ? (
+        <Tooltip key="bind-all" title={`Bind all ${bindableAgents.length} remaining agents`}>
+            <Chip
+                size="small"
+                variant="outlined"
+                color="primary"
+                icon={<DoneAllIcon fontSize="small" />}
+                label={`bind all ${bindableAgents.length}`}
+                disabled={busy}
+                onClick={() => onBindAll(bindableAgents)}
+                data-testid={`${testIdPrefix}-agent-bind-all`}
+            />
+        </Tooltip>
+    ) : null;
+
+    const toggleChip = bindableAgents.length > 0 ? (
+        <Tooltip key="toggle" title={paletteOpen
+            ? 'Hide the unbound agents'
+            : `Show the ${bindableAgents.length} agents not bound to this`}>
+            <Chip
+                size="small"
+                variant="outlined"
+                color={paletteOpen ? 'primary' : 'default'}
+                icon={paletteOpen
+                    ? <CloseIcon fontSize="small" />
+                    : <AddIcon fontSize="small" />}
+                label={paletteOpen ? 'done' : bindableAgents.length}
+                onClick={togglePalette}
+                sx={compact ? { flexShrink: 0 } : undefined}
+                data-testid={`${testIdPrefix}-agent-add`}
+            />
+        </Tooltip>
+    ) : null;
+
+    const spinner = busy
+        ? <CircularProgress key="busy" size={14} sx={{ ml: 0.5, flexShrink: 0 }} />
+        : null;
+
+    // ---- layout 1: the card. The palette unfurls in place. ----
+
+    if (!compact) {
+        return (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap', rowGap: 0.75 }}>
+                {emptyNote}
+                {boundChips}
+                {paletteOpen && paletteChips}
+                {paletteOpen && bindAllChip}
+                {toggleChip}
+                {spinner}
+            </Box>
+        );
+    }
+
+    // ---- layout 2: the grid cell. One line; the palette is a Popover. ----
+
     return (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap', rowGap: 0.75 }}>
-            {bound.length === 0 && !paletteOpen && (
-                <Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
-                    No agent loads this yet —
-                </Typography>
-            )}
-
-            {bound.map(agent => {
-                const slot = slotOf?.(agent.id);
-                const orderNote = Number.isFinite(slot)
-                    ? `Loads at #${slot} in ${agent.name}'s order — reorder on that agent's page.`
-                    : `${agent.name} loads this at boot — set its position on that agent's page.`;
-                return (
-                    <Tooltip
-                        key={agent.id}
-                        title={agent.closed
-                            ? `${agent.name} is closed — it never boots, so this binding loads nothing. `
-                              + 'It is still real data a hard delete would cascade away.'
-                            : orderNote}
-                    >
-                        <Chip
-                            label={agent.closed ? `${agent.name} (closed)` : agent.name}
-                            size="small"
-                            clickable
-                            // Deliberately NOT MUI's `disabled` for a closed agent:
-                            // that would kill both the drill-through and the ✕, and
-                            // the binding still has to be removable — it is data a
-                            // hard delete would cascade. Muted styling instead.
-                            variant={agent.closed ? 'outlined' : 'filled'}
-                            sx={agent.closed ? { opacity: 0.6 } : undefined}
-                            onClick={() => onOpenAgent(agent.id)}
-                            onDelete={() => requestUnbind(agent)}
-                            // The canonical testid stays on EVERY chip regardless of
-                            // the agent's closed state. A test reaching for this
-                            // binding should not have to know whether the agent
-                            // happens to be closed today; closedness is exposed
-                            // through the label and the attribute below instead.
-                            data-testid={`${testIdPrefix}-agent-${agent.id}`}
-                            data-agent-closed={agent.closed ? '1' : '0'}
-                        />
-                    </Tooltip>
-                );
-            })}
-
-            {paletteOpen && bindableAgents.map(agent => (
-                <Tooltip key={agent.id} title={`Not bound — click to bind ${agent.name}`}>
-                    <Chip
-                        label={agent.name}
-                        size="small"
-                        clickable
-                        variant="outlined"
-                        sx={ghostChipSx}
-                        disabled={busy}
-                        onClick={() => onBind(agent.id)}
-                        data-testid={`${testIdPrefix}-bind-${agent.id}`}
-                    />
-                </Tooltip>
-            ))}
-
-            {/* Bind-all sits with the palette, not on the resting card: it is only
-                meaningful once you can see WHICH agents it would bind. Offered from
-                two upwards — at one remaining agent it is just that agent's chip
-                with a longer name. Additive and individually reversible, so no
-                confirmation; unbinding is the direction that gets a dialog. */}
-            {paletteOpen && bindableAgents.length > 1 && (
-                <Tooltip title={`Bind all ${bindableAgents.length} remaining agents`}>
-                    <Chip
-                        size="small"
-                        variant="outlined"
-                        color="primary"
-                        icon={<DoneAllIcon fontSize="small" />}
-                        label={`bind all ${bindableAgents.length}`}
-                        disabled={busy}
-                        onClick={() => onBindAll(bindableAgents)}
-                        data-testid={`${testIdPrefix}-agent-bind-all`}
-                    />
-                </Tooltip>
-            )}
-
-            {bindableAgents.length > 0 && (
-                <Tooltip title={paletteOpen
-                    ? 'Hide the unbound agents'
-                    : `Show the ${bindableAgents.length} agents not bound to this`}>
-                    <Chip
-                        size="small"
-                        variant="outlined"
-                        color={paletteOpen ? 'primary' : 'default'}
-                        icon={paletteOpen
-                            ? <CloseIcon fontSize="small" />
-                            : <AddIcon fontSize="small" />}
-                        label={paletteOpen ? 'done' : bindableAgents.length}
-                        onClick={() => setPaletteOpen(v => !v)}
-                        data-testid={`${testIdPrefix}-agent-add`}
-                    />
-                </Tooltip>
-            )}
-
-            {busy && <CircularProgress size={14} sx={{ ml: 0.5 }} />}
-        </Box>
+        <>
+            {/* nowrap + hidden, NOT wrap: the row height is fixed, so a second line
+                of chips would be clipped rather than shown. What overflows is
+                reachable through the palette, which lists the whole roster. */}
+            <Box sx={{
+                display: 'flex', alignItems: 'center', gap: 0.5,
+                flexWrap: 'nowrap', overflow: 'hidden', width: '100%',
+            }}>
+                {emptyNote}
+                {boundChips}
+                {toggleChip}
+                {spinner}
+            </Box>
+            <Popover
+                // `bindableAgents.length > 0` is part of the OPEN condition, not
+                // just a guard. Binding the last remaining agent unmounts the
+                // toggle chip — which is the anchor — and a Popover left open on a
+                // detached anchorEl warns and floats at the origin. Closing on the
+                // same condition that removes the anchor is also the right
+                // behaviour: there is nothing left to bind.
+                open={paletteOpen && !!paletteAnchor && bindableAgents.length > 0}
+                anchorEl={paletteAnchor}
+                onClose={() => setPaletteOpen(false)}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                // The Popover renders through a PORTAL, outside the DataGrid — which
+                // is why a test scoping its queries to `instructions-datagrid` has to
+                // reach for this content at page level instead. Documented in
+                // memory/darwin-viewer-pages.md.
+                slotProps={{ paper: { 'data-testid': `${testIdPrefix}-agent-palette` } }}
+            >
+                <Box sx={{
+                    p: 1.5, maxWidth: 520,
+                    display: 'flex', alignItems: 'center', gap: 0.5,
+                    flexWrap: 'wrap', rowGap: 0.75,
+                }}>
+                    {paletteChips}
+                    {bindAllChip}
+                </Box>
+            </Popover>
+        </>
     );
 };
 

--- a/src/Agents/InstructionRowMenu.jsx
+++ b/src/Agents/InstructionRowMenu.jsx
@@ -1,0 +1,110 @@
+// The per-row options menu for an instruction (req #3067).
+//
+// Extracted from the card so the CARD and the TABLE cannot drift: both views offer
+// the same three actions, with the same graduated-close semantics and the same
+// data-testids, because they render the same component. A second copy under a
+// `renderCell` would have been the easy path and the wrong one — the ellipsis on
+// "Close instruction…" is a real behavioural affordance (it is how the user tells
+// the dialog path from the immediate one), and two copies is how one of them
+// silently loses it.
+//
+// This is a RENDERER, not a decision-maker. Every handler belongs to the page,
+// which owns the write queue, the dialog state and the blast-radius gate.
+//
+// IT OWNS ITS OWN ANCHOR, and that is a correctness property rather than tidiness.
+// The page used to hold `{ id, el }` for whichever row's menu was open. Nothing
+// cleared that when a ROW went away on its own — and in the table a row can vanish
+// with no user gesture at all (a background refetch reshuffling a page boundary,
+// or the rightmost column scrolling out of the virtualization context). The menu
+// then remounted with `open` still true against a DETACHED anchor element, which
+// MUI renders at the viewport origin. Anchor state that lives inside the row cannot
+// outlive the row.
+//
+// It also kept `columns` from memoizing in the table: a page-level anchor is a new
+// value on every menu open, so the column definitions were rebuilt each time — see
+// the ref note in InstructionsTableView.
+
+import { useState } from 'react';
+
+import IconButton from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Divider from '@mui/material/Divider';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Tooltip from '@mui/material/Tooltip';
+import CloseIcon from '@mui/icons-material/Close';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import UnarchiveIcon from '@mui/icons-material/Unarchive';
+
+const InstructionRowMenu = ({
+    row,
+    onCloseInstruction,
+    onReopen,
+    onDelete,
+}) => {
+    const [anchorEl, setAnchorEl] = useState(null);
+    const close = () => setAnchorEl(null);
+
+    // Dismiss FIRST, then act. The handlers open dialogs, and a menu still on
+    // screen behind a dialog is the artefact this ordering avoids. It also means
+    // the page's handlers no longer have to know a menu exists.
+    const pick = (handler) => () => { close(); handler(row); };
+
+    return (
+        <>
+            <Tooltip title="Instruction options">
+                <IconButton
+                    size="small"
+                    onClick={(e) => setAnchorEl(e.currentTarget)}
+                    sx={{ maxWidth: '25px', maxHeight: '25px' }}
+                    data-testid={`instruction-card-menu-${row.id}`}
+                >
+                    <MoreVertIcon fontSize="small" />
+                </IconButton>
+            </Tooltip>
+            <Menu
+                anchorEl={anchorEl}
+                open={!!anchorEl}
+                onClose={close}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                slotProps={{ list: { 'data-testid': `instruction-card-menu-popup-${row.id}` } }}
+            >
+                {row.closed ? (
+                    <MenuItem onClick={pick(onReopen)}
+                              data-testid={`instruction-menu-reopen-${row.id}`}>
+                        <ListItemIcon><UnarchiveIcon fontSize="small" /></ListItemIcon>
+                        <ListItemText>Reopen instruction</ListItemText>
+                    </MenuItem>
+                ) : (
+                    <MenuItem onClick={pick(onCloseInstruction)}
+                              data-testid={`instruction-menu-close-${row.id}`}>
+                        <ListItemIcon><CloseIcon fontSize="small" /></ListItemIcon>
+                        {/* Ellipsis = opens the dialog, because this row is bound and
+                            the agents it would unload from must be shown. No ellipsis =
+                            closes immediately. Read from the LIVE row, never a
+                            snapshot: a refetch can land while the menu is open. */}
+                        <ListItemText>
+                            {row.refs.length === 0
+                                ? 'Close instruction'
+                                : 'Close instruction…'}
+                        </ListItemText>
+                    </MenuItem>
+                )}
+                <Divider />
+                <MenuItem onClick={pick(onDelete)}
+                          sx={{ color: 'error.main' }}
+                          data-testid={`instruction-menu-delete-${row.id}`}>
+                    <ListItemIcon>
+                        <DeleteForeverIcon fontSize="small" sx={{ color: 'error.main' }} />
+                    </ListItemIcon>
+                    <ListItemText>Delete permanently…</ListItemText>
+                </MenuItem>
+            </Menu>
+        </>
+    );
+};
+
+export default InstructionRowMenu;

--- a/src/Agents/InstructionsPage.jsx
+++ b/src/Agents/InstructionsPage.jsx
@@ -11,10 +11,21 @@
 // name and content are labelled bordered fields that commit on blur,
 // membership is edited by the agent chips themselves
 // (InstructionAgentChips), and a new row is created through the house template-row
-// pattern instead of a button. Cards survive all of this on purpose: `content` is
-// prose, and a DataGrid would either truncate it into uselessness or need auto row
-// height. The card is the only view that shows the text and its blast radius
-// together, which is the read this page exists for.
+// pattern instead of a button.
+//
+// Req #3067 added the Table view and, in doing so, retired an argument this comment
+// used to make. It said a DataGrid "would either truncate `content` into uselessness
+// or need auto row height", and that was a false dichotomy: a FIXED row height
+// containing an internally-scrollable four-line field is the third option, and it is
+// what InstructionsTableView ships. What survives is the softer and truer claim —
+// the CARD is where long prose is composed, because four lines is enough to read an
+// instruction and not enough to write one. The Table is for scanning the catalog and
+// correcting fields. Both views write the same rows through the same component.
+//
+// The two views share ONE of everything that can disagree: one `fieldErrors` map,
+// one serialized membership queue, one set of graduated close/delete handlers, one
+// GhostTextField. That is deliberate and it is the whole point of #3067 — see
+// memory/darwin-viewer-pages.md.
 //
 // The fields started as ghost fields — plain text until hovered — and were
 // converted to labelled outlined ones during manual UI review. What survived that
@@ -43,31 +54,19 @@ import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
-import IconButton from '@mui/material/IconButton';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import ListSubheader from '@mui/material/ListSubheader';
-import Divider from '@mui/material/Divider';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import ToggleButton from '@mui/material/ToggleButton';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
-import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
-import CloseIcon from '@mui/icons-material/Close';
-import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
-import SettingsIcon from '@mui/icons-material/Settings';
-import UnarchiveIcon from '@mui/icons-material/Unarchive';
+import TableChartIcon from '@mui/icons-material/TableChart';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 
 import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
 import GhostTextField from '../Components/GhostField/GhostTextField';
+import ViewerHeader from '../Components/ViewerHeader/ViewerHeader';
+import { normalizeView } from '../Components/ViewerHeader/normalizeView';
 import {
     useInstructions, useAgents, useAgentInstructions,
     instructionKeys, agentInstructionKeys,
@@ -90,7 +89,17 @@ import {
 } from './instructionSort';
 import InstructionAgentChips from './InstructionAgentChips';
 import InstructionDeleteDialog from './InstructionDeleteDialog';
+import InstructionRowMenu from './InstructionRowMenu';
 import InstructionUnbindDialog from './InstructionUnbindDialog';
+import InstructionsTableView from './InstructionsTableView';
+
+// The page's views, in toggle order. A module constant rather than an inline array:
+// `normalizeView` is called with it on every render and a fresh array each time
+// would defeat any future memoization of the header.
+const VIEWS = [
+    { value: 'cards', label: 'Cards view', icon: ViewModuleIcon },
+    { value: 'table', label: 'Table view', icon: TableChartIcon },
+];
 
 // CardContent adds a 24px bottom pad to its last child on top of its own 16px.
 // Pinning both to the old Paper's `p: 2` keeps the card interiors identical to the
@@ -105,6 +114,9 @@ const InstructionsPage = () => {
     const showError = useSnackBarStore(s => s.showError);
     const isMobile = useMediaQuery('(max-width:899px)');
     const creatorFk = profile?.userName;
+    // Only the Table view renders dates, but it is read here so the page stays the
+    // single place profile is consumed.
+    const timezone = profile?.timezone;
 
     const { data: instructions, isLoading } = useInstructions(creatorFk);
     const { data: agents } = useAgents(creatorFk);
@@ -125,22 +137,23 @@ const InstructionsPage = () => {
 
     const [showClosed, setShowClosed] = useState(false);
     const [view, setView] = useViewPreference('darwin-instructions-view', 'cards');
-    // Only Cards is built; the Table view is req #3067. Kept after the Table button
-    // was removed, because a 'table' value can still be sitting in this browser's
-    // storage from before — an unmatched ToggleButtonGroup value selects nothing and
-    // the toggle would render with no active state.
-    const activeView = view === 'table' ? 'cards' : view;
+    // The page-level normalization. `ViewerHeader` normalizes internally too, but
+    // the CONDITIONAL RENDER below has to branch on the same value or the header
+    // would show one view selected while the body rendered another. Req #3063's
+    // hand-rolled `view === 'table' ? 'cards' : view` line is gone: with a real
+    // Table button that mapping is actively wrong — it would pin the page to Cards
+    // forever — and every browser still holding 'table' in storage from before the
+    // button was pulled now gets the view it originally asked for.
+    const activeView = normalizeView(view, VIEWS);
 
     const [sortMode, setSortMode] = useState(readStoredSort);
     const [sortDesc, setSortDesc] = useState(
         () => SORT_MODES.find(m => m.value === readStoredSort())?.defaultDesc ?? true);
-    const [sortAnchor, setSortAnchor] = useState(null);
     const [deleteTarget, setDeleteTarget] = useState(null);
-    // Per-card options menu. Stores the ROW ID plus the anchor element, never the
-    // row object: a refetch can land while the menu is open (every agent-chip click
-    // invalidates this query), and a snapshotted row would make the graduated-close
-    // decision below from a stale `refs.length`. The handlers read the live row.
-    const [menuAnchor, setMenuAnchor] = useState(null);
+    // The per-row options menu owns its own anchor (InstructionRowMenu). It used to
+    // live here as `{ id, el }`, which nothing cleared when a ROW disappeared on its
+    // own — in the table that happens with no user gesture at all, and the menu
+    // remounted open against a detached element. Anchor state belongs inside the row.
     // WHY the dialog was opened. `deleteTarget` alone cannot say, and a dialog
     // titled "Delete …" opened from a menu item labelled Close is a lie.
     const [dialogIntent, setDialogIntent] = useState('delete');
@@ -212,11 +225,15 @@ const InstructionsPage = () => {
     // CategoryCard's shipped idiom: picking the ACTIVE mode flips its direction and
     // keeps the menu open so the arrow change is visible; picking a new mode adopts
     // that mode's natural direction and closes.
-    const chooseSort = (value, defaultDesc) => {
+    //
+    // `close` is handed in by ViewerHeader rather than owned here. The component
+    // cannot infer which of its menu items should dismiss the menu, so it delegates
+    // — and this is exactly the item that must NOT dismiss on one of its two paths.
+    const chooseSort = (value, defaultDesc, close) => {
         if (sortMode === value) { setSortDesc(d => !d); return; }
         setSortMode(value);
         setSortDesc(defaultDesc);
-        setSortAnchor(null);
+        close?.();
     };
 
     const agentIndex = useMemo(() => byId(agents || []), [agents]);
@@ -424,6 +441,12 @@ const InstructionsPage = () => {
         defaultInfo: {},
     });
 
+    // Both views raise the unbind through here, so the slot the dialog warns about
+    // is captured the same way in each. `slot` rides on the agent object because
+    // that is the shape InstructionUnbindDialog already reads.
+    const requestUnbind = (row, agent, slot) =>
+        unbindConfirm.openDialog({ row, agent: { ...agent, slot } });
+
     /** The junction slot an agent currently loads this row at. */
     const slotOf = (rowId) => (agentId) => (instrLinks.get(agentId) || [])
         .find(l => l.instruction_fk === rowId)?.sort_order;
@@ -500,8 +523,6 @@ const InstructionsPage = () => {
         }
     };
 
-    const closeMenu = () => setMenuAnchor(null);
-
     /**
      * CLOSE IS GRADUATED ON BLAST RADIUS.
      *
@@ -514,7 +535,6 @@ const InstructionsPage = () => {
      * does. The trailing ellipsis on the menu label is what tells the two apart.
      */
     const menuCloseInstruction = (row) => {
-        closeMenu();
         if (row.refs.length === 0) { setClosedFlag(row, 1); return; }
         setDialogIntent('close');
         setDeleteTarget(row);
@@ -524,12 +544,11 @@ const InstructionsPage = () => {
     // disclose and no dialog — the worst case is an agent loading an instruction it
     // used to load. Closed rows are only visible with the Closed filter on, so the
     // user is already in a deliberate mode when they can reach this.
-    const menuReopenInstruction = (row) => { closeMenu(); setClosedFlag(row, 0); };
+    const menuReopenInstruction = (row) => setClosedFlag(row, 0);
 
     // Delete ALWAYS goes through the dialog. `agent_instructions` CASCADEs on both
     // FKs; the chip list and the typed-name challenge are the only guardrail.
     const menuDeleteInstruction = (row) => {
-        closeMenu();
         setDialogIntent('delete');
         setDeleteTarget(row);
     };
@@ -574,41 +593,18 @@ const InstructionsPage = () => {
 
     return (
         <Box sx={{ gridArea: 'content', p: isMobile ? 1 : 3 }}>
-            {/* Canonical viewer header (req #3013, memory/view-switchable-pages.md).
-                Reading order is fixed for every viewer:
-                  [view toggle] [title, flex:1] [filters] [settings]
-                The toggle is the far-left anchor so the title starts at the same x
-                on every viewer page; the title's `flex: 1` IS the spacer — do not
-                add a second flexGrow Box. Filters sit beside the title because they
-                change WHAT is listed; the settings gear is pinned right because
-                that is where SwarmView puts settings. */}
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5, flexWrap: 'wrap' }}>
-                {/* Cards only. The frontend-architect's V1 ruling was that a
-                    not-yet-built view should render as a DISABLED ToggleButton so the
-                    group holds its final width and the title's x-position matches the
-                    other viewers; the user removed that button, so this group has one
-                    child until req #3067 adds the Table view back. Keeping the group
-                    (rather than dropping it for a bare title) is what preserves the
-                    anchor in the meantime. */}
-                <ToggleButtonGroup
-                    size="small"
-                    exclusive
-                    value={activeView}
-                    onChange={(_e, v) => setView(v)}
-                    sx={{ flexShrink: 0 }}
-                    data-testid="instructions-view-toggle"
-                >
-                    <Tooltip title="Cards view">
-                        <ToggleButton value="cards" aria-label="cards view"
-                                      data-testid="view-toggle-cards">
-                            <ViewModuleIcon fontSize="small" />
-                        </ToggleButton>
-                    </Tooltip>
-                </ToggleButtonGroup>
-
-                <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ flex: 1 }}>Instructions</Typography>
-
-                {hasClosed && (
+            {/* The canonical viewer header, now a shared component
+                (Components/ViewerHeader, req #3067). The reading order it enforces —
+                [toggle][title flex:1][filters][settings][actions] — used to be three
+                hand-rolled copies across /agents, /agents/instructions and
+                /agents/documents, which is precisely how they drifted. */}
+            <ViewerHeader
+                title="Instructions"
+                views={VIEWS}
+                view={activeView}
+                onViewChange={setView}
+                testIdPrefix="instructions"
+                filters={hasClosed && (
                     <Tooltip title={showClosed ? 'Hide closed instructions' : 'Show closed instructions'}>
                         <Chip
                             label="Closed"
@@ -621,59 +617,79 @@ const InstructionsPage = () => {
                         />
                     </Tooltip>
                 )}
-
-                <Tooltip title="Sort & display settings">
-                    <IconButton size="small" onClick={(e) => setSortAnchor(e.currentTarget)}
-                                sx={{ flexShrink: 0 }}
-                                data-testid="instructions-settings-button">
-                        <SettingsIcon fontSize="small" />
-                    </IconButton>
-                </Tooltip>
-                <Menu
-                    anchorEl={sortAnchor}
-                    open={!!sortAnchor}
-                    onClose={() => setSortAnchor(null)}
-                    anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-                    transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-                    slotProps={{ list: { 'data-testid': 'instructions-sort-menu' } }}
-                >
-                    <ListSubheader disableSticky sx={{ lineHeight: '32px' }}>Sort by</ListSubheader>
-                    {SORT_MODES.map(({ value, label, icon: Icon, defaultDesc }) => {
-                        const active = sortMode === value;
-                        return (
-                            <MenuItem key={value} selected={active}
-                                      onClick={() => chooseSort(value, defaultDesc)}
-                                      data-testid={`instructions-sort-${value}`}>
-                                <ListItemIcon><Icon fontSize="small" /></ListItemIcon>
-                                <ListItemText>{label}</ListItemText>
-                                {/* The arrow is the only affordance telling the user
-                                    that re-picking the active mode reverses it —
-                                    without it the second click looks broken. */}
-                                {active && (sortDesc
-                                    ? <ArrowDownwardIcon fontSize="small" sx={{ ml: 2, opacity: 0.7 }} />
-                                    : <ArrowUpwardIcon fontSize="small" sx={{ ml: 2, opacity: 0.7 }} />)}
-                            </MenuItem>
-                        );
-                    })}
-                </Menu>
-            </Box>
-
-            {/* Accounting only. The prose that used to live here explained the
-                interaction, which the cards now demonstrate on their own. */}
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}
-                        data-testid="instructions-accounting">
-                {[
+                // THE GEAR IS CARDS-ONLY. The Table view sorts through its own column
+                // headers — that is what a DataGrid header is for, and a grid whose
+                // headers do nothing reads as broken. Offering both at once would be
+                // two sort UIs on one page that can disagree with each other. The
+                // grid is SEEDED from this mode when it mounts (see
+                // `gridSortFromMode`), so switching views is continuous rather than a
+                // jump.
+                settingsItems={activeView === 'cards' ? [{
+                    id: 'sort',
+                    heading: 'Sort by',
+                    items: SORT_MODES.map(({ value, label, icon: Icon, defaultDesc }) => ({
+                        id: value,
+                        label,
+                        icon: <Icon fontSize="small" />,
+                        selected: sortMode === value,
+                        // The arrow is the only affordance telling the user that
+                        // re-picking the active mode reverses it — without it the
+                        // second click looks broken.
+                        trailing: sortMode === value
+                            ? (sortDesc
+                                ? <ArrowDownwardIcon fontSize="small" sx={{ ml: 2, opacity: 0.7 }} />
+                                : <ArrowUpwardIcon fontSize="small" sx={{ ml: 2, opacity: 0.7 }} />)
+                            : null,
+                        onClick: (close) => chooseSort(value, defaultDesc, close),
+                    })),
+                }] : undefined}
+                // Accounting only. The prose that used to live here explained the
+                // interaction, which the views now demonstrate on their own.
+                accounting={[
                     `${openCount} instruction${openCount === 1 ? '' : 's'}`,
                     unboundCount > 0 && `${unboundCount} not bound`,
                     closedCount > 0 && `${closedCount} closed`,
                 ].filter(Boolean).join(' · ')}
-            </Typography>
+            />
 
-            {/* Card grid, matching the /agents index. `alignItems: start` so a card
-                with long content grows on its own instead of stretching every card
-                in its row to match — the content is prose of wildly varying length,
-                which is why this page is cards and not a DataGrid in the first
-                place. One column on small screens keeps the cards readable. */}
+            {activeView === 'table' ? (
+                <InstructionsTableView
+                    rows={rows}
+                    instructions={instructions}
+                    fieldErrors={fieldErrors}
+                    agentIndex={agentIndex}
+                    openAgents={openAgents}
+                    slotOf={slotOf}
+                    membershipBusyIds={membershipBusyIds}
+                    timezone={timezone}
+                    sortMode={sortMode}
+                    sortDesc={sortDesc}
+                    commitField={commitField}
+                    noteFieldError={noteFieldError}
+                    onBind={bindAgent}
+                    onBindAll={bindAllAgents}
+                    onRequestUnbind={requestUnbind}
+                    onOpenAgent={(agentId) => navigate(`/agents/${agentId}#instructions`)}
+                    onCloseInstruction={menuCloseInstruction}
+                    onReopen={menuReopenInstruction}
+                    onDelete={menuDeleteInstruction}
+                    draftName={draftName}
+                    setDraftName={setDraftName}
+                    draftContent={draftContent}
+                    setDraftContent={setDraftContent}
+                    creating={creating}
+                    onMaybeCreate={maybeCreate}
+                    templateNameRef={templateNameRef}
+                    renameNotice={renameNotice}
+                    onDismissRenameNotice={() => setRenameNotice(null)}
+                />
+            ) : (
+            /* Card grid, matching the /agents index. `alignItems: start` so a card
+               with long content grows on its own instead of stretching every card in
+               its row to match. Cards remain the place to COMPOSE long prose: the
+               Table view fits four lines per row and scrolls the rest inside the
+               cell, which is right for scanning and correcting but not for writing.
+               One column on small screens keeps the cards readable. */
             <Box
                 data-testid="instructions-registry"
                 sx={{
@@ -798,55 +814,15 @@ const InstructionsPage = () => {
                                     }}
                                     testId={`instruction-name-input-${row.id}`}
                                 />
-                                <Tooltip title="Instruction options">
-                                    <IconButton
-                                        size="small"
-                                        onClick={(e) => setMenuAnchor({ id: row.id, el: e.currentTarget })}
-                                        sx={{ maxWidth: '25px', maxHeight: '25px' }}
-                                        data-testid={`instruction-card-menu-${row.id}`}
-                                    >
-                                        <MoreVertIcon fontSize="small" />
-                                    </IconButton>
-                                </Tooltip>
-                                <Menu
-                                    anchorEl={menuAnchor?.el}
-                                    open={menuAnchor?.id === row.id}
-                                    onClose={closeMenu}
-                                    anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-                                    transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-                                    slotProps={{ list: { 'data-testid': `instruction-card-menu-popup-${row.id}` } }}
-                                >
-                                    {row.closed ? (
-                                        <MenuItem onClick={() => menuReopenInstruction(row)}
-                                                  data-testid={`instruction-menu-reopen-${row.id}`}>
-                                            <ListItemIcon><UnarchiveIcon fontSize="small" /></ListItemIcon>
-                                            <ListItemText>Reopen instruction</ListItemText>
-                                        </MenuItem>
-                                    ) : (
-                                        <MenuItem onClick={() => menuCloseInstruction(row)}
-                                                  data-testid={`instruction-menu-close-${row.id}`}>
-                                            <ListItemIcon><CloseIcon fontSize="small" /></ListItemIcon>
-                                            {/* Ellipsis = opens the dialog, because
-                                                this row is bound and the agents it
-                                                would unload from must be shown. No
-                                                ellipsis = closes immediately. */}
-                                            <ListItemText>
-                                                {row.refs.length === 0
-                                                    ? 'Close instruction'
-                                                    : 'Close instruction…'}
-                                            </ListItemText>
-                                        </MenuItem>
-                                    )}
-                                    <Divider />
-                                    <MenuItem onClick={() => menuDeleteInstruction(row)}
-                                              sx={{ color: 'error.main' }}
-                                              data-testid={`instruction-menu-delete-${row.id}`}>
-                                        <ListItemIcon>
-                                            <DeleteForeverIcon fontSize="small" sx={{ color: 'error.main' }} />
-                                        </ListItemIcon>
-                                        <ListItemText>Delete permanently…</ListItemText>
-                                    </MenuItem>
-                                </Menu>
+                                {/* The same component the table's actions column
+                                    renders, so the two views cannot drift on the
+                                    graduated-close affordance or on their testids. */}
+                                <InstructionRowMenu
+                                    row={row}
+                                    onCloseInstruction={menuCloseInstruction}
+                                    onReopen={menuReopenInstruction}
+                                    onDelete={menuDeleteInstruction}
+                                />
                             </Box>
 
                             {/* mb: 2 — the pills need visible air between them and the
@@ -926,8 +902,7 @@ const InstructionsPage = () => {
                                 slotOf={slotOf(row.id)}
                                 onBind={(agentId) => bindAgent(row, agentId)}
                                 onBindAll={(agentsToBind) => bindAllAgents(row, agentsToBind)}
-                                onRequestUnbind={(agent, slot) => unbindConfirm.openDialog(
-                                    { row, agent: { ...agent, slot } })}
+                                onRequestUnbind={(agent, slot) => requestUnbind(row, agent, slot)}
                                 onOpenAgent={(agentId) => navigate(`/agents/${agentId}#instructions`)}
                                 busy={membershipBusy}
                                 testIdPrefix={`instruction-${row.id}`}
@@ -969,7 +944,6 @@ const InstructionsPage = () => {
                             onCommit={maybeCreate}
                             inputProps={{ maxLength: INSTRUCTION_NAME_MAX }}
                             inputRef={templateNameRef}
-                            sx={{ '& .MuiInputBase-input': { fontFamily: 'monospace' } }}
                             testId="instruction-name-input-template"
                         />
                         {creating && <CircularProgress size={14} sx={{ mt: 1.5 }} />}
@@ -992,6 +966,7 @@ const InstructionsPage = () => {
                   </CardContent>
                 </Card>
             </Box>
+            )}
 
             <InstructionUnbindDialog
                 open={unbindConfirm.dialogOpen}

--- a/src/Agents/InstructionsTableView.jsx
+++ b/src/Agents/InstructionsTableView.jsx
@@ -1,0 +1,491 @@
+// /agents/instructions — the Table view (req #3067).
+//
+// THE POINT IS NOT THE TABLE. It is that this view and the Cards view are the SAME
+// EDIT-IN-PLACE IMPLEMENTATION seen twice. Every writable cell here is a
+// `GhostTextField` — the identical component the card renders — reached through
+// `ghostTextColumn`, with the identical commit contract: no dialog, no Save button,
+// one PUT per column, a rejected value kept on screen rather than silently
+// reverted. Both views hand their verdicts to ONE `fieldErrors` map in the page and
+// their membership writes to ONE serialized queue. That is what makes this a
+// pattern rather than a second feature, and it is why the E2E suite can drive both
+// views through one set of data-testids.
+//
+// NOT DataGrid edit mode. `ghostTextColumn` pins `editable: false`. DataGrid's own
+// editing state machine owns commit timing, validation and rollback — all of which
+// GhostTextField already owns, and owns better (an invalid value stays visible in
+// red instead of being discarded). Running both would give the cell two answers to
+// "what is in you".
+//
+// THE PROSE PROBLEM, and why the old header comment on InstructionsPage was a false
+// dichotomy. That comment said a DataGrid "would either truncate it into
+// uselessness or need auto row height". There is a third option, and it is what
+// ships here: a FIXED row containing an INTERNALLY SCROLLABLE field. `multiline
+// maxRows={4}` caps the rendered height at four lines and hands the textarea
+// `overflow: auto` past that, so the whole of a long instruction stays reachable
+// inside its own cell while the row height never moves. `getRowHeight={() =>
+// 'auto'}` stays forbidden (it mis-measures on re-sort — memory/table-design.md);
+// this makes it unnecessary rather than negotiating with it.
+//
+// The Cards view is still the place to COMPOSE long prose. The Table is for
+// scanning the catalog and correcting fields. Both write the same rows.
+
+import { useMemo, useRef } from 'react';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Checkbox from '@mui/material/Checkbox';
+import CircularProgress from '@mui/material/CircularProgress';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+
+import GhostCell from '../Components/GhostField/GhostCell';
+import GhostTextField from '../Components/GhostField/GhostTextField';
+import { ghostTextColumn } from '../Components/GhostField/ghostTextColumn';
+import InstructionAgentChips from './InstructionAgentChips';
+import InstructionRowMenu from './InstructionRowMenu';
+import { gridSortFromMode, lastTouched, dbTimestamp } from './instructionSort';
+import {
+    instructionNameError, instructionContentError, INSTRUCTION_NAME_MAX,
+} from './agentRegistryUtils';
+import { formatDate } from '../utils/dateFormat';
+
+// `rowHeight` is a PRE-DENSITY figure. `useGridDimensions` computes the real row
+// height as `Math.floor(rowHeight * densityFactor)`, and `density="compact"` is
+// 0.7 — so 132 lands at 92px, which is four lines of the grid's body2 cell type
+// (~20px each) plus its 2 × 6px vertical padding. Passing 92 here would give 64px
+// and clip the fourth line. The same trap applies to the `rowHeight={52}` figure
+// quoted elsewhere in the memory docs; it is likewise pre-density.
+const ROW_HEIGHT = 132;
+const CONTENT_MAX_ROWS = 4;
+
+const InstructionsTableView = ({
+    // Already filtered and sorted by the page — the table re-sorts through its own
+    // column headers, but the row SET is the page's decision (R5).
+    rows,
+    // The whole catalog, for the uniqueness check. NOT `rows`: a name colliding
+    // with a filtered-out closed row is still a collision.
+    instructions,
+    fieldErrors,
+    agentIndex,
+    openAgents,
+    slotOf,
+    membershipBusyIds,
+    timezone,
+    sortMode,
+    sortDesc,
+    // --- callbacks, all owned by the page ---
+    commitField,
+    noteFieldError,
+    onBind,
+    onBindAll,
+    onRequestUnbind,
+    onOpenAgent,
+    onCloseInstruction,
+    onReopen,
+    onDelete,
+    // --- template row ---
+    draftName,
+    setDraftName,
+    draftContent,
+    setDraftContent,
+    creating,
+    onMaybeCreate,
+    templateNameRef,
+    // The card view renders this advisory inside the renamed row. A grid row has
+    // nowhere to put an Alert, so the table shows it above the grid — but it MUST
+    // show it somewhere: `commitField` raises the notice on any rename of a row
+    // bound to two or more agents, and without a renderer here the advice is
+    // silently dropped and then reappears, out of context, if the user later
+    // switches to Cards.
+    renameNotice,
+    onDismissRenameNotice,
+}) => {
+    // EVERY page-supplied callback read through this ref, and `columns` memoized on
+    // an EMPTY dep array.
+    //
+    // This is not a micro-optimization; without it a user's column RESIZE is
+    // silently discarded. `commitField`, `noteFieldError`, `bindAgent`, `slotOf`
+    // and the rest are plain function declarations in InstructionsPage, so they are
+    // new values on every render — which means a dep array listing them can never
+    // hit, and `columns` is a fresh array each time. DataGrid's `useGridColumns`
+    // effect only short-circuits on `props.columns === lastColumnsProp`, so a fresh
+    // array rebuilds the column state, and `resolveProps` lets the colDef's literal
+    // `width: 260` win over the width the user dragged to. Opening any row menu,
+    // binding an agent or typing a character that crosses a validity boundary would
+    // snap every resized column back.
+    //
+    // `renderCell` runs DURING render, so reading `live.current` inside it always
+    // sees this render's values — the definitions are stable while the data they
+    // close over is not.
+    //
+    // THE INVARIANT THAT MAKES THAT TRUE, and it is not obvious: `renderCell` only
+    // re-runs when the DataGrid re-renders, and DataGrid is `React.memo`'d. It
+    // re-renders on every parent render today ONLY because `slots`, `slotProps`,
+    // `initialState`, `sx`, `getRowClassName` and `pageSizeOptions` below are fresh
+    // literals each time, so the memo can never bail out. Hoisting any of them to
+    // module scope is an obvious-looking optimization — the same instinct that
+    // produced the broken `useMemo` this ref replaced — and it would freeze every
+    // cell on the last-rendered snapshot with no error and no failing test.
+    // If you ever need to stabilize those props, put the changing values in the dep
+    // array instead of in this ref.
+    const live = useRef();
+    live.current = {
+        instructions, agentIndex, openAgents, slotOf, timezone,
+        commitField, noteFieldError,
+        onBind, onBindAll, onRequestUnbind, onOpenAgent,
+        onCloseInstruction, onReopen, onDelete,
+    };
+
+    // Per-row STATE is hoisted onto the row instead, because that is what DataGrid
+    // reconciles on: a changed row object re-renders its cells without touching the
+    // column definitions. `noteFieldError` returns the previous state object when
+    // nothing changed, so this memo churns only when a field genuinely enters or
+    // leaves an error — exactly when the marker must move.
+    const gridRows = useMemo(() => rows.map(row => ({
+        ...row,
+        blockedMessages: Object.entries(fieldErrors)
+            .filter(([key]) => key.startsWith(`${row.id}:`))
+            .map(([, message]) => message),
+        membershipBusy: membershipBusyIds.has(row.id),
+    })), [rows, fieldErrors, membershipBusyIds]);
+
+    const columns = useMemo(() => [
+        {
+            // THE UNSAVED SIGNAL. With no Save button, "blocked" has no natural
+            // affordance — the card uses a chip, and a table needs an equivalent
+            // that is visible without hovering, or the user navigates away
+            // believing the value was written. This marker plus the row tint below
+            // plus the field's own red text are the three that replace it.
+            field: 'blocked',
+            headerName: '',
+            width: 44,
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            disableExport: true,
+            // NOT hideable. It is the only always-visible blocked signal, and the
+            // toolbar's Columns button would otherwise let a user turn it off and
+            // then silently lose edits.
+            hideable: false,
+            align: 'center',
+            renderCell: (p) => (p.row.blockedMessages.length === 0 ? null : (
+                <GhostCell align="center">
+                    <Tooltip title={p.row.blockedMessages.join(' · ')}>
+                        <ErrorOutlineIcon color="error" fontSize="small"
+                                          data-testid={`instruction-unsaved-${p.row.id}`} />
+                    </Tooltip>
+                </GhostCell>
+            )),
+        },
+        ghostTextColumn({
+            field: 'name',
+            headerName: 'Name',
+            width: 260,
+            required: true,
+            // WRAPS but does not accept newlines — `commitOnEnter` defaults to
+            // `!multiline`, so adding `multiline` without keeping this explicit
+            // would silently turn Enter into a newline inside a name.
+            multiline: true,
+            commitOnEnter: true,
+            maxRows: 3,
+            // MySQL 8's collation is NO PAD, so "  x  " and "x" are DIFFERENT rows
+            // under the unique key — a padded name would block the clean one as a
+            // collision the user cannot see. Collapses newlines too, so a pasted
+            // two-line string cannot store an invisible \n in a name.
+            normalize: (text) => text.replace(/\s+/g, ' ').trim(),
+            validate: (text, row) => instructionNameError(text, live.current.instructions, row.id),
+            onCommit: (row) => live.current.commitField(row, 'name', 'instruction name'),
+            onErrorChange: (row) => live.current.noteFieldError(row.id, 'name'),
+            inputProps: { maxLength: INSTRUCTION_NAME_MAX },
+            testId: (row) => `instruction-name-input-${row.id}`,
+        }),
+        ghostTextColumn({
+            field: 'content',
+            headerName: 'Instruction text',
+            // The single column that absorbs the slack, per table-design.md.
+            flex: 1,
+            minWidth: 420,
+            required: true,
+            multiline: true,
+            maxRows: CONTENT_MAX_ROWS,
+            validate: (text) => instructionContentError(text),
+            onCommit: (row) => live.current.commitField(row, 'content', 'instruction content'),
+            onErrorChange: (row) => live.current.noteFieldError(row.id, 'content'),
+            testId: (row) => `instruction-content-input-${row.id}`,
+        }),
+        {
+            // What makes the gear's "Agent Count" mode reachable as a column sort,
+            // and the blast radius legible at a glance — the read this whole page
+            // exists for.
+            field: 'agent_count',
+            headerName: 'Agents',
+            width: 90,
+            type: 'number',
+            valueGetter: (_value, row) => row.refs.length,
+            renderCell: (p) => (
+                <GhostCell align="flex-end">
+                    <Typography variant="body2"
+                                color={p.row.refs.length === 0 ? 'warning.main' : 'text.primary'}
+                                data-testid={`instruction-agent-count-${p.row.id}`}>
+                        {p.row.refs.length}
+                    </Typography>
+                </GhostCell>
+            ),
+        },
+        {
+            field: 'agents',
+            headerName: 'Bound to',
+            width: 300,
+            // There is no total order over a chip set worth offering, and the
+            // adjacent count column is the sortable form of the same question.
+            sortable: false,
+            filterable: false,
+            // Not exported: a chip set has no total order worth offering, and the
+            // CSV would carry an empty column.
+            disableExport: true,
+            renderCell: (p) => {
+                const l = live.current;
+                const boundSet = new Set(p.row.refs);
+                return (
+                    <GhostCell>
+                        <InstructionAgentChips
+                            variant="compact"
+                            boundAgentIds={p.row.refs}
+                            agentIndex={l.agentIndex}
+                            bindableAgents={l.openAgents.filter(a => !boundSet.has(a.id))}
+                            slotOf={l.slotOf(p.row.id)}
+                            onBind={(agentId) => l.onBind(p.row, agentId)}
+                            onBindAll={(agentsToBind) => l.onBindAll(p.row, agentsToBind)}
+                            onRequestUnbind={(agent, slot) => l.onRequestUnbind(p.row, agent, slot)}
+                            onOpenAgent={l.onOpenAgent}
+                            busy={p.row.membershipBusy}
+                            testIdPrefix={`instruction-${p.row.id}`}
+                        />
+                    </GhostCell>
+                );
+            },
+        },
+        {
+            // THE MOST IMPORTANT CORRECTNESS POINT IN THIS FILE.
+            //
+            // This checkbox is an AFFORDANCE FOR THE PAGE'S EXISTING HANDLER, never
+            // a write path of its own. Closing an instruction drops it out of every
+            // bound agent's boot payload, so the page graduates the action on blast
+            // radius: an unbound row closes immediately, a BOUND row goes through
+            // InstructionDeleteDialog where the agent chips are. A checkbox that
+            // PUT `closed` directly would put that silent unloading one stray click
+            // from every row in the catalog — the single worst regression this
+            // requirement could ship. It calls the same two functions the menu
+            // does, and gains nothing of its own.
+            field: 'closed',
+            headerName: 'Closed',
+            width: 90,
+            type: 'boolean',
+            renderCell: (p) => (
+                <GhostCell align="center">
+                    <Tooltip title={p.row.closed
+                        ? 'Reopen — restores this instruction to every bound agent’s boot payload'
+                        : 'Close — drops this instruction from every bound agent’s boot payload'}>
+                        <Checkbox
+                            size="small"
+                            checked={!!p.row.closed}
+                            onChange={() => (p.row.closed
+                                ? live.current.onReopen(p.row)
+                                : live.current.onCloseInstruction(p.row))}
+                            inputProps={{ 'data-testid': `instruction-closed-toggle-${p.row.id}` }}
+                        />
+                    </Tooltip>
+                </GhostCell>
+            ),
+        },
+        {
+            field: 'update_ts',
+            headerName: 'Last updated',
+            width: 150,
+            type: 'dateTime',
+            // `lastTouched` falls back to `create_ts` when a row has never been
+            // edited. Reused from instructionSort.js rather than re-derived, so the
+            // column and the gear's Last-updated mode can never disagree about what
+            // "last touched" means.
+            valueGetter: (_value, row) => {
+                const ms = lastTouched(row);
+                return ms ? new Date(ms) : null;
+            },
+            valueFormatter: (value) => (value ? formatDate(value, live.current.timezone) : '—'),
+        },
+        {
+            // Hidden by default: two date columns cost 300px and only one of them is
+            // ever the question. The toolbar's Columns button reveals it.
+            field: 'create_ts',
+            headerName: 'Created',
+            width: 150,
+            type: 'dateTime',
+            // Routed through the SAME parser as `update_ts` above. These two columns
+            // sit side by side, so any disagreement about how a bare MySQL DATETIME
+            // is interpreted shows up as one row printing two different days.
+            valueGetter: (value) => {
+                const ms = dbTimestamp(value);
+                return ms ? new Date(ms) : null;
+            },
+            valueFormatter: (value) => (value ? formatDate(value, live.current.timezone) : '—'),
+        },
+        {
+            field: 'actions',
+            headerName: '',
+            width: 56,
+            sortable: false,
+            filterable: false,
+            disableColumnMenu: true,
+            disableExport: true,
+            hideable: false,
+            align: 'center',
+            renderCell: (p) => (
+                <GhostCell align="center">
+                    {/* The menu owns its own anchor, so it cannot outlive its row —
+                        and the column definitions do not depend on menu state. */}
+                    <InstructionRowMenu
+                        row={p.row}
+                        onCloseInstruction={live.current.onCloseInstruction}
+                        onReopen={live.current.onReopen}
+                        onDelete={live.current.onDelete}
+                    />
+                </GhostCell>
+            ),
+        },
+        // EMPTY, deliberately — see the `live` ref above. Every value these columns
+        // need is read at render time through that ref, so the definitions never have
+        // to be rebuilt, and DataGrid keeps the user's column widths.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    ], []);
+
+    return (
+        <>
+            {renameNotice && (
+                <Alert severity="info" sx={{ mb: 1.5, py: 0 }}
+                       onClose={onDismissRenameNotice}
+                       data-testid="instruction-rename-warning">
+                    Renamed <code>{renameNotice.from}</code> →{' '}
+                    <code>{renameNotice.to}</code>. Safe: nothing resolves an
+                    instruction by name, and the charter stubs and memory docs cite
+                    it as <code>instruction #{renameNotice.id}</code> rather than by
+                    title (req #3068).
+                </Alert>
+            )}
+
+            <Box sx={{ width: '100%' }} data-testid="instructions-datagrid">
+                <DataGrid
+                    // NOT COSMETIC. `autoHeight` makes the virtualizer render every
+                    // row on the page (`lastRowIndex = firstRowIndex + rows.length`)
+                    // instead of only the visible window — so a row cannot be
+                    // unmounted out from under a field the user is still typing in.
+                    // GhostTextField's re-seed guard protects against an external
+                    // value landing mid-edit; it cannot protect against its own
+                    // unmount, and nothing inside the component could.
+                    autoHeight
+                    rows={gridRows}
+                    columns={columns}
+                    rowHeight={ROW_HEIGHT}
+                    density="compact"
+                    slots={{ toolbar: GridToolbar }}
+                    slotProps={{ toolbar: { showQuickFilter: true } }}
+                    initialState={{
+                        pagination: { paginationModel: { pageSize: 25 } },
+                        // Seeded ONCE from the persisted gear mode so switching from
+                        // Cards is not a jump to an unrelated order. The grid is the
+                        // sort authority from here on and never writes back.
+                        sorting: { sortModel: [gridSortFromMode(sortMode, sortDesc)] },
+                        columns: { columnVisibilityModel: { create_ts: false } },
+                    }}
+                    pageSizeOptions={[25, 50, 100]}
+                    // No row-click navigation and no row selection: in an
+                    // edit-in-place table a click on a cell means "edit this", and a
+                    // second meaning for the same gesture is how a user loses an
+                    // edit to an accidental navigation.
+                    disableRowSelectionOnClick
+                    getRowClassName={(p) => (p.row.blockedMessages.length
+                        ? 'instruction-row--blocked'
+                        : (p.row.closed ? 'instruction-row--closed' : ''))}
+                    sx={(theme) => ({
+                        // The second half of the unsaved signal: findable after the
+                        // marker column has been scrolled past horizontally.
+                        '& .instruction-row--blocked': {
+                            boxShadow: `inset 3px 0 0 ${theme.palette.error.main}`,
+                        },
+                        // Matches the card grid's `opacity: 0.55` on a closed row.
+                        // Applied to the CELLS rather than the row so the row's own
+                        // hover/selection background is not dimmed with it.
+                        '& .instruction-row--closed .MuiDataGrid-cell': { opacity: 0.55 },
+                        // The cells host live inputs, so the grid's own cell focus
+                        // ring is noise on top of the field's focus underline.
+                        '& .MuiDataGrid-cell:focus, & .MuiDataGrid-cell:focus-within': {
+                            outline: 'none',
+                        },
+                    })}
+                />
+            </Box>
+
+            {/* THE TEMPLATE ROW, deliberately BELOW the grid rather than inside it.
+                Per instruction #41 an inline-editable list ends with a blank item
+                the user fills in place — but a blank row inside a SORTABLE grid does
+                not stay at the end: it scatters to wherever an empty name sorts, and
+                the MIT DataGrid has no pinned rows to stop it. Rendered here it is
+                still literally the last row of the list, still fills in place, and
+                the fixed-row-height invariant above survives.
+
+                Same state, same predicate, same testids as the card view's
+                template: `maybeCreate` fires on every blur of either field and is
+                idempotent, which is what makes a failed create retryable by
+                clicking back in and out. */}
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: 2,
+                    mt: 1,
+                    p: 1.5,
+                    border: '1px dashed',
+                    borderColor: 'divider',
+                    borderRadius: 1,
+                }}
+                data-testid="instruction-row-template"
+            >
+                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, width: 260, flexShrink: 0 }}>
+                    <GhostTextField
+                        value={draftName}
+                        onChangeText={setDraftName}
+                        outlined
+                        label="Name"
+                        fullWidth
+                        commitOnEnter
+                        placeholder="New instruction name"
+                        validate={(text) => instructionNameError(text, instructions, null)}
+                        onCommit={onMaybeCreate}
+                        inputProps={{ maxLength: INSTRUCTION_NAME_MAX }}
+                        inputRef={templateNameRef}
+                        testId="instruction-name-input-template"
+                    />
+                    {creating && <CircularProgress size={14} sx={{ mt: 1.5 }} />}
+                </Box>
+                <GhostTextField
+                    value={draftContent}
+                    onChangeText={setDraftContent}
+                    outlined
+                    label="Instruction text"
+                    fullWidth
+                    multiline
+                    placeholder="Binding text — loaded verbatim into every agent bound to it."
+                    validate={instructionContentError}
+                    hint={(text) => (draftName.trim() && !text.trim()
+                        ? 'Fill both fields — the row is created when the second one is filled.'
+                        : null)}
+                    onCommit={onMaybeCreate}
+                    testId="instruction-content-input-template"
+                />
+            </Box>
+        </>
+    );
+};
+
+export default InstructionsTableView;

--- a/src/Agents/__tests__/InstructionAgentChips.compact.test.jsx
+++ b/src/Agents/__tests__/InstructionAgentChips.compact.test.jsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+//
+// Req #3067 — the compact (table-cell) variant of the membership control.
+//
+// The variant exists because a 92px grid row cannot hold an inline palette of
+// twelve ghost chips. What must NOT change with it is anything behavioural: one
+// chip is still one write, the unbind is still only REQUESTED (the page confirms
+// it), and the drill-through still works.
+//
+// THE DEFECT THIS FILE PRIMARILY GUARDS AGAINST is a testid collision. The first
+// design had the compact variant render this component recursively inside its
+// Popover, which reads well and puts the bound chips and the toggle in the DOM
+// TWICE — duplicating the exact ids the Playwright suite reaches for, so
+// `getByTestId` goes strict-mode ambiguous and every membership test fails with a
+// message about locators rather than about membership. The shipped design shares
+// the chip GROUPS instead. These assertions are counts for that reason; they look
+// pedantic and are not.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import InstructionAgentChips from '../InstructionAgentChips';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container;
+let root;
+
+beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+});
+
+const AGENTS = [
+    { id: 1, name: 'alpha' },
+    { id: 2, name: 'beta' },
+    { id: 3, name: 'gamma' },
+];
+const agentIndex = new Map(AGENTS.map(a => [a.id, a]));
+
+// The Popover portals to document.body, so every query is document-wide. Counting
+// across the WHOLE document is the point — a duplicate in the portal is exactly the
+// bug being guarded against.
+const all = (testId) => document.body.querySelectorAll(`[data-testid="${testId}"]`);
+const one = (testId) => document.body.querySelector(`[data-testid="${testId}"]`);
+
+const render = (props = {}) => act(() => {
+    root.render(
+        <InstructionAgentChips
+            boundAgentIds={[1]}
+            agentIndex={agentIndex}
+            bindableAgents={AGENTS.filter(a => a.id !== 1)}
+            slotOf={() => 1}
+            onBind={() => {}}
+            onBindAll={() => {}}
+            onRequestUnbind={() => {}}
+            onOpenAgent={() => {}}
+            testIdPrefix="instruction-10"
+            {...props}
+        />);
+});
+
+const click = (el) => act(() => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+});
+
+describe('InstructionAgentChips — compact variant, DOM shape', () => {
+    it('shows the bound chips and the toggle, and hides the palette until asked', () => {
+        render({ variant: 'compact' });
+        expect(one('instruction-10-agent-1')).toBeTruthy();
+        expect(one('instruction-10-agent-add')).toBeTruthy();
+        expect(one('instruction-10-bind-2')).toBeFalsy();
+    });
+
+    it('opens the palette into a Popover, NOT inline', () => {
+        render({ variant: 'compact' });
+        click(one('instruction-10-agent-add'));
+        expect(one('instruction-10-agent-palette')).toBeTruthy();
+        expect(one('instruction-10-bind-2')).toBeTruthy();
+        expect(one('instruction-10-bind-3')).toBeTruthy();
+    });
+
+    it('renders each testid EXACTLY ONCE while the palette is open', () => {
+        // The recursion trap. Every one of these would be 2 under the design that
+        // rendered the component inside its own Popover.
+        render({ variant: 'compact' });
+        click(one('instruction-10-agent-add'));
+
+        expect(all('instruction-10-agent-1')).toHaveLength(1);
+        expect(all('instruction-10-agent-add')).toHaveLength(1);
+        expect(all('instruction-10-bind-2')).toHaveLength(1);
+        expect(all('instruction-10-agent-bind-all')).toHaveLength(1);
+    });
+});
+
+describe('InstructionAgentChips — compact variant, behaviour is unchanged', () => {
+    it('binds ONE agent per palette chip click', () => {
+        const onBind = vi.fn();
+        render({ variant: 'compact', onBind });
+        click(one('instruction-10-agent-add'));
+        click(one('instruction-10-bind-2'));
+        expect(onBind).toHaveBeenCalledTimes(1);
+        expect(onBind).toHaveBeenCalledWith(2);
+    });
+
+    it('offers bind-all from two remaining upwards, and passes the whole list', () => {
+        const onBindAll = vi.fn();
+        render({ variant: 'compact', onBindAll });
+        click(one('instruction-10-agent-add'));
+        click(one('instruction-10-agent-bind-all'));
+        expect(onBindAll).toHaveBeenCalledWith(AGENTS.filter(a => a.id !== 1));
+    });
+
+    it('withholds bind-all at one remaining agent', () => {
+        render({ variant: 'compact', bindableAgents: [AGENTS[1]] });
+        click(one('instruction-10-agent-add'));
+        expect(one('instruction-10-agent-bind-all')).toBeFalsy();
+    });
+
+    it('REQUESTS an unbind rather than performing one, with the slot', () => {
+        const onRequestUnbind = vi.fn();
+        render({ variant: 'compact', onRequestUnbind, slotOf: () => 4 });
+        click(one('instruction-10-agent-1').querySelector('.MuiChip-deleteIcon'));
+        expect(onRequestUnbind).toHaveBeenCalledWith(AGENTS[0], 4);
+    });
+
+    it('drills through to the agent on a chip body click', () => {
+        const onOpenAgent = vi.fn();
+        render({ variant: 'compact', onOpenAgent });
+        click(one('instruction-10-agent-1'));
+        expect(onOpenAgent).toHaveBeenCalledWith(1);
+    });
+
+    it('does not REOPEN itself after the anchor has been through an unmount', async () => {
+        // The regression, and it is not hypothetical: `paletteOpen` used to be
+        // cleared only by the Popover's own onClose. Binding the last agent unmounts
+        // the toggle chip — the anchor — while leaving `paletteOpen` true, so the
+        // moment an unbind made a bindable agent reappear a NEW toggle mounted, the
+        // open condition went true again, and the palette reopened with no user
+        // action, anchored to a detached node that MUI clamps to the top-left of the
+        // viewport.
+        render({ variant: 'compact' });
+        click(one('instruction-10-agent-add'));
+        expect(one('instruction-10-agent-palette')).toBeTruthy();
+
+        // Everything bound: anchor gone.
+        render({ variant: 'compact', bindableAgents: [] });
+        await act(async () => { await new Promise(r => setTimeout(r, 600)); });
+
+        // Somebody is unbound again — a bindable agent, and a new toggle chip, are back.
+        render({ variant: 'compact', bindableAgents: [AGENTS[1]] });
+        expect(one('instruction-10-agent-add')).toBeTruthy();
+        expect(one('instruction-10-agent-palette')).toBeFalsy();
+        // ...and it still opens on a real click.
+        click(one('instruction-10-agent-add'));
+        expect(one('instruction-10-agent-palette')).toBeTruthy();
+    });
+
+    it('closes the palette when the last bindable agent is taken', async () => {
+        // Not cosmetic: the toggle chip IS the Popover's anchor, so leaving it open
+        // once the chip unmounts leaves MUI holding a detached anchorEl — which
+        // warns and parks the popover at the viewport origin.
+        render({ variant: 'compact' });
+        click(one('instruction-10-agent-add'));
+        expect(one('instruction-10-agent-palette')).toBeTruthy();
+        expect(one('instruction-10-agent-add')).toBeTruthy();
+
+        render({ variant: 'compact', bindableAgents: [] });
+        // The anchor really is gone — this is the half that makes an open Popover a
+        // problem rather than a cosmetic oddity.
+        expect(one('instruction-10-agent-add')).toBeFalsy();
+        // MUI keeps the Paper mounted through its Grow exit, so wait past the
+        // transition rather than asserting on a half-torn-down tree.
+        await act(async () => { await new Promise(r => setTimeout(r, 600)); });
+        expect(one('instruction-10-agent-palette')).toBeFalsy();
+    });
+});
+
+describe('InstructionAgentChips — the inline variant is untouched', () => {
+    it('still unfurls the palette in place, with no Popover', () => {
+        render({});
+        click(one('instruction-10-agent-add'));
+        expect(one('instruction-10-bind-2')).toBeTruthy();
+        expect(one('instruction-10-agent-palette')).toBeFalsy();
+    });
+
+    it('keeps the card wording for an unbound row', () => {
+        render({ boundAgentIds: [] });
+        expect(container.textContent).toContain('No agent loads this yet');
+    });
+
+    it('uses the terse wording in a grid row, where there is no space for prose', () => {
+        render({ variant: 'compact', boundAgentIds: [] });
+        expect(document.body.textContent).toContain('not bound');
+    });
+});

--- a/src/Agents/__tests__/InstructionsTableView.test.jsx
+++ b/src/Agents/__tests__/InstructionsTableView.test.jsx
@@ -1,0 +1,382 @@
+// @vitest-environment jsdom
+//
+// Req #3067 — the Table view's WIRING.
+//
+// Mounted through InstructionsPage, not in isolation, and deliberately so: every
+// claim worth making about this view is a claim about it sharing the PAGE's
+// machinery with the card view, and a standalone harness would let each of them
+// pass against a private copy.
+//
+// The four things that would break silently:
+//
+//   * THE CLOSED CELL MUST NOT WRITE. It is an affordance for the page's graduated
+//     handler — unbound closes immediately, BOUND opens the blast-radius dialog. A
+//     checkbox wired straight to `updateInstruction` looks identical, passes any
+//     test that only checks "the row closed", and puts silent unloading of twelve
+//     architects' boot payloads one stray click from every row.
+//   * ONE PUT PER FIELD, from the table exactly as from the card. A shared
+//     `commitField` is the mechanism; only a test that inspects the ARGUMENTS can
+//     tell it apart from a table-local writer that happens to work today.
+//   * THE UNSAVED MARKER. There is no Save button, so with the marker missing a
+//     blocked value is indistinguishable from a saved one. Both halves are
+//     asserted: no write, and a visible signal.
+//   * ONE MEMBERSHIP QUEUE. The table must feed the page's serialized queue, not
+//     open a second one — two queues re-create the max(sort_order)+1 race the
+//     single queue exists to remove.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const navigateSpy = vi.fn();
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigateSpy }));
+
+let instructionsData = [];
+let agentsData = [];
+let junctionData = [];
+
+vi.mock('../../hooks/useDataQueries', () => ({
+    useInstructions: () => ({ data: instructionsData, isLoading: false }),
+    useAgents: () => ({ data: agentsData }),
+    useAgentInstructions: () => ({ data: junctionData }),
+    instructionKeys: { all: (c) => ['instructions', c] },
+    agentInstructionKeys: { all: (c) => ['agent_instructions', c] },
+}));
+
+vi.mock('../actions/instructionsApi', () => ({
+    createInstruction: vi.fn(),
+    updateInstruction: vi.fn(),
+    deleteInstruction: vi.fn(),
+    linkAgentInstruction: vi.fn(),
+    linkAgentInstructions: vi.fn(),
+    unlinkAgentInstruction: vi.fn(),
+}));
+
+import InstructionsPage from '../InstructionsPage';
+import * as api from '../actions/instructionsApi';
+import AppContext from '../../Context/AppContext';
+import AuthContext from '../../Context/AuthContext';
+
+const URI = 'http://test.local';
+const TOKEN = 'tok';
+const CREATOR = 'tester';
+
+// Row 10 is BOUND (blast radius, the dialog path); row 11 is UNBOUND (the
+// immediate path). Every graduated branch needs both sides.
+const seed = () => {
+    instructionsData = [
+        { id: 10, name: 'bound-rule', content: 'Body of the bound rule.', closed: 0,
+          create_ts: '2026-07-01 10:00:00', update_ts: '2026-07-10 10:00:00' },
+        { id: 11, name: 'lonely-rule', content: 'Body of the lonely rule.', closed: 0,
+          create_ts: '2026-07-02 10:00:00', update_ts: null },
+    ];
+    agentsData = [
+        { id: 1, name: 'alpha', closed: 0 },
+        { id: 2, name: 'beta', closed: 0 },
+    ];
+    junctionData = [
+        { agent_fk: 1, instruction_fk: 10, sort_order: 1 },
+        { agent_fk: 2, instruction_fk: 10, sort_order: 5 },
+    ];
+};
+
+let container;
+let root;
+
+beforeEach(() => {
+    seed();
+    vi.clearAllMocks();
+    api.updateInstruction.mockResolvedValue({});
+    api.linkAgentInstruction.mockResolvedValue({});
+    api.linkAgentInstructions.mockResolvedValue({});
+    // The view preference is read from storage on mount; pin it to the table.
+    sessionStorage.setItem('darwin-instructions-view', 'table');
+    localStorage.setItem('darwin-instructions-view', 'table');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    sessionStorage.clear();
+    localStorage.clear();
+});
+
+const mount = async () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    await act(async () => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AuthContext.Provider value={{ profile: { userName: CREATOR }, idToken: TOKEN }}>
+                    <AppContext.Provider value={{ darwinUri: URI }}>
+                        <InstructionsPage />
+                    </AppContext.Provider>
+                </AuthContext.Provider>
+            </QueryClientProvider>);
+    });
+};
+
+const one = (testId) => document.body.querySelector(`[data-testid="${testId}"]`);
+const all = (testId) => document.body.querySelectorAll(`[data-testid="${testId}"]`);
+
+const click = (el) => act(() => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+});
+
+const typeInto = (el, value) => act(() => {
+    const proto = el instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, 'value').set.call(el, value);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+});
+
+const editField = async (testId, value) => {
+    const el = one(testId);
+    act(() => el.focus());
+    typeInto(el, value);
+    await act(async () => { el.blur(); });
+};
+
+describe('InstructionsTableView — it really is the table', () => {
+    it('renders the grid rather than the card registry', async () => {
+        await mount();
+        expect(one('instructions-datagrid')).toBeTruthy();
+        expect(one('instructions-registry')).toBeFalsy();
+        expect(one('view-toggle-table').getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('carries the SAME field testids as the cards — one contract, two views', async () => {
+        // This is the assertion behind the whole requirement. If these ids diverged
+        // per view, no test could ever prove the two views commit identically.
+        await mount();
+        expect(one('instruction-name-input-10')).toBeTruthy();
+        expect(one('instruction-content-input-10')).toBeTruthy();
+        expect(one('instruction-name-input-template')).toBeTruthy();
+        expect(one('instruction-content-input-template')).toBeTruthy();
+    });
+
+    it('renders each row field exactly once', async () => {
+        await mount();
+        expect(all('instruction-name-input-10')).toHaveLength(1);
+        expect(all('instruction-content-input-10')).toHaveLength(1);
+    });
+});
+
+describe('InstructionsTableView — one PUT per field', () => {
+    it('writes only the name column when the name cell commits', async () => {
+        await mount();
+        await editField('instruction-name-input-10', 'renamed-rule');
+
+        expect(api.updateInstruction).toHaveBeenCalledTimes(1);
+        const [, , id, body] = api.updateInstruction.mock.calls[0];
+        expect(id).toBe(10);
+        // Asserted as a KEY SET: a rejected name must not be able to take an edited
+        // body down with it.
+        expect(Object.keys(body)).toEqual(['name']);
+        expect(body.name).toBe('renamed-rule');
+    });
+
+    it('writes only the content column when the content cell commits', async () => {
+        await mount();
+        await editField('instruction-content-input-10', 'Rewritten body.');
+
+        expect(api.updateInstruction).toHaveBeenCalledTimes(1);
+        const [, , , body] = api.updateInstruction.mock.calls[0];
+        expect(Object.keys(body)).toEqual(['content']);
+    });
+
+    it('normalizes a name before storing it — NO PAD collation makes padding real', async () => {
+        await mount();
+        await editField('instruction-name-input-10', '  spaced   out  ');
+        expect(api.updateInstruction.mock.calls[0][3].name).toBe('spaced out');
+    });
+});
+
+describe('InstructionsTableView — a blocked value writes NOTHING and says so', () => {
+    it('refuses a duplicate name, keeps it visible, and raises the row marker', async () => {
+        await mount();
+        await editField('instruction-name-input-10', 'lonely-rule');   // row 11's name
+
+        expect(api.updateInstruction).not.toHaveBeenCalled();
+        // The dirty text survives the blur rather than silently reverting.
+        expect(one('instruction-name-input-10').value).toBe('lonely-rule');
+        // The table's replacement for the card's `unsaved` chip.
+        expect(one('instruction-unsaved-10')).toBeTruthy();
+    });
+
+    it('suppresses the per-field caption, which has nowhere to go in a fixed row', async () => {
+        await mount();
+        await editField('instruction-name-input-10', 'lonely-rule');
+        expect(one('instruction-name-input-10-message')).toBeFalsy();
+    });
+
+    it('clears the marker once the value is fixed', async () => {
+        await mount();
+        await editField('instruction-name-input-10', 'lonely-rule');
+        expect(one('instruction-unsaved-10')).toBeTruthy();
+
+        await editField('instruction-name-input-10', 'a-fine-name');
+        expect(one('instruction-unsaved-10')).toBeFalsy();
+        expect(api.updateInstruction).toHaveBeenCalledTimes(1);
+    });
+
+    it('raises no marker on a row that is merely being edited', async () => {
+        await mount();
+        await editField('instruction-name-input-11', 'still-lonely');
+        expect(one('instruction-unsaved-11')).toBeFalsy();
+    });
+});
+
+describe('InstructionsTableView — the closed cell is gated on blast radius', () => {
+    it('closes an UNBOUND row immediately, with no dialog', async () => {
+        await mount();
+        await act(async () => {
+            one('instruction-closed-toggle-11').click();
+        });
+        expect(one('instruction-delete-dialog')).toBeFalsy();
+        expect(api.updateInstruction).toHaveBeenCalledTimes(1);
+        expect(api.updateInstruction.mock.calls[0][2]).toBe(11);
+        expect(api.updateInstruction.mock.calls[0][3]).toEqual({ closed: 1 });
+    });
+
+    it('routes a BOUND row through the dialog and writes NOTHING until confirmed', async () => {
+        // The regression that would matter most: a checkbox that PUT `closed`
+        // directly would pass a "the row closed" assertion and silently drop the
+        // instruction out of two agents' boot payloads with no disclosure.
+        await mount();
+        await act(async () => {
+            one('instruction-closed-toggle-10').click();
+        });
+        expect(api.updateInstruction).not.toHaveBeenCalled();
+        expect(one('instruction-delete-dialog')).toBeTruthy();
+    });
+
+    it('reopens without ceremony — it restores a duty rather than removing one', async () => {
+        instructionsData[1].closed = 1;
+        await mount();
+        // Closed rows are hidden until the filter is on.
+        click(one('instructions-show-closed'));
+        await act(async () => {
+            one('instruction-closed-toggle-11').click();
+        });
+        expect(one('instruction-delete-dialog')).toBeFalsy();
+        expect(api.updateInstruction.mock.calls[0][3]).toEqual({ closed: 0 });
+    });
+});
+
+describe('InstructionsTableView — membership from the row', () => {
+    it('binds one agent at max+1 through the page queue', async () => {
+        await mount();
+        click(one('instruction-11-agent-add'));
+        await act(async () => {
+            one('instruction-11-bind-1').dispatchEvent(
+                new MouseEvent('click', { bubbles: true }));
+        });
+        expect(api.linkAgentInstruction).toHaveBeenCalledTimes(1);
+        const [, , agentId, rowId, slot] = api.linkAgentInstruction.mock.calls[0];
+        expect(agentId).toBe(1);
+        expect(rowId).toBe(11);
+        // agent 1 already holds slot 1 on row 10, so its next free slot is 2.
+        expect(slot).toBe(2);
+    });
+
+    it('binds the rest in ONE bulk call, each with its own slot', async () => {
+        await mount();
+        click(one('instruction-11-agent-add'));
+        await act(async () => {
+            one('instruction-11-agent-bind-all').dispatchEvent(
+                new MouseEvent('click', { bubbles: true }));
+        });
+        expect(api.linkAgentInstructions).toHaveBeenCalledTimes(1);
+        const rows = api.linkAgentInstructions.mock.calls[0][2];
+        expect(rows).toEqual([
+            { agent_fk: 1, instruction_fk: 11, sort_order: 2 },
+            { agent_fk: 2, instruction_fk: 11, sort_order: 6 },
+        ]);
+    });
+
+    it('drills through to the agent page', async () => {
+        await mount();
+        click(one('instruction-10-agent-1'));
+        expect(navigateSpy).toHaveBeenCalledWith('/agents/1#instructions');
+    });
+
+    it('asks before unbinding rather than writing', async () => {
+        await mount();
+        click(one('instruction-10-agent-1').querySelector('.MuiChip-deleteIcon'));
+        expect(one('instruction-unbind-dialog')).toBeTruthy();
+        expect(api.unlinkAgentInstruction).not.toHaveBeenCalled();
+    });
+});
+
+describe('InstructionsTableView — the template row', () => {
+    it('waits for BOTH required columns before posting', async () => {
+        await mount();
+        await editField('instruction-name-input-template', 'brand-new');
+        expect(api.createInstruction).not.toHaveBeenCalled();
+
+        await editField('instruction-content-input-template', 'Some binding text.');
+        expect(api.createInstruction).toHaveBeenCalledTimes(1);
+        expect(api.createInstruction.mock.calls[0][2]).toEqual({
+            name: 'brand-new', content: 'Some binding text.', creator_fk: CREATOR,
+        });
+    });
+
+    it('refuses a name already in the catalog', async () => {
+        await mount();
+        await editField('instruction-name-input-template', 'bound-rule');
+        await editField('instruction-content-input-template', 'Some binding text.');
+        expect(api.createInstruction).not.toHaveBeenCalled();
+    });
+});
+
+describe('InstructionsTableView — the rename advisory reaches the table', () => {
+    it('surfaces the notice after renaming a row bound to two or more agents', async () => {
+        // `commitField` raises `renameNotice` from the PAGE, but the card renders it
+        // inside the row. A grid row has nowhere for an Alert, so without a renderer
+        // in the table the advice was raised into state and never shown — then
+        // appeared out of context if the user later switched to Cards.
+        await mount();
+        await editField('instruction-name-input-10', 'renamed-bound-rule');
+        expect(api.updateInstruction).toHaveBeenCalledTimes(1);
+        expect(one('instruction-rename-warning')).toBeTruthy();
+        expect(one('instruction-rename-warning').textContent).toContain('renamed-bound-rule');
+    });
+
+    it('stays silent for a row nobody shares', async () => {
+        // Row 11 is unbound, so there is nothing to advise about.
+        await mount();
+        await editField('instruction-name-input-11', 'renamed-lonely-rule');
+        expect(one('instruction-rename-warning')).toBeFalsy();
+    });
+});
+
+describe('InstructionsTableView — the header adapts to the view', () => {
+    it('hides the sort gear, because the grid headers are the sort authority', async () => {
+        // Two sort UIs on one page that can disagree is a bug generator.
+        await mount();
+        expect(one('instructions-settings-button')).toBeFalsy();
+    });
+
+    it('shows the gear again in Cards view', async () => {
+        sessionStorage.setItem('darwin-instructions-view', 'cards');
+        localStorage.setItem('darwin-instructions-view', 'cards');
+        await mount();
+        expect(one('instructions-settings-button')).toBeTruthy();
+    });
+
+    it('keeps the accounting line, counting the WHOLE catalog', async () => {
+        await mount();
+        expect(one('instructions-accounting').textContent)
+            .toBe('2 instructions · 1 not bound');
+    });
+});

--- a/src/Agents/__tests__/instructionSort.test.js
+++ b/src/Agents/__tests__/instructionSort.test.js
@@ -15,6 +15,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import {
     compareInstructionRows, SORT_ASC, lastTouched,
     readStoredSort, DEFAULT_SORT_MODE, SORT_MODES, SORT_STORAGE_KEY,
+    gridSortFromMode, GRID_FIELD_BY_SORT_MODE, dbTimestamp,
 } from '../instructionSort';
 
 const row = (id, name, refs, extra = {}) => ({
@@ -56,8 +57,13 @@ describe('lastTouched', () => {
     it('falls back to create_ts for a row that has never been edited', () => {
         // `update_ts` is NULL until the first edit. Without the fallback every
         // untouched row would sort as if it were from 1970.
+        //
+        // The expectation is written with an explicit `Z` because the stored value
+        // IS UTC: `lastTouched` normalizes a bare timestamp before parsing it, so
+        // comparing against a bare `Date.parse` would assert the old local-time
+        // reading and fail in every timezone but UTC.
         expect(lastTouched({ update_ts: null, create_ts: '2026-07-24T00:00:00' }))
-            .toBe(Date.parse('2026-07-24T00:00:00'));
+            .toBe(Date.parse('2026-07-24T00:00:00Z'));
     });
 
     it('returns 0 rather than NaN for a row with neither date', () => {
@@ -183,5 +189,103 @@ describe('readStoredSort — the persisted browse preference', () => {
         // The mode alone round-trips; there is no second key and no encoded suffix.
         expect(Object.keys(store)).toEqual([SORT_STORAGE_KEY]);
         expect(SORT_MODES.find(m => m.value === 'date').defaultDesc).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Req #3067 — the gear-mode → grid-column mapping.
+//
+// The Table view sorts through its own column headers, so switching from Cards
+// has to SEED the grid from the persisted mode or the rows jump to an unrelated
+// order for no reason the user can see. The mapping is the only thing tying the
+// two vocabularies together, and a typo'd field name fails silently: DataGrid
+// ignores a sort model naming a column it does not have, so the grid would simply
+// fall back to its natural order and look merely "wrong" rather than broken.
+// ---------------------------------------------------------------------------
+
+describe('gridSortFromMode', () => {
+    it('maps every gear mode onto a real grid column', () => {
+        expect(gridSortFromMode('agents', true)).toEqual({ field: 'agent_count', sort: 'desc' });
+        expect(gridSortFromMode('name', false)).toEqual({ field: 'name', sort: 'asc' });
+        expect(gridSortFromMode('date', true)).toEqual({ field: 'update_ts', sort: 'desc' });
+    });
+
+    it('covers EVERY mode the gear can be in', () => {
+        // The guard against adding a fourth sort mode and forgetting the table.
+        for (const { value } of SORT_MODES) {
+            expect(GRID_FIELD_BY_SORT_MODE[value]).toBeTruthy();
+        }
+    });
+
+    it('carries the direction through', () => {
+        expect(gridSortFromMode('name', true).sort).toBe('desc');
+        expect(gridSortFromMode('name', false).sort).toBe('asc');
+    });
+
+    it('falls back to the page default for an unknown mode', () => {
+        // `readStoredSort` already filters storage, but the mapping is also reached
+        // from a seeded prop and must not emit `field: undefined`.
+        expect(gridSortFromMode('nonsense', true).field)
+            .toBe(GRID_FIELD_BY_SORT_MODE[DEFAULT_SORT_MODE]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Req #3067 — MySQL DATETIME strings are UTC and carry no marker.
+//
+// A bare `Date.parse('2026-07-26 02:00:00')` treats the space-separated form as
+// LOCAL time. For SORTING that offset is uniform and cancels, which is why the bug
+// survived #3063 unnoticed. #3067 made `lastTouched` the value behind the
+// `Last updated` COLUMN, and a display is not offset-invariant: every row stored
+// between midnight and ~08:00 UTC rendered TOMORROW's date to a US Pacific viewer,
+// and disagreed with the `Created` column beside it.
+//
+// `TZ` is pinned per-assertion via the parsed instant rather than the formatted
+// string, so this test means the same thing in every timezone CI might run in.
+// ---------------------------------------------------------------------------
+
+describe('lastTouched — MySQL DATETIME is UTC', () => {
+    it('parses the space-separated MySQL form as UTC, not local', () => {
+        expect(lastTouched({ update_ts: '2026-07-26 02:00:00' }))
+            .toBe(Date.parse('2026-07-26T02:00:00Z'));
+    });
+
+    it('agrees with the ISO form for the same instant', () => {
+        expect(lastTouched({ update_ts: '2026-07-26 02:00:00' }))
+            .toBe(lastTouched({ update_ts: '2026-07-26T02:00:00Z' }));
+    });
+
+    it('applies the same parse to the create_ts fallback', () => {
+        expect(lastTouched({ update_ts: null, create_ts: '2026-07-24 23:30:00' }))
+            .toBe(Date.parse('2026-07-24T23:30:00Z'));
+    });
+
+    it('tolerates the microsecond tail MySQL DATETIME(6) can carry', () => {
+        expect(lastTouched({ update_ts: '2026-07-26 02:00:00.000000' }))
+            .toBe(Date.parse('2026-07-26T02:00:00.000Z'));
+    });
+
+    it('normalizes the ISO-WITHOUT-OFFSET form too, not just the space form', () => {
+        // `dbTimestamp` is exported under a generic name, so the caller that
+        // re-acquires this bug will be a future one passing `2026-07-26T02:00:00`.
+        // The guard is "carries no timezone information", not "contains a space".
+        expect(dbTimestamp('2026-07-26T02:00:00')).toBe(Date.parse('2026-07-26T02:00:00Z'));
+        expect(dbTimestamp('2026-07-26T02:00:00')).toBe(dbTimestamp('2026-07-26 02:00:00'));
+    });
+
+    it('leaves an explicit offset alone', () => {
+        // A value that already says what it means must not be re-interpreted.
+        expect(dbTimestamp('2026-07-26T02:00:00Z')).toBe(Date.parse('2026-07-26T02:00:00Z'));
+        expect(dbTimestamp('2026-07-26T02:00:00-07:00'))
+            .toBe(Date.parse('2026-07-26T02:00:00-07:00'));
+    });
+
+    it('dbTimestamp returns 0 for null/empty/garbage rather than NaN', () => {
+        // NaN would poison the comparator's subtraction and make it non-transitive
+        // — an unstable sort rather than a wrong one, which is far harder to spot.
+        expect(dbTimestamp(null)).toBe(0);
+        expect(dbTimestamp('')).toBe(0);
+        expect(dbTimestamp(undefined)).toBe(0);
+        expect(dbTimestamp('not a date')).toBe(0);
     });
 });

--- a/src/Agents/instructionSort.js
+++ b/src/Agents/instructionSort.js
@@ -31,7 +31,38 @@ export const SORT_MODES = [
 // `update_ts` is NULL until a row is first edited, so an unedited row falls back
 // to its creation time — otherwise every never-touched instruction sorts as if it
 // were from 1970 and the "newest" list is meaningless.
-export const lastTouched = (i) => Date.parse(i.update_ts || i.create_ts || '') || 0;
+//
+// THE STORED VALUE IS UTC AND CARRIES NO MARKER. Lambda-Rest hands the frontend
+// MySQL DATETIME strings in `YYYY-MM-DD HH:MM:SS` form; ECMAScript parses that
+// space-separated shape as LOCAL time, so a bare `Date.parse` shifts every
+// timestamp by the viewer's UTC offset. The `T`/`Z` normalization here is the same
+// one `utils/dateFormat.js` applies, kept in this module so a single call site
+// cannot get it wrong.
+//
+// It was invisible until req #3067. For SORTING the offset is uniform and cancels,
+// so the ordering has always been right — but #3067 made this the `Last updated`
+// COLUMN's value, and a display is not offset-invariant. Every row stored between
+// 00:00 and 08:00 UTC rendered tomorrow's date to a US Pacific viewer, and disagreed
+// with the `Created` column beside it, which parsed correctly.
+// The condition is "carries NO timezone information", not "contains a space".
+// `utils/dateFormat.js` normalizes only the space form, which is sufficient there
+// because it is only ever handed Lambda-Rest output — but this is an EXPORTED helper
+// with a generic name, and the next caller to pass it an ISO-without-offset string
+// (`2026-07-26T02:00:00`) would silently re-acquire the exact off-by-one-day defect
+// it exists to remove. Widened deliberately: on every input either function actually
+// sees this is a superset of dateFormat's behaviour, so the two cannot disagree on
+// real data — they only differ on a shape Lambda-Rest never emits.
+const NO_TIMEZONE = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?$/;
+
+export const dbTimestamp = (value) => {
+    if (!value) return 0;
+    const iso = (typeof value === 'string' && NO_TIMEZONE.test(value))
+        ? `${value.replace(' ', 'T')}Z`
+        : value;
+    return Date.parse(iso) || 0;
+};
+
+export const lastTouched = (i) => dbTimestamp(i.update_ts || i.create_ts);
 
 export const SORT_ASC = {
     agents: (a, b) => a.refs.length - b.refs.length,
@@ -48,6 +79,33 @@ export const readStoredSort = () => {
         return SORT_MODES.some(m => m.value === stored) ? stored : DEFAULT_SORT_MODE;
     } catch { return DEFAULT_SORT_MODE; }   // Safari private mode
 };
+
+// The Table view sorts through the DataGrid's own column headers rather than
+// through the gear — two sort UIs on one page that can disagree is a bug generator,
+// and a grid with dead headers reads as broken. This maps the gear's vocabulary onto
+// the grid's columns so switching views SEEDS the grid from the persisted mode
+// instead of jumping to an unrelated order (req #3067).
+//
+// The mapping is one-way and seed-only. The grid never writes a sort back to
+// `darwin-instructions-sort`: a column click is a transient act on this table, while
+// the stored mode is a standing preference about the catalog.
+//
+// KNOWN LOSS, and it is deliberate. `compareInstructionRows` pins closed rows last
+// STRUCTURALLY, in every mode and both directions. A DataGrid sort model cannot
+// express a primary key it did not sort by, so in Table view a closed row can sort
+// above open ones. Acceptable because closed rows only appear once the user has
+// turned the Closed filter on — they are already in a deliberate mode. Cards keep
+// the pin.
+export const GRID_FIELD_BY_SORT_MODE = {
+    agents: 'agent_count',
+    name:   'name',
+    date:   'update_ts',
+};
+
+export const gridSortFromMode = (mode, desc) => ({
+    field: GRID_FIELD_BY_SORT_MODE[mode] || GRID_FIELD_BY_SORT_MODE[DEFAULT_SORT_MODE],
+    sort: desc ? 'desc' : 'asc',
+});
 
 /**
  * The full row comparator: the open/closed split OUTRANKS the user's chosen sort,

--- a/src/Components/GhostField/GhostCell.jsx
+++ b/src/Components/GhostField/GhostCell.jsx
@@ -1,0 +1,77 @@
+// The DataGrid cell wrapper for always-live edit-in-place content (req #3067).
+//
+// Wraps ANY editable cell content — a GhostTextField, a chip row, a checkbox, a
+// menu button — and owns the event contract that makes an interactive control
+// survive inside a DataGrid cell. DataGrid edit mode is NOT involved: no column
+// using this sets `editable`, so the grid's own editing state machine never starts.
+//
+// WHY THE KEYDOWN STOP IS THE LOAD-BEARING PART. The Maps precedent
+// (MapRuns/GhostCellEditors.jsx) stops `onClick` only, and that is not enough.
+// Verified against the installed @mui/x-data-grid@8.27.3:
+//
+//   * `components/cell/GridCell.js` publishes `cellKeyDown` from the cell's own
+//     `onKeyDown` with NO input-target guard — it does not care that the event came
+//     from inside a text field.
+//   * `utils/keyboardUtils.js` classifies the SPACE CHARACTER as a navigation key,
+//     alongside Arrow*, Page*, Home and End.
+//   * `hooks/features/keyboardNavigation/useGridKeyboardNavigation.js` responds to
+//     every navigation key with `goToCell(...)` + `event.preventDefault()`.
+//
+// The consequences, in order of how badly they break the feature:
+//   1. A SPACE CANNOT BE TYPED into the cell at all. Not degraded — impossible.
+//   2. An arrow key moves grid focus instead of the caret, which blurs the field
+//      and therefore COMMITS the half-typed value on its way out.
+//   3. Tab traverses grid cells rather than fields.
+//
+// Tab is stopped deliberately rather than reluctantly: native tab order (name →
+// content → next row) is the right traversal for an edit-in-place table, and each
+// hop blurs and commits exactly as a click away would.
+//
+// Enter and Escape are NOT intercepted by the grid — they are not navigation keys,
+// and `useGridCellEditing` gates all of its Enter/printable/Delete handling behind
+// `params.isEditable`, which is false because no column sets `editable`. They are
+// covered by this stop anyway, harmlessly: GhostTextField's own handler sits on the
+// input, deeper in the tree, so it runs first and the stop happens on the way up.
+//
+// WHAT IS DELIBERATELY NOT STOPPED: mousedown and mouseup. `useGridFocus` registers
+// its document handler on mouseup and `cellMouseDown` records `lastClickedCell`, and
+// the grid keeps the FOCUSED cell rendered even when it falls outside the render
+// context. Stopping those would forfeit that protection to prevent nothing.
+
+import Box from '@mui/material/Box';
+
+const stop = (e) => e.stopPropagation();
+
+const GhostCell = ({
+    children,
+    // Cross-axis placement of the content within the cell. `flex-end` for a number
+    // column, so the digits line up with the header the grid right-aligns.
+    align = 'flex-start',
+    sx = {},
+}) => (
+    <Box
+        // Keep a click inside the cell from reaching the row: row click navigation,
+        // row selection and column sort all live above this. The Maps precedent.
+        onClick={stop}
+        // See the header comment. This one is not optional.
+        onKeyDown={stop}
+        sx={{
+            width: '100%',
+            height: '100%',
+            // Without this a long unbroken value forces the flex item wider than its
+            // column and the grid scrolls horizontally by a cell rather than
+            // wrapping or clipping.
+            minWidth: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: align,
+            py: '2px',
+            ...sx,
+        }}
+    >
+        {children}
+    </Box>
+);
+
+export default GhostCell;

--- a/src/Components/GhostField/GhostCell.jsx
+++ b/src/Components/GhostField/GhostCell.jsx
@@ -5,8 +5,8 @@
 // survive inside a DataGrid cell. DataGrid edit mode is NOT involved: no column
 // using this sets `editable`, so the grid's own editing state machine never starts.
 //
-// WHY THE KEYDOWN STOP IS THE LOAD-BEARING PART. The Maps precedent
-// (MapRuns/GhostCellEditors.jsx) stops `onClick` only, and that is not enough.
+// WHY THE KEYDOWN STOP IS THE LOAD-BEARING PART. Stopping `onClick` alone — which
+// is all MapRuns/GhostCellEditors.jsx did until req #3073 — is not enough.
 // Verified against the installed @mui/x-data-grid@8.27.3:
 //
 //   * `components/cell/GridCell.js` publishes `cellKeyDown` from the cell's own
@@ -37,6 +37,16 @@
 // its document handler on mouseup and `cellMouseDown` records `lastClickedCell`, and
 // the grid keeps the FOCUSED cell rendered even when it falls outside the render
 // context. Stopping those would forfeit that protection to prevent nothing.
+//
+// AN OPEN DIVERGENCE, recorded rather than silently resolved. Req #3073 landed the
+// same fix on the Maps editors within hours of this file, independently, and chose
+// an ALLOWLIST (`EDITOR_KEYS`: arrows, Home, End, Enter, Escape, Space) over this
+// blanket stop — on the grounds that stopping wholesale also takes out PageUp/PageDown
+// paging and the grid's Tab tracking, which an editor has no use for. That is the
+// better-considered position on keys; this file's full-cell flex sizing is the
+// better-considered position on layout. The two wrappers should converge, but that
+// touches two live pages and is not a drive-by edit. See
+// memory/darwin-viewer-pages.md § 7.
 
 import Box from '@mui/material/Box';
 

--- a/src/Components/GhostField/GhostTextField.jsx
+++ b/src/Components/GhostField/GhostTextField.jsx
@@ -85,6 +85,16 @@ const GhostTextField = ({
     // Fires whenever the verdict changes. A blocked value has no Save button to
     // leave disabled, so the CARD has to be able to say "this is not saved".
     onErrorChange,
+    // Suppress the inline error/hint caption THIS COMPONENT renders — display only.
+    //
+    // For a DataGrid cell (req #3067), where the row height is fixed and a caption
+    // would either overflow the row or steal a line from the value. Nothing about
+    // WHEN it writes changes, the field still turns red, and `onErrorChange` still
+    // fires — which is the point: the verdict is not suppressed, it is HOISTED. The
+    // table surfaces it as a row-level marker plus a tooltip, because the V-rule
+    // that a blocked value must be visible without hovering holds in every view;
+    // only the place the message can fit differs.
+    hideMessage = false,
     // Render as a conventional bordered field with a notched label instead of as
     // plain text. Everything about WHEN it writes is unchanged.
     outlined = false,
@@ -319,7 +329,7 @@ const GhostTextField = ({
                 // The message the ghost mode renders itself belongs in the
                 // field's own helper slot here, where MUI already reserves and
                 // colours it.
-                helperText={error || advisory || undefined}
+                helperText={hideMessage ? undefined : (error || advisory || undefined)}
                 inputProps={{ ...inputProps, 'data-testid': testId }}
                 sx={sx}
             />
@@ -379,7 +389,7 @@ const GhostTextField = ({
                     },
                 })}
             />
-            {(error || advisory) && (
+            {!hideMessage && (error || advisory) && (
                 <Typography
                     variant="caption"
                     color={error ? 'error' : 'text.secondary'}

--- a/src/Components/GhostField/__tests__/GhostCell.test.jsx
+++ b/src/Components/GhostField/__tests__/GhostCell.test.jsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+//
+// Req #3067 — the DataGrid cell wrapper's event contract.
+//
+// THIS IS THE HIGHEST-VALUE TEST OF THE NEW COMPONENTS, and it looks trivial,
+// which is the problem it guards against. The wrapper's whole job is two
+// `stopPropagation` calls, and the keydown one is easy to "clean up" as redundant
+// because nothing in the component's own render depends on it.
+//
+// It is not redundant. Verified against the installed @mui/x-data-grid@8.27.3:
+// `GridCell` publishes `cellKeyDown` from its own `onKeyDown` with no
+// input-target guard, and `keyboardUtils.isNavigationKey` classifies the SPACE
+// CHARACTER as a navigation key — so `useGridKeyboardNavigation` answers a space
+// with `goToCell()` + `preventDefault()`. Without the stop, a space cannot be typed
+// into an edit-in-place cell AT ALL, and an arrow key blurs the field mid-edit
+// (which commits it). The existing Maps editors stop click but not keydown and are
+// believed to carry exactly this defect; it is filed as a follow-up.
+//
+// The test asserts the events do not REACH a listener on an ancestor, which is what
+// the grid is.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import GhostCell from '../GhostCell';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container;
+let root;
+
+beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+});
+
+/** Stands in for the DataGrid cell that would otherwise receive the event. */
+const renderInGrid = (handlers) => {
+    act(() => {
+        root.render(
+            <div {...handlers}>
+                <GhostCell>
+                    <input data-testid="inner" />
+                </GhostCell>
+            </div>);
+    });
+    return container.querySelector('[data-testid="inner"]');
+};
+
+describe('GhostCell — what it keeps away from the grid', () => {
+    it('stops a click from reaching the row', () => {
+        // Row click navigation, row selection and column sort all live above the
+        // cell. A click inside an editable cell means "edit this" and nothing else.
+        const onClick = vi.fn();
+        const input = renderInGrid({ onClick });
+        act(() => input.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+        expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('stops SPACE from reaching the grid — otherwise it cannot be typed', () => {
+        const onKeyDown = vi.fn();
+        const input = renderInGrid({ onKeyDown });
+        act(() => input.dispatchEvent(
+            new KeyboardEvent('keydown', { key: ' ', bubbles: true })));
+        expect(onKeyDown).not.toHaveBeenCalled();
+    });
+
+    it('stops the arrow keys — otherwise they blur the field and commit it', () => {
+        const onKeyDown = vi.fn();
+        const input = renderInGrid({ onKeyDown });
+        for (const key of ['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight']) {
+            act(() => input.dispatchEvent(
+                new KeyboardEvent('keydown', { key, bubbles: true })));
+        }
+        expect(onKeyDown).not.toHaveBeenCalled();
+    });
+
+    it('stops Home/End/PageUp/PageDown and Tab', () => {
+        const onKeyDown = vi.fn();
+        const input = renderInGrid({ onKeyDown });
+        for (const key of ['Home', 'End', 'PageUp', 'PageDown', 'Tab']) {
+            act(() => input.dispatchEvent(
+                new KeyboardEvent('keydown', { key, bubbles: true })));
+        }
+        expect(onKeyDown).not.toHaveBeenCalled();
+    });
+
+    it('does NOT stop mousedown or mouseup', () => {
+        // Deliberate, and load-bearing: `useGridFocus` registers its document
+        // handler on mouseup and `cellMouseDown` records the last-clicked cell —
+        // and the grid keeps the FOCUSED cell rendered even when it falls outside
+        // the render context. Stopping these would forfeit that for nothing.
+        const onMouseDown = vi.fn();
+        const onMouseUp = vi.fn();
+        const input = renderInGrid({ onMouseDown, onMouseUp });
+        act(() => {
+            input.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            input.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+        });
+        expect(onMouseDown).toHaveBeenCalledTimes(1);
+        expect(onMouseUp).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets the inner field see the keystroke it stopped from bubbling', () => {
+        // The stop happens on the way UP. A handler on the input itself — which is
+        // where GhostTextField's Enter/Escape handling lives — must still fire.
+        const onKeyDown = vi.fn();
+        act(() => {
+            root.render(
+                <GhostCell>
+                    <input data-testid="inner" onKeyDown={onKeyDown} />
+                </GhostCell>);
+        });
+        const input = container.querySelector('[data-testid="inner"]');
+        act(() => input.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })));
+        expect(onKeyDown).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/Components/GhostField/__tests__/ghostTextColumn.test.jsx
+++ b/src/Components/GhostField/__tests__/ghostTextColumn.test.jsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+//
+// Req #3067 — the column factory.
+//
+// Two things are worth pinning, and only two:
+//
+//   1. `editable` is FALSE and cannot be overridden. That single flag is what keeps
+//      DataGrid's own edit-mode state machine — which owns commit timing,
+//      validation and rollback — from competing with GhostTextField, which already
+//      owns all three and owns them better (an invalid value stays visible in red
+//      instead of being silently discarded). A caller passing `editable: true`
+//      through the rest-spread would produce a cell with two answers to "what is
+//      in you", and nothing else in the codebase would notice.
+//   2. The per-row bindings really reach the field: the validator is given the row
+//      (so a name is not a duplicate of itself), the commit is bound to the row,
+//      and the caption is suppressed so a fixed-height cell is not overflowed.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import { ghostTextColumn } from '../ghostTextColumn';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container;
+let root;
+
+beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+});
+
+const ROW = { id: 7, name: 'alpha' };
+
+const baseSpec = (overrides = {}) => ({
+    field: 'name',
+    headerName: 'Name',
+    width: 200,
+    onCommit: () => vi.fn().mockResolvedValue(undefined),
+    testId: (row) => `cell-${row.id}`,
+    ...overrides,
+});
+
+const renderCell = (col, row = ROW) => {
+    act(() => root.render(col.renderCell({ row })));
+    return container.querySelector(`[data-testid="cell-${row.id}"]`);
+};
+
+const typeInto = (el, value) => act(() => {
+    const proto = el instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, 'value').set.call(el, value);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+});
+
+describe('ghostTextColumn — the column definition', () => {
+    it('pins editable false', () => {
+        expect(ghostTextColumn(baseSpec()).editable).toBe(false);
+    });
+
+    it('refuses to let a caller turn DataGrid edit mode back on', () => {
+        // `editable` is applied AFTER the rest-spread precisely so this cannot be
+        // smuggled through. If this test fails, two competing edit state machines
+        // are live in the same cell.
+        const col = ghostTextColumn(baseSpec({ editable: true }));
+        expect(col.editable).toBe(false);
+    });
+
+    it('passes through the sizing and any extra GridColDef keys', () => {
+        const col = ghostTextColumn(baseSpec({
+            width: undefined, flex: 1, minWidth: 420, sortable: false,
+        }));
+        expect(col.flex).toBe(1);
+        expect(col.minWidth).toBe(420);
+        expect(col.sortable).toBe(false);
+        // Omitted sizing keys are left off entirely rather than set to undefined,
+        // which DataGrid treats differently from absent.
+        expect('width' in col).toBe(false);
+    });
+});
+
+describe('ghostTextColumn — the rendered cell', () => {
+    it('renders the row value in a field carrying the derived testid', () => {
+        const el = renderCell(ghostTextColumn(baseSpec()));
+        expect(el).toBeTruthy();
+        expect(el.value).toBe('alpha');
+    });
+
+    it('gives the validator the ROW, so a value is not a duplicate of itself', () => {
+        const validate = vi.fn().mockReturnValue(null);
+        const el = renderCell(ghostTextColumn(baseSpec({ validate })));
+        typeInto(el, 'beta');
+        expect(validate).toHaveBeenCalledWith('beta', ROW);
+    });
+
+    it('binds onCommit to the row', async () => {
+        const commit = vi.fn().mockResolvedValue(undefined);
+        const onCommit = vi.fn(() => commit);
+        const el = renderCell(ghostTextColumn(baseSpec({ onCommit })));
+        expect(onCommit).toHaveBeenCalledWith(ROW);
+
+        // Focus first: jsdom fires no blur event on an element that never held
+        // focus, so a blur-commit assertion without it passes vacuously.
+        act(() => el.focus());
+        typeInto(el, 'beta');
+        await act(async () => { el.blur(); });
+        expect(commit).toHaveBeenCalledWith('beta');
+    });
+
+    it('SUPPRESSES the inline caption but still reports the verdict', async () => {
+        // The two halves of `hideMessage`. A fixed-height row has nowhere to put a
+        // caption, so the verdict is hoisted to the table's row-level marker — but
+        // it must still be RAISED, or a blocked value would have no signal at all.
+        const onErrorChange = vi.fn();
+        const el = renderCell(ghostTextColumn(baseSpec({
+            validate: (text) => (text === 'taken' ? 'that name already exists' : null),
+            onErrorChange: () => onErrorChange,
+        })));
+
+        typeInto(el, 'taken');
+        expect(container.querySelector('[data-testid="cell-7-message"]')).toBeFalsy();
+        expect(onErrorChange).toHaveBeenCalledWith('that name already exists');
+    });
+
+    it('does not write a value the validator blocked', async () => {
+        const commit = vi.fn().mockResolvedValue(undefined);
+        const el = renderCell(ghostTextColumn(baseSpec({
+            onCommit: () => commit,
+            validate: (text) => (text === 'taken' ? 'that name already exists' : null),
+        })));
+
+        typeInto(el, 'taken');
+        await act(async () => { el.blur(); });
+        expect(commit).not.toHaveBeenCalled();
+        // ...and the rejected text stays on screen rather than silently reverting,
+        // which is the difference from the Maps editors' skip-and-forget.
+        expect(el.value).toBe('taken');
+    });
+});

--- a/src/Components/GhostField/ghostTextColumn.jsx
+++ b/src/Components/GhostField/ghostTextColumn.jsx
@@ -1,0 +1,90 @@
+// GridColDef factory for an always-live edit-in-place text column (req #3067).
+//
+// The column-shape half of the contract; GhostCell.jsx is the DOM/event half. This
+// exists so a table cell and a card field are demonstrably the SAME implementation
+// rather than two that happen to agree today — which is the whole thesis of req
+// #3067 and the reason the E2E suite can reuse one set of testids across both views.
+//
+// THE ONE THING EVERY CALLER MUST NOT DO: set `editable`. It is pinned false here.
+// DataGrid's own edit mode is a competing state machine — it owns commit timing,
+// validation and rollback, all of which GhostTextField already owns and owns
+// better (a rejected value stays on screen in red rather than silently reverting).
+// Running both would mean two answers to "what is in this cell".
+
+import GhostCell from './GhostCell';
+import GhostTextField from './GhostTextField';
+
+/**
+ * @param {object}   spec
+ * @param {string}   spec.field         row property to read and write
+ * @param {string}   spec.headerName    the column header — and, in ghost mode, the
+ *                                      field's only label
+ * @param {Function} spec.onCommit      (row) => (nextValue) => Promise. Must REJECT
+ *                                      on failure so the field can roll back.
+ * @param {Function} spec.onErrorChange (row) => (error|null) => void. How the
+ *                                      blocked verdict reaches the row-level marker.
+ * @param {Function} spec.testId        (row) => string
+ * @param {Function} [spec.validate]    (text, row) => error string | null
+ */
+export const ghostTextColumn = ({
+    field,
+    headerName,
+    width,
+    flex,
+    minWidth,
+    multiline = false,
+    maxRows,
+    commitOnEnter,
+    required = false,
+    normalize,
+    validate,
+    onCommit,
+    onErrorChange,
+    onEditingChange,
+    testId,
+    inputProps,
+    placeholder,
+    sx,
+    ...rest
+}) => ({
+    field,
+    headerName,
+    ...(width !== undefined && { width }),
+    ...(flex !== undefined && { flex }),
+    ...(minWidth !== undefined && { minWidth }),
+    renderCell: (params) => (
+        <GhostCell>
+            <GhostTextField
+                value={params.row[field]}
+                multiline={multiline}
+                maxRows={maxRows}
+                commitOnEnter={commitOnEnter}
+                required={required}
+                placeholder={placeholder}
+                normalize={normalize}
+                // Bound to the ROW so a validator can exclude the row from its own
+                // uniqueness check — a name is not a duplicate of itself.
+                validate={validate ? (text) => validate(text, params.row) : undefined}
+                onCommit={onCommit(params.row)}
+                onErrorChange={onErrorChange?.(params.row)}
+                onEditingChange={onEditingChange?.(params.row)}
+                // The caption has nowhere to go in a fixed-height row. The verdict
+                // still fires through onErrorChange; the table hoists it to the
+                // row's marker column and tooltip.
+                hideMessage
+                testId={testId(params.row)}
+                inputProps={inputProps}
+                sx={{ width: '100%', ...sx }}
+            />
+        </GhostCell>
+    ),
+    // Every other GridColDef key a caller passes lands above; `editable` lands
+    // BELOW the spread, deliberately, so it cannot be smuggled back on. That
+    // ordering is the enforcement — with `editable: false` written above `...rest`
+    // a caller passing `editable: true` silently wins, which is how a cell ends up
+    // with two competing edit state machines. There is a unit test on exactly this.
+    ...rest,
+    editable: false,
+});
+
+export default ghostTextColumn;

--- a/src/Components/ViewerHeader/ViewerHeader.jsx
+++ b/src/Components/ViewerHeader/ViewerHeader.jsx
@@ -1,0 +1,243 @@
+// The canonical Darwin viewer header, as a component (req #3067).
+//
+// Every Darwin VIEWER page — a page whose job is to list one dataset — opens with
+// the same row, in the same reading order:
+//
+//     [ view toggle ] [ title, flex:1 ] [ filters ] [ settings ] [ actions ]
+//                       ──────── accounting line ────────
+//
+// The toggle leads so the title starts at the same x-position on every viewer;
+// that is the whole reason it is first rather than the title. Filters sit beside
+// the title because they change WHAT is listed. The gear is pinned right because
+// that is where SwarmView already puts settings.
+//
+// WHY IT IS A COMPONENT NOW. The rules (V1–V8 in
+// memory/view-switchable-pages.md § I) were issued in req #3013 and re-stated in
+// #3063, and by the time #3067 opened there were THREE hand-rolled copies —
+// AgentsPage, InstructionsPage, DocumentsPage — which had already drifted:
+// AgentsPage was the codebase's single user of TableRowsIcon over the canonical
+// TableChartIcon, used a non-conforming storage key, and had no accounting line at
+// all despite silently filtering closed rows out of its own list. Rules that live
+// only in prose drift; rules a component enforces cannot.
+//
+// WHAT IS DELIBERATELY NOT CONFIGURABLE. The order of the children. A page that
+// wants filters left of the title, or the toggle anywhere but first, does not want
+// this component — it is not a viewer. `sx` reaches the header row only, and an
+// `sx` carrying `flexDirection`, `order` or `justifyContent` is a code-review
+// reject. See memory/darwin-viewer-pages.md.
+
+import { useState } from 'react';
+
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import ListSubheader from '@mui/material/ListSubheader';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import SettingsIcon from '@mui/icons-material/Settings';
+
+import { normalizeView } from './normalizeView';
+
+const ViewerHeader = ({
+    // Rendered `variant={isMobile ? 'h6' : 'h5'} sx={{ flex: 1 }}`. The component
+    // owns the media query so no caller has to remember the breakpoint.
+    title,
+    // [{ value, label, icon, disabled?, disabledReason? }]
+    //
+    // `label` is REQUIRED and is never rendered as text: the shipped viewer
+    // toggles are icon-only with a Tooltip (V5 governs which icon, not whether
+    // there is a caption), so `label` becomes the aria-label and the tooltip.
+    views = [],
+    view,
+    // Pass useViewPreference's setter directly — it already null-guards the
+    // deselect click that ToggleButtonGroup sends in exclusive mode.
+    onViewChange,
+    // Node, right of the title. Chips that change WHAT is listed.
+    filters,
+    // [{ id, heading, items: [{ id, label, icon, selected?, trailing?, onClick }] }]
+    //
+    // Omit ⇒ no gear at all. `onClick` is called with a `close` callback rather
+    // than closing automatically: re-picking the ACTIVE sort mode must reverse it
+    // and KEEP THE MENU OPEN so the arrow flip is visible (the shipped CategoryCard
+    // idiom), while adopting a new mode closes. The component cannot infer which
+    // of those a given item is, so it delegates the decision instead of guessing.
+    settingsItems,
+    // Node, far right.
+    actions,
+    // The sub-header line. Omit ⇒ not rendered.
+    accounting,
+    // Derives `<prefix>-view-toggle`, `<prefix>-settings-button`,
+    // `<prefix>-sort-menu`, `<prefix>-accounting`, and each menu item's
+    // `<prefix>-<groupId>-<itemId>`. Per-button ids stay literal:
+    // `view-toggle-<value>`.
+    testIdPrefix,
+    // Escape hatch, applied to the header ROW ONLY — never to the title, toggle,
+    // gear, menu or accounting line. Caller wins on conflict.
+    sx = {},
+    // For pages on the `.app-content-planpage` CSS grid, which assign grid areas by
+    // CLASS (`app-content-view-toggle`), not by sx.
+    className,
+}) => {
+    const isMobile = useMediaQuery('(max-width:899px)');
+    // The gear anchor is pure presentation with no page semantics, every caller
+    // wrote the identical three lines, and owning it is what lets this component
+    // guarantee the menu's testid and the between-group Dividers.
+    const [settingsAnchor, setSettingsAnchor] = useState(null);
+
+    // Defensive second line. The PAGE must normalize too — its conditional render
+    // has to branch on the same value, or the header shows Cards selected while the
+    // body renders a Table that does not exist — but a caller who forgets still
+    // gets a toggle with an active state rather than a dead one.
+    const activeView = normalizeView(view, views);
+
+    const closeSettings = () => setSettingsAnchor(null);
+
+    return (
+        <>
+            <Box
+                className={className}
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    // The accounting line supplies its own bottom margin when it is
+                    // there; without it the row has to carry the gap itself.
+                    mb: accounting ? 0.5 : 2,
+                    flexWrap: 'wrap',
+                    ...sx,
+                }}
+            >
+                {/* V1 — always first, always rendered, even at length 1. A group
+                    with one child still holds the far-left anchor and keeps the
+                    title's x-position stable against the other viewers. */}
+                <ToggleButtonGroup
+                    size="small"
+                    exclusive
+                    value={activeView}
+                    onChange={(_e, v) => onViewChange(v)}
+                    sx={{ flexShrink: 0 }}
+                    data-testid={`${testIdPrefix}-view-toggle`}
+                >
+                    {views.map(({ value, label, icon: Icon, disabled, disabledReason }) => {
+                        const button = (
+                            <ToggleButton
+                                value={value}
+                                disabled={!!disabled}
+                                aria-label={label}
+                                data-testid={`view-toggle-${value}`}
+                            >
+                                <Icon fontSize="small" />
+                            </ToggleButton>
+                        );
+                        // MUI cannot fire a Tooltip on a disabled button — the
+                        // button carries `pointer-events: none`, so no mouse event
+                        // ever reaches it. The documented fix is a wrapper element,
+                        // and it is SAFE HERE specifically: MUI v7's
+                        // ToggleButtonGroup passes value/onChange/position down
+                        // through CONTEXT rather than cloneElement, so an
+                        // intervening span cannot break grouping. (#3063 used a
+                        // `pointerEvents: auto` override instead; it was never
+                        // verified to work and is not reinstated here.)
+                        return disabled ? (
+                            <Tooltip key={value} title={disabledReason || label}>
+                                <span style={{ display: 'inline-flex' }}>{button}</span>
+                            </Tooltip>
+                        ) : (
+                            <Tooltip key={value} title={label}>{button}</Tooltip>
+                        );
+                    })}
+                </ToggleButtonGroup>
+
+                {/* V2 — the title carries flex:1 and IS the spacer. There is
+                    deliberately no separate flexGrow Box; adding one is the exact
+                    failure the rule exists to prevent. */}
+                <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ flex: 1 }}>
+                    {title}
+                </Typography>
+
+                {/* V3 — filters, then settings, then actions. Never interleaved. */}
+                {filters}
+
+                {settingsItems && settingsItems.length > 0 && (
+                    <>
+                        <Tooltip title="Sort & display settings">
+                            <IconButton
+                                size="small"
+                                onClick={(e) => setSettingsAnchor(e.currentTarget)}
+                                sx={{ flexShrink: 0 }}
+                                data-testid={`${testIdPrefix}-settings-button`}
+                            >
+                                <SettingsIcon fontSize="small" />
+                            </IconButton>
+                        </Tooltip>
+                        <Menu
+                            anchorEl={settingsAnchor}
+                            open={!!settingsAnchor}
+                            onClose={closeSettings}
+                            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                            // `slotProps.list` is the MUI v7 path for props on the
+                            // MenuList; the older `MenuListProps` is deprecated in
+                            // @mui/material@7.3.7's own type declarations.
+                            //
+                            // The name is `-sort-menu`, not `-settings-menu`, on a
+                            // component that can hold non-sort groups. That is a
+                            // wart, and a deliberate one: the shipped E2E suite
+                            // reaches for `instructions-sort-menu`, and renaming a
+                            // testid is a test-architecture change rather than a
+                            // side effect of extracting a component.
+                            slotProps={{ list: { 'data-testid': `${testIdPrefix}-sort-menu` } }}
+                        >
+                            {settingsItems.flatMap((group, gi) => [
+                                // Between groups only — a leading rule above the
+                                // first subheader reads as a stray line.
+                                gi > 0 ? <Divider key={`divider-${group.id}`} /> : null,
+                                <ListSubheader key={`heading-${group.id}`} disableSticky
+                                               sx={{ lineHeight: '32px' }}>
+                                    {group.heading}
+                                </ListSubheader>,
+                                ...group.items.map(item => (
+                                    <MenuItem
+                                        key={item.id}
+                                        selected={!!item.selected}
+                                        onClick={() => item.onClick(closeSettings)}
+                                        data-testid={`${testIdPrefix}-${group.id}-${item.id}`}
+                                    >
+                                        <ListItemIcon>{item.icon}</ListItemIcon>
+                                        <ListItemText>{item.label}</ListItemText>
+                                        {/* Carries the sort-direction arrow. It is
+                                            the only affordance saying that
+                                            re-picking the active mode reverses it,
+                                            so it is not decorative. */}
+                                        {item.trailing}
+                                    </MenuItem>
+                                )),
+                            ]).filter(Boolean)}
+                        </Menu>
+                    </>
+                )}
+
+                {actions}
+            </Box>
+
+            {/* V7 — a separate body2/text.secondary line BELOW the row, counting the
+                WHOLE dataset. A count that changed when you toggled a view filter
+                would not be an accounting line. */}
+            {accounting && (
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}
+                            data-testid={`${testIdPrefix}-accounting`}>
+                    {accounting}
+                </Typography>
+            )}
+        </>
+    );
+};
+
+export default ViewerHeader;

--- a/src/Components/ViewerHeader/__tests__/ViewerHeader.test.jsx
+++ b/src/Components/ViewerHeader/__tests__/ViewerHeader.test.jsx
@@ -1,0 +1,256 @@
+// @vitest-environment jsdom
+//
+// Req #3067 — the shared viewer header.
+//
+// What is worth testing here is NOT that MUI renders a toggle group. It is the
+// handful of contracts that, if broken, break silently:
+//
+//   * THE TESTIDS IT DERIVES. Three shipped pages and an 864-line Playwright suite
+//     reach for `instructions-view-toggle`, `instructions-settings-button`,
+//     `instructions-sort-menu` and `instructions-sort-agents`. Those are now
+//     produced by a template inside this component. A change to the template is
+//     invisible in every unit test that does not assert the exact strings, and
+//     surfaces as a mass E2E failure with no obvious cause.
+//   * IT MUST NOT WRITE THE NORMALIZED VIEW BACK. Normalizing for display is
+//     correct; persisting the normalization silently rewrites a preference the user
+//     set and can never get back. Only a "the setter was not called" assertion can
+//     catch a regression here — the rendered output is identical either way.
+//   * THE `onClick(close)` DELEGATION. Re-picking the active sort mode must reverse
+//     it and KEEP THE MENU OPEN so the arrow flip is visible. A component that
+//     closed on every click would look completely normal and quietly destroy that
+//     affordance.
+//   * OMITTED SLOTS RENDER NOTHING. `/agents` passes no filters, no gear and (until
+//     this req) no accounting line. A component that rendered an empty gear or a
+//     blank accounting line would put furniture on a page that asked for none.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import TableChartIcon from '@mui/icons-material/TableChart';
+import SortByAlphaIcon from '@mui/icons-material/SortByAlpha';
+
+import ViewerHeader from '../ViewerHeader';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container;
+let root;
+
+beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+});
+
+const VIEWS = [
+    { value: 'cards', label: 'Cards view', icon: ViewModuleIcon },
+    { value: 'table', label: 'Table view', icon: TableChartIcon },
+];
+
+// Menus and tooltips PORTAL to document.body, not into `container`. Querying the
+// container for a menu item is the classic way to write a test that can only fail.
+const byId = (testId) => document.body.querySelector(`[data-testid="${testId}"]`);
+
+const render = (props) => act(() => {
+    root.render(
+        <ViewerHeader
+            title="Instructions"
+            views={VIEWS}
+            view="cards"
+            onViewChange={() => {}}
+            testIdPrefix="instructions"
+            {...props}
+        />);
+});
+
+const click = (el) => act(() => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+});
+
+describe('ViewerHeader — the testids it derives', () => {
+    it('emits the exact ids three shipped pages and the E2E suite depend on', () => {
+        render({
+            settingsItems: [{
+                id: 'sort',
+                heading: 'Sort by',
+                items: [{
+                    id: 'agents', label: 'Agent Count',
+                    icon: <SortByAlphaIcon fontSize="small" />, onClick: () => {},
+                }],
+            }],
+            accounting: '3 instructions',
+        });
+
+        expect(byId('instructions-view-toggle')).toBeTruthy();
+        expect(byId('instructions-settings-button')).toBeTruthy();
+        expect(byId('instructions-accounting')).toBeTruthy();
+        // Per-button ids stay LITERAL — they are not prefixed, because a test
+        // switching views should not have to know which page it is on.
+        expect(byId('view-toggle-cards')).toBeTruthy();
+        expect(byId('view-toggle-table')).toBeTruthy();
+
+        click(byId('instructions-settings-button'));
+        // `<prefix>-sort-menu`, not `-settings-menu`: a deliberate wart, kept so the
+        // shipped Playwright suite stays green.
+        expect(byId('instructions-sort-menu')).toBeTruthy();
+        // `<prefix>-<groupId>-<itemId>` reproduces `instructions-sort-agents`
+        // byte-identically. This assertion IS the compatibility guarantee.
+        expect(byId('instructions-sort-agents')).toBeTruthy();
+    });
+
+    it('marks the active view pressed', () => {
+        render({ view: 'table' });
+        expect(byId('view-toggle-table').getAttribute('aria-pressed')).toBe('true');
+        expect(byId('view-toggle-cards').getAttribute('aria-pressed')).toBe('false');
+    });
+});
+
+describe('ViewerHeader — view normalization', () => {
+    it('selects a fallback view when the stored one is not available', () => {
+        // A browser holding 'table' from before the button existed.
+        render({ views: [VIEWS[0]], view: 'table' });
+        expect(byId('view-toggle-cards').getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('NEVER writes the normalized value back through onViewChange', () => {
+        // The whole point. `useViewPreference`'s setter writes localStorage as well
+        // as sessionStorage, so a write-back here would permanently and invisibly
+        // overwrite a cross-tab preference the user chose — and req #3067 is the
+        // proof it matters, because it hands 'table' back to exactly those users.
+        const onViewChange = vi.fn();
+        render({ views: [VIEWS[0]], view: 'table', onViewChange });
+        expect(onViewChange).not.toHaveBeenCalled();
+    });
+
+    it('forwards a real user selection unchanged', () => {
+        const onViewChange = vi.fn();
+        render({ onViewChange });
+        click(byId('view-toggle-table'));
+        expect(onViewChange).toHaveBeenCalledWith('table');
+    });
+});
+
+describe('ViewerHeader — the settings menu', () => {
+    const sortItems = (onClick, selected = 'agents') => [{
+        id: 'sort',
+        heading: 'Sort by',
+        items: [
+            {
+                id: 'agents', label: 'Agent Count',
+                icon: <SortByAlphaIcon fontSize="small" />,
+                selected: selected === 'agents',
+                trailing: <span data-testid="arrow">↓</span>,
+                onClick,
+            },
+            {
+                id: 'name', label: 'Name',
+                icon: <SortByAlphaIcon fontSize="small" />,
+                selected: selected === 'name',
+                onClick,
+            },
+        ],
+    }];
+
+    it('hands the item a `close` callback rather than closing by itself', () => {
+        // The delegation exists because the component cannot infer which items
+        // should dismiss the menu. Re-picking the ACTIVE mode must not.
+        const onClick = vi.fn();
+        render({ settingsItems: sortItems(onClick) });
+
+        click(byId('instructions-settings-button'));
+        click(byId('instructions-sort-agents'));
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+        expect(typeof onClick.mock.calls[0][0]).toBe('function');
+        // Not called => not closed. The menu is still on screen.
+        expect(byId('instructions-sort-menu')).toBeTruthy();
+    });
+
+    it('closes when the item calls the callback it was given', async () => {
+        const onClick = vi.fn((close) => close());
+        render({ settingsItems: sortItems(onClick) });
+
+        click(byId('instructions-settings-button'));
+        expect(byId('instructions-sort-menu')).toBeTruthy();
+
+        await act(async () => {
+            byId('instructions-sort-name').dispatchEvent(
+                new MouseEvent('click', { bubbles: true }));
+        });
+        // MUI closes the Menu through a Grow transition and unmounts on exit, so
+        // the DOM does not settle synchronously. Wait past the transition rather
+        // than asserting on a half-torn-down tree — the alternative is reaching into
+        // MUI's `visibility: hidden`-during-exit internals, which is a test that
+        // breaks on a library upgrade rather than on a real regression.
+        await act(async () => { await new Promise(r => setTimeout(r, 600)); });
+        expect(document.body.querySelector('.MuiModal-root')).toBeFalsy();
+    });
+
+    it('renders the trailing node — the only affordance saying a re-pick reverses', () => {
+        render({ settingsItems: sortItems(() => {}) });
+        click(byId('instructions-settings-button'));
+        expect(byId('arrow')).toBeTruthy();
+    });
+});
+
+describe('ViewerHeader — omitted slots', () => {
+    it('renders no gear when settingsItems is omitted', () => {
+        render({});
+        expect(byId('instructions-settings-button')).toBeFalsy();
+        expect(byId('instructions-sort-menu')).toBeFalsy();
+    });
+
+    it('renders no gear for an EMPTY settingsItems array', () => {
+        // A page computing its groups conditionally (InstructionsPage renders the
+        // sort group in Cards view only) can legitimately arrive here with [].
+        render({ settingsItems: [] });
+        expect(byId('instructions-settings-button')).toBeFalsy();
+    });
+
+    it('renders no accounting line when accounting is omitted', () => {
+        render({});
+        expect(byId('instructions-accounting')).toBeFalsy();
+    });
+
+    it('still renders the toggle group at length 1, to hold the left anchor', () => {
+        // V1's spirit: dropping the group for a bare title is what moves the
+        // title's x-position away from every other viewer.
+        render({ views: [VIEWS[0]] });
+        expect(byId('instructions-view-toggle')).toBeTruthy();
+        expect(byId('view-toggle-cards')).toBeTruthy();
+    });
+});
+
+describe('ViewerHeader — disabled views', () => {
+    it('renders a disabled entry as a real disabled button', () => {
+        render({
+            views: [VIEWS[0], { ...VIEWS[1], disabled: true, disabledReason: 'Not built yet' }],
+            view: 'cards',
+        });
+        const table = byId('view-toggle-table');
+        expect(table).toBeTruthy();
+        expect(table.hasAttribute('disabled')).toBe(true);
+        // Wrapped in a span so MUI can fire a Tooltip over it — the documented fix,
+        // and safe because v7's ToggleButtonGroup uses context rather than
+        // cloneElement, so an intervening element cannot break grouping.
+        expect(table.parentElement.tagName).toBe('SPAN');
+    });
+
+    it('keeps grouping intact through the span wrapper', () => {
+        // The regression the span could plausibly cause: the enabled sibling losing
+        // its selected state because the group could not reach it.
+        render({
+            views: [VIEWS[0], { ...VIEWS[1], disabled: true }],
+            view: 'cards',
+        });
+        expect(byId('view-toggle-cards').getAttribute('aria-pressed')).toBe('true');
+    });
+});

--- a/src/Components/ViewerHeader/__tests__/normalizeView.test.js
+++ b/src/Components/ViewerHeader/__tests__/normalizeView.test.js
@@ -1,0 +1,57 @@
+// Req #3067 — the generic form of the `activeView` line.
+//
+// Pure function, so no harness. The rules it encodes are small and each one
+// corresponds to a real failure that shipped or nearly shipped:
+//
+//   * An unmatched ToggleButtonGroup value selects NOTHING. That is what makes a
+//     stale stored view a visible bug rather than a harmless one, and it is why
+//     this function exists at all.
+//   * It must never write back. The test for that is in ViewerHeader's suite,
+//     because "did not call a setter" is a statement about the component.
+
+import { describe, it, expect } from 'vitest';
+
+import { normalizeView } from '../normalizeView';
+
+const CARDS = { value: 'cards', label: 'Cards view' };
+const TABLE = { value: 'table', label: 'Table view' };
+
+describe('normalizeView', () => {
+    it('passes an enabled value straight through', () => {
+        expect(normalizeView('table', [CARDS, TABLE])).toBe('table');
+        expect(normalizeView('cards', [CARDS, TABLE])).toBe('cards');
+    });
+
+    it('falls back to the first entry when the value names no view at all', () => {
+        // The req #3063 case: 'table' sitting in storage with no Table button.
+        expect(normalizeView('table', [CARDS])).toBe('cards');
+        // And a view that was deleted outright rather than merely disabled.
+        expect(normalizeView('trends', [CARDS, TABLE])).toBe('cards');
+    });
+
+    it('falls back past a DISABLED entry rather than selecting it', () => {
+        // V1's disabled-button form: the button is on screen holding the group's
+        // width, but selecting it would render a view that does not exist.
+        expect(normalizeView('table', [CARDS, { ...TABLE, disabled: true }])).toBe('cards');
+    });
+
+    it('picks the first ENABLED entry, not the first entry, when falling back', () => {
+        // The ordering trap: a page whose first view is the disabled one would
+        // otherwise normalize to something it cannot render.
+        const views = [{ ...CARDS, disabled: true }, TABLE];
+        expect(normalizeView('trends', views)).toBe('table');
+    });
+
+    it('still returns something when every entry is disabled', () => {
+        // Degenerate, but the alternative is `undefined` reaching
+        // ToggleButtonGroup — which is the no-selection state this function was
+        // written to prevent.
+        const views = [{ ...CARDS, disabled: true }, { ...TABLE, disabled: true }];
+        expect(normalizeView('trends', views)).toBe('cards');
+    });
+
+    it('tolerates an empty or missing view list', () => {
+        expect(normalizeView('cards', [])).toBeUndefined();
+        expect(normalizeView('cards')).toBeUndefined();
+    });
+});

--- a/src/Components/ViewerHeader/normalizeView.js
+++ b/src/Components/ViewerHeader/normalizeView.js
@@ -1,0 +1,43 @@
+// The generic form of the `activeView` line every hand-rolled viewer header grew
+// (req #3067).
+//
+// ITS OWN MODULE, with no JSX and no MUI import. Two reasons, both learned the hard
+// way on `instructionSort.js`: mixing non-component exports into a component file
+// drops that file out of React Fast Refresh, and a pure module can be exercised by
+// vitest without pulling MUI into the test environment.
+
+/**
+ * The view value that should actually be RENDERED, given what the page offers.
+ *
+ * A stored preference can name a view that no longer exists, or one that exists but
+ * is disabled — `/agents/instructions` shipped for a fortnight with a `'table'`
+ * value reachable in storage and no Table button to match it. An unmatched
+ * ToggleButtonGroup value selects nothing, so the toggle renders with no active
+ * state at all.
+ *
+ * NEVER WRITE THE RESULT BACK through `onViewChange`. The stored value is a record
+ * of what the USER ASKED FOR; a missing or disabled view is a temporary condition of
+ * the PAGE. Writing back converts that temporary condition into a permanent
+ * preference change the user never made and cannot detect — and because
+ * `useViewPreference` writes `localStorage` as well as `sessionStorage`, it would be
+ * permanent across every tab. Req #3063 is the worked example: a user who chose
+ * Table before the button was pulled still means Table, and req #3067 gives it back
+ * to them for free precisely because nothing overwrote it.
+ *
+ * This is the same principle as GhostTextField's re-seed guard — never let an
+ * external condition silently overwrite uncommitted user intent — applied to
+ * preferences instead of text.
+ *
+ * @param {string} view    the stored/selected value
+ * @param {Array<{value: string, disabled?: boolean}>} views  the page's view list
+ * @returns {string|undefined} `view` when it names an enabled entry, otherwise the
+ *   first enabled entry's value (falling back to the first entry at all, so a list
+ *   that is somehow entirely disabled still selects something rather than nothing).
+ */
+export const normalizeView = (view, views = []) => {
+    const enabled = views.filter(v => !v.disabled);
+    if (enabled.some(v => v.value === view)) return view;
+    return enabled[0]?.value ?? views[0]?.value;
+};
+
+export default normalizeView;

--- a/tests/tests/agents-instructions.spec.ts
+++ b/tests/tests/agents-instructions.spec.ts
@@ -16,11 +16,28 @@
 // the dependency explicit and stops one failure cascading into a dozen.
 //
 // Beyond that, each test owns its own seeded rows and is individually runnable
-// under `--grep`. There is exactly ONE ordering constraint, and it is worth
-// knowing before reordering anything: AGENT-01 asserts that agent a1 holds
-// exactly the slots {1,2,100}, and AGENT-04's bind-all later binds `c-bind` to
-// every open agent — a1 included, at slot 101. AGENT-01 must therefore stay
-// ahead of AGENT-04.
+// under `--grep`. There are exactly THREE ordering constraints, all worth knowing
+// before reordering anything:
+//   1. AGENT-01 asserts that agent a1 holds exactly the slots {1,2,100}, and
+//      AGENT-04's bind-all later binds `c-bind` to every open agent — a1 included,
+//      at slot 101. AGENT-01 must stay ahead of AGENT-04.
+//   2. AGENT-12 asserts `j-table-edit` still carries its seeded name; AGENT-13
+//      renames it. 12 before 13.
+//   3. AGENT-16 binds `k-table-bind` to a3, and AGENT-17 needs it BOUND to reach
+//      the dialog branch of the graduated close. 16 before 17.
+//
+// TABLE VIEW — AGENT-12..20 (req #3067). The table is not a second feature, it is
+// the SAME edit-in-place implementation in a second presentation, and these tests
+// are written to assert exactly that: they reuse the card tests' per-field
+// data-testids and distinguish the views by SCOPING to `instructions-datagrid`
+// versus `instructions-registry` (see `viewRoot`). A per-view testid scheme would
+// have made the central claim untestable. AGENT-13 deliberately mirrors AGENT-02
+// assertion for assertion.
+//
+// PORTALS ARE THE EXCEPTION TO THE SCOPING. MUI renders `Menu`, `Popover` and every
+// dialog outside the grid, so the roster palette, the per-row options menu and the
+// delete/unbind dialogs are page-scoped even in table tests. Scoping one of those
+// to `viewRoot` produces a locator failure that reads like a feature failure.
 //
 // WHY THE WRITES ARE INSPECTED, NOT INFERRED. Two of this page's contracts are
 // invisible in the DOM: "one PUT per field" (a rejected name must not be able to
@@ -215,6 +232,49 @@ async function gotoRegistry(page: Page): Promise<void> {
   await expect(page.getByTestId('instructions-registry')).toBeVisible({ timeout: 30000 });
 }
 
+/**
+ * THE VIEW PREFERENCE IS PER-TAB, and that is what makes it settable at all.
+ *
+ * `useViewPreference` reads sessionStorage first and falls back to localStorage, so
+ * seeding BOTH before the app mounts is what pins the view deterministically. Doing
+ * it by clicking the toggle instead would work, but every table test would then
+ * begin with a click that could fail for an unrelated reason and report itself as a
+ * table bug.
+ *
+ * `addInitScript` runs before any page script on EVERY navigation in this context,
+ * which matters because several of these tests reload.
+ */
+async function useView(page: Page, view: 'cards' | 'table'): Promise<void> {
+  await page.addInitScript((v) => {
+    try {
+      sessionStorage.setItem('darwin-instructions-view', v);
+      localStorage.setItem('darwin-instructions-view', v);
+    } catch { /* private mode */ }
+  }, view);
+}
+
+async function gotoTable(page: Page): Promise<void> {
+  await useView(page, 'table');
+  await page.goto('/agents/instructions');
+  await expect(page.getByTestId('instructions-datagrid')).toBeVisible({ timeout: 30000 });
+}
+
+/**
+ * The root a field assertion should be scoped to.
+ *
+ * Req #3067's thesis is that Cards and Table are ONE implementation, so both views
+ * carry the SAME per-field testids (`instruction-name-input-<id>` and friends).
+ * That is deliberate — a per-view id would make it structurally impossible to
+ * assert the two views commit identically — and it means a test says which view it
+ * is in by scoping, not by using a different name.
+ *
+ * ONE EXCEPTION, and it bites: MUI `Menu` and `Popover` render through a PORTAL, so
+ * the roster palette, the per-row options menu and every dialog live OUTSIDE this
+ * root. Those stay page-scoped. Documented in memory/darwin-viewer-pages.md.
+ */
+const viewRoot = (page: Page, view: 'cards' | 'table') =>
+  page.getByTestId(view === 'table' ? 'instructions-datagrid' : 'instructions-registry');
+
 async function openCardMenu(page: Page, rowId: number): Promise<void> {
   await page.getByTestId(`instruction-card-menu-${rowId}`).click();
   await expect(page.getByTestId(`instruction-card-menu-popup-${rowId}`)).toBeVisible();
@@ -286,6 +346,9 @@ test.describe.serial('Instruction registry (/agents/instructions)', () => {
       'b-edit', 'c-bind', 'd-unbind',
       'e-close-unbound', 'f-close-bound',
       'g-del-guard', 'h-del-hard',
+      // Owned by the table-view tests (AGENT-12+) so they cannot disturb the
+      // fixtures AGENT-01..11 assert against.
+      'j-table-edit', 'k-table-bind',
     ];
     for (const suffix of suffixes) {
       const name = nm(suffix);
@@ -860,5 +923,362 @@ test.describe.serial('Instruction registry (/agents/instructions)', () => {
       openRows.map(r => ({ id: r.id, name: r.name })));
     await expect.poll(async () => (await cardOrder(page)).filter(id => mine.has(id)),
       { timeout: 20000 }).toEqual(expectedOrder);
+  });
+
+  // -------------------------------------------------------------------------
+  // AGENT-12 — the Table view exists, and it is the SAME data.
+  //
+  // Also pins the two header fixes req #3067 folded in: the Table button is real
+  // (not disabled), and the `activeView` normalization line that used to pin a
+  // stored 'table' back to Cards is gone. A page that still carried that line
+  // would render Cards here and every later table test would fail on a missing
+  // grid rather than on the thing it was testing.
+  // -------------------------------------------------------------------------
+  test('AGENT-12: the Cards | Table toggle switches views and honours a stored preference', async ({ page }) => {
+    const rowId = instrIds['j-table-edit'];
+
+    await gotoRegistry(page);
+    await expect(page.getByTestId('view-toggle-cards')).toHaveAttribute('aria-pressed', 'true');
+    const tableButton = page.getByTestId('view-toggle-table');
+    await expect(tableButton).toBeVisible();
+    // The button #3063 never shipped. If it were rendered disabled, the click
+    // below would silently do nothing and the failure would point at the grid.
+    await expect(tableButton).toBeEnabled();
+
+    await tableButton.click();
+    await expect(page.getByTestId('instructions-datagrid')).toBeVisible({ timeout: 20000 });
+    await expect(page.getByTestId('instructions-registry')).toHaveCount(0);
+    await expect(page.getByTestId('view-toggle-table')).toHaveAttribute('aria-pressed', 'true');
+
+    // Same rows, same values — the views share one query, not two.
+    await expect(viewRoot(page, 'table').getByTestId(`instruction-name-input-${rowId}`))
+      .toHaveValue(nm('j-table-edit'));
+
+    // THE STORED PREFERENCE SURVIVES A RELOAD. This is the assertion that would
+    // have caught the retired normalization line: with it in place the page comes
+    // back as Cards no matter what was stored.
+    await page.reload();
+    await expect(page.getByTestId('instructions-datagrid')).toBeVisible({ timeout: 30000 });
+
+    // ...and back again, so the toggle is not one-way.
+    await page.getByTestId('view-toggle-cards').click();
+    await expect(page.getByTestId('instructions-registry')).toBeVisible({ timeout: 20000 });
+  });
+
+  // -------------------------------------------------------------------------
+  // AGENT-13 — EDIT IN PLACE IN THE TABLE, one PUT per field.
+  //
+  // The load-bearing requirement of #3067. This is AGENT-02 run against the other
+  // view, deliberately asserting the same contract with the same testids: that is
+  // what "one implementation, two presentations" has to mean to be worth claiming.
+  // -------------------------------------------------------------------------
+  test('AGENT-13: table cells commit on blur, one PUT per field, and survive a reload', async ({ page }) => {
+    const rowId = instrIds['j-table-edit'];
+    const newName = `${nm('j-table-edit')}-renamed`;
+    const newContent = 'Rewritten from the TABLE view — only the content column may move.';
+
+    const writes = captureWrites(page);
+    await gotoTable(page);
+    const root = viewRoot(page, 'table');
+
+    // --- name ---
+    const nameField = root.getByTestId(`instruction-name-input-${rowId}`);
+    await expect(nameField).toHaveValue(nm('j-table-edit'));
+    await nameField.fill(newName);
+    await nameField.blur();
+
+    await expect.poll(() => writesTo(writes, 'PUT', 'instructions').length,
+      { timeout: 20000 }).toBe(1);
+
+    const namePut = writesTo(writes, 'PUT', 'instructions')[0].body as Array<Record<string, unknown>>;
+    expect(namePut).toHaveLength(1);
+    // The contract as a KEY SET: a name edit carries nothing else, so a rejected
+    // name cannot take an edited body down with it.
+    expect(Object.keys(namePut[0]).sort()).toEqual(['id', 'name']);
+    expect(Number(namePut[0].id)).toBe(rowId);
+    expect(namePut[0].name).toBe(newName);
+
+    await expectStored(rowId, 'name', newName, idToken);
+    expect((await fetchInstruction(rowId, idToken)).content).toBe(SEED_CONTENT);
+    // Re-read AFTER the round trips: `expect.poll(...).toBe(1)` stops the moment it
+    // sees 1, so on its own it asserts "reached one PUT", not "issued exactly one".
+    expect(writesTo(writes, 'PUT', 'instructions')).toHaveLength(1);
+
+    // --- content ---
+    const contentField = root.getByTestId(`instruction-content-input-${rowId}`);
+    await contentField.fill(newContent);
+    await contentField.blur();
+
+    await expect.poll(() => writesTo(writes, 'PUT', 'instructions').length,
+      { timeout: 20000 }).toBe(2);
+    const contentPut = writesTo(writes, 'PUT', 'instructions')[1].body as Array<Record<string, unknown>>;
+    expect(Object.keys(contentPut[0]).sort()).toEqual(['content', 'id']);
+    expect(contentPut[0].content).toBe(newContent);
+
+    await expectStored(rowId, 'content', newContent, idToken);
+    expect((await fetchInstruction(rowId, idToken)).name).toBe(newName);
+    expect(writesTo(writes, 'PUT', 'instructions')).toHaveLength(2);
+
+    // THE CROSS-VIEW ASSERTION. The edits were made in the Table and are read back
+    // in the Cards view through the SAME testids — which is only possible because
+    // both views render one component against one query.
+    await useView(page, 'cards');
+    await gotoRegistry(page);
+    const cards = viewRoot(page, 'cards');
+    await expect(cards.getByTestId(`instruction-name-input-${rowId}`)).toHaveValue(newName);
+    await expect(cards.getByTestId(`instruction-content-input-${rowId}`)).toHaveValue(newContent);
+  });
+
+  // -------------------------------------------------------------------------
+  // AGENT-14 — a blocked value in the TABLE writes nothing and says so.
+  //
+  // The card shows an `unsaved` chip. A fixed-height grid row has nowhere to put
+  // the field's own caption, so the verdict is HOISTED to a row marker instead —
+  // and if that hoist were dropped, a blocked value would look exactly like a
+  // saved one. There is no Save button to be left disabled.
+  // -------------------------------------------------------------------------
+  test('AGENT-14: a duplicate name in a table cell is refused, kept on screen and marked', async ({ page }) => {
+    const rowId = instrIds['k-table-bind'];
+    const taken = (await fetchInstruction(instrIds['a-order-1'], idToken)).name;
+    const original = (await fetchInstruction(rowId, idToken)).name;
+
+    const writes = captureWrites(page);
+    await gotoTable(page);
+    const root = viewRoot(page, 'table');
+
+    const nameField = root.getByTestId(`instruction-name-input-${rowId}`);
+    await nameField.fill(taken);
+    await nameField.blur();
+
+    await expect(page.getByTestId(`instruction-unsaved-${rowId}`)).toBeVisible();
+    await expect(nameField).toHaveValue(taken);          // the dirty text survives
+
+    // Read the row back FIRST — that round trip is what gives a PUT time to have
+    // appeared, so "no write" is a real negative rather than a race we won.
+    expect((await fetchInstruction(rowId, idToken)).name).toBe(original);
+    expect(writesTo(writes, 'PUT', 'instructions')).toHaveLength(0);
+
+    // Escape abandons: marker and text both go.
+    await nameField.click();
+    await nameField.press('Escape');
+    await expect(page.getByTestId(`instruction-unsaved-${rowId}`)).toHaveCount(0);
+    await expect(nameField).toHaveValue(original);
+    await settle(idToken);
+    expect(writesTo(writes, 'PUT', 'instructions')).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // AGENT-15 — SPACE can be typed into a table cell.
+  //
+  // Looks absurd; is the single most likely defect in this view. DataGrid
+  // classifies the space character as a NAVIGATION key and answers it with
+  // `goToCell()` + `preventDefault()`, with no check for whether the event came
+  // from a text input. Without GhostCell's keydown `stopPropagation`, a space is
+  // simply not insertable — and every other test here would still pass, because
+  // `fill()` sets the value directly and never presses a key.
+  //
+  // So this test types with the KEYBOARD on purpose. `fill()` would not detect it.
+  // -------------------------------------------------------------------------
+  test('AGENT-15: typing a space into a table cell inserts a space, it does not move the grid', async ({ page }) => {
+    const rowId = instrIds['k-table-bind'];
+    const typed = 'two words';
+
+    await gotoTable(page);
+    const contentField = viewRoot(page, 'table').getByTestId(`instruction-content-input-${rowId}`);
+
+    await contentField.click();
+    await contentField.fill('');
+    await contentField.pressSequentially(typed, { delay: 20 });
+    // If the grid had swallowed the space this would read 'twowords'.
+    await expect(contentField).toHaveValue(typed);
+
+    await contentField.blur();
+    await expectStored(rowId, 'content', typed, idToken);
+
+    // Arrow keys move the caret, not the grid focus. If they reached the grid the
+    // field would blur — and a blur COMMITS, so the edit below would be written
+    // half-typed. Asserting the field still holds focus is asserting that did not
+    // happen.
+    await contentField.click();
+    await contentField.press('ArrowLeft');
+    await contentField.press('ArrowRight');
+    await expect(contentField).toBeFocused();
+  });
+
+  // -------------------------------------------------------------------------
+  // AGENT-16 — membership from a table row, through the popover palette.
+  //
+  // The compact variant moves the roster into a Popover because twelve ghost
+  // chips do not fit in a grid row. Everything behavioural must be unchanged:
+  // one chip is one write, and the chip drills through to the agent.
+  //
+  // NOTE the scoping. The palette is a PORTAL, so its chips are page-scoped while
+  // the row's own chips are grid-scoped. Getting this wrong is a locator error
+  // that reads like a feature failure.
+  // -------------------------------------------------------------------------
+  test('AGENT-16: the table row binds one agent at max+1 and drills through', async ({ page }) => {
+    const rowId = instrIds['k-table-bind'];
+
+    const before = await fetchLinksForAgent(agentIds.a3, idToken);
+    const expectedSlot = Math.max(0, ...before
+      .map(l => l.sort_order)
+      .filter((o): o is number => Number.isFinite(o as number))) + 1;
+
+    await gotoTable(page);
+    const root = viewRoot(page, 'table');
+
+    // Resting row: chips visible, palette closed.
+    await expect(root.getByTestId(`instruction-${rowId}-agent-add`)).toBeVisible();
+    await expect(page.getByTestId(`instruction-${rowId}-bind-${agentIds.a3}`)).toHaveCount(0);
+
+    await root.getByTestId(`instruction-${rowId}-agent-add`).click();
+    // The palette is a Popover — page-scoped, NOT inside `instructions-datagrid`.
+    await expect(page.getByTestId(`instruction-${rowId}-agent-palette`)).toBeVisible();
+    await page.getByTestId(`instruction-${rowId}-bind-${agentIds.a3}`).click();
+
+    // Ghost chip becomes a solid chip, back inside the row.
+    await expect(root.getByTestId(`instruction-${rowId}-agent-${agentIds.a3}`))
+      .toBeVisible({ timeout: 20000 });
+
+    const links = await fetchLinksForInstruction(rowId, idToken);
+    const bound = links.find(l => l.agent_fk === agentIds.a3);
+    expect(bound).toBeTruthy();
+    expect(bound!.sort_order).toBe(expectedSlot);
+
+    // The agent-count column is the sortable form of the same fact, and it is what
+    // makes blast radius legible at a glance in the table.
+    await expect(root.getByTestId(`instruction-agent-count-${rowId}`))
+      .toHaveText(String(links.length));
+
+    // Drill-through survives the variant.
+    await root.getByTestId(`instruction-${rowId}-agent-${agentIds.a3}`).click();
+    await expect(page).toHaveURL(new RegExp(`/agents/${agentIds.a3}`), { timeout: 20000 });
+  });
+
+  // -------------------------------------------------------------------------
+  // AGENT-17 — the closed checkbox is gated on blast radius, not a write path.
+  //
+  // THE MOST IMPORTANT TEST IN THE TABLE SET. A checkbox wired straight to
+  // `closed` would pass any "the row closed" assertion while putting the silent
+  // unloading of every bound agent's boot payload one stray click from every row.
+  // The two branches are asserted separately because they must do genuinely
+  // different things.
+  // -------------------------------------------------------------------------
+  test('AGENT-17: the closed cell dialogs a BOUND row and writes nothing until confirmed', async ({ page }) => {
+    const rowId = instrIds['k-table-bind'];
+    const linksBefore = await fetchLinksForInstruction(rowId, idToken);
+    expect(linksBefore.length).toBeGreaterThan(0);   // bound by AGENT-16
+
+    const writes = captureWrites(page);
+    await gotoTable(page);
+
+    await viewRoot(page, 'table').getByTestId(`instruction-closed-toggle-${rowId}`).click();
+
+    const dialog = page.getByTestId('instruction-delete-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText(nm('agent-a3'));      // the blast radius, named
+
+    // Cancelling really cancels — and NOTHING was written on the way in.
+    await settle(idToken);
+    expect(writesTo(writes, 'PUT', 'instructions')).toHaveLength(0);
+    expect((await fetchInstruction(rowId, idToken)).closed).toBe(0);
+
+    await page.getByTestId('instruction-delete-close-btn').click();
+    await expect.poll(async () => (await fetchInstruction(rowId, idToken)).closed,
+      { timeout: 20000 }).toBe(1);
+    // CLOSING IS NOT DELETING: every binding survives.
+    expect(await fetchLinksForInstruction(rowId, idToken))
+      .toHaveLength(linksBefore.length);
+  });
+
+  test('AGENT-18: the closed cell closes an UNBOUND row immediately, and reopens it', async ({ page }) => {
+    const rowId = instrIds['j-table-edit'];
+    expect(await fetchLinksForInstruction(rowId, idToken)).toHaveLength(0);
+
+    await gotoTable(page);
+    const root = viewRoot(page, 'table');
+
+    await root.getByTestId(`instruction-closed-toggle-${rowId}`).click();
+    // Two-sided proof that no dialog was involved: nothing rendered, AND the row
+    // closed anyway — a dialog would have parked the write behind a button.
+    await expect(page.getByTestId('instruction-delete-dialog')).toHaveCount(0);
+    await expect.poll(async () => (await fetchInstruction(rowId, idToken)).closed,
+      { timeout: 20000 }).toBe(1);
+
+    // Reopen restores a duty rather than removing one, so it has no dialog either.
+    await page.getByTestId('instructions-show-closed').click();
+    await root.getByTestId(`instruction-closed-toggle-${rowId}`).click();
+    await expect(page.getByTestId('instruction-delete-dialog')).toHaveCount(0);
+    await expect.poll(async () => (await fetchInstruction(rowId, idToken)).closed,
+      { timeout: 20000 }).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // AGENT-19 — row creation from the table.
+  //
+  // The template renders BELOW the grid rather than as a grid row: a blank name
+  // sorts wherever a blank name sorts, and the MIT DataGrid has no pinned rows to
+  // stop it scattering. It is still the last thing in the list and still fills in
+  // place, and it reuses the card view's state and testids.
+  // -------------------------------------------------------------------------
+  test('AGENT-19: the table template creates on the second field and then empties itself', async ({ page }) => {
+    const name = nm('l-table-template');
+    const content = 'Created through the TABLE view template row.';
+
+    const writes = captureWrites(page);
+    await gotoTable(page);
+
+    const nameField = page.getByTestId('instruction-name-input-template');
+    const contentField = page.getByTestId('instruction-content-input-template');
+    await expect(nameField).toBeVisible();
+
+    // First field alone is NOT a create — both columns are NOT NULL. `settle`
+    // first, or a POST would have had no chance to reach the listener and this
+    // would pass vacuously.
+    await nameField.fill(name);
+    await nameField.blur();
+    await settle(idToken);
+    expect(writesTo(writes, 'POST', 'instructions')).toHaveLength(0);
+
+    await contentField.fill(content);
+    await contentField.blur();
+
+    await expect.poll(async () => (await fetchMyInstructions(idToken))
+      .some(r => r.name === name), { timeout: 20000 }).toBe(true);
+    expect(writesTo(writes, 'POST', 'instructions')).toHaveLength(1);
+
+    const created = (await fetchMyInstructions(idToken)).find(r => r.name === name);
+    createdInstructionIds.push(created!.id);
+
+    // The new row appears in the grid, unbound, with its content intact.
+    await expect(viewRoot(page, 'table')
+      .getByTestId(`instruction-content-input-${created!.id}`))
+      .toHaveValue(content, { timeout: 20000 });
+    expect(await fetchLinksForInstruction(created!.id, idToken)).toHaveLength(0);
+
+    // THE REGRESSION: both template fields come back blank, so the next row
+    // inherits nothing.
+    await expect(nameField).toHaveValue('');
+    await expect(contentField).toHaveValue('');
+  });
+
+  // -------------------------------------------------------------------------
+  // AGENT-20 — the header adapts to the view.
+  //
+  // The gear is Cards-only: the grid's own column headers are the Table view's
+  // sort authority, and offering both at once is two sort UIs on one page that
+  // can disagree. The accounting line belongs to neither view and stays.
+  // -------------------------------------------------------------------------
+  test('AGENT-20: the sort gear is Cards-only and the accounting line survives both views', async ({ page }) => {
+    await gotoRegistry(page);
+    await expect(page.getByTestId('instructions-settings-button')).toBeVisible();
+    const cardsAccounting = await page.getByTestId('instructions-accounting').textContent();
+
+    await page.getByTestId('view-toggle-table').click();
+    await expect(page.getByTestId('instructions-datagrid')).toBeVisible({ timeout: 20000 });
+
+    await expect(page.getByTestId('instructions-settings-button')).toHaveCount(0);
+    // Counted over the WHOLE catalog, so it cannot differ between views.
+    await expect(page.getByTestId('instructions-accounting')).toHaveText(cardsAccounting!);
   });
 });


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-07-26T23:28:53Z
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3067-instructions-table-view-hardened-1
- wip(Darwin): 2026-07-26T23:25:28Z
- chore: init swarm session feature/3067-instructions-table-view-hardened-1

## Files changed
```
 src/Agents/AgentsPage.jsx                          | 135 ++++--
 src/Agents/DocumentsPage.jsx                       | 221 ++++------
 src/Agents/InstructionAgentChips.jsx               | 314 ++++++++-----
 src/Agents/InstructionRowMenu.jsx                  | 110 +++++
 src/Agents/InstructionsPage.jsx                    | 319 ++++++-------
 src/Agents/InstructionsTableView.jsx               | 491 +++++++++++++++++++++
 .../InstructionAgentChips.compact.test.jsx         | 204 +++++++++
 .../__tests__/InstructionsTableView.test.jsx       | 382 ++++++++++++++++
 src/Agents/__tests__/instructionSort.test.js       | 106 ++++-
 src/Agents/instructionSort.js                      |  60 ++-
 src/Components/GhostField/GhostCell.jsx            |  87 ++++
 src/Components/GhostField/GhostTextField.jsx       |  14 +-
 .../GhostField/__tests__/GhostCell.test.jsx        | 127 ++++++
 .../GhostField/__tests__/ghostTextColumn.test.jsx  | 148 +++++++
 src/Components/GhostField/ghostTextColumn.jsx      |  90 ++++
 src/Components/ViewerHeader/ViewerHeader.jsx       | 243 ++++++++++
 .../ViewerHeader/__tests__/ViewerHeader.test.jsx   | 256 +++++++++++
 .../ViewerHeader/__tests__/normalizeView.test.js   |  57 +++
 src/Components/ViewerHeader/normalizeView.js       |  43 ++
 tests/tests/agents-instructions.spec.ts            | 430 +++++++++++++++++-
 20 files changed, 3394 insertions(+), 443 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)