### PR TITLE
Migrate the Maps ghost editors onto the shared GhostTextField

### DIFF
--- a/src/Components/GhostField/GhostTextField.jsx
+++ b/src/Components/GhostField/GhostTextField.jsx
@@ -6,6 +6,10 @@
 // (MapRuns/GhostCellEditors), which hand-rolled it per field against the shared
 // `ghostBase` sx.
 //
+// Req #3073 migrated both of those onto this component, so the list below is now
+// a record of what the migration FIXED in the Maps views rather than of how they
+// still differ.
+//
 // What this component adds over those two, and the reason it exists rather than
 // a third copy:
 //
@@ -41,15 +45,6 @@ import Typography from '@mui/material/Typography';
 
 import { ghostBase } from '../../utils/ghostFieldStyles';
 
-// `ghostBase` hard-codes a black hover underline, which is invisible on a dark
-// background. Every consumer of this component is theme-aware, so the hover and
-// focus colours are resolved from the palette here instead. Deliberately NOT
-// fixed in ghostBase itself: that object is shared with the Maps views and
-// changing it would alter their appearance from inside this requirement.
-const underlineHover = (theme) => theme.palette.mode === 'dark'
-    ? 'rgba(255,255,255,0.4)'
-    : 'rgba(0,0,0,0.3)';
-
 const GhostTextField = ({
     value,
     onCommit,
@@ -64,6 +59,15 @@ const GhostTextField = ({
     hint,
     // NOT NULL column: an emptied field reverts rather than writing ''.
     required = false,
+    // Passed straight to the underlying input. `datetime-local` is the one that
+    // matters: the Maps start_time fields need a native date/time picker AND the
+    // commit contract, and there is nothing about the contract that is specific to
+    // free text — validate/normalize just operate on the picker's string form.
+    //
+    // Undefined by default rather than 'text', and suppressed on a multiline field:
+    // `type` is not a valid attribute on a <textarea>, so defaulting it would put a
+    // React DOM warning and a stray attribute on every multiline field in the app.
+    type,
     multiline = false,
     // Enter commits instead of inserting a newline. Defaults to "whenever this is
     // not a multiline field", but the two are separable: a NAME is single-line
@@ -73,8 +77,33 @@ const GhostTextField = ({
     maxRows,
     placeholder,
     disabled = false,
+    // Lay the field out as part of the surrounding line rather than as a block of
+    // its own. RouteCard's stats table renders the value and its unit as one run of
+    // text — `12.5` + ` mi` — and the default block wrapper would drop the unit onto
+    // the next line. The verdict/hint caption still stacks underneath.
+    //
+    // Specifically inline-FLEX-column, not inline-block. An inline-block takes its
+    // baseline from its LAST line box, so the instant a verdict appeared under the
+    // value the trailing ` mi` would jump up beside the caption — the same
+    // line-breaking bug this prop exists to prevent, merely deferred to the first
+    // invalid keystroke. A flex container baselines on its FIRST item, so the input
+    // sits on the row's baseline whether or not a message is showing.
+    //
+    // Meaningless on a multiline field, which is a block of text by definition.
+    inline = false,
+    // Take the verdict/hint caption OUT of flow and hang it below the field.
+    // For the Maps DataGrid: rows are `getRowHeight: 'auto'` inside an `autoHeight`
+    // grid, and validation runs per keystroke, so an in-flow caption re-measures the
+    // row and shifts every row under it on and off with each character typed.
+    overlayMessage = false,
     // Merged into the input sx so the idle field inherits the typography of
     // whatever it replaced and looks unchanged until hovered.
+    //
+    // A PLAIN OBJECT, not the theme callback or array that MUI's own `sx` also
+    // accepts: the ghost branch spreads this and reads its nested
+    // '& .MuiInputBase-input' key by hand, so a function would spread to nothing and
+    // the caller's styling would vanish with no error. Resolve the theme in the
+    // caller if you need it.
     sx = {},
     inputProps = {},
     inputRef,
@@ -133,9 +162,31 @@ const GhostTextField = ({
     // and the re-seed it is guarding would never happen again.
     const lastSeeded = useRef(stored);
 
+    // The `stored` value a commit was issued against, held until the prop moves off
+    // it — see the re-seed effect below. Null when no write is outstanding; `stored`
+    // is always a string, so null is an unambiguous sentinel.
+    const staleStored = useRef(null);
+
     useEffect(() => {
         if (controlled) return;                    // no local copy to re-seed
         if (focused.current) return;
+        // OUR OWN WRITE HAS NOT COME BACK YET. `stored` is still the value from
+        // before the commit, and it stays that way until the caller's invalidation
+        // round-trips. Meanwhile the field has already adopted the committed text,
+        // so by the dirty test below it looks clean — and the re-seed would paint
+        // the pre-edit value back over the user's own successful edit.
+        //
+        // That is not a flicker: it lasts a whole network round trip, it reads as
+        // "the save failed", and the retry it invites writes the same value a second
+        // time. It only bites when `normalize` rewrites the text — typing `20` into
+        // a one-decimal column, `45:00` into a duration — which is why it stayed
+        // latent until the Maps migration gave every numeric field a normalizer.
+        //
+        // The latch is released by the PROP MOVING, not by the promise settling: the
+        // write resolves a microtask before React commits the render this guard has
+        // to survive, so anything cleared in a `finally` would already be gone.
+        if (staleStored.current !== null && stored === staleStored.current) return;
+        staleStored.current = null;
         if (text !== lastSeeded.current) return;   // dirty — keep the user's work
         lastSeeded.current = stored;
         setLocalText(stored);
@@ -194,6 +245,10 @@ const GhostTextField = ({
 
     const revert = () => {
         lastSeeded.current = stored;
+        // Whatever write was outstanding is over — a rejection, or an abandoned
+        // edit. The field is back on the stored value, so the stale-prop latch has
+        // nothing left to protect.
+        staleStored.current = null;
         applyText(stored);
         setError(null);
     };
@@ -228,7 +283,13 @@ const GhostTextField = ({
         if (!controlled && untouched) {
             // Nothing typed. If the server moved while we held focus, adopt that
             // value now — this is the re-seed the effect had to skip.
-            if (text !== stored) revert();
+            //
+            // `stored !== staleStored.current` is the same guard the effect applies:
+            // a write of ours may still be outstanding, in which case `stored` is
+            // the value from BEFORE it and adopting it would undo the edit. Clicking
+            // into a field and straight back out is exactly how a user checks that
+            // an edit took, so this path is anything but hypothetical.
+            if (text !== stored && stored !== staleStored.current) revert();
             return;
         }
 
@@ -262,6 +323,15 @@ const GhostTextField = ({
             // this same text, and the re-seed effect has to recognise that as
             // clean rather than as an external change arriving over a dirty field.
             lastSeeded.current = next;
+            // Until the prop catches up with this write, THIS FIELD — not the stale
+            // `stored` it was issued against — is the authority on its own value.
+            //
+            // Uncontrolled only, and stated rather than left to fall out: a draft
+            // field has no local copy to protect, so both readers of this ref (the
+            // re-seed effect and the `untouched` branch above) are behind
+            // `!controlled` already. Setting it there would be inert state that
+            // reads as meaningful.
+            if (!controlled) staleStored.current = stored;
             await onCommit(next);
         } catch {
             // The caller reports the failure; this only makes sure the field
@@ -308,6 +378,7 @@ const GhostTextField = ({
                 label={label}
                 variant="outlined"
                 size="small"
+                type={multiline ? undefined : type}
                 multiline={multiline}
                 minRows={minRows}
                 maxRows={maxRows}
@@ -327,13 +398,23 @@ const GhostTextField = ({
     }
 
     return (
-        <Box sx={{ minWidth: 0 }}>
+        <Box sx={{
+            minWidth: 0,
+            ...(inline && !multiline && {
+                display: 'inline-flex',
+                flexDirection: 'column',
+                alignItems: 'flex-start',
+                verticalAlign: 'baseline',
+            }),
+            ...(overlayMessage && { position: 'relative' }),
+        }}>
             <InputBase
                 value={text}
                 onChange={handleChange}
                 onFocus={() => setEditing(true)}
                 onBlur={commit}
                 onKeyDown={handleKeyDown}
+                type={multiline ? undefined : type}
                 multiline={multiline}
                 minRows={minRows}
                 maxRows={maxRows}
@@ -354,36 +435,58 @@ const GhostTextField = ({
                     }),
                     'data-testid': testId,
                 }}
-                sx={(theme) => ({
-                    ...ghostBase,
-                    // A content-sized multiline field (autoWidthCh) must NOT be
-                    // stretched to full width — it wraps inside the width its own
-                    // text asks for.
-                    ...(multiline && {
-                        display: 'flex',
-                        ...(autoWidthCh ? {} : { width: '100%' }),
-                    }),
-                    ...sx,
-                    '& .MuiInputBase-input': {
-                        ...ghostBase['& .MuiInputBase-input'],
-                        ...(sx['& .MuiInputBase-input'] || {}),
-                        ...(error && { color: theme.palette.error.main }),
-                        '&:hover': { borderBottomColor: underlineHover(theme) },
-                        '&:focus': {
-                            outline: 'none',
-                            borderBottomColor: error
-                                ? theme.palette.error.main
-                                : theme.palette.primary.main,
+                sx={(theme) => {
+                    const base = ghostBase(theme);
+                    return {
+                        ...base,
+                        // A content-sized multiline field (autoWidthCh) must NOT be
+                        // stretched to full width — it wraps inside the width its own
+                        // text asks for.
+                        ...(multiline && {
+                            display: 'flex',
+                            ...(autoWidthCh ? {} : { width: '100%' }),
+                        }),
+                        ...sx,
+                        '& .MuiInputBase-input': {
+                            ...base['& .MuiInputBase-input'],
+                            ...(sx['& .MuiInputBase-input'] || {}),
+                            ...(error && { color: theme.palette.error.main }),
+                            // Only the ERROR case differs from the shared base, so
+                            // only that is restated: a blocked field underlines in
+                            // red rather than primary while it holds focus.
+                            ...(error && {
+                                '&:focus': {
+                                    outline: 'none',
+                                    borderBottomColor: theme.palette.error.main,
+                                },
+                            }),
+                            '&::placeholder': { color: theme.palette.text.disabled, opacity: 1 },
                         },
-                        '&::placeholder': { color: theme.palette.text.disabled, opacity: 1 },
-                    },
-                })}
+                    };
+                }}
             />
             {(error || advisory) && (
                 <Typography
                     variant="caption"
                     color={error ? 'error' : 'text.secondary'}
-                    sx={{ display: 'block', mt: 0.25 }}
+                    sx={{
+                        display: 'block',
+                        mt: 0.25,
+                        ...(overlayMessage && {
+                            position: 'absolute',
+                            top: '100%',
+                            left: 0,
+                            zIndex: 2,
+                            mt: 0,
+                            whiteSpace: 'nowrap',
+                            // It is floating over whatever is beneath it, so it needs
+                            // its own surface to stay legible.
+                            px: 0.5,
+                            borderRadius: 0.5,
+                            bgcolor: 'background.paper',
+                            boxShadow: 1,
+                        }),
+                    }}
                     data-testid={testId ? `${testId}-message` : undefined}
                 >
                     {error || advisory}

--- a/src/Components/GhostField/__tests__/GhostTextFieldProps.test.jsx
+++ b/src/Components/GhostField/__tests__/GhostTextFieldProps.test.jsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+//
+// Req #3073 — what the Maps migration added to the shared field, kept in a sibling
+// file so GhostTextField.test.jsx stays the untouched behavioural spec from #3063.
+//
+// The important half of this file is the stale-prop latch. Everything else here is a
+// presentation prop; that one is a correctness fix to the commit contract itself, and
+// it applies to every consumer, not just Maps.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import GhostTextField from '../GhostTextField';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container;
+let root;
+
+beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+});
+
+const field = () => container.querySelector('[data-testid="f"]');
+const message = () => container.querySelector('[data-testid="f-message"]');
+
+const render = (props) => act(() => {
+    root.render(<GhostTextField testId="f" {...props} />);
+});
+
+const typeInto = (el, value) => act(() => {
+    const proto = el instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, 'value').set.call(el, value);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+});
+
+const focus = (el) => act(() => el.focus());
+const blur = (el) => act(async () => { el.blur(); });
+
+// A normalizer that rewrites the text is what makes the stale-prop window visible:
+// the field's own value changes at commit time, so the re-seed effect re-runs while
+// the `value` prop is still the pre-write one.
+const oneDecimal = (t) => {
+    const n = Number(t);
+    return Number.isFinite(n) ? n.toFixed(1) : t;
+};
+
+describe('GhostTextField — a committed value survives until the prop catches up', () => {
+    it('does NOT repaint the pre-write value after a successful commit', async () => {
+        // The caller invalidates its query on success, but that round trip takes a
+        // network hop. Until it lands, `value` is still what it was before the write.
+        // Repainting it there undoes the user's edit in front of them, reads as a
+        // failed save, and the retry it invites writes the same value twice.
+        const onCommit = vi.fn().mockResolvedValue(undefined);
+        render({ value: '12.5', onCommit, normalize: oneDecimal });
+
+        focus(field());
+        typeInto(field(), '20');
+        await blur(field());
+
+        expect(onCommit).toHaveBeenCalledExactlyOnceWith('20.0');
+        expect(field().value).toBe('20.0');
+    });
+
+    it('holds the committed value across an unrelated re-render', async () => {
+        const onCommit = vi.fn().mockResolvedValue(undefined);
+        render({ value: '12.5', onCommit, normalize: oneDecimal });
+
+        focus(field());
+        typeInto(field(), '20');
+        await blur(field());
+
+        render({ value: '12.5', onCommit, normalize: oneDecimal, placeholder: 'x' });
+        expect(field().value).toBe('20.0');
+    });
+
+    it('does not undo the edit when the user clicks back in and straight out', async () => {
+        // Which is exactly how somebody checks that an edit took.
+        const onCommit = vi.fn().mockResolvedValue(undefined);
+        render({ value: '12.5', onCommit, normalize: oneDecimal });
+
+        focus(field());
+        typeInto(field(), '20');
+        await blur(field());
+
+        focus(field());
+        await blur(field());
+
+        expect(onCommit).toHaveBeenCalledExactlyOnceWith('20.0');
+        expect(field().value).toBe('20.0');
+    });
+
+    it('adopts the prop as soon as it moves', async () => {
+        const onCommit = vi.fn().mockResolvedValue(undefined);
+        render({ value: '12.5', onCommit, normalize: oneDecimal });
+
+        focus(field());
+        typeInto(field(), '20');
+        await blur(field());
+
+        render({ value: '20.0', onCommit, normalize: oneDecimal });
+        expect(field().value).toBe('20.0');
+
+        // ...and the latch is released, so a later external change still lands.
+        render({ value: '31.4', onCommit, normalize: oneDecimal });
+        expect(field().value).toBe('31.4');
+    });
+
+    it('releases the latch when the write is refused', async () => {
+        const onCommit = vi.fn().mockRejectedValue(new Error('500'));
+        render({ value: '12.5', onCommit, normalize: oneDecimal });
+
+        focus(field());
+        typeInto(field(), '20');
+        await blur(field());
+
+        expect(field().value).toBe('12.5');
+
+        render({ value: '31.4', onCommit, normalize: oneDecimal });
+        expect(field().value).toBe('31.4');
+    });
+
+    it('still adopts a genuinely newer value that arrives while the field holds focus', async () => {
+        // The latch must not swallow the case it was carved out of: nothing typed,
+        // no write outstanding, and the server moved underneath a parked caret.
+        const onCommit = vi.fn().mockResolvedValue(undefined);
+        render({ value: '12.5', onCommit, normalize: oneDecimal });
+
+        focus(field());
+        render({ value: '31.4', onCommit, normalize: oneDecimal });
+        expect(field().value).toBe('12.5');       // refused to re-seed a focused field
+
+        await blur(field());
+        expect(onCommit).not.toHaveBeenCalled();  // nothing was typed
+        expect(field().value).toBe('31.4');       // adopted on the way out
+    });
+});
+
+describe('GhostTextField — type', () => {
+    it('reaches the input', () => {
+        render({ value: '2026-03-15T11:30', onCommit: vi.fn(), type: 'datetime-local' });
+        expect(field().getAttribute('type')).toBe('datetime-local');
+    });
+
+    it('is suppressed on a multiline field, where it is invalid DOM', () => {
+        render({ value: 'prose', onCommit: vi.fn(), multiline: true, type: 'datetime-local' });
+        expect(field().tagName).toBe('TEXTAREA');
+        expect(field().hasAttribute('type')).toBe(false);
+    });
+
+    it('leaves the default to InputBase rather than forcing one', () => {
+        // The prop defaults to undefined so that MUI decides — which is what makes
+        // the multiline suppression above possible at all.
+        render({ value: 'a', onCommit: vi.fn() });
+        expect(field().getAttribute('type')).toBe('text');
+    });
+});
+
+describe('GhostTextField — inline and overlayMessage', () => {
+    const wrapper = () => field().closest('.MuiInputBase-root').parentElement;
+
+    // `sx` compiles to an emotion class, not an inline style, so the rules have to
+    // be read back off the stylesheet emotion injected rather than off el.style.
+    const styleOf = (el) => window.getComputedStyle(el);
+
+    it('lays a normal field out as a block', () => {
+        render({ value: 'a', onCommit: vi.fn() });
+        expect(styleOf(wrapper()).display).not.toBe('inline-flex');
+    });
+
+    it('lays an inline field out as a flex COLUMN, so its baseline is the input\'s', () => {
+        // An inline-block would baseline on its LAST line box, so a trailing unit
+        // beside the field would jump the moment a verdict appeared beneath it.
+        render({ value: 'a', onCommit: vi.fn(), inline: true });
+        expect(styleOf(wrapper()).display).toBe('inline-flex');
+        expect(styleOf(wrapper()).flexDirection).toBe('column');
+        expect(styleOf(wrapper()).verticalAlign).toBe('baseline');
+    });
+
+    it('ignores inline on a multiline field, which is a block of text by definition', () => {
+        render({ value: 'a', onCommit: vi.fn(), inline: true, multiline: true });
+        expect(styleOf(wrapper()).display).not.toBe('inline-flex');
+    });
+
+    it('keeps the verdict in flow by default', () => {
+        render({ value: 'a', onCommit: vi.fn(), validate: () => 'nope' });
+        focus(field());
+        typeInto(field(), 'b');
+        expect(styleOf(message()).position).toBe('');
+    });
+
+    it('takes the verdict out of flow when asked, so it cannot widen the field', () => {
+        render({ value: 'a', onCommit: vi.fn(), validate: () => 'nope', overlayMessage: true });
+        focus(field());
+        typeInto(field(), 'b');
+        expect(styleOf(message()).position).toBe('absolute');
+        expect(styleOf(wrapper()).position).toBe('relative');
+    });
+});

--- a/src/MapRuns/GhostCellEditors.jsx
+++ b/src/MapRuns/GhostCellEditors.jsx
@@ -1,71 +1,130 @@
 import React, { useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
-import InputBase from '@mui/material/InputBase';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 import Chip from '@mui/material/Chip';
 
-import { ghostBase } from '../utils/ghostFieldStyles';
-import { toDateTimeLocalValue, fromDateTimeLocalValue } from '../utils/dateFormat';
+import GhostTextField from '../Components/GhostField/GhostTextField';
+import { ghostSelectBase, ghostAutocompleteInputBase } from '../utils/ghostFieldStyles';
+import { dateTimeField, notesField } from '../utils/ghostFieldParsers';
 
 // Always-editable "ghost" cell editors for the Maps Table (MapRunsView) DataGrid.
 // Each editor renders as plain text until clicked, then edits in place and saves on
 // blur (text) or change (Select/Autocomplete) — mirroring the map-card design
 // (RouteCard). No DataGrid edit-mode; these live in `renderCell` and are always live.
 //
+// The three TEXT editors are now thin adapters over the shared GhostTextField
+// (req #3073). What they used to hand-roll, and what the shared component does
+// instead:
+//
+//   * They skipped the save when a value failed to parse (`if (parsed !== null)`)
+//     and left no trace, so a bad value looked saved until the next refetch quietly
+//     reverted it. Now it stays on screen in red with the reason beside it, and no
+//     write is issued.
+//   * They re-seeded from the row on ANY value change, which overwrote in-progress
+//     typing whenever a genuinely external change landed. Now a field re-seeds only
+//     when it is neither focused NOR dirty.
+//   * A rejected write left the failed value on screen. Now `onSave` is awaited and
+//     the field reverts when it rejects — so the cell never shows a value the
+//     database does not hold. This is why MapRunsView's `saveRunFields` rethrows.
+//   * There was no way to abandon an edit. Escape now reverts.
+//
+// They also stopped writing on every blur: tabbing through a row used to PUT each
+// cell unconditionally, which silently rewrote `avg_speed_mph` (DECIMAL(5,2)) with
+// its own one-decimal display value. GhostTextField only commits a value the user
+// actually changed.
+//
+// GhostSelectCell and GhostPartnersCell stay hand-rolled: a Select and a multi-value
+// Autocomplete are not text fields, and forcing them through a text component would
+// model them badly. They share the theme-aware underline and now roll back their
+// optimistic state on a failed write, which is the part that was worth having.
+//
 // Shared contract:
-//   - local state seeded from the row, reset via useEffect on [row.id, <value>] so an
-//     external data change (query invalidation, another session) refreshes the cell
-//     without clobbering in-progress typing (the saved value round-trips unchanged).
 //   - onClick stopPropagation on the wrapper so clicking inside a cell never toggles
 //     row selection or column sort.
+//   - onKeyDown stopPropagation for the keys an open editor owns — see EDITOR_KEYS.
+//
+// The verdict caption stays IN FLOW here, unlike the card. `.MuiDataGrid-cell` is
+// `overflow: hidden` with no vertical padding, so a caption hung below the field
+// would be clipped away and the user would see red text with no reason for it —
+// which is only half of the silent-drop fix. Letting the row grow instead costs a
+// reflow on the transitions into and out of an invalid value, and that is the
+// cheaper of the two.
 
 const cellWrapSx = { width: '100%', py: '2px' };
 const stop = (e) => e.stopPropagation();
 
 /**
- * Ghost InputBase for numeric / duration cells.
- * @param row      DataGrid row
- * @param field    field name on the row to edit
- * @param format   (rawValue) => display string
- * @param parse    (displayString) => API value, or null to skip the save
- * @param validate (displayString) => boolean; false renders the text red (optional)
- * @param onSave   (rowId, {[field]: value}) => void
- * @param align    'left' | 'right' (default 'right' to match number columns)
+ * The keys a permanently-open cell editor consumes, which must NOT reach the
+ * DataGrid's keyboard navigation: caret movement, selection, commit and abandon.
+ *
+ * Deliberately not "every key". The DataGrid registers `cellKeyDown` as a React
+ * synthetic handler on the cell, so stopping propagation wholesale also takes out
+ * PageUp/PageDown paging and the grid's cell-to-cell Tab tracking, neither of which
+ * an editor has any use for.
  */
-export const GhostInputCell = ({ row, field, format, parse, validate, onSave, align = 'right' }) => {
-    const rawValue = row[field];
-    const [value, setValue] = useState(() => format(rawValue));
+const EDITOR_KEYS = new Set([
+    'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
+    'Home', 'End', 'Enter', 'Escape', ' ',
+]);
+const stopEditorKeys = (e) => { if (EDITOR_KEYS.has(e.key)) e.stopPropagation(); };
 
-    useEffect(() => {
-        setValue(format(rawValue));
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [row.id, rawValue]);
+/**
+ * Ghost text field for a numeric / duration cell.
+ * @param row    DataGrid row
+ * @param field  column on the row to edit
+ * @param rule   the column's entry from utils/ghostFieldParsers — owns format,
+ *               normalize, validate, toApi and whether an emptied field reverts
+ * @param onSave (rowId, {[field]: value}) => Promise, REJECTING on failure
+ * @param align  'left' | 'right' (default 'right' to match number columns)
+ */
+export const GhostInputCell = ({ row, field, rule, onSave, align = 'right' }) => (
+    <Box sx={cellWrapSx} onClick={stop} onKeyDown={stopEditorKeys}>
+        <GhostTextField
+            value={rule.format(row[field])}
+            required={rule.required}
+            normalize={rule.normalize}
+            validate={rule.validate}
+            // Returns the promise: GhostTextField awaits it and reverts on rejection.
+            // An adapter that forgot to return would resolve instantly and disable
+            // the rollback with no visible symptom at all.
+            onCommit={(text) => onSave(row.id, { [field]: rule.toApi(text) })}
+            testId={`map-run-${field}`}
+            sx={{
+                width: '100%',
+                '& .MuiInputBase-input': { width: '100%', textAlign: align },
+            }}
+        />
+    </Box>
+);
 
-    const handleBlur = () => {
-        const parsed = parse(value);
-        if (parsed !== null) onSave(row.id, { [field]: parsed });
-    };
-
-    const isInvalid = validate ? !validate(value) : false;
-
+/**
+ * Ghost datetime-local for the start_time cell.
+ * @param row       DataGrid row (uses row.start_time)
+ * @param timezone  user's timezone
+ * @param onSave    (rowId, { start_time }) => Promise, REJECTING on failure
+ */
+export const GhostDateTimeCell = ({ row, timezone, onSave }) => {
+    const rule = dateTimeField(timezone);
     return (
-        <Box sx={cellWrapSx} onClick={stop}>
-            <InputBase
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                onBlur={handleBlur}
+        <Box sx={cellWrapSx} onClick={stop} onKeyDown={stopEditorKeys}>
+            <GhostTextField
+                type="datetime-local"
+                value={rule.format(row.start_time)}
+                required={rule.required}
+                validate={rule.validate}
+                onCommit={(text) => onSave(row.id, { start_time: rule.toApi(text) })}
+                testId="map-run-start-time"
                 sx={{
-                    ...ghostBase,
                     width: '100%',
-                    '& .MuiInputBase-input': {
-                        ...ghostBase['& .MuiInputBase-input'],
-                        width: '100%',
-                        textAlign: align,
-                        ...(isInvalid && { color: 'error.main' }),
-                    },
+                    // Without this Chrome's own picker button opens on click and
+                    // swallows the first Escape to close itself, so the field never
+                    // sees the abandon key.
+                    '& input::-webkit-calendar-picker-indicator': { display: 'none' },
+                    '& input::-webkit-inner-spin-button': { display: 'none' },
+                    '& .MuiInputBase-input': { width: '100%' },
                 }}
             />
         </Box>
@@ -73,11 +132,37 @@ export const GhostInputCell = ({ row, field, format, parse, validate, onSave, al
 };
 
 /**
+ * Ghost multiline italic field for the notes cell.
+ * @param row     DataGrid row (uses row.notes)
+ * @param onSave  (rowId, { notes }) => Promise, REJECTING on failure. '' => 'NULL'.
+ */
+export const GhostNotesCell = ({ row, onSave }) => (
+    <Box sx={cellWrapSx} onClick={stop} onKeyDown={stopEditorKeys}>
+        <GhostTextField
+            multiline
+            value={notesField.format(row.notes)}
+            normalize={notesField.normalize}
+            onCommit={(text) => onSave(row.id, { notes: notesField.toApi(text) })}
+            testId="map-run-notes"
+            sx={{
+                fontStyle: 'italic',
+                color: 'text.secondary',
+                '& .MuiInputBase-input': {
+                    fontStyle: 'italic',
+                    color: 'text.secondary',
+                    minHeight: '1.2em',
+                },
+            }}
+        />
+    </Box>
+);
+
+/**
  * Ghost Select for route / activity cells.
  * @param row       DataGrid row
  * @param value     current selected value
  * @param options   [{ value, label }]
- * @param onSave    (rowId, newValue) => void  (fires on change)
+ * @param onSave    (rowId, newValue) => Promise, REJECTING on failure (fires on change)
  */
 export const GhostSelectCell = ({ row, value: controlledValue, options, onSave }) => {
     const [value, setValue] = useState(controlledValue);
@@ -87,26 +172,27 @@ export const GhostSelectCell = ({ row, value: controlledValue, options, onSave }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [row.id, controlledValue]);
 
-    const handleChange = (e) => {
-        const newVal = e.target.value;
-        setValue(newVal);
-        onSave(row.id, newVal);
+    // Optimistic, then rolled back if the write is refused — otherwise the cell keeps
+    // showing a route the run was never assigned. The catch is also what keeps a
+    // rejecting onSave from escaping this void handler as an unhandled rejection.
+    const handleChange = async (e) => {
+        const previous = value;
+        setValue(e.target.value);
+        try {
+            await onSave(row.id, e.target.value);
+        } catch {
+            setValue(previous);   // already reported by the caller
+        }
     };
 
     return (
-        <Box sx={cellWrapSx} onClick={stop}>
+        <Box sx={cellWrapSx} onClick={stop} onKeyDown={stopEditorKeys}>
             <Select
                 value={value}
                 onChange={handleChange}
                 variant="standard"
                 IconComponent={() => null}
-                sx={{
-                    width: '100%',
-                    fontSize: 'inherit',
-                    '& .MuiSelect-select': { py: 0, pr: '0 !important' },
-                    '&:before': { borderBottomColor: 'transparent' },
-                    '&:hover:not(.Mui-disabled):before': { borderBottomColor: 'rgba(0,0,0,0.3)' },
-                }}
+                sx={(theme) => ({ ...ghostSelectBase(theme), width: '100%' })}
             >
                 {options.map((opt) => (
                     <MenuItem key={String(opt.value)} value={opt.value} sx={{ fontSize: '0.8125rem' }}>
@@ -119,95 +205,12 @@ export const GhostSelectCell = ({ row, value: controlledValue, options, onSave }
 };
 
 /**
- * Ghost datetime-local for the start_time cell.
- * @param row       DataGrid row (uses row.start_time)
- * @param timezone  user's timezone
- * @param onSave    (rowId, { start_time }) => void  (fires on blur)
- */
-export const GhostDateTimeCell = ({ row, timezone, onSave }) => {
-    const [value, setValue] = useState(() => toDateTimeLocalValue(row.start_time, timezone));
-
-    useEffect(() => {
-        setValue(toDateTimeLocalValue(row.start_time, timezone));
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [row.id, row.start_time, timezone]);
-
-    const handleBlur = () => {
-        const parsed = fromDateTimeLocalValue(value, timezone);
-        if (parsed) onSave(row.id, { start_time: parsed });
-    };
-
-    return (
-        <Box sx={cellWrapSx} onClick={stop}>
-            <InputBase
-                type="datetime-local"
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                onBlur={handleBlur}
-                sx={{
-                    ...ghostBase,
-                    width: '100%',
-                    '& input::-webkit-calendar-picker-indicator': { display: 'none' },
-                    '& input::-webkit-inner-spin-button': { display: 'none' },
-                    '& .MuiInputBase-input': {
-                        ...ghostBase['& .MuiInputBase-input'],
-                        width: '100%',
-                    },
-                }}
-            />
-        </Box>
-    );
-};
-
-/**
- * Ghost multiline italic InputBase for the notes cell.
- * @param row     DataGrid row (uses row.notes)
- * @param onSave  (rowId, { notes }) => void  (fires on blur; '' => 'NULL')
- */
-export const GhostNotesCell = ({ row, onSave }) => {
-    const [value, setValue] = useState(row.notes || '');
-
-    useEffect(() => {
-        setValue(row.notes || '');
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [row.id, row.notes]);
-
-    const handleBlur = () => {
-        onSave(row.id, { notes: value.trim() || 'NULL' });
-    };
-
-    return (
-        <Box sx={cellWrapSx} onClick={stop}>
-            <InputBase
-                fullWidth
-                multiline
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                onBlur={handleBlur}
-                sx={{
-                    ...ghostBase,
-                    display: 'flex',
-                    width: '100%',
-                    fontStyle: 'italic',
-                    color: 'text.secondary',
-                    '& .MuiInputBase-input': {
-                        ...ghostBase['& .MuiInputBase-input'],
-                        fontStyle: 'italic',
-                        color: 'text.secondary',
-                        minHeight: '1.2em',
-                    },
-                }}
-            />
-        </Box>
-    );
-};
-
-/**
  * Ghost Autocomplete for the partners cell.
  * @param row          DataGrid row
  * @param partners     all partner records [{ id, name }]
  * @param runPartners  all run-partner links [{ map_run_fk, map_partner_fk }]
- * @param onSave       (rowId, newNames[]) => void  (fires on change; parent diffs add/remove)
+ * @param onSave       (rowId, newNames[]) => Promise, REJECTING on failure
+ *                     (fires on change; parent diffs add/remove)
  */
 export const GhostPartnersCell = ({ row, partners, runPartners, onSave }) => {
     const computeNames = () => {
@@ -221,13 +224,18 @@ export const GhostPartnersCell = ({ row, partners, runPartners, onSave }) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [row.id, runPartners, partners]);
 
-    const handleChange = (e, newNames) => {
+    const handleChange = async (e, newNames) => {
+        const previous = value;
         setValue(newNames);
-        onSave(row.id, newNames);
+        try {
+            await onSave(row.id, newNames);
+        } catch {
+            setValue(previous);
+        }
     };
 
     return (
-        <Box sx={cellWrapSx} onClick={stop}>
+        <Box sx={cellWrapSx} onClick={stop} onKeyDown={stopEditorKeys}>
             <Autocomplete
                 multiple
                 freeSolo
@@ -247,16 +255,9 @@ export const GhostPartnersCell = ({ row, partners, runPartners, onSave }) => {
                         {...params}
                         variant="standard"
                         placeholder={value.length === 0 ? 'No partners' : ''}
-                        sx={{
-                            '& .MuiInput-underline:before': { borderBottomColor: 'transparent' },
-                            '& .MuiInput-underline:hover:not(.Mui-disabled, .Mui-error):before': {
-                                borderBottomColor: 'rgba(0,0,0,0.3)',
-                            },
-                            '& .MuiInputBase-input::placeholder': {
-                                color: 'text.disabled', opacity: 1, fontSize: '0.8125rem',
-                            },
-                            '& .MuiInputBase-root': { flexWrap: 'wrap', gap: 0.5 },
-                        }}
+                        sx={(theme) => ghostAutocompleteInputBase(theme, {
+                            placeholderFontSize: '0.8125rem',
+                        })}
                     />
                 )}
             />

--- a/src/MapRuns/MapRunsView.jsx
+++ b/src/MapRuns/MapRunsView.jsx
@@ -28,7 +28,8 @@ import call_rest_api from '../RestApi/RestApi';
 import { asyncPool } from '../utils/asyncPool';
 import { mapRunKeys, mapRouteKeys, mapPartnerKeys, mapRunPartnerKeys } from '../hooks/useQueryKeys';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
-import { formatDuration, parseDuration } from '../utils/mapDataUtils';
+import { formatDuration } from '../utils/mapDataUtils';
+import { mapRunFields } from '../utils/ghostFieldParsers';
 import {
     GhostInputCell,
     GhostSelectCell,
@@ -170,8 +171,7 @@ const MapRunsView = ({ runs = [], routes = [], partners = [], runPartners = [], 
                 <GhostInputCell
                     row={params.row}
                     field="distance_mi"
-                    format={v => v != null ? Number(v).toFixed(1) : ''}
-                    parse={v => { const n = parseFloat(v); return isNaN(n) ? null : n; }}
+                    rule={mapRunFields.distance_mi}
                     onSave={saveRunFields}
                 />
             ),
@@ -186,9 +186,7 @@ const MapRunsView = ({ runs = [], routes = [], partners = [], runPartners = [], 
                 <GhostInputCell
                     row={params.row}
                     field="run_time_sec"
-                    format={v => v != null ? formatDuration(v) : ''}
-                    parse={v => { const s = parseDuration(v); return isNaN(s) ? null : s; }}
-                    validate={v => v === '' || !isNaN(parseDuration(v))}
+                    rule={mapRunFields.run_time_sec}
                     onSave={saveRunFields}
                     align="left"
                 />
@@ -204,8 +202,7 @@ const MapRunsView = ({ runs = [], routes = [], partners = [], runPartners = [], 
                 <GhostInputCell
                     row={params.row}
                     field="ascent_ft"
-                    format={v => v != null ? String(Math.round(Number(v))) : ''}
-                    parse={v => v === '' ? 'NULL' : (isNaN(parseInt(v, 10)) ? null : parseInt(v, 10))}
+                    rule={mapRunFields.ascent_ft}
                     onSave={saveRunFields}
                 />
             ),
@@ -220,8 +217,7 @@ const MapRunsView = ({ runs = [], routes = [], partners = [], runPartners = [], 
                 <GhostInputCell
                     row={params.row}
                     field="descent_ft"
-                    format={v => v != null ? String(Math.round(Number(v))) : ''}
-                    parse={v => v === '' ? 'NULL' : (isNaN(parseInt(v, 10)) ? null : parseInt(v, 10))}
+                    rule={mapRunFields.descent_ft}
                     onSave={saveRunFields}
                 />
             ),
@@ -236,8 +232,7 @@ const MapRunsView = ({ runs = [], routes = [], partners = [], runPartners = [], 
                 <GhostInputCell
                     row={params.row}
                     field="max_speed_mph"
-                    format={v => v != null ? Number(v).toFixed(1) : ''}
-                    parse={v => v === '' ? 'NULL' : (isNaN(parseFloat(v)) ? null : parseFloat(v))}
+                    rule={mapRunFields.max_speed_mph}
                     onSave={saveRunFields}
                 />
             ),
@@ -252,8 +247,7 @@ const MapRunsView = ({ runs = [], routes = [], partners = [], runPartners = [], 
                 <GhostInputCell
                     row={params.row}
                     field="avg_speed_mph"
-                    format={v => v != null ? Number(v).toFixed(1) : ''}
-                    parse={v => v === '' ? 'NULL' : (isNaN(parseFloat(v)) ? null : parseFloat(v))}
+                    rule={mapRunFields.avg_speed_mph}
                     onSave={saveRunFields}
                 />
             ),
@@ -287,18 +281,36 @@ const MapRunsView = ({ runs = [], routes = [], partners = [], runPartners = [], 
     ];
 
     // ── Inline-edit save helpers (mirror RouteCard) ──────────────────────────
+
+    /**
+     * REJECTS on failure, and that is the contract, not an oversight.
+     *
+     * The ghost cell editors await this and revert the cell when it rejects, so a
+     * write that resolved after a 500 would leave the failed value sitting in the
+     * grid looking saved until the next refetch quietly replaced it — the exact
+     * defect req #3073 exists to remove. The Select and Autocomplete cells catch it
+     * themselves and roll back their own optimistic state.
+     */
     const saveRunFields = async (rowId, fields) => {
+        let result;
         try {
-            const result = await call_rest_api(
+            result = await call_rest_api(
                 `${darwinUri}/map_runs`, 'PUT', [{ id: rowId, ...fields }], idToken
             );
-            if (result.httpStatus.httpStatus > 204) showError(result, 'Failed to update activity');
-            else queryClient.invalidateQueries({ queryKey: mapRunKeys.all(creatorFk) });
         } catch (err) {
             showError(err, 'Failed to update activity');
+            throw err;
         }
+        if (result.httpStatus.httpStatus > 204) {
+            showError(result, 'Failed to update activity');
+            throw new Error('Failed to update activity');
+        }
+        queryClient.invalidateQueries({ queryKey: mapRunKeys.all(creatorFk) });
     };
 
+    // Rethrows so GhostSelectCell can roll its optimistic value back. The route
+    // invalidation is deliberately inside the success path — a refused write has not
+    // changed which runs belong to which route.
     const handleRouteChange = async (rowId, newValue) => {
         await saveRunFields(rowId, { map_route_fk: newValue === NO_ROUTE ? 'NULL' : newValue });
         queryClient.invalidateQueries({ queryKey: mapRouteKeys.all(creatorFk) });
@@ -328,6 +340,7 @@ const MapRunsView = ({ runs = [], routes = [], partners = [], runPartners = [], 
             queryClient.invalidateQueries({ queryKey: mapRunPartnerKeys.all(creatorFk) });
         } catch (err) {
             showError(err, 'Failed to update partners');
+            throw err;   // GhostPartnersCell rolls its chips back
         }
     };
 

--- a/src/MapRuns/__tests__/GhostCellEditors.test.jsx
+++ b/src/MapRuns/__tests__/GhostCellEditors.test.jsx
@@ -1,0 +1,379 @@
+// @vitest-environment jsdom
+//
+// Req #3073 — the Maps cell editors after the migration onto GhostTextField.
+//
+// GhostTextField.test.jsx pins the commit contract in isolation. This file pins that
+// the Maps editors are actually WIRED to it: that the rules from ghostFieldParsers
+// reach the right props, that `onSave` is returned rather than dropped (an adapter
+// that forgets to return resolves instantly and disables the rollback with no visible
+// symptom), and that the Select/Autocomplete cells — which are NOT GhostTextFields —
+// roll their own optimistic state back.
+//
+// Every test below is one of the four defects named in the requirement.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import {
+    GhostInputCell,
+    GhostNotesCell,
+    GhostSelectCell,
+    GhostDateTimeCell,
+} from '../GhostCellEditors';
+import { mapRunFields } from '../../utils/ghostFieldParsers';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container;
+let root;
+
+beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+});
+
+const render = (el) => act(() => root.render(el));
+const byTestId = (id) => container.querySelector(`[data-testid="${id}"]`);
+
+// A controlled React input ignores a plain `el.value = x`; the value has to go
+// through the native setter so React's own change tracking sees it.
+const typeInto = (el, value) => act(() => {
+    const proto = el instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, 'value').set.call(el, value);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+});
+
+const focus = (el) => act(() => el.focus());
+
+// ASYNC act: blur starts the commit, and the commit's own follow-up state changes
+// (the revert on a rejected write) land in a later microtask.
+const blur = (el) => act(async () => { el.blur(); });
+
+const pressKey = (el, key) => act(() => {
+    el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+});
+
+const run = (over = {}) => ({
+    id: 7,
+    distance_mi: 12.5,
+    avg_speed_mph: 15.28,
+    run_time_sec: 3661,
+    notes: 'a note',
+    start_time: '2026-03-15 18:30:00',
+    map_route_fk: 3,
+    ...over,
+});
+
+const inputCell = (props) => (
+    <GhostInputCell
+        row={run()}
+        field="distance_mi"
+        rule={mapRunFields.distance_mi}
+        {...props}
+    />
+);
+
+describe('GhostInputCell — an invalid value is blocked, not silently dropped', () => {
+    it('issues no write, keeps the bad text on screen, and says why', () => {
+        // The original skipped the save whenever `parse` returned null and left no
+        // trace at all, so the bad value sat in the grid looking saved until the next
+        // refetch quietly reverted it.
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(inputCell({ onSave }));
+
+        const el = byTestId('map-run-distance_mi');
+        focus(el);
+        typeInto(el, '12abc');
+
+        expect(onSave).not.toHaveBeenCalled();
+        expect(el.value).toBe('12abc');
+        expect(byTestId('map-run-distance_mi-message').textContent).toBe('Enter a number');
+    });
+
+    it('clears the verdict as the value becomes valid again', () => {
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(inputCell({ onSave }));
+
+        const el = byTestId('map-run-distance_mi');
+        focus(el);
+        typeInto(el, 'nope');
+        expect(byTestId('map-run-distance_mi-message')).not.toBeNull();
+
+        typeInto(el, '14');
+        expect(byTestId('map-run-distance_mi-message')).toBeNull();
+    });
+});
+
+describe('GhostInputCell — a rejected write never stays on screen', () => {
+    it('reverts the cell when onSave rejects', async () => {
+        // Only reachable because MapRunsView's saveRunFields rethrows. If the adapter
+        // in GhostCellEditors forgot to RETURN the promise this would silently pass
+        // the write and fail here.
+        const onSave = vi.fn().mockRejectedValue(new Error('500'));
+        render(inputCell({ onSave }));
+
+        const el = byTestId('map-run-distance_mi');
+        focus(el);
+        typeInto(el, '20');
+        await blur(el);
+
+        expect(onSave).toHaveBeenCalledExactlyOnceWith(7, { distance_mi: 20 });
+        expect(el.value).toBe('12.5');
+    });
+});
+
+describe('GhostInputCell — what it writes', () => {
+    it('normalizes before it writes, so the stored value is the displayed one', async () => {
+        // Without this the write stores 20.34, the refetch returns '20.3', and the
+        // cell repaints after every commit.
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(inputCell({ onSave }));
+
+        const el = byTestId('map-run-distance_mi');
+        focus(el);
+        typeInto(el, '  20.34  ');
+        await blur(el);
+
+        expect(onSave).toHaveBeenCalledExactlyOnceWith(7, { distance_mi: 20.3 });
+    });
+
+    it('KEEPS the committed value while the refetch is still in flight', async () => {
+        // The row prop is still the pre-write value here — that is the real state of
+        // the app between a successful PUT and the invalidation round-tripping. The
+        // cell must not repaint 12.5 over the edit it just made: that lasts a whole
+        // network round trip, reads as "the save failed", and the retry it invites
+        // writes the same value a second time.
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(inputCell({ onSave }));
+
+        const el = byTestId('map-run-distance_mi');
+        focus(el);
+        typeInto(el, '20');
+        await blur(el);
+
+        expect(byTestId('map-run-distance_mi').value).toBe('20.0');
+    });
+
+    it('adopts the server value once the refetch lands', async () => {
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(inputCell({ onSave }));
+
+        const el = byTestId('map-run-distance_mi');
+        focus(el);
+        typeInto(el, '20');
+        await blur(el);
+
+        // The write went through and the query came back — including the case where
+        // the server stored something other than what was sent.
+        render(inputCell({ onSave, row: run({ distance_mi: 20 }) }));
+        expect(byTestId('map-run-distance_mi').value).toBe('20.0');
+
+        render(inputCell({ onSave, row: run({ distance_mi: 19.9 }) }));
+        expect(byTestId('map-run-distance_mi').value).toBe('19.9');
+    });
+
+    it('does NOT write when the user only tabbed through', async () => {
+        // The real bug this kills: every blur used to PUT unconditionally, so tabbing
+        // across a row rewrote avg_speed_mph — DECIMAL(5,2) in the schema — with its
+        // own one-decimal DISPLAY value. 15.28 became 15.3 in the database with no
+        // edit at all.
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(inputCell({
+            onSave, field: 'avg_speed_mph', rule: mapRunFields.avg_speed_mph,
+        }));
+
+        const el = byTestId('map-run-avg_speed_mph');
+        // Shown at the column's own DECIMAL(5,2) scale. Displaying it to one decimal
+        // is what made the round-trip lossy in the first place.
+        expect(el.value).toBe('15.28');
+        focus(el);
+        await blur(el);
+
+        expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it('sends the SQL NULL sentinel when a nullable column is emptied', async () => {
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(inputCell({
+            onSave, field: 'avg_speed_mph', rule: mapRunFields.avg_speed_mph,
+        }));
+
+        const el = byTestId('map-run-avg_speed_mph');
+        focus(el);
+        typeInto(el, '');
+        await blur(el);
+
+        expect(onSave).toHaveBeenCalledExactlyOnceWith(7, { avg_speed_mph: 'NULL' });
+    });
+
+    it('reverts rather than emptying a NOT NULL column', async () => {
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(inputCell({ onSave }));
+
+        const el = byTestId('map-run-distance_mi');
+        focus(el);
+        typeInto(el, '');
+        await blur(el);
+
+        expect(onSave).not.toHaveBeenCalled();
+        expect(el.value).toBe('12.5');
+    });
+});
+
+describe('GhostInputCell — Escape abandons the edit', () => {
+    it('restores the stored value and issues no write', async () => {
+        // There was no way to abandon an edit before. Note the trap pinned in #3063:
+        // Escape blurs, and that blur lands in commit() with the abandoned value
+        // still in scope — a naive implementation COMMITS what Escape threw away.
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(inputCell({ onSave }));
+
+        const el = byTestId('map-run-distance_mi');
+        focus(el);
+        typeInto(el, '99');
+        pressKey(el, 'Escape');
+        await blur(el);
+
+        expect(onSave).not.toHaveBeenCalled();
+        expect(el.value).toBe('12.5');
+    });
+});
+
+describe('GhostInputCell — an external refetch does not clobber work in progress', () => {
+    it('re-seeds a clean cell', () => {
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(inputCell({ onSave }));
+        expect(byTestId('map-run-distance_mi').value).toBe('12.5');
+
+        render(inputCell({ onSave, row: run({ distance_mi: 30 }) }));
+        expect(byTestId('map-run-distance_mi').value).toBe('30.0');
+    });
+
+    it('leaves a DIRTY cell alone', () => {
+        // The original re-seeded on any value change, which is harmless for its own
+        // round trip and destroys in-progress typing when a genuinely external change
+        // lands — another session, or a sibling write invalidating the row query.
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(inputCell({ onSave }));
+
+        const el = byTestId('map-run-distance_mi');
+        focus(el);
+        typeInto(el, '44');
+
+        render(inputCell({ onSave, row: run({ distance_mi: 30 }) }));
+        expect(byTestId('map-run-distance_mi').value).toBe('44');
+    });
+});
+
+describe('GhostNotesCell', () => {
+    it('stores NULL rather than an empty string when the note is cleared', async () => {
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(<GhostNotesCell row={run()} onSave={onSave} />);
+
+        const el = byTestId('map-run-notes');
+        focus(el);
+        typeInto(el, '   ');
+        await blur(el);
+
+        expect(onSave).toHaveBeenCalledExactlyOnceWith(7, { notes: 'NULL' });
+    });
+
+    it('is a textarea, and therefore carries no type attribute', () => {
+        // `type` is invalid DOM on a <textarea>; GhostTextField suppresses it there.
+        render(<GhostNotesCell row={run()} onSave={vi.fn()} />);
+        const el = byTestId('map-run-notes');
+        expect(el.tagName).toBe('TEXTAREA');
+        expect(el.hasAttribute('type')).toBe(false);
+    });
+});
+
+describe('GhostDateTimeCell', () => {
+    it('renders a native datetime-local seeded from the row', () => {
+        render(<GhostDateTimeCell row={run()} timezone="America/Los_Angeles" onSave={vi.fn()} />);
+        const el = byTestId('map-run-start-time');
+        expect(el.getAttribute('type')).toBe('datetime-local');
+        expect(el.value).toBe('2026-03-15T11:30');
+    });
+
+    it('writes the value back as a UTC datetime', async () => {
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(<GhostDateTimeCell row={run()} timezone="America/Los_Angeles" onSave={onSave} />);
+
+        const el = byTestId('map-run-start-time');
+        focus(el);
+        typeInto(el, '2026-03-15T12:30');
+        await blur(el);
+
+        expect(onSave).toHaveBeenCalledExactlyOnceWith(7, { start_time: '2026-03-15 19:30:00' });
+    });
+
+    it('reverts rather than writing NULL when the picker reads back blank', async () => {
+        // A datetime-local reports '' until every segment is filled, so a half-typed
+        // date arrives at commit as an empty string over a NOT NULL column.
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(<GhostDateTimeCell row={run()} timezone="America/Los_Angeles" onSave={onSave} />);
+
+        const el = byTestId('map-run-start-time');
+        focus(el);
+        typeInto(el, '');
+        await blur(el);
+
+        expect(onSave).not.toHaveBeenCalled();
+        expect(el.value).toBe('2026-03-15T11:30');
+    });
+});
+
+describe('GhostSelectCell — not a text field, but it still rolls back', () => {
+    const options = [
+        { value: 3, label: 'Old Route' },
+        { value: 4, label: 'New Route' },
+    ];
+
+    const selected = () => container.querySelector('[role="combobox"]').textContent;
+
+    // MUI's Select opens on mousedown, not click, and renders its listbox into a
+    // portal outside `container`.
+    const openAndPick = async (index) => {
+        await act(async () => {
+            container.querySelector('[role="combobox"]')
+                .dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        });
+        await act(async () => {
+            document.querySelectorAll('[role="option"]')[index].click();
+        });
+    };
+
+    it('keeps the new value when the write succeeds', async () => {
+        const onSave = vi.fn().mockResolvedValue(undefined);
+        render(<GhostSelectCell row={run()} value={3} options={options} onSave={onSave} />);
+        expect(selected()).toBe('Old Route');
+
+        await openAndPick(1);
+
+        expect(onSave).toHaveBeenCalledExactlyOnceWith(7, 4);
+        expect(selected()).toBe('New Route');
+    });
+
+    it('rolls the optimistic value back when the write is refused', async () => {
+        // Without this the cell keeps showing a route the run was never assigned.
+        // The catch is also what stops a rejecting onSave escaping this void handler
+        // as an unhandled rejection.
+        const onSave = vi.fn().mockRejectedValue(new Error('500'));
+        render(<GhostSelectCell row={run()} value={3} options={options} onSave={onSave} />);
+
+        await openAndPick(1);
+
+        expect(onSave).toHaveBeenCalledExactlyOnceWith(7, 4);
+        expect(selected()).toBe('Old Route');
+    });
+});

--- a/src/RouteCards/RouteCard.jsx
+++ b/src/RouteCards/RouteCard.jsx
@@ -1,10 +1,9 @@
-import React, { useState, useEffect, useMemo, useContext } from 'react';
+import React, { useState, useMemo, useContext } from 'react';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
-import InputBase from '@mui/material/InputBase';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Autocomplete from '@mui/material/Autocomplete';
@@ -26,12 +25,48 @@ import { checkPhotosProxy, startScan } from '../photo-browser/scanUtils.js';
 import { IS_MACOS } from '../photo-browser/proxyConfig.js';
 import RouteMapThumbnail from './RouteMapThumbnail';
 import RideDeleteDialog from './RideDeleteDialog';
-import { formatDuration, parseDuration } from '../utils/mapDataUtils';
-import { toDateTimeLocalValue, fromDateTimeLocalValue } from '../utils/dateFormat';
-import { ghostBase } from '../utils/ghostFieldStyles';
+import GhostTextField from '../Components/GhostField/GhostTextField';
+import { mapRunFields, dateTimeField, notesField } from '../utils/ghostFieldParsers';
+import { ghostSelectBase, ghostAutocompleteInputBase } from '../utils/ghostFieldStyles';
 
 const NO_ROUTE = '__no_route__';
 const ACTIVITY_TYPES = ['Ride', 'Hike'];
+
+/**
+ * One row of the stats table: label, ghost-editable value, unit.
+ *
+ * `rule` is the column's entry from ghostFieldParsers — it owns the display format,
+ * the canonical form a commit normalizes to, the verdict on a bad value, and the
+ * shape of the PUT payload. The card just wires it to a field and a save.
+ *
+ * `inline` is what keeps `12.5` and ` mi` on the same line inside the <td>, and
+ * `overlayMessage` is what keeps them there once a verdict appears: an inline-flex
+ * box is as wide as its widest child, so an in-flow "Enter a number" would be three
+ * times the width of the value and would shove the unit across the cell. Nothing on
+ * the card clips it, unlike the DataGrid cells.
+ */
+const StatRow = ({ label, column, rule, raw, unit, widthCh, onSave, testId }) => (
+    <tr>
+        <td>{label}</td>
+        <td>
+            <GhostTextField
+                inline
+                overlayMessage
+                value={rule.format(raw)}
+                required={rule.required}
+                normalize={rule.normalize}
+                validate={rule.validate}
+                // Returns the promise on purpose: GhostTextField awaits onCommit and
+                // reverts on rejection, and an adapter that forgets to return would
+                // resolve immediately and disable the rollback with no symptom.
+                onCommit={(text) => onSave({ [column]: rule.toApi(text) })}
+                autoWidthCh={widthCh}
+                testId={testId}
+            />
+            {unit ? ` ${unit}` : null}
+        </td>
+    </tr>
+);
 
 const RouteCard = ({ run, routeName, routes, allRuns, partners = [], runPartners = [], dedupedPhotoIndex = null }) => {
     const navigate = useNavigate();
@@ -44,61 +79,73 @@ const RouteCard = ({ run, routeName, routes, allRuns, partners = [], runPartners
 
     const [deleteOpen, setDeleteOpen] = useState(false);
 
-    // Editable state — mirrors run props
+    // Only the three controls that are NOT ghost text fields still mirror the run in
+    // local state — a Select and an Autocomplete both have to render optimistically
+    // and be rolled back by hand. Every stat field below reads straight from `run`;
+    // GhostTextField owns its own text between focus and blur and re-seeds itself
+    // from the prop when a refetch lands, which is what makes the old per-field
+    // useState block and its `[run.id]` reset effect unnecessary.
     const [routeValue, setRouteValue] = useState(run.map_route_fk ?? NO_ROUTE);
     const [activityType, setActivityType] = useState(run.activity_name || '');
-    const [startTime, setStartTime] = useState(() => toDateTimeLocalValue(run.start_time, timezone));
-    const [distance, setDistance] = useState(Number(run.distance_mi).toFixed(1));
-    const [avgSpeed, setAvgSpeed] = useState(run.avg_speed_mph != null ? Number(run.avg_speed_mph).toFixed(1) : '');
-    const [maxSpeed, setMaxSpeed] = useState(run.max_speed_mph != null ? Number(run.max_speed_mph).toFixed(1) : '');
-    const [ascent, setAscent] = useState(run.ascent_ft != null ? String(Math.round(Number(run.ascent_ft))) : '');
-    const [rideTime, setRideTime] = useState(formatDuration(run.run_time_sec));
-    const [stoppedTime, setStoppedTime] = useState(formatDuration(run.stopped_time_sec || 0));
-    const [notes, setNotes] = useState(run.notes || '');
     const [selectedPartners, setSelectedPartners] = useState(() => {
         const ids = runPartners.filter(rp => rp.map_run_fk === run.id).map(rp => rp.map_partner_fk);
         return partners.filter(p => ids.includes(p.id)).map(p => p.name);
     });
 
-    // Reset when a different run is displayed
-    useEffect(() => {
-        setRouteValue(run.map_route_fk ?? NO_ROUTE);
-        setActivityType(run.activity_name || '');
-        setStartTime(toDateTimeLocalValue(run.start_time, timezone));
-        setDistance(Number(run.distance_mi).toFixed(1));
-        setAvgSpeed(run.avg_speed_mph != null ? Number(run.avg_speed_mph).toFixed(1) : '');
-        setMaxSpeed(run.max_speed_mph != null ? Number(run.max_speed_mph).toFixed(1) : '');
-        setAscent(run.ascent_ft != null ? String(Math.round(Number(run.ascent_ft))) : '');
-        setRideTime(formatDuration(run.run_time_sec));
-        setStoppedTime(formatDuration(run.stopped_time_sec || 0));
-        setNotes(run.notes || '');
-        const ids = runPartners.filter(rp => rp.map_run_fk === run.id).map(rp => rp.map_partner_fk);
-        setSelectedPartners(partners.filter(p => ids.includes(p.id)).map(p => p.name));
-    }, [run.id]); // eslint-disable-line react-hooks/exhaustive-deps
-
+    const startTime = useMemo(() => dateTimeField(timezone), [timezone]);
 
     const sortedRoutes = useMemo(() =>
         [...(routes || [])].sort((a, b) => a.name.localeCompare(b.name)), [routes]);
 
     // ── Save helpers ─────────────────────────────────────────────────────────
 
+    /**
+     * REJECTS on failure, and that is the contract, not an oversight.
+     *
+     * GhostTextField awaits onCommit and reverts the field when it rejects, so a
+     * write that resolves after a 500 would leave the failed value sitting on screen
+     * looking saved until the next refetch quietly replaced it — the exact defect
+     * req #3073 exists to remove. Every caller that is NOT a GhostTextField catches
+     * this itself and rolls back its own optimistic state.
+     */
     const saveRunFields = async (fields) => {
+        let result;
         try {
-            const result = await call_rest_api(`${darwinUri}/map_runs`, 'PUT', [{ id: run.id, ...fields }], idToken);
-            if (result.httpStatus.httpStatus > 204) showError(result, 'Failed to update activity');
-            else queryClient.invalidateQueries({ queryKey: mapRunKeys.all(creatorFk) });
+            result = await call_rest_api(`${darwinUri}/map_runs`, 'PUT', [{ id: run.id, ...fields }], idToken);
         } catch (err) {
             showError(err, 'Failed to update activity');
+            throw err;
         }
+        if (result.httpStatus.httpStatus > 204) {
+            showError(result, 'Failed to update activity');
+            throw new Error('Failed to update activity');
+        }
+        queryClient.invalidateQueries({ queryKey: mapRunKeys.all(creatorFk) });
     };
 
     const handleRouteChange = async (newValue) => {
+        const previous = routeValue;
         setRouteValue(newValue);
-        await saveRunFields({ map_route_fk: newValue === NO_ROUTE ? 'NULL' : newValue });
-        queryClient.invalidateQueries({ queryKey: mapRouteKeys.all(creatorFk) });
+        try {
+            await saveRunFields({ map_route_fk: newValue === NO_ROUTE ? 'NULL' : newValue });
+            queryClient.invalidateQueries({ queryKey: mapRouteKeys.all(creatorFk) });
+        } catch {
+            setRouteValue(previous);   // already reported by saveRunFields
+        }
+    };
+
+    const handleActivityChange = async (newValue) => {
+        const previous = activityType;
+        setActivityType(newValue);
+        try {
+            await saveRunFields({ activity_name: newValue });
+        } catch {
+            setActivityType(previous);
+        }
     };
 
     const handlePartnerChange = async (newNames) => {
+        const previous = selectedPartners;
         setSelectedPartners(newNames);
         const existingIds = runPartners.filter(rp => rp.map_run_fk === run.id).map(rp => rp.map_partner_fk);
         const existingNames = partners.filter(p => existingIds.includes(p.id)).map(p => p.name);
@@ -121,7 +168,10 @@ const RouteCard = ({ run, routeName, routes, allRuns, partners = [], runPartners
             }
             queryClient.invalidateQueries({ queryKey: mapPartnerKeys.all(creatorFk) });
             queryClient.invalidateQueries({ queryKey: mapRunPartnerKeys.all(creatorFk) });
-        } catch (err) { showError(err, 'Failed to update partners'); }
+        } catch (err) {
+            showError(err, 'Failed to update partners');
+            setSelectedPartners(previous);
+        }
     };
 
     const handleDeleteConfirm = async () => {
@@ -152,9 +202,6 @@ const RouteCard = ({ run, routeName, routes, allRuns, partners = [], runPartners
         else navigate('/maps/settings/photos');
     };
 
-    // w: width in ch units for the input, sized to current value length
-    const w = (val, min = 2) => ({ style: { width: `${Math.max((val ?? '').length, min)}ch` } });
-
     return (
         <>
             <Card raised={true}
@@ -171,12 +218,10 @@ const RouteCard = ({ run, routeName, routes, allRuns, partners = [], runPartners
                         displayEmpty
                         IconComponent={() => null}
                         data-testid="route-card-route-select"
-                        sx={{
+                        sx={(theme) => ({
+                            ...ghostSelectBase(theme),
                             fontSize: 24, fontWeight: 'normal', flexGrow: 1,
-                            '& .MuiSelect-select': { py: 0, pr: '0 !important' },
-                            '&:before': { borderBottomColor: 'transparent' },
-                            '&:hover:not(.Mui-disabled):before': { borderBottomColor: 'rgba(0,0,0,0.3)' },
-                        }}
+                        })}
                     >
                         <MenuItem value={NO_ROUTE}><em>No route</em></MenuItem>
                         {sortedRoutes.map(r => (
@@ -197,38 +242,38 @@ const RouteCard = ({ run, routeName, routes, allRuns, partners = [], runPartners
                         <Box sx={{ flexGrow: 1, display: 'flex', alignItems: 'baseline', flexWrap: 'wrap' }}>
                             <Select
                                 value={activityType}
-                                onChange={async (e) => { setActivityType(e.target.value); await saveRunFields({ activity_name: e.target.value }); }}
+                                onChange={(e) => handleActivityChange(e.target.value)}
                                 variant="standard"
                                 IconComponent={() => null}
                                 data-testid="route-card-activity-type"
-                                sx={{
+                                sx={(theme) => ({
+                                    ...ghostSelectBase(theme),
                                     fontSize: '0.875rem',
                                     color: 'text.secondary',
-                                    '& .MuiSelect-select': { py: 0, pr: '0 !important' },
-                                    '&:before': { borderBottomColor: 'transparent' },
-                                    '&:hover:not(.Mui-disabled):before': { borderBottomColor: 'rgba(0,0,0,0.3)' },
-                                }}
+                                })}
                             >
                                 {ACTIVITY_TYPES.map(t => <MenuItem key={t} value={t} sx={{ fontSize: '0.875rem' }}>{t}</MenuItem>)}
                             </Select>
                             <Typography variant="body2" color="text.secondary" component="span" sx={{ mx: 0.75 }}>·</Typography>
-                            <InputBase
+                            <GhostTextField
+                                inline
+                                overlayMessage
                                 type="datetime-local"
-                                value={startTime}
-                                onChange={(e) => setStartTime(e.target.value)}
-                                onBlur={async () => { const p = fromDateTimeLocalValue(startTime, timezone); if (p) await saveRunFields({ start_time: p }); }}
+                                value={startTime.format(run.start_time)}
+                                required={startTime.required}
+                                validate={startTime.validate}
+                                onCommit={(text) => saveRunFields({ start_time: startTime.toApi(text) })}
+                                testId="route-card-start-time"
                                 sx={{
-                                    ...ghostBase,
                                     fontSize: '0.875rem',
                                     color: 'text.secondary',
+                                    // Without this Chrome's own picker button opens on
+                                    // click and swallows the first Escape to close
+                                    // itself, so the field never sees the abandon key.
                                     '& input::-webkit-calendar-picker-indicator': { display: 'none' },
                                     '& input::-webkit-inner-spin-button': { display: 'none' },
-                                    '& .MuiInputBase-input': {
-                                        ...ghostBase['& .MuiInputBase-input'],
-                                        minWidth: '16ch',
-                                    },
+                                    '& .MuiInputBase-input': { minWidth: '16ch' },
                                 }}
-                                data-testid="route-card-start-time"
                             />
                         </Box>
                         {featureEnabled && (
@@ -250,93 +295,50 @@ const RouteCard = ({ run, routeName, routes, allRuns, partners = [], runPartners
                     </Box>
 
                     {/* Stats table — matches original sx exactly.
-                        Right column: InputBase (ghost text) followed by " unit" text, same as original "{value} unit". */}
+                        Right column: ghost text field followed by " unit", same as original "{value} unit". */}
                     <Box component="table" sx={{ width: '100%', '& td': { py: 0.2 }, '& td:first-of-type': { color: 'text.secondary', pr: 1.5 } }}>
                         <tbody>
-                            <tr>
-                                <td>Distance</td>
-                                <td>
-                                    <InputBase value={distance} onChange={(e) => setDistance(e.target.value)}
-                                        onBlur={async () => { const v = parseFloat(distance); if (!isNaN(v)) await saveRunFields({ distance_mi: v }); }}
-                                        inputProps={w(distance, 3)} sx={ghostBase} data-testid="route-card-distance"
-                                    /> mi
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Avg Speed</td>
-                                <td>
-                                    <InputBase value={avgSpeed} onChange={(e) => setAvgSpeed(e.target.value)}
-                                        onBlur={async () => { const v = avgSpeed === '' ? 'NULL' : parseFloat(avgSpeed); if (avgSpeed === '' || !isNaN(v)) await saveRunFields({ avg_speed_mph: v }); }}
-                                        inputProps={w(avgSpeed, 3)} sx={ghostBase} data-testid="route-card-avg-speed"
-                                    /> mph
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Max Speed</td>
-                                <td>
-                                    <InputBase value={maxSpeed} onChange={(e) => setMaxSpeed(e.target.value)}
-                                        onBlur={async () => { const v = maxSpeed === '' ? 'NULL' : parseFloat(maxSpeed); if (maxSpeed === '' || !isNaN(v)) await saveRunFields({ max_speed_mph: v }); }}
-                                        inputProps={w(maxSpeed, 3)} sx={ghostBase} data-testid="route-card-max-speed"
-                                    /> mph
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Ascent</td>
-                                <td>
-                                    <InputBase value={ascent} onChange={(e) => setAscent(e.target.value)}
-                                        onBlur={async () => { const v = ascent === '' ? 'NULL' : parseInt(ascent, 10); if (ascent === '' || !isNaN(v)) await saveRunFields({ ascent_ft: v }); }}
-                                        inputProps={w(ascent, 1)} sx={ghostBase} data-testid="route-card-ascent"
-                                    /> ft
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Ride Time</td>
-                                <td>
-                                    <InputBase value={rideTime} onChange={(e) => setRideTime(e.target.value)}
-                                        onBlur={async () => { const s = parseDuration(rideTime); if (!isNaN(s)) await saveRunFields({ run_time_sec: s }); }}
-                                        inputProps={w(rideTime, 7)}
-                                        sx={{ ...ghostBase, '& .MuiInputBase-input': { ...ghostBase['& .MuiInputBase-input'], color: rideTime !== '' && isNaN(parseDuration(rideTime)) ? 'error.main' : 'inherit' } }}
-                                        data-testid="route-card-ride-time"
-                                    />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Stop Time</td>
-                                <td>
-                                    <InputBase value={stoppedTime} onChange={(e) => setStoppedTime(e.target.value)}
-                                        onBlur={async () => { const s = parseDuration(stoppedTime); if (!isNaN(s)) await saveRunFields({ stopped_time_sec: s }); }}
-                                        inputProps={w(stoppedTime, 7)}
-                                        sx={{ ...ghostBase, '& .MuiInputBase-input': { ...ghostBase['& .MuiInputBase-input'], color: stoppedTime !== '' && isNaN(parseDuration(stoppedTime)) ? 'error.main' : 'inherit' } }}
-                                        data-testid="route-card-stopped-time"
-                                    />
-                                </td>
-                            </tr>
+                            <StatRow label="Distance" column="distance_mi" rule={mapRunFields.distance_mi}
+                                raw={run.distance_mi} unit="mi" widthCh={3}
+                                onSave={saveRunFields} testId="route-card-distance" />
+                            <StatRow label="Avg Speed" column="avg_speed_mph" rule={mapRunFields.avg_speed_mph}
+                                raw={run.avg_speed_mph} unit="mph" widthCh={3}
+                                onSave={saveRunFields} testId="route-card-avg-speed" />
+                            <StatRow label="Max Speed" column="max_speed_mph" rule={mapRunFields.max_speed_mph}
+                                raw={run.max_speed_mph} unit="mph" widthCh={3}
+                                onSave={saveRunFields} testId="route-card-max-speed" />
+                            <StatRow label="Ascent" column="ascent_ft" rule={mapRunFields.ascent_ft}
+                                raw={run.ascent_ft} unit="ft" widthCh={1}
+                                onSave={saveRunFields} testId="route-card-ascent" />
+                            <StatRow label="Ride Time" column="run_time_sec" rule={mapRunFields.run_time_sec}
+                                raw={run.run_time_sec} widthCh={7}
+                                onSave={saveRunFields} testId="route-card-ride-time" />
+                            <StatRow label="Stop Time" column="stopped_time_sec" rule={mapRunFields.stopped_time_sec}
+                                raw={run.stopped_time_sec} widthCh={7}
+                                onSave={saveRunFields} testId="route-card-stopped-time" />
                         </tbody>
                     </Box>
 
                     {/* Notes — matches original: body2 secondary italic.
                         Always visible (empty = blank line, hover shows affordance). */}
-                    <InputBase
-                        fullWidth multiline
-                        value={notes}
-                        onChange={(e) => setNotes(e.target.value)}
-                        onBlur={async () => saveRunFields({ notes: notes.trim() || 'NULL' })}
+                    <GhostTextField
+                        multiline
+                        value={notesField.format(run.notes)}
+                        normalize={notesField.normalize}
+                        onCommit={(text) => saveRunFields({ notes: notesField.toApi(text) })}
+                        testId="route-card-notes"
                         sx={{
-                            ...ghostBase,
-                            display: 'flex',
                             mt: 1,
                             fontSize: '0.875rem',
                             color: 'text.secondary',
                             fontStyle: 'italic',
                             '& .MuiInputBase-input': {
-                                ...ghostBase['& .MuiInputBase-input'],
                                 fontSize: '0.875rem',
                                 color: 'text.secondary',
                                 fontStyle: 'italic',
                                 minHeight: '1.2em',
                             },
                         }}
-                        data-testid="route-card-notes"
                     />
 
                     {/* Partners row — Autocomplete on left, delete button on right */}
@@ -358,12 +360,9 @@ const RouteCard = ({ run, routeName, routes, allRuns, partners = [], runPartners
                                     {...params}
                                     variant="standard"
                                     placeholder={selectedPartners.length === 0 ? 'No partners' : ''}
-                                    sx={{
-                                        '& .MuiInput-underline:before': { borderBottomColor: 'transparent' },
-                                        '& .MuiInput-underline:hover:not(.Mui-disabled, .Mui-error):before': { borderBottomColor: 'rgba(0,0,0,0.3)' },
-                                        '& .MuiInputBase-input::placeholder': { color: 'text.disabled', opacity: 1, fontSize: '0.875rem' },
-                                        '& .MuiInputBase-root': { flexWrap: 'wrap', gap: 0.5 },
-                                    }}
+                                    sx={(theme) => ghostAutocompleteInputBase(theme, {
+                                        placeholderFontSize: '0.875rem',
+                                    })}
                                 />
                             )}
                             data-testid="route-card-partners"

--- a/src/utils/__tests__/ghostFieldParsers.test.js
+++ b/src/utils/__tests__/ghostFieldParsers.test.js
@@ -1,0 +1,183 @@
+// Req #3073 — the field rules the two Maps views now share.
+//
+// These are the rules that used to be written out longhand at each of the fourteen
+// call sites, which is how the card and the table drifted apart. Each one answers
+// three questions the old `if (!isNaN(v))` could not: what does a bad value LOOK
+// like, what gets STORED, and what happens to an emptied field.
+
+import { describe, it, expect } from 'vitest';
+
+import {
+    mapRunFields,
+    notesField,
+    dateTimeField,
+    SQL_NULL,
+} from '../ghostFieldParsers';
+
+const TZ = 'America/Los_Angeles';
+
+describe('ghostFieldParsers — decimal columns', () => {
+    const distance = mapRunFields.distance_mi;
+
+    it('formats a stored value to its display precision', () => {
+        expect(distance.format(12)).toBe('12.0');
+        expect(distance.format(12.34)).toBe('12.3');
+    });
+
+    it('renders a missing value as blank, not as zero', () => {
+        expect(distance.format(null)).toBe('');
+        expect(distance.format(undefined)).toBe('');
+    });
+
+    it('normalizes a committed value into the display form', () => {
+        // Without this the field repaints after every commit: the write stores 12,
+        // the refetch returns '12.0', and the re-seed guard has to reconcile the two.
+        expect(distance.normalize('12')).toBe('12.0');
+        expect(distance.normalize('  12.34  ')).toBe('12.3');
+    });
+
+    it('leaves an unparseable value alone so the user can see what they typed', () => {
+        expect(distance.normalize('abc')).toBe('abc');
+    });
+
+    it('REJECTS a value that is only partly a number', () => {
+        // The originals used parseFloat, which reads '12abc' as 12 and stored it
+        // without telling anybody. That is the silent drop wearing a different hat.
+        expect(distance.validate('12abc')).toBe('Enter a number');
+        expect(distance.validate('abc')).toBe('Enter a number');
+    });
+
+    it('accepts a number in any of the forms a user actually types', () => {
+        for (const text of ['12', '12.5', '.5', '-3', '  7  ', '1e2']) {
+            expect(distance.validate(text)).toBeNull();
+        }
+    });
+
+    it('treats blank as a question for `required`, not as a parse failure', () => {
+        // Conflating the two would flash "Enter a number" the instant a user
+        // select-all-deletes in order to retype.
+        expect(distance.validate('')).toBeNull();
+        expect(distance.validate('   ')).toBeNull();
+    });
+
+    it('marks the NOT NULL column required and the nullable ones not', () => {
+        expect(mapRunFields.distance_mi.required).toBe(true);
+        expect(mapRunFields.avg_speed_mph.required).toBe(false);
+        expect(mapRunFields.max_speed_mph.required).toBe(false);
+    });
+
+    it('sends the SQL NULL sentinel when a nullable column is emptied', () => {
+        expect(mapRunFields.avg_speed_mph.toApi('')).toBe(SQL_NULL);
+        expect(mapRunFields.max_speed_mph.toApi('  ')).toBe(SQL_NULL);
+    });
+
+    it('sends a number, not a string, when there is a value', () => {
+        expect(distance.toApi('12.5')).toBe(12.5);
+        expect(mapRunFields.avg_speed_mph.toApi('15.28')).toBe(15.28);
+    });
+});
+
+describe('ghostFieldParsers — integer columns', () => {
+    const ascent = mapRunFields.ascent_ft;
+
+    it('displays and stores a whole number', () => {
+        expect(ascent.format(1234.6)).toBe('1235');
+        expect(ascent.normalize('1234.6')).toBe('1235');
+        // Rounds rather than truncating, so the stored value matches the one the
+        // field showed. The original parseInt() displayed 1235 and stored 1234.
+        expect(ascent.toApi('1234.6')).toBe(1235);
+    });
+
+    it('is nullable and sends the sentinel when emptied', () => {
+        expect(ascent.required).toBe(false);
+        expect(ascent.toApi('')).toBe(SQL_NULL);
+        expect(mapRunFields.descent_ft.toApi('')).toBe(SQL_NULL);
+    });
+
+    it('rejects a non-number', () => {
+        expect(ascent.validate('1,234')).toBe('Enter a number');
+    });
+});
+
+describe('ghostFieldParsers — duration columns', () => {
+    const rideTime = mapRunFields.run_time_sec;
+
+    it('renders a missing duration as blank rather than as 00:00:00', () => {
+        // formatDuration() does not null-check; unguarded it reports a duration the
+        // row does not have. The card used to show 00:00:00 here and the table blank.
+        expect(rideTime.format(null)).toBe('');
+        expect(rideTime.format(3661)).toBe('01:01:01');
+    });
+
+    it('canonicalizes every accepted input form to H:MM:SS', () => {
+        expect(rideTime.normalize('1:01:01')).toBe('01:01:01');
+        expect(rideTime.normalize('5:30')).toBe('00:05:30');
+        expect(rideTime.normalize('90')).toBe('00:01:30');
+    });
+
+    it('names the expected format when the value will not parse', () => {
+        expect(rideTime.validate('half an hour')).toBe('Use H:MM:SS');
+        expect(rideTime.validate('1:02:03')).toBeNull();
+    });
+
+    it('stores seconds', () => {
+        expect(rideTime.toApi('01:01:01')).toBe(3661);
+    });
+
+    it('treats both duration columns as required', () => {
+        // Neither view has ever written an empty duration: parseDuration('') is NaN
+        // and the old guard skipped the save. `required` makes that visible — the
+        // field reverts to the stored value instead of doing nothing.
+        expect(mapRunFields.run_time_sec.required).toBe(true);
+        expect(mapRunFields.stopped_time_sec.required).toBe(true);
+    });
+});
+
+describe('ghostFieldParsers — notes', () => {
+    it('shows a missing note as an empty field', () => {
+        expect(notesField.format(null)).toBe('');
+        expect(notesField.format('hi')).toBe('hi');
+    });
+
+    it('stores NULL rather than an empty string when the note is cleared', () => {
+        expect(notesField.toApi('')).toBe(SQL_NULL);
+        expect(notesField.toApi('   ')).toBe(SQL_NULL);
+    });
+
+    it('trims, so a note cannot carry invisible padding', () => {
+        expect(notesField.normalize('  a note  ')).toBe('a note');
+        expect(notesField.toApi('  a note  ')).toBe('a note');
+    });
+
+    it('never blocks a write — any text is a valid note', () => {
+        expect(notesField.validate('anything at all')).toBeNull();
+    });
+});
+
+describe('ghostFieldParsers — start_time', () => {
+    const rule = dateTimeField(TZ);
+
+    it('round-trips a stored UTC datetime through the local picker form', () => {
+        // 2026-03-15 18:30 UTC is 11:30 on the 15th in Los Angeles (PDT, UTC-7).
+        const local = rule.format('2026-03-15 18:30:00');
+        expect(local).toBe('2026-03-15T11:30');
+        expect(rule.toApi(local)).toBe('2026-03-15 18:30:00');
+    });
+
+    it('is required, because a half-typed datetime-local reads back as blank', () => {
+        // The input reports '' until every segment is filled. Under `required` that
+        // reverts visibly to the stored value; left to validate it would either
+        // write NULL over a NOT NULL column or paint an error mid-edit.
+        expect(rule.required).toBe(true);
+        expect(rule.validate('')).toBeNull();
+    });
+
+    it('does not throw on a malformed value', () => {
+        // fromDateTimeLocalValue() splits on 'T' and dereferences the time half
+        // unguarded. validate() runs on every keystroke and must not be the thing
+        // that takes the page down.
+        expect(() => rule.validate('not-a-date')).not.toThrow();
+        expect(rule.validate('not-a-date')).toBe('Enter a date and time');
+        expect(rule.toApi('not-a-date')).toBeNull();
+    });
+});

--- a/src/utils/ghostFieldParsers.js
+++ b/src/utils/ghostFieldParsers.js
@@ -1,0 +1,158 @@
+// Field rules for the editable map_runs columns (req #3073).
+//
+// The card view (RouteCards/RouteCard) and the table view (MapRuns/MapRunsView) edit
+// the SAME columns through two different controls, and before this module each
+// hand-rolled its own format / parse / isNaN check per field. That is exactly how the
+// two drifted: the table validated its Duration column and the card did not, the card
+// rendered a null stopped_time_sec as "00:00:00" while the table rendered it blank, and
+// both silently skipped the write when a value failed to parse. One rule per column,
+// used by both views, and the rule is unit-testable on its own.
+//
+// A rule is the vocabulary GhostTextField already speaks:
+//
+//   format(raw)      stored column value  → the text the field shows
+//   normalize(text)  committed text       → its canonical display form
+//   validate(text)   text                 → an error string, or null to allow the write
+//   toApi(text)      display text         → the value to PUT
+//   required         true when an emptied field must revert rather than write
+//
+// `validate` returns null for blank on purpose. Emptiness is not a parse failure, and
+// conflating the two would flash "Enter a number" the moment a user select-all-deletes
+// to retype. What happens to a blank is decided by `required` (revert) or by `toApi`
+// (write SQL NULL) — never by an error message.
+
+import { formatDuration, parseDuration } from './mapDataUtils';
+import { toDateTimeLocalValue, fromDateTimeLocalValue } from './dateFormat';
+
+// Lambda-Rest's PUT body is an array of column bags, so the only way to express SQL
+// NULL over JSON is this literal. See CLAUDE.md § Key Lessons.
+export const SQL_NULL = 'NULL';
+
+const isBlank = (text) => (text ?? '').trim() === '';
+
+/**
+ * Strict numeric read — deliberately `Number`, NOT `parseFloat`.
+ *
+ * The originals used `parseFloat`, which reads "12abc" as 12 and stored it without
+ * telling anybody. That is the silent-drop defect wearing a different hat: the user
+ * typed something the field did not understand and got a number back anyway. `Number`
+ * rejects the whole string, so it surfaces as a verdict instead.
+ */
+const asNumber = (text) => {
+    if (isBlank(text)) return NaN;
+    const n = Number(String(text).trim());
+    return Number.isFinite(n) ? n : NaN;
+};
+
+/** A decimal column rendered to a fixed number of places. */
+const decimal = ({ places = 1, required = false } = {}) => ({
+    required,
+    format: (raw) => (raw == null ? '' : Number(raw).toFixed(places)),
+    normalize: (text) => {
+        const n = asNumber(text);
+        return isNaN(n) ? text : n.toFixed(places);
+    },
+    validate: (text) => (isBlank(text) || !isNaN(asNumber(text)) ? null : 'Enter a number'),
+    toApi: (text) => (isBlank(text) ? SQL_NULL : asNumber(text)),
+});
+
+/** A whole-number column (feet of ascent / descent). */
+const integer = ({ required = false } = {}) => ({
+    required,
+    format: (raw) => (raw == null ? '' : String(Math.round(Number(raw)))),
+    normalize: (text) => {
+        const n = asNumber(text);
+        return isNaN(n) ? text : String(Math.round(n));
+    },
+    validate: (text) => (isBlank(text) || !isNaN(asNumber(text)) ? null : 'Enter a number'),
+    toApi: (text) => (isBlank(text) ? SQL_NULL : Math.round(asNumber(text))),
+});
+
+/** A seconds column edited as H:MM:SS (parseDuration also accepts M:SS and raw seconds). */
+const duration = ({ required = false } = {}) => ({
+    required,
+    // Null-guarded: the shared formatDuration() does not null-check and would render a
+    // missing duration as "00:00:00", which is a real value the row does not hold.
+    format: (raw) => (raw == null ? '' : formatDuration(raw)),
+    normalize: (text) => {
+        const s = parseDuration(text);
+        return isNaN(s) ? text : formatDuration(s);
+    },
+    validate: (text) => (isBlank(text) || !isNaN(parseDuration(text)) ? null : 'Use H:MM:SS'),
+    toApi: (text) => (isBlank(text) ? SQL_NULL : parseDuration(text)),
+});
+
+/** Free text stored as a nullable column — an emptied field means NULL, not ''. */
+export const notesField = {
+    required: false,
+    format: (raw) => raw || '',
+    normalize: (text) => text.trim(),
+    validate: () => null,
+    toApi: (text) => text.trim() || SQL_NULL,
+};
+
+/**
+ * A UTC DATETIME column edited in the user's timezone through an <input
+ * type="datetime-local">. Depends on the timezone, so it is a factory rather than a
+ * constant.
+ *
+ * `required: true` is load-bearing and is NOT interchangeable with a validate rule
+ * here. A datetime-local input whose segments are only partly filled reads back as
+ * '' from the DOM, so a half-typed date arrives at commit as an empty string. Under
+ * `required` that reverts to the stored value — visibly, in front of the user, which
+ * is the honest outcome. Left to `validate` instead it would either write SQL NULL
+ * over a NOT NULL column or paint an error under a field the user is still mid-way
+ * through filling in, once per keystroke.
+ */
+export const dateTimeField = (timezone) => {
+    // fromDateTimeLocalValue() assumes a well-formed 'YYYY-MM-DDTHH:MM' and throws on
+    // anything else (it splits on 'T' and dereferences the time half unguarded). A
+    // native datetime-local input only ever emits that shape or '', but validate() runs
+    // on every keystroke and must not be the thing that takes the page down.
+    const toUtc = (text) => {
+        try {
+            return fromDateTimeLocalValue(text, timezone);
+        } catch {
+            return null;
+        }
+    };
+    return {
+        required: true,
+        format: (raw) => toDateTimeLocalValue(raw, timezone),
+        normalize: (text) => text,
+        validate: (text) => (isBlank(text) || toUtc(text) ? null : 'Enter a date and time'),
+        toApi: toUtc,
+    };
+};
+
+/**
+ * The editable numeric/duration columns of map_runs.
+ *
+ * `required` mirrors what the two views already did rather than what the schema
+ * permits: distance and the two duration columns have never been writable as empty
+ * from either view, so an emptied field reverts. The rest send SQL NULL, which is
+ * also what both views already did.
+ */
+// `places` is the COLUMN's scale, not a display preference, and KEEPING IT THAT WAY
+// IS LOAD-BEARING. Both views used to show avg_speed_mph — DECIMAL(5,2) — to one
+// decimal, which is worse than cosmetic now that a field only writes a value the user
+// changed: normalize rounded 15.28 to 15.3, that equalled the displayed value, and the
+// commit short-circuited. A two-decimal average speed was unenterable from either view.
+//
+// The deeper reason to keep these in step: GhostTextField holds a committed value on
+// screen until the `value` prop moves off what the write was issued against. That rests
+// on every rule round-tripping — format(toApi(x)) === x. Let `places` drift below the
+// column's scale again and the server rounds the value straight back to the pre-edit
+// display string, the prop never moves, and the field stays on a value the database
+// does not hold instead of correcting itself one refetch later.
+export const mapRunFields = {
+    distance_mi: decimal({ places: 1, required: true }),     // DECIMAL(6,1) NOT NULL
+    avg_speed_mph: decimal({ places: 2 }),                   // DECIMAL(5,2) NULL
+    max_speed_mph: decimal({ places: 1 }),                   // DECIMAL(5,1) NULL
+    ascent_ft: integer(),
+    descent_ft: integer(),
+    run_time_sec: duration({ required: true }),
+    stopped_time_sec: duration({ required: true }),
+};
+
+export { decimal, integer, duration };

--- a/src/utils/ghostFieldStyles.js
+++ b/src/utils/ghostFieldStyles.js
@@ -1,9 +1,29 @@
-// Shared "ghost" InputBase styling: renders as plain text with a subtle hover/focus
-// underline affordance, so a field looks read-only until the user clicks into it.
-// Used by both the map Cards (RouteCard) and the Table view inline editors
-// (MapRuns/GhostCellEditors) so the in-place editing design is pixel-identical
-// across both views. Defined once here to prevent visual drift.
-export const ghostBase = {
+// Shared "ghost" field styling: a control renders as plain text with a subtle
+// hover/focus underline affordance, so it looks read-only until the user clicks into
+// it. Used by the shared GhostTextField (Components/GhostField) and by the two ghost
+// controls that are NOT text fields — the route/activity Select and the partners
+// Autocomplete in the Maps card and table views. Defined once here to prevent drift.
+//
+// THESE ARE THEME FUNCTIONS, not plain objects (req #3073). They used to be a literal
+// with `borderBottomColor: 'rgba(0,0,0,0.3)'` baked in, which is invisible against a
+// dark background — every ghost field in the app lost its hover affordance in dark
+// mode. Req #3063 spotted it and worked around it locally inside GhostTextField rather
+// than change an object it shared with the Maps views; this is the fix at the source.
+//
+// MUI's `sx` accepts a function of the theme, so `sx={ghostBase}` works directly and a
+// caller composing its own styles spreads `...ghostBase(theme)` from inside its own sx
+// callback.
+
+/**
+ * The hover underline. Not `theme.palette.divider` — that is a 12%-alpha hairline meant
+ * to separate regions, and as a hover affordance it reads as nothing happening.
+ */
+export const ghostUnderlineHover = (theme) => (
+    theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.4)' : 'rgba(0,0,0,0.3)'
+);
+
+/** The base ghost styling for an InputBase-shaped control. */
+export const ghostBase = (theme) => ({
     display: 'inline-flex',
     verticalAlign: 'baseline',
     fontSize: 'inherit',
@@ -21,7 +41,39 @@ export const ghostBase = {
         letterSpacing: 'inherit',
         borderBottom: '1px solid transparent',
         transition: 'border-bottom-color 150ms',
-        '&:hover': { borderBottomColor: 'rgba(0,0,0,0.3)' },
-        '&:focus': { outline: 'none', borderBottomColor: 'primary.main' },
+        '&:hover': { borderBottomColor: ghostUnderlineHover(theme) },
+        '&:focus': { outline: 'none', borderBottomColor: theme.palette.primary.main },
     },
-};
+});
+
+/**
+ * The same affordance for a `variant="standard"` Select. A Select paints its underline
+ * with ::before/::after pseudo-elements rather than a border on the input, so it cannot
+ * share `ghostBase` — only the colour rule is common, which is the part that was wrong
+ * in dark mode.
+ */
+export const ghostSelectBase = (theme) => ({
+    fontSize: 'inherit',
+    '& .MuiSelect-select': { py: 0, pr: '0 !important' },
+    '&:before': { borderBottomColor: 'transparent' },
+    '&:hover:not(.Mui-disabled):before': { borderBottomColor: ghostUnderlineHover(theme) },
+});
+
+/**
+ * The same affordance for the `variant="standard"` TextField that an Autocomplete
+ * renders as its input.
+ */
+export const ghostAutocompleteInputBase = (theme, { placeholderFontSize } = {}) => ({
+    '& .MuiInput-underline:before': { borderBottomColor: 'transparent' },
+    '& .MuiInput-underline:hover:not(.Mui-disabled, .Mui-error):before': {
+        borderBottomColor: ghostUnderlineHover(theme),
+    },
+    '& .MuiInputBase-input::placeholder': {
+        color: theme.palette.text.disabled,
+        opacity: 1,
+        // The card and the table sit at different type scales, and the placeholder
+        // is the one part of this that does not inherit.
+        ...(placeholderFontSize && { fontSize: placeholderFontSize }),
+    },
+    '& .MuiInputBase-root': { flexWrap: 'wrap', gap: 0.5 },
+});


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-07-26T23:15:33Z
- chore: init swarm session feature/3073-migrate-the-maps-ghost-editors-onto-1

## Files changed
```
 src/Components/GhostField/GhostTextField.jsx       | 173 ++++++++--
 .../__tests__/GhostTextFieldProps.test.jsx         | 210 ++++++++++++
 src/MapRuns/GhostCellEditors.jsx                   | 303 ++++++++--------
 src/MapRuns/MapRunsView.jsx                        |  47 ++-
 src/MapRuns/__tests__/GhostCellEditors.test.jsx    | 379 +++++++++++++++++++++
 src/RouteCards/RouteCard.jsx                       | 267 ++++++++-------
 src/utils/__tests__/ghostFieldParsers.test.js      | 183 ++++++++++
 src/utils/ghostFieldParsers.js                     | 158 +++++++++
 src/utils/ghostFieldStyles.js                      |  70 +++-
 9 files changed, 1444 insertions(+), 346 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)