### PR TITLE
Swarm Orchestration: final polish & showcase - full live 3083 plan in darwin_dev, dev-server walkthrough, executive summary

### DIFF
--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -85,12 +85,25 @@ const RequirementDetail = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const fromCalendar = location.state?.from === 'calendar';
+    // Req #3119: arriving from a plan (the plan table's requirement link or the
+    // visualizer's requirement label) must go BACK to that plan, not to the
+    // Roadmap. Without this the only exit from a requirement opened out of the
+    // visualizer was the Requirements cards view — a different page than the one
+    // the user left, so the plan (and the mode/layout toggles they had set) had
+    // to be found again by hand.
+    const fromPipelineId = location.state?.from === 'pipeline'
+        ? Number(location.state?.pipelineId) : null;
+    const hasPipelineOrigin = Number.isFinite(fromPipelineId) && fromPipelineId > 0;
     // "new" mode (req #2414): the user came from the aggregator template row.
     // No DB record exists yet — the requirement is POSTed only when the user
     // picks a category. Until then this page edits a purely local draft.
     const isNew = id === 'new';
-    const handleBack = () => navigate(fromCalendar ? '/calview' : '/swarm');
-    const backLabel = fromCalendar ? 'Back to Calendar' : 'Back to Roadmap';
+    const handleBack = () => {
+        if (hasPipelineOrigin) return navigate(`/swarm/pipeline/${fromPipelineId}`);
+        return navigate(fromCalendar ? '/calview' : '/swarm');
+    };
+    const backLabel = hasPipelineOrigin ? 'Back to Plan'
+        : (fromCalendar ? 'Back to Calendar' : 'Back to Roadmap');
     const { idToken, profile } = useContext(AuthContext);
     const timezone = profile?.timezone;
     const { darwinUri } = useContext(AppContext);
@@ -586,7 +599,7 @@ const RequirementDetail = () => {
                 <Tooltip title="Previous requirement" enterDelay={400}>
                     <span>
                         <IconButton
-                            onClick={() => navigate(`/swarm/requirement/${prevId}`)}
+                            onClick={() => navigate(`/swarm/requirement/${prevId}`, { state: location.state })}
                             disabled={!prevId}
                             data-testid="btn-prev-requirement"
                             sx={{ maxWidth: 25, maxHeight: 25 }}
@@ -598,7 +611,7 @@ const RequirementDetail = () => {
                 <Tooltip title="Next requirement" enterDelay={400}>
                     <span>
                         <IconButton
-                            onClick={() => navigate(`/swarm/requirement/${nextId}`)}
+                            onClick={() => navigate(`/swarm/requirement/${nextId}`, { state: location.state })}
                             disabled={!nextId}
                             data-testid="btn-next-requirement"
                             sx={{ maxWidth: 25, maxHeight: 25 }}

--- a/src/SwarmView/pipelines/PipelineCardsView.jsx
+++ b/src/SwarmView/pipelines/PipelineCardsView.jsx
@@ -20,12 +20,19 @@ import { machineTitle } from './pipelineViewModel';
 
 const EMPTY_SUMMARY = { total: 0, done: 0, running: 0, pending: 0 };
 
-export default function PipelineCardsView({ pipelines, summaries, machines, onOpen }) {
+export default function PipelineCardsView({ pipelines, summaries, machines, onOpen,
+    filtered = false }) {
     if (!pipelines.length) {
+        // "No pipelines yet" is a claim about the DATA, and it is false whenever
+        // a status filter is what emptied the view — the page's own accounting
+        // line says "0 of 2" two inches above it. Distinguish the two; an empty
+        // result the user caused should say so, and say how to undo it.
         return (
             <Typography variant="body2" color="text.secondary" sx={{ px: 1, py: 3 }}
                         data-testid="pipelines-cards-empty">
-                No pipelines yet.
+                {filtered
+                    ? 'No pipelines match this status filter — choose All to see them.'
+                    : 'No pipelines yet.'}
             </Typography>
         );
     }

--- a/src/SwarmView/pipelines/PipelineDetail.jsx
+++ b/src/SwarmView/pipelines/PipelineDetail.jsx
@@ -20,22 +20,29 @@
 // refetchInterval — a poll here would be the POC's manual regenerate step wearing
 // a different hat.
 
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
+import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Link from '@mui/material/Link';
-import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
+import call_rest_api from '../../RestApi/RestApi';
+import { useSnackBarStore } from '../../stores/useSnackBarStore';
+import { pipelineKeys } from '../../hooks/useQueryKeys';
+import AppContext from '../../Context/AppContext';
 import AuthContext from '../../Context/AuthContext';
+import '../../CalendarFC/CalendarFC.css';
 import {
     ALL_ROWS,
     useAllEpics,
@@ -78,6 +85,79 @@ import {
 // honest in the error path the costError branch exists to handle.
 const EMPTY = Object.freeze([]);
 
+// ── Editable pipeline description (req #3119) ───────────────────────────────
+// The plan's goal text is the one field on this page a human authors, and it was
+// read-only prose. It is now the house edit-in-place field: an outlined
+// TextField whose notched "Description" label sits on the top-left border, saved
+// on blur, exactly like the requirement description.
+//
+// Local draft + save-on-blur rather than a controlled write per keystroke: the
+// query cache is the source of truth and re-rendering the whole plan on every
+// character would re-run the ordering engine.
+//
+// The draft ADOPTS a server value that arrives or changes later, but only while
+// the field is clean. Seeding state once at mount is the standard version of
+// this component and it has a data-loss shape: if the row is rendered before its
+// description is in hand, the draft is '' forever, and the next edit-and-blur
+// writes that '' over real text. `savedRef` doubles as the clean/dirty marker —
+// equal to `draft` means untouched since the last known-good value.
+function PipelineDescription({ pipeline }) {
+    const { idToken, profile } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
+    const queryClient = useQueryClient();
+    const showError = useSnackBarStore((s) => s.showError);
+    const incoming = pipeline.description || '';
+    const [draft, setDraft] = useState(incoming);
+    const savedRef = useRef(incoming);
+
+    useEffect(() => {
+        if (incoming === savedRef.current) return;   // nothing new from the server
+        if (draft !== savedRef.current) return;      // user is mid-edit — never clobber
+        savedRef.current = incoming;
+        setDraft(incoming);
+    }, [incoming, draft]);
+
+    const save = () => {
+        const value = draft;
+        if (value === savedRef.current) return;      // nothing changed — no write
+        savedRef.current = value;
+        call_rest_api(`${darwinUri}/pipelines`, 'PUT',
+            [{ id: pipeline.id, description: value }], idToken)
+            .then((result) => {
+                const code = result?.httpStatus?.httpStatus;
+                if (code !== 200 && code !== 204) {
+                    showError(result, 'Unable to update the pipeline description');
+                } else {
+                    queryClient.invalidateQueries({
+                        queryKey: pipelineKeys.all(profile?.userName) });
+                }
+            })
+            .catch((error) => showError(error, 'Unable to update the pipeline description'));
+    };
+
+    return (
+        <TextField
+            label="Description"
+            variant="outlined"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={save}
+            fullWidth
+            multiline
+            minRows={1}
+            maxRows={4}
+            size="small"
+            autoComplete="off"
+            // House spacing for a description block (RequirementDetail uses a
+            // full `mb: 2` unit around its own): the field was sitting flush
+            // against the header row above and the plan below, which is the one
+            // thing that made it read as chrome rather than content.
+            sx={{ mt: 2, mb: 3, maxWidth: 1100 }}
+            data-testid="pipeline-goal"
+        />
+    );
+}
+
 export default function PipelineDetail() {
     const { id } = useParams();
     const navigate = useNavigate();
@@ -88,6 +168,22 @@ export default function PipelineDetail() {
 
     const [mode, setMode] = useViewPreference(
         PIPELINE_DETAIL_MODE_STORAGE_KEY, DEFAULT_PIPELINE_DETAIL_MODE);
+
+    // ── Mode toolbar state, OWNED HERE (req #3119) ──────────────────────────
+    // The controls render in the header row beside the pipeline name — the
+    // SwarmView/VisualizerToolbar arrangement (req #2407), where the panel is the
+    // canvas and the page owns the chrome. That is what buys the visualizer a
+    // full-height canvas: every row of chrome it used to carry is now shared.
+    const [showCost, setShowCost] = useState(false);
+    const [reqLayoutPref, setReqLayoutPref] = useViewPreference(
+        'darwin-pipeline-viz-req-layout', 'horizontal');
+    const [stepLabelPref, setStepLabelPref] = useViewPreference(
+        'darwin-pipeline-viz-step-label', 'id');
+    const [colorKeyPref, setColorKeyPref] = useViewPreference(
+        'darwin-pipeline-viz-color-key', 'state');
+    const reqLayout = reqLayoutPref === 'vertical' ? 'vertical' : 'horizontal';
+    const stepLabel = stepLabelPref === 'title' ? 'title' : 'id';
+    const colorKey = colorKeyPref === 'machine' ? 'machine' : 'state';
 
     // Req #3115 cross-mode handshake: a bead click in the Plan visualizer lands
     // the user on the SAME step in the table — the visualizer calls
@@ -179,6 +275,18 @@ export default function PipelineDetail() {
         [model, costIndex]);
     const summary = useMemo(() => pipelineSummary(plan.rows), [plan.rows]);
 
+    // Every distinct machine the plan's steps actually touch, derived from the
+    // requirements (design rule 10's level). Sorted for a stable chip.
+    const planMachines = useMemo(() => {
+        const seen = [];
+        for (const row of plan.rows || []) {
+            for (const label of row.machineLabels || []) {
+                if (!seen.includes(label)) seen.push(label);
+            }
+        }
+        return seen.sort((a, b) => a.localeCompare(b));
+    }, [plan.rows]);
+
     if (isLoading) {
         return (
             <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
@@ -204,8 +312,20 @@ export default function PipelineDetail() {
     const ActiveComponent = (findPipelineDetailMode(activeMode)
         || PIPELINE_DETAIL_MODES[0]).Component;
 
+    // `minWidth: 0` is load-bearing, not tidiness (req #3119 polish pass). This
+    // Box is an item of the `.app-layout` CSS grid, whose items default to
+    // `min-width: auto` — "never shrink below your content". The plan table is
+    // ~1640px of NOWRAP columns, so on the real 41-step plan this Box grew past
+    // its grid track and took the WHOLE PAGE into horizontal scroll: measured
+    // 187px of document overflow at 1680px wide and 427px at 1440px, dragging the
+    // nav rail and header sideways with it. The TableContainer already carries
+    // `overflow-x: auto` and `min-width: 0` and was never getting the chance to
+    // use them — it cannot scroll content that its own ancestor widened to fit.
+    // One property restores what PipelinePlanTable's GroupCell comment already
+    // claims happens ("The TableContainer scrolls instead"), and it is scoped to
+    // this page: nothing else reads it.
     return (
-        <Box sx={{ p: 3 }} data-testid="pipeline-detail">
+        <Box sx={{ p: 3, minWidth: 0 }} data-testid="pipeline-detail">
             <Breadcrumbs sx={{ mb: 1 }}>
                 <Link component="button" variant="body2" underline="hover"
                       onClick={() => navigate('/swarm/pipelines')}
@@ -215,6 +335,11 @@ export default function PipelineDetail() {
                 <Typography variant="body2" color="text.primary">{pipeline.title}</Typography>
             </Breadcrumbs>
 
+            {/* ONE header row (req #3119): mode switch, name, the accounting line
+                immediately right of the name, then the active mode's controls and
+                the status chips. Everything the plan used to stack above itself
+                now shares this line, which is what leaves room for a full-height
+                canvas below. */}
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap',
                         mb: 1 }}>
                 <ToggleButtonGroup
@@ -227,7 +352,7 @@ export default function PipelineDetail() {
                 >
                     {PIPELINE_DETAIL_MODES.map(({ value, label, icon: Icon, disabled }) => (
                         <ToggleButton key={value} value={value} disabled={disabled}
-                                      sx={{ px: 2 }}
+                                      className="cal-toggle-btn" sx={{ px: 1.5 }}
                                       data-testid={`pipeline-mode-${value}`}>
                             <Tooltip title={`${label} view`}>
                                 <Icon fontSize="small" />
@@ -236,46 +361,93 @@ export default function PipelineDetail() {
                     ))}
                 </ToggleButtonGroup>
 
-                <Typography variant="h6" sx={{ flex: 1 }} data-testid="pipeline-title">
+                <Typography variant="h6" sx={{ flexShrink: 0 }} data-testid="pipeline-title">
                     {pipeline.title}
                 </Typography>
+
+                {/* Accounting — the whole plan, never a filtered view
+                    (view-switchable-pages § V7). */}
+                <Typography variant="body2" color="text.secondary" sx={{ flexShrink: 0 }}
+                            data-testid="pipeline-accounting">
+                    {summary.total} step{summary.total === 1 ? '' : 's'} —{' '}
+                    {summary.done} complete · {summary.running} running ·{' '}
+                    {summary.pending} scheduled
+                    {pipeline.started_at
+                        ? ` · started ${formatDateTime(pipeline.started_at, timezone)}` : ''}
+                    {pipeline.completed_at
+                        ? ` · completed ${formatDateTime(pipeline.completed_at, timezone)}` : ''}
+                </Typography>
+
+                <Box sx={{ flexGrow: 1 }} />
+
+                {activeMode === 'table' ? (
+                    <Button
+                        size="small"
+                        className="cal-toggle-btn"
+                        variant={showCost ? 'contained' : 'outlined'}
+                        onClick={() => setShowCost((v) => !v)}
+                        data-testid="pipeline-cost-toggle"
+                    >
+                        Time / Tokens
+                    </Button>
+                ) : (
+                    <>
+                        <ToggleButtonGroup value={reqLayout} exclusive size="small"
+                                           onChange={(_e, v) => v && setReqLayoutPref(v)}
+                                           data-testid="pipeline-viz-reqlayout-toggle">
+                            <ToggleButton value="horizontal" className="cal-toggle-btn">
+                                Reqs: Horizontal
+                            </ToggleButton>
+                            <ToggleButton value="vertical" className="cal-toggle-btn">
+                                Reqs: Vertical
+                            </ToggleButton>
+                        </ToggleButtonGroup>
+                        <ToggleButtonGroup value={stepLabel} exclusive size="small"
+                                           onChange={(_e, v) => v && setStepLabelPref(v)}
+                                           data-testid="pipeline-viz-steplabel-toggle">
+                            <ToggleButton value="id" className="cal-toggle-btn">
+                                Step: ID
+                            </ToggleButton>
+                            <ToggleButton value="title" className="cal-toggle-btn">
+                                Step: Title
+                            </ToggleButton>
+                        </ToggleButtonGroup>
+                        {/* Machine colours the REQUIREMENT IDS, not the beads —
+                            the bead's fill is derived state and stays that. */}
+                        <ToggleButtonGroup value={colorKey} exclusive size="small"
+                                           onChange={(_e, v) => v && setColorKeyPref(v)}
+                                           data-testid="pipeline-viz-colorkey-toggle">
+                            <ToggleButton value="state" className="cal-toggle-btn">
+                                State
+                            </ToggleButton>
+                            <ToggleButton value="machine" className="cal-toggle-btn">
+                                Machine
+                            </ToggleButton>
+                        </ToggleButtonGroup>
+                    </>
+                )}
 
                 <Chip size="small" label={pipeline.pipeline_status}
                       {...pipelineStatusChipProps(pipeline.pipeline_status)}
                       data-testid="pipeline-status-chip" />
-                <Chip size="small" variant="outlined"
-                      label={machineTitle(pipeline.machine_fk, machines)}
-                      data-testid="pipeline-machine-chip" />
+                {/* The machine chip reports what the PLAN ACTUALLY SPANS, not
+                    just `pipelines.machine_fk` (req #3119). The stored field is a
+                    single id, and the live Substrate plan runs 25 steps on the
+                    Mac mini, 6 on the WSL box and 8 unpinned — so a bare "Mac
+                    mini" here read as "this plan is Mac-mini only", which is how
+                    the discrepancy was noticed. One machine still prints its
+                    name; more prints the count and names them on hover. */}
+                <Tooltip title={planMachines.length > 1
+                    ? `Steps run on: ${planMachines.join(', ')}` : ''}>
+                    <Chip size="small" variant="outlined"
+                          label={planMachines.length > 1
+                              ? `${planMachines.length} machines`
+                              : (planMachines[0] || machineTitle(pipeline.machine_fk, machines))}
+                          data-testid="pipeline-machine-chip" />
+                </Tooltip>
             </Box>
 
-            {pipeline.description && (
-                <Typography variant="body2" color="text.secondary"
-                            sx={{ mb: 1, maxWidth: 900 }}
-                            data-testid="pipeline-goal">
-                    {pipeline.description}
-                </Typography>
-            )}
-
-            {/* Accounting line — the whole plan, never the filtered view
-                (view-switchable-pages § V7). */}
-            <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: 'wrap' }}
-                   alignItems="center" data-testid="pipeline-accounting">
-                <Typography variant="body2" color="text.secondary">
-                    {summary.total} step{summary.total === 1 ? '' : 's'} —{' '}
-                    {summary.done} complete · {summary.running} running ·{' '}
-                    {summary.pending} scheduled
-                </Typography>
-                {pipeline.started_at && (
-                    <Typography variant="body2" color="text.secondary">
-                        · started {formatDateTime(pipeline.started_at, timezone)}
-                    </Typography>
-                )}
-                {pipeline.completed_at && (
-                    <Typography variant="body2" color="text.secondary">
-                        · completed {formatDateTime(pipeline.completed_at, timezone)}
-                    </Typography>
-                )}
-            </Stack>
+            <PipelineDescription pipeline={pipeline} />
 
             {dictionaryError && (
                 <Alert severity="error" variant="outlined" sx={{ mb: 2 }}
@@ -289,7 +461,10 @@ export default function PipelineDetail() {
 
             <ActiveComponent plan={plan} model={model} pipeline={pipeline} timezone={timezone}
                              focusStepId={focusStepId} onStepFocus={onStepFocus}
-                             costError={!!costError} />
+                             costError={!!costError}
+                             showCost={showCost}
+                             reqLayout={reqLayout} stepLabel={stepLabel} colorKey={colorKey}
+                             />
         </Box>
     );
 }

--- a/src/SwarmView/pipelines/PipelinePlanTable.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanTable.jsx
@@ -52,7 +52,8 @@ import {
     rowMachineLabel,
     batchMachineLabel,
     formatTimeGates,
-    stepProse,
+    stepName,
+    stepDescription,
 } from './pipelineViewModel';
 import {
     stepStateLabel,
@@ -82,6 +83,12 @@ const COL = {
     cost: 96,
     epic: 190,
     feature: 170,
+    // The step NAME (req #3119) — its own column, because a name and a
+    // description answer different questions and the plan is skimmed by name.
+    // Sized to the live plan's longest ("Guiding Principles and Data Refactor",
+    // 36 chars) without flexing: a name column that reflows on content would
+    // make the whole grid jump between plans.
+    name: 210,
     reqs: 168,
     deps: 200,
 };
@@ -223,7 +230,7 @@ function BatchBannerRow({ batch, colSpan, timezone }) {
 
 // ── Requirement(s) cell ─────────────────────────────────────────────────────
 // Ids link to their own detail page and carry NO '#' (production directive).
-function RequirementLinks({ row }) {
+function RequirementLinks({ row, pipelineId }) {
     if (!row.reqIds.length) return <span>—</span>;
     return (
         <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
@@ -232,6 +239,9 @@ function RequirementLinks({ row }) {
                     key={id}
                     component={RouterLink}
                     to={`/swarm/requirement/${id}`}
+                    // Provenance, so the detail page's Back returns to THIS plan
+                    // rather than the Roadmap (req #3119).
+                    state={pipelineId ? { from: 'pipeline', pipelineId } : undefined}
                     underline="hover"
                     sx={{ fontFamily: 'monospace' }}
                     data-testid={`pipeline-req-link-${id}`}
@@ -265,18 +275,18 @@ function GroupCell({ show, value, labels, width, color, testid }) {
     return extra ? <Tooltip title={`All: ${extra}`}>{cell}</Tooltip> : cell;
 }
 
-export default function PipelinePlanTable({ plan, timezone, focusStepId,
-    costError = false }) {
-    // The POC shipped with the Cost column HIDDEN (`<body class="hidecost">`) and
-    // a "Time / Tokens" button to reveal it. Same default here: cost is a
-    // secondary question about a plan whose primary job is showing what runs
-    // next, and the column is the widest thing that can be added to a row that
-    // already carries nine.
+export default function PipelinePlanTable({ plan, pipeline, timezone, focusStepId,
+    costError = false, showCost = false }) {
+    // `showCost` is OWNED BY THE PAGE since req #3119 — the Time / Tokens control
+    // renders in the header row beside the pipeline name, with the visualizer's
+    // toggles, so both modes put their controls in one place.
     //
-    // The values are REAL as of req #3117 — `row.cost` comes from the server-side
-    // rollup (migration 20260727052402) via two bounded list reads, not from the
+    // It still defaults OFF, as the POC did (`<body class="hidecost">`): cost is a
+    // secondary question about a plan whose primary job is showing what runs next,
+    // and the column is the widest thing that can be added to a row already
+    // carrying ten. The values are REAL as of req #3117 — `row.cost` comes from
+    // the server-side rollup via two bounded list reads, not from the
     // per-requirement fan-out that got the POC's version disabled.
-    const [showCost, setShowCost] = useState(false);
 
     const renderRows = useMemo(() => planRenderRows(plan), [plan]);
     const hasBatches = (plan.batches || []).length > 0;
@@ -293,7 +303,8 @@ export default function PipelinePlanTable({ plan, timezone, focusStepId,
 
     // Column count for the banner colSpan — must track the Cost column's
     // visibility or the banner under-spans and leaves a ragged edge.
-    const colSpan = 9 + (showCost ? 1 : 0);
+    // 10 fixed columns since the Name column landed (req #3119).
+    const colSpan = 10 + (showCost ? 1 : 0);
 
     if (!renderRows.length) {
         return (
@@ -316,15 +327,11 @@ export default function PipelinePlanTable({ plan, timezone, focusStepId,
                 key={(plan.proposals || []).map((p) => p.stepIds.join('-')).join('|')}
                 proposals={plan.proposals || []} />
 
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1, flexWrap: 'wrap' }}>
-                <Button
-                    size="small"
-                    variant={showCost ? 'contained' : 'outlined'}
-                    onClick={() => setShowCost((v) => !v)}
-                    data-testid="pipeline-cost-toggle"
-                >
-                    Time / Tokens
-                </Button>
+            {/* The Time / Tokens control moved to the page header row (req
+                #3119). What stays here is the pair of things that describe THIS
+                table: the cost-read failure notice and the batch legend. */}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1, flexWrap: 'wrap',
+                        minHeight: (showCost && costError) || hasBatches ? undefined : 0 }}>
                 {showCost && costError && (
                     <Typography variant="caption" color="error"
                                 data-testid="pipeline-cost-error">
@@ -352,6 +359,7 @@ export default function PipelinePlanTable({ plan, timezone, focusStepId,
                     <TableHead>
                         <TableRow>
                             <TableCell sx={{ ...NOWRAP, width: COL.step }}>Step</TableCell>
+                            <TableCell sx={{ ...NOWRAP, width: COL.name }}>Name</TableCell>
                             <TableCell sx={{ ...NOWRAP, width: COL.status }}>Status</TableCell>
                             <TableCell sx={{ ...NOWRAP, width: COL.run }}>Run</TableCell>
                             <TableCell sx={{ ...NOWRAP, width: COL.machine }}>Machine</TableCell>
@@ -404,7 +412,8 @@ export default function PipelinePlanTable({ plan, timezone, focusStepId,
                             // deliberately permits).
                             const depIds = row.depIds.map(String);
                             const timeGates = formatTimeGates(row.timeDeps, timezone);
-                            const prose = stepProse(row);
+                            const name = stepName(row);
+                            const description = stepDescription(row);
                             return (
                                 <TableRow
                                     key={row.id}
@@ -484,19 +493,27 @@ export default function PipelinePlanTable({ plan, timezone, focusStepId,
                                                labels={row.featureLabels} width={COL.feature}
                                                color="#0f9b8e"
                                                testid={`pipeline-feature-${row.id}`} />
+                                    {/* Name — the step's own short label. Wraps
+                                        rather than clipping (two lines at most
+                                        for this plan's longest), and a name that
+                                        a legacy row made prose-length is cut with
+                                        the full string on hover. */}
+                                    <TableCell sx={{ width: COL.name, fontWeight: 600 }}
+                                               data-testid={`pipeline-name-${row.id}`}>
+                                        {name.truncated ? (
+                                            <Tooltip title={name.full}>
+                                                <span>{name.text}</span>
+                                            </Tooltip>
+                                        ) : name.text}
+                                    </TableCell>
                                     <TableCell sx={{ width: COL.reqs }}>
-                                        <RequirementLinks row={row} />
+                                        <RequirementLinks row={row} pipelineId={pipeline?.id} />
                                     </TableCell>
                                     <TableCell sx={{ minWidth: 340 }}>
-                                        <Typography variant="body2">{prose.text}</Typography>
-                                        {prose.notes && (
-                                            <Typography variant="caption"
-                                                        color="text.secondary"
-                                                        sx={{ display: 'block', mt: 0.5 }}
-                                                        data-testid={`pipeline-notes-${row.id}`}>
-                                                {prose.notes}
-                                            </Typography>
-                                        )}
+                                        <Typography variant="body2"
+                                                    data-testid={`pipeline-notes-${row.id}`}>
+                                            {description}
+                                        </Typography>
                                     </TableCell>
                                     <TableCell sx={{ ...NOWRAP, width: COL.deps,
                                                       color: 'text.secondary' }}

--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -47,11 +47,8 @@ import { zoom as d3zoom, zoomIdentity } from 'd3-zoom';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
-import ToggleButton from '@mui/material/ToggleButton';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
 
-import { useViewPreference } from '../../hooks/useViewPreference';
 import { semanticLevel } from '../konvaSwarmModel';
 import {
     formatTimeGates, rowMachineLabel, batchMachineLabel, STEP_RUNNING,
@@ -65,8 +62,6 @@ import {
 } from './pipelinePlanLayout';
 import '../../CalendarFC/swarmVisualizer.css';
 
-const REQ_LAYOUT_KEY = 'darwin-pipeline-viz-req-layout';
-const STEP_LABEL_KEY = 'darwin-pipeline-viz-step-label';
 const MONO = '"SF Mono", "JetBrains Mono", Menlo, monospace';
 
 const LEVEL_NAME = { out: 'Overview', mid: 'Plan', in: 'Detail' };
@@ -88,12 +83,45 @@ function LegendDot({ fill, ring, dashed, label }) {
     );
 }
 
-export default function PipelinePlanVisualizer({ plan, timezone, onStepFocus }) {
+// Machine colours for the requirement ids (req #3119) — the high-contrast
+// ecosystem pairing (user directive 2026-07-27): each machine reads as its
+// PLATFORM at a glance, so the two are told apart by association rather than by
+// consulting a key.
+//
+// Keyed on `machines.platform`, NOT on position in the plan's machine list. A
+// positional palette makes a machine's colour depend on which OTHER machines a
+// plan happens to use, so the Mac mini would be one colour on a two-machine plan
+// and another on a three-machine one — and the whole value of an ecosystem
+// pairing is that it is the same everywhere.
+const MACHINE_MAC_COLOR = '#FF5F56';       // Apple traffic-light red
+const MACHINE_WINDOWS_COLOR = '#0078D4';   // Microsoft blue
+const MACHINE_ANY_COLOR = '#8fa4c4';       // no pin — not a machine
+// A machine outside the pairing still has to be distinguishable, so it takes a
+// hue that is neither ecosystem colour.
+const MACHINE_FALLBACK_PALETTE = ['#8ce99a', '#c8a2ff', '#6ee7e7', '#ffb86b', '#f78ca0'];
+
+// Which ecosystem a MACHINE ROW belongs to. Colour is resolved per machine id —
+// the requirement carries `machine_fk` and that id decides the colour — but the
+// id itself says nothing about the ecosystem, so the machine record does.
+// `platform` first because it is the field that means this; hostname/title only
+// as a backstop, since a machine registered without a platform would otherwise
+// silently drop out of the pairing into a fallback hue.
+function machineEcosystem(machine) {
+    const hay = `${machine?.platform || ''} ${machine?.title || ''} ${machine?.hostname || ''}`
+        .toLowerCase();
+    if (/darwin|mac|osx|os x/.test(hay)) return 'mac';
+    if (/wsl|win32|windows|cygwin|msys|mchp/.test(hay)) return 'windows';
+    return null;
+}
+
+export default function PipelinePlanVisualizer({
+    plan, model, pipeline, timezone, onStepFocus,
+    // Toolbar state is OWNED BY THE PAGE since req #3119 — the controls render in
+    // the header row beside the pipeline name (the SwarmView/VisualizerToolbar
+    // pattern, req #2407), so the panel is the canvas and nothing else.
+    reqLayout = 'horizontal', stepLabel = 'id', colorKey = 'state',
+}) {
     const navigate = useNavigate();
-    const [reqLayoutPref, setReqLayoutPref] = useViewPreference(REQ_LAYOUT_KEY, 'horizontal');
-    const [stepLabelPref, setStepLabelPref] = useViewPreference(STEP_LABEL_KEY, 'id');
-    const reqLayout = reqLayoutPref === 'vertical' ? 'vertical' : 'horizontal';
-    const stepLabel = stepLabelPref === 'title' ? 'title' : 'id';
 
     const rows = plan.rows || [];
     const rowById = useMemo(() => new Map(rows.map((r) => [r.id, r])), [rows]);
@@ -101,9 +129,58 @@ export default function PipelinePlanVisualizer({ plan, timezone, onStepFocus }) 
         () => new Map((plan.batches || []).map((b) => [b.letter, b])), [plan.batches]);
     const eligibleStepIds = plan.eligibleStepIds || new Set();
 
+    // Requirement name + status for the hover tooltip (req #3119). The canvas
+    // keeps drawing bare IDS — a plan title is many times the width of the
+    // column it hangs under, so putting names on the surface either shrinks them
+    // to nothing or blows the layout apart. The name belongs on demand.
+    // From the SAME light projection the page already read; no extra fetch.
+    const reqInfo = useMemo(
+        () => new Map((model?.requirements || [])
+            .map((r) => [r.id, { title: r.title, status: r.requirement_status }])),
+        [model]);
     const layout = useMemo(
         () => computePlanLayout(rows, plan.batches || [], { reqLayout, stepLabel }),
         [rows, plan.batches, reqLayout, stepLabel]);
+
+    // ── Machine identity on the REQUIREMENT IDS (req #3119) ─────────────────
+    // Machine rides the requirement ids, never the bead: the bead's fill already
+    // carries derived state (rule 1), and repainting it would trade that reading
+    // for this one. Colour + weight, so the distinction survives at small sizes.
+    //
+    // Colour comes from the machine's PLATFORM, so it is the same on every plan.
+    const machineView = useMemo(() => {
+        const reqMachine = new Map((model?.requirements || [])
+            .map((r) => [r.id, r.machine_fk == null ? null : r.machine_fk]));
+        const machineById = new Map((model?.machines || []).map((m) => [m.id, m]));
+        const titleById = new Map((model?.machines || []).map((m) => [m.id, m.title]));
+        const used = [...new Set([...reqMachine.values()].filter((v) => v != null))]
+            .sort((a, b) => a - b);
+        let fallbackNext = 0;
+        const colorById = new Map(used.map((id) => {
+            const eco = machineEcosystem(machineById.get(id));
+            if (eco === 'mac') return [id, MACHINE_MAC_COLOR];
+            if (eco === 'windows') return [id, MACHINE_WINDOWS_COLOR];
+            const c = MACHINE_FALLBACK_PALETTE[fallbackNext % MACHINE_FALLBACK_PALETTE.length];
+            fallbackNext += 1;
+            return [id, c];
+        }));
+        const anyPresent = [...reqMachine.values()].some((v) => v == null);
+        return {
+            colorOf: (reqId) => {
+                const m = reqMachine.get(reqId);
+                return m == null ? MACHINE_ANY_COLOR : (colorById.get(m) || MACHINE_ANY_COLOR);
+            },
+            legend: [
+                ...used.map((id) => ({
+                    key: id, color: colorById.get(id),
+                    label: titleById.get(id) || `Machine ${id}`,
+                })),
+                ...(anyPresent
+                    ? [{ key: 'any', color: MACHINE_ANY_COLOR, label: 'Any' }] : []),
+            ],
+        };
+    }, [model]);
+    const byMachine = colorKey === 'machine';
 
     // The container is tracked as STATE, not a bare ref: with an empty plan the
     // component returns the empty panel and no container exists — if the first
@@ -130,6 +207,25 @@ export default function PipelinePlanVisualizer({ plan, timezone, onStepFocus }) 
         setSize({ w: containerEl.clientWidth, h: containerEl.clientHeight });
         return () => ro.disconnect();
     }, [containerEl]);
+
+    // The canvas fills whatever is left below it, MEASURED (req #3119). A
+    // `calc(100vh - Npx)` constant — which is what the swarm canvas can afford,
+    // because its chrome is fixed — assumes this page's header height, and this
+    // page's header is not fixed: the breadcrumb, a one- or two-line description,
+    // and an order-violations alert that appears only on some plans all move it.
+    // Guessing put the panel 57px below the fold on the live plan. `top` does not
+    // depend on the panel's own height, so writing height from it cannot loop.
+    const [availH, setAvailH] = useState(null);
+    useLayoutEffect(() => {
+        if (!containerEl) return undefined;
+        const recompute = () => {
+            const { top } = containerEl.getBoundingClientRect();
+            setAvailH(Math.max(480, Math.round(window.innerHeight - top - 14)));
+        };
+        recompute();
+        window.addEventListener('resize', recompute);
+        return () => window.removeEventListener('resize', recompute);
+    }, [containerEl, plan, colorKey, reqLayout, stepLabel]);
 
     // Fit-to-width base scale — the POC page rendered the whole plan across the
     // panel; kBase is that view, and semanticLevel(curK / kBase) matches the
@@ -246,6 +342,10 @@ export default function PipelinePlanVisualizer({ plan, timezone, onStepFocus }) 
         const p = e?.target?.getStage?.()?.getPointerPosition?.();
         if (p && batch) setCard({ x: p.x, y: p.y, kind: 'batch', batch });
     }, [batchByLetter]);
+    const showReqCard = useCallback((reqId, e) => {
+        const p = e?.target?.getStage?.()?.getPointerPosition?.();
+        if (p) setCard({ x: p.x, y: p.y, kind: 'req', reqId, info: reqInfo.get(reqId) });
+    }, [reqInfo]);
     const hideCard = useCallback(() => setCard(null), []);
 
     if (!rows.length) {
@@ -264,6 +364,84 @@ export default function PipelinePlanVisualizer({ plan, timezone, onStepFocus }) 
 
     const hasBatchBoxes = layout.batchBoxes.length > 0;
 
+    // ── Floating epic labels (req #3119, prototype item 3) ──────────────────
+    // The epic name rides its band's top edge, CLAMPS to the top of the viewport
+    // while any part of the band is visible, and slides away only as the band's
+    // bottom passes. Static world text scrolls off the moment you pan into a tall
+    // band, and a full-height canvas makes bands taller — so on the live plan you
+    // could be four screens deep in a band with nothing on screen saying which.
+    //
+    // HTML overlay rather than a Konva node: the clamp is a per-frame position
+    // that has nothing to do with the world transform, and computing it here
+    // keeps the world purely a function of the layout. `pointerEvents: 'none'` on
+    // the strip so it never eats a drag-pan; the label itself re-enables them so
+    // the epic stays clickable (production directive).
+    const LABEL_H = 20;      // the HTML chip's own height, in SCREEN px
+    const CHAR_W = 7.3;      // 12px bold mono, for the width estimate
+    const floatingEpics = layout.bands.map((band) => {
+        // Band geometry in SCREEN space.
+        const top = t.y + band.y * t.k;
+        const bottom = t.y + (band.y + band.height) * t.k;
+        const headerBottom = t.y + (band.y + band.headerH) * t.k;
+        const left = t.x + 2 * t.k;
+        const right = t.x + (layout.width - 2) * t.k;
+        // Off-screen on EITHER axis means no label. Vertical alone was not
+        // enough: panning far right leaves a band's rectangle entirely to the
+        // left of the panel, and clamping x into a rectangle that is off-screen
+        // puts the label off-screen with it — correct, but it should simply not
+        // render. (Caught by the pan sweep, which found three labels at negative
+        // x after a -1100px drag.)
+        if (bottom < 0 || top > size.h) return null;
+        if (right < 0 || left > size.w) return null;
+
+        // VERTICAL: confined to the band's HEADER STRIP, never into lane space.
+        //
+        // The strip is the only part of the epic rectangle that holds no step
+        // content, so this is what "must not overlap another swim lane's text"
+        // reduces to. It also keeps the label inside its own rectangle at both
+        // ends, which a plain viewport clamp did not: a band whose bottom edge
+        // had scrolled just past the top of the view still parked its label at
+        // the viewport top, i.e. below its own band.
+        //
+        // The label is sized in SCREEN px while the header is reserved in WORLD
+        // px — that mismatch is the actual cause of the overlap. At fit zoom
+        // (k≈0.67) a 40+14pxworld header is only ~36px on screen, and the label is
+        // 20 of them; zoom out further and the strip becomes shorter than the
+        // label, so the clamp below pins to the strip's TOP and lets it extend
+        // over the band's own first lane rather than over a neighbouring band.
+        const minY = top + 3;
+        const maxY = Math.max(minY, headerBottom - LABEL_H - 2);
+        const y = Math.min(Math.max(4, minY), maxY);
+        // WHOLLY on screen or not at all. Testing only the label's TOP left a
+        // band whose header strip ends 2px above the panel floor rendering a
+        // label that hung 2px past it.
+        if (y < 0 || y + LABEL_H > size.h) return null;
+
+        // HORIZONTAL: inside the band rectangle too, so a pan never leaves the
+        // label hanging in the margin beside the plan it labels.
+        const estW = band.epic.length * CHAR_W + 18;
+        // Confine to the part of the band that is BOTH inside the rectangle and
+        // on screen. When the band has scrolled far enough that its visible
+        // sliver is narrower than the label, there is no honest position left:
+        // clamping to the rectangle alone hangs the label off the panel edge
+        // (measured at x=-40 after a -1200px drag), and clamping to the panel
+        // alone puts it outside the rectangle. Hide it instead — the band is
+        // leaving anyway.
+        const visLeft = Math.max(0, left);
+        const visRight = Math.min(size.w, right);
+        if (visRight - visLeft < estW + 12) return null;
+        const x = Math.min(Math.max(visLeft + 6, left + 6), right - estW - 6);
+
+        return {
+            key: band.key == null ? 'none' : band.key,
+            epicId: band.epicId,
+            text: band.epic,
+            color: band.color,
+            x,
+            y,
+        };
+    }).filter(Boolean);
+
     // ── World-space nodes ───────────────────────────────────────────────────
     const worldNodes = [];
 
@@ -276,7 +454,9 @@ export default function PipelinePlanVisualizer({ plan, timezone, onStepFocus }) 
                   height={band.height} cornerRadius={8}
                   stroke={band.color} strokeWidth={1} opacity={0.35} />);
         for (let l = 0; l < band.sub; l++) {
-            const wy = band.y + band.headerH + l * band.pitch + 10;
+            // band.laneY, not l × pitch — lanes have individual heights since
+            // req #3119 and a constant-pitch wire would drift off its beads.
+            const wy = band.y + band.headerH + band.laneY[l] + 10;
             worldNodes.push(
                 <Line key={`wire-${band.key}-${l}`}
                       points={[36, wy, layout.width - 14, wy]}
@@ -343,10 +523,34 @@ export default function PipelinePlanVisualizer({ plan, timezone, onStepFocus }) 
             if (level === 'out') return;
             worldNodes.push(
                 <Text key={`lbl-${i}`} x={label.x} y={label.y} text={label.text}
-                      fontSize={F.req} fontFamily={MONO} fill={P.req}
-                      onMouseEnter={(e) => cursorPointer(e, true)}
-                      onMouseLeave={(e) => cursorPointer(e, false)}
-                      onActivate={() => navigate(`/swarm/requirement/${label.reqId}`)} />);
+                      fontSize={F.req} fontFamily={MONO}
+                      // Machine colour + bold on the ids themselves. Applied on
+                      // the SAME node in both requirement layouts — the SVG
+                      // prototype coloured only the horizontal one, because a
+                      // `text { fill }` CSS rule beat the attribute on <text> but
+                      // never reached its <tspan> children. Konva has no tspans,
+                      // so the cause cannot recur here; the symptom is asserted
+                      // against both layouts anyway.
+                      // WHITE by default, machine colour when that key is on
+                      // (user directive 2026-07-27). A requirement number is an
+                      // identifier, and colouring it was reading as a status —
+                      // status already lives in the bead's fill and the row
+                      // highlight, which is where it belongs. The palette's
+                      // `req` blue is retained for anything that wants it, but
+                      // the id itself no longer carries a second signal.
+                      fill={byMachine ? machineView.colorOf(label.reqId) : P.text}
+                      fontStyle={byMachine ? 'bold' : 'normal'}
+                      onMouseEnter={(e) => { cursorPointer(e, true); showReqCard(label.reqId, e); }}
+                      onMouseLeave={(e) => { cursorPointer(e, false); hideCard(); }}
+                      // Carry the plan's identity so the requirement page's Back
+                      // returns HERE and not to the Roadmap (req #3119). The
+                      // mode/layout/label toggles restore themselves — they are
+                      // useViewPreference — so landing back on this route is
+                      // enough to resume the view; only pan/zoom re-fits.
+                      onActivate={() => navigate(`/swarm/requirement/${label.reqId}`,
+                          pipeline?.id
+                              ? { state: { from: 'pipeline', pipelineId: pipeline.id } }
+                              : undefined)} />);
         } else if (label.kind === 'title') {
             if (level !== 'in') return;
             worldNodes.push(
@@ -354,17 +558,8 @@ export default function PipelinePlanVisualizer({ plan, timezone, onStepFocus }) 
                       fontSize={F.title} fontFamily={MONO} fill={P.dim}
                       listening={false} />);
         } else if (label.kind === 'epic') {
-            const clickable = label.epicId != null;
-            worldNodes.push(
-                <Text key={`lbl-${i}`} x={label.x} y={label.y} text={label.text}
-                      fontSize={F.epic} fontFamily={MONO} fontStyle="bold"
-                      fill={(layout.bands.find((b) => b.epicId === label.epicId) || {}).color || P.text}
-                      onMouseEnter={clickable ? (e) => cursorPointer(e, true) : undefined}
-                      onMouseLeave={clickable ? (e) => cursorPointer(e, false) : undefined}
-                      onActivate={clickable
-                          ? () => navigate(`/swarm/features?epic=${label.epicId}`)
-                          : undefined}
-                      listening={clickable} />);
+            // Drawn as an HTML overlay below, not in the world — see
+            // `floatingEpics`. Nothing is pushed here.
         } else if (label.kind === 'batch') {
             worldNodes.push(
                 <Text key={`lbl-${i}`} x={label.x} y={label.y} text={label.text}
@@ -385,47 +580,10 @@ export default function PipelinePlanVisualizer({ plan, timezone, onStepFocus }) 
         <Box>
             <OrderViolationsAlert plan={plan} />
 
-            {/* Toolbar: the two POC layout toggles + the legend. */}
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1,
-                        flexWrap: 'wrap' }}>
-                <ToggleButtonGroup value={reqLayout} exclusive size="small"
-                                   onChange={(_e, v) => v && setReqLayoutPref(v)}
-                                   data-testid="pipeline-viz-reqlayout-toggle">
-                    <ToggleButton value="horizontal" sx={{ px: 1.5, textTransform: 'none' }}>
-                        Reqs: Horizontal
-                    </ToggleButton>
-                    <ToggleButton value="vertical" sx={{ px: 1.5, textTransform: 'none' }}>
-                        Reqs: Vertical
-                    </ToggleButton>
-                </ToggleButtonGroup>
-                <ToggleButtonGroup value={stepLabel} exclusive size="small"
-                                   onChange={(_e, v) => v && setStepLabelPref(v)}
-                                   data-testid="pipeline-viz-steplabel-toggle">
-                    <ToggleButton value="id" sx={{ px: 1.5, textTransform: 'none' }}>
-                        Step: ID
-                    </ToggleButton>
-                    <ToggleButton value="title" sx={{ px: 1.5, textTransform: 'none' }}>
-                        Step: Title
-                    </ToggleButton>
-                </ToggleButtonGroup>
-                <Box sx={{ flexGrow: 1 }} />
-                <Stack direction="row" spacing={1.5} alignItems="center" flexWrap="wrap"
-                       useFlexGap>
-                    <LegendDot fill={P.doneFill} label="Complete" />
-                    <LegendDot fill={P.runningFill} label="Running" />
-                    <LegendDot fill={P.pendingFill} ring="#5b7293" label="Scheduled" />
-                    <LegendDot ring={P.manualRing} label="Manual" />
-                    <LegendDot ring={P.eligibleRing} label="eligible now" />
-                    {/* Batch key ONLY when a batch box is actually drawn —
-                        production directive, kept from the POC. */}
-                    {hasBatchBoxes && (
-                        <Box data-testid="pipeline-viz-batch-legend">
-                            <LegendDot ring={P.batch} dashed
-                                       label="launch batch = one /swarm-start" />
-                        </Box>
-                    )}
-                </Stack>
-            </Box>
+            {/* The layout toggles moved into the page header row (req #3119).
+                What stays with the canvas is the LEGEND — it describes the marks
+                on this surface and nothing else — and it now floats INSIDE the
+                panel, so it costs the plan no vertical space. */}
 
             {/* `data-transform` mirrors the world transform d3-zoom computes.
                 The canvas is a bitmap, so pan and zoom are otherwise only
@@ -437,8 +595,13 @@ export default function PipelinePlanVisualizer({ plan, timezone, onStepFocus }) 
                 purpose as the `pipeline-viz-zoom-level` chip beside it. */}
             <Box ref={setContainer} data-testid="pipeline-plan-visualizer"
                  data-transform={`${t.x.toFixed(2)},${t.y.toFixed(2)},${t.k.toFixed(4)}`}
-                 sx={{ position: 'relative', height: 'calc(100vh - 350px)',
-                        minHeight: 460, overflow: 'hidden', borderRadius: '8px',
+                 // Full-page canvas (req #3119), the KonvaSwarmCanvas figure
+                 // verbatim. It only fits because the page header collapsed to
+                 // one row: the toggles, the accounting line and the legend all
+                 // left this column.
+                 sx={{ position: 'relative',
+                        height: availH ? `${availH}px` : 'calc(100vh - 260px)',
+                        minHeight: 480, overflow: 'hidden', borderRadius: '8px',
                         border: `1px solid ${P.line}`, background: P.panel,
                         touchAction: 'none' }}>
                 {size.w > 0 && (
@@ -450,6 +613,72 @@ export default function PipelinePlanVisualizer({ plan, timezone, onStepFocus }) 
                         </Layer>
                     </Stage>
                 )}
+
+                {/* Floating epic labels — pinned to their band, clamped to the
+                    top of the viewport while the band is on screen. The strip
+                    ignores the pointer so it can never swallow a drag-pan; each
+                    label re-enables it so the epic stays clickable. */}
+                <Box sx={{ position: 'absolute', inset: 0, pointerEvents: 'none',
+                            overflow: 'hidden' }}
+                     data-testid="pipeline-viz-epic-layer">
+                    {floatingEpics.map((e) => (
+                        <Box
+                            key={e.key}
+                            onClick={e.epicId != null
+                                ? () => navigate(`/swarm/features?epic=${e.epicId}`) : undefined}
+                            data-testid={`pipeline-viz-epic-${e.key}`}
+                            sx={{
+                                position: 'absolute', left: e.x, top: e.y,
+                                height: 20, lineHeight: '14px',
+                                display: 'flex', alignItems: 'center',
+                                fontFamily: MONO, fontSize: 12, fontWeight: 700,
+                                color: e.color,
+                                // OPAQUE, not a wash: the chip sits over the
+                                // canvas, and a translucent one let whatever is
+                                // behind it read through the epic name.
+                                background: P.panel,
+                                px: 0.9, py: 0.2, borderRadius: '5px',
+                                border: `1px solid ${e.color}55`,
+                                whiteSpace: 'nowrap', userSelect: 'none',
+                                pointerEvents: e.epicId != null ? 'auto' : 'none',
+                                cursor: e.epicId != null ? 'pointer' : 'default',
+                            }}
+                        >
+                            {e.text}
+                        </Box>
+                    ))}
+                </Box>
+
+                {/* Legend, floated into the panel so it costs the plan no height. */}
+                <Stack direction="row" spacing={1.25} alignItems="center" flexWrap="wrap"
+                       useFlexGap
+                       data-testid="pipeline-viz-legend"
+                       sx={{ position: 'absolute', top: 8, right: 10,
+                              background: 'rgba(13, 20, 32, 0.82)',
+                              px: 1, py: 0.4, borderRadius: '10px',
+                              pointerEvents: 'none', userSelect: 'none', maxWidth: '70%' }}>
+                    {byMachine ? (
+                        machineView.legend.map((m) => (
+                            <LegendDot key={m.key} fill={m.color} label={m.label} />
+                        ))
+                    ) : (
+                        <>
+                            <LegendDot fill={P.doneFill} label="Complete" />
+                            <LegendDot fill={P.runningFill} label="Running" />
+                            <LegendDot fill={P.pendingFill} ring="#5b7293" label="Scheduled" />
+                            <LegendDot ring={P.manualRing} label="Manual" />
+                            <LegendDot ring={P.eligibleRing} label="eligible now" />
+                        </>
+                    )}
+                    {/* Batch key ONLY when a batch box is actually drawn —
+                        production directive, kept from the POC. */}
+                    {hasBatchBoxes && (
+                        <Box data-testid="pipeline-viz-batch-legend">
+                            <LegendDot ring={P.batch} dashed
+                                       label="launch batch = one /swarm-start" />
+                        </Box>
+                    )}
+                </Stack>
 
                 <Box sx={{ position: 'absolute', bottom: 8, right: 10, fontSize: 11,
                             color: P.dim, background: 'rgba(0,0,0,0.45)',
@@ -502,7 +731,20 @@ function PlanDataCard({ card, timezone, level, containerW, containerH }) {
     );
 
     let body;
-    if (card.kind === 'batch') {
+    if (card.kind === 'req') {
+        // Requirement hover (req #3119): the NAME and the STATUS, which is what
+        // an id alone cannot tell you. Deliberately not on the canvas — see the
+        // reqInfo comment. Requirement status is the requirement's OWN field, not
+        // the step state derived from it, so it is shown verbatim.
+        const info = card.info || {};
+        body = (
+            <div className="ts-datacard">
+                <div className="ts-datacard-title">{card.reqId}</div>
+                {rowEl('Name', info.title || '(untitled)')}
+                {rowEl('Status', info.status || 'unknown')}
+            </div>
+        );
+    } else if (card.kind === 'batch') {
         const b = card.batch;
         const timeGates = formatTimeGates(b.timeDeps, timezone);
         body = (

--- a/src/SwarmView/pipelines/PipelinesPage.jsx
+++ b/src/SwarmView/pipelines/PipelinesPage.jsx
@@ -148,11 +148,14 @@ export default function PipelinesPage() {
                 </Stack>
 
                 {/* Accounting line counts the WHOLE dataset, with the filtered
-                    subset named separately (V7). */}
+                    subset named separately (V7). The call-to-action names what
+                    the ACTIVE view actually shows — "click a row" is wrong
+                    advice in Cards, where the click target is a card. */}
                 <Typography variant="caption" sx={{ color: 'text.secondary' }}
                             data-testid="pipelines-accounting">
                     {filtered.length} of {pipelines.length} pipeline
-                    {pipelines.length === 1 ? '' : 's'} — click a row for the plan
+                    {pipelines.length === 1 ? '' : 's'} — click a{' '}
+                    {activeView === 'table' ? 'row' : 'card'} for the plan
                 </Typography>
 
                 <Box sx={{ flexGrow: 1 }} />
@@ -173,6 +176,7 @@ export default function PipelinesPage() {
                         summaries={summaries}
                         machines={machines}
                         onOpen={open}
+                        filtered={statusFilter !== null}
                     />
                 )}
             </Box>

--- a/src/SwarmView/pipelines/__tests__/pipelineModel.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineModel.test.js
@@ -22,8 +22,16 @@ import { PLAN_JSON_ROWS, SUBSTRATE_REBUILD_MODEL } from './substrateRebuildFixtu
 // Both golden orders pass the archived verify_order.
 const E1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 21, 10, 26, 25, 28, 11, 22, 16, 23, 33,
     12, 13, 14, 19, 38, 34, 39, 40, 41, 43, 42, 17, 18, 31, 20];
-const E2 = [1, 2, 3, 4, 5, 6, 8, 9, 7, 21, 10, 26, 25, 28, 11, 22, 16, 23, 33,
-    12, 13, 14, 19, 38, 34, 39, 40, 41, 43, 42, 17, 18, 31, 20];
+// There used to be a SECOND expectation here, E2, identical to E1 except that
+// step 7 sorted three places later (…6, 8, 9, 7, 21… instead of …6, 7, 8, 9…).
+// It existed because the req-less step 7 derived NO epic — rule 10 attaches
+// labels to requirements and step 7 links none — and epic order is a tie-break
+// in displayOrder, so the product's own output disagreed with the POC's on the
+// one row where the POC read the label straight off the plan.
+//
+// req #3119 closed that gap: a req-less step now INHERITS its dependencies'
+// dominant label (see buildPlanRows), so the full derivation reproduces E1
+// exactly and there is one expected order again, not two.
 
 const PLAN_STATE = { done: STEP_DONE, active: STEP_RUNNING, pending: STEP_PENDING };
 
@@ -70,10 +78,15 @@ describe('POC parity — the archived generate.py output is the contract', () =>
         expect(verifyOrder(result.rows)).toEqual([]);
     });
 
-    it('reproduces E2 over the table-shaped fixture via full derivation', () => {
+    // The stronger form of the parity contract: derivation from the TABLE-SHAPED
+    // fixture — junction rows, requirement statuses, feature→epic chains — must
+    // land on the same order as the POC reading the PLAN-JSON's own columns.
+    // Same expectation as E1, deliberately: two orders would mean the product
+    // and its own acceptance fixture disagree about the plan.
+    it('reproduces E1 over the table-shaped fixture via full derivation', () => {
         const rows = buildPlanRows(SUBSTRATE_REBUILD_MODEL);
         const result = displayOrder(rows);
-        expect(ids(result.rows)).toEqual(E2);
+        expect(ids(result.rows)).toEqual(E1);
         expect(result.cycleDetected).toBe(false);
         expect(verifyOrder(result.rows)).toEqual([]);
     });
@@ -86,19 +99,39 @@ describe('POC parity — the archived generate.py output is the contract', () =>
         }
     });
 
-    it('derives every fixture epic/feature label equal to the PLAN-JSON labels ' +
-       '(null for the req-less step 7)', () => {
+    it('derives every fixture epic/feature label equal to the PLAN-JSON labels, '
+       + 'the req-less step 7 included', () => {
         const byId = new Map(buildPlanRows(SUBSTRATE_REBUILD_MODEL).map((r) => [r.id, r]));
         for (const planRow of PLAN_JSON_ROWS) {
             const derived = byId.get(Number(planRow.step));
-            if (planRow.reqs.length === 0) {
-                expect(derived.epic).toBeNull();
-                expect(derived.feature).toBeNull();
-            } else {
-                expect(derived.epic, `step ${planRow.step}`).toBe(planRow.epic);
-                expect(derived.feature, `step ${planRow.step}`).toBe(planRow.feature);
-            }
+            expect(derived.epic, `step ${planRow.step}`).toBe(planRow.epic);
+            expect(derived.feature, `step ${planRow.step}`).toBe(planRow.feature);
         }
+    });
+
+    // The mechanism behind that, stated on its own so a regression names itself:
+    // step 7 links no requirement, so it has nothing of its own to derive from
+    // and borrows from step 6 — which is what the plan itself records for it.
+    it('a req-less step inherits its dependency label, and claims no label set', () => {
+        const byId = new Map(buildPlanRows(SUBSTRATE_REBUILD_MODEL).map((r) => [r.id, r]));
+        const seven = byId.get(7);
+        expect(seven.reqIds).toEqual([]);
+        expect(seven.depIds).toEqual([6]);
+        expect(seven.epic).toBe(byId.get(6).epic);
+        expect(seven.feature).toBe(byId.get(6).feature);
+        // Borrowed, not spanned: the label SETS stay empty, so the "spans more
+        // than one epic" tooltip never fires on an inherited label.
+        expect(seven.epicLabels).toEqual([]);
+        expect(seven.featureLabels).toEqual([]);
+    });
+
+    it('a step with its OWN requirements never inherits from a dependency', () => {
+        const byId = new Map(buildPlanRows(SUBSTRATE_REBUILD_MODEL).map((r) => [r.id, r]));
+        // Step 19 spans epics by design (rule 10) and gates step 38, which sits
+        // under a different epic; 38 must keep its own, not 19's.
+        expect(byId.get(38).depIds).toEqual([19]);
+        expect(byId.get(38).epic).toBe('Swarm Orchestration Feature');
+        expect(byId.get(38).epicLabels.length).toBeGreaterThan(0);
     });
 
     it('joins dependencies faithfully (spot checks)', () => {
@@ -157,6 +190,52 @@ describe('verifyOrder — each invariant caught on a seeded bad input', () => {
         expect(violations.some((v) => v.invariant === 'state-banding'
             && v.stepIds[0] === 2)).toBe(true);
     });
+
+    // Design rule 3 orders its criteria "topological, THEN state bands", so
+    // topology WINS. When a step's own gate sits in a later band, no ordering
+    // satisfies both and dependency-first is the only correct answer — reporting
+    // it was the checker being stricter than the rule, and it fired on every
+    // render of the live plan (step 19 Running gates step 38 Complete).
+    it('invariant 2: a band inversion FORCED by a dependency is not a violation', () => {
+        const gate = row(19, STEP_RUNNING);
+        const dependent = row(38, STEP_DONE, [19]);
+        const violations = verifyOrder([gate, dependent]);
+        expect(violations.filter((v) => v.invariant === 'state-banding')).toEqual([]);
+        // ...and the order is topologically sound, so nothing else fires either.
+        expect(violations).toEqual([]);
+    });
+
+    it('invariant 2: transitively forced inversions are accepted too', () => {
+        const violations = verifyOrder([
+            row(1, STEP_RUNNING),
+            row(2, STEP_DONE, [1]),
+            row(3, STEP_DONE, [2]),
+        ]);
+        expect(violations).toEqual([]);
+    });
+
+    it('invariant 2: an inversion the order did NOT have to make is still caught', () => {
+        // Same shape, minus the dependency — step 38 could have rendered first,
+        // so the sink is a real ordering defect. This is the 4th regression the
+        // invariant was built for: state losing to stream grouping.
+        const violations = verifyOrder([row(19, STEP_RUNNING), row(38, STEP_DONE)]);
+        const banding = violations.filter((v) => v.invariant === 'state-banding');
+        expect(banding).toHaveLength(1);
+        expect(banding[0].stepIds).toEqual([38, 19]);
+    });
+
+    it('invariant 2: depending on ONE running row does not excuse sinking below another',
+        () => {
+            // 38 must follow 19 (dependency). It need not follow 20, and does.
+            const violations = verifyOrder([
+                row(19, STEP_RUNNING),
+                row(20, STEP_RUNNING),
+                row(38, STEP_DONE, [19]),
+            ]);
+            const banding = violations.filter((v) => v.invariant === 'state-banding');
+            expect(banding).toHaveLength(1);
+            expect(banding[0].stepIds).toEqual([38, 20]);
+        });
 
     it('invariant 3 (batch contiguity): a split launch batch is caught', () => {
         const a = row(3, STEP_PENDING, [1]);

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -161,18 +161,30 @@ describe('chain lanes with cross-column reservation', () => {
 
     it('continues a chain along its dependency lane when the lane is free', () => {
         // Same-band chain inside "Swarm Substrate Rebuild": 10 → 26 → 25 (25
-        // gates on both). Each link should inherit its dependency's lane. (The
-        // 6 → 7 link canNOT be asserted here: step 7 links no requirements, so
-        // the engine derives no epic for it and it lives in the 'No epic' band —
-        // chain-lane inheritance is same-band by design.)
+        // gates on both). Each link should inherit its dependency's lane.
         const n10 = layout.nodes.get(10);
         const n26 = layout.nodes.get(26);
         const n25 = layout.nodes.get(25);
         expect(n26.lane).toBe(n10.lane);
         expect(n25.lane).toBe(n26.lane);
-        // And the req-less step really is banded separately.
-        const bandOf7 = layout.bands[layout.nodes.get(7).bandIndex];
-        expect(bandOf7.epicId).toBeNull();
+    });
+
+    it('the req-less step bands with the epic it inherits, and its chain holds', () => {
+        // This assertion used to read the other way: step 7 links no
+        // requirements, derived no epic, and sat alone in a 'No epic' band —
+        // which put a single bead in a band of its own between the two epics it
+        // belongs between, and broke the 6 → 7 chain because lane inheritance is
+        // same-band by design. req #3119: a req-less step inherits its
+        // dependencies' label, so both the band and the chain now hold.
+        const n6 = layout.nodes.get(6);
+        const n7 = layout.nodes.get(7);
+        const band6 = layout.bands[n6.bandIndex];
+        const band7 = layout.bands[n7.bandIndex];
+        expect(band7.epicId).toBe(band6.epicId);
+        expect(band7.epic).toBe('Swarm Substrate Rebuild');
+        expect(n7.lane).toBe(n6.lane);
+        // No 'No epic' band survives on this fixture at all.
+        expect(layout.bands.filter((b) => b.epicId == null)).toEqual([]);
     });
 });
 
@@ -194,16 +206,78 @@ describe('zero label overlap — all four layout/label combinations', () => {
             }
         });
 
-        it(`step/req/title labels stay inside their column slab (${name})`, () => {
+        // Column containment is now KIND-DEPENDENT (req #3119). Requirement ids
+        // still live strictly inside their column. The two STAGGERED kinds —
+        // the title slot, and the step label in title mode — are placed one line
+        // off on odd columns precisely so they may reach into their neighbours,
+        // which is what buys a readable title without a 5800px-wide world. Their
+        // guarantee is not "inside the slab" but "reaches no further than a
+        // bounded fraction of one neighbour", which combined with the parity
+        // offset is what makes the no-two-labels-intersect test above pass.
+        it(`req labels stay inside their column slab (${name})`, () => {
             const layout = computePlanLayout(plan.rows, plan.batches, opts);
             for (const label of layout.labels) {
-                if (label.stepId == null) continue;
+                if (label.stepId == null || label.kind !== 'req') continue;
                 const n = layout.nodes.get(label.stepId);
                 const left = layout.colX[n.depth] - layout.colW[n.depth] / 2;
                 const right = layout.colX[n.depth] + layout.colW[n.depth] / 2;
                 expect(label.x).toBeGreaterThanOrEqual(left - 0.01);
                 expect(label.x + label.w).toBeLessThanOrEqual(right + 0.01);
             }
+        });
+
+        // Assert the PAIRWISE property the module actually promises, not the
+        // per-label budget it is derived from. The first version of this test
+        // asserted "each label fits its budget and is centred on its column",
+        // which is exactly the placement rule — so it agreed with a budget that
+        // admitted a 40px overlap and could never have contradicted it (found in
+        // review). A per-label invariant that implies nothing about pairs is not
+        // coverage for a pairwise guarantee.
+        it(`no two same-line staggered labels overlap, at any column width (${name})`, () => {
+            const check = (rows, batches, label) => {
+                const layout = computePlanLayout(rows, batches, opts);
+                const staggered = layout.labels.filter((l) => l.stepId != null
+                    && (l.kind === 'title'
+                        || (l.kind === 'step' && opts.stepLabel === 'title')));
+                for (let i = 0; i < staggered.length; i++) {
+                    for (let j = i + 1; j < staggered.length; j++) {
+                        const a = staggered[i];
+                        const b = staggered[j];
+                        // Same line ⇒ same y. Different lines cannot collide.
+                        if (Math.abs(a.y - b.y) > 0.01) continue;
+                        const overlap = a.x < b.x + b.w && b.x < a.x + a.w;
+                        if (overlap) {
+                            throw new Error(`${label}: staggered labels overlap on one line — `
+                                + `${JSON.stringify(a)} vs ${JSON.stringify(b)}`);
+                        }
+                    }
+                }
+            };
+            check(plan.rows, plan.batches, `fixture (${name})`);
+            // The fixture's columns happen to be near-uniform. The failure mode
+            // needs WIDE outer columns around a NARROW shared one, so construct
+            // it: one chain (⇒ one lane, ⇒ same line for d and d+2) whose ends
+            // carry many requirement ids and whose middle carries one.
+            const wide = [5001, 5002, 5003, 5004, 5005].map((id, i) => ({
+                id,
+                title: 'A step title long enough to want the whole budget',
+                run: 'auto',
+                notes: null,
+                state: 'pending',
+                reqIds: (i === 0 || i === 4)
+                    ? [3001, 3002, 3003, 3004, 3005] : [3001],
+                depIds: i === 0 ? [] : [5000 + i],
+                timeDeps: [],
+                epicId: 1,
+                epic: 'E',
+                featureId: 1,
+                feature: 'F',
+                epicLabels: [{ id: 1, title: 'E' }],
+                featureLabels: [{ id: 1, title: 'F' }],
+                machineLabels: [],
+                machineLabel: '',
+            }));
+            check(wide, [], `wide-outer-columns (${name})`);
         });
     }
 
@@ -456,7 +530,7 @@ describe('step labels', () => {
     it('title mode truncates long titles with an ellipsis', () => {
         const long = 'x'.repeat(80);
         const label = stepLabelText({ id: 1, title: long }, 'title');
-        expect(label.length).toBeLessThanOrEqual(40);
+        expect(label.length).toBeLessThanOrEqual(60);
         expect(label.endsWith('…')).toBe(true);
     });
 });

--- a/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
@@ -17,6 +17,8 @@ import {
     rowMachineLabel,
     batchMachineLabel,
     stepProse,
+    stepName,
+    stepDescription,
     formatTimeGate,
     formatTimeGates,
 } from '../pipelineViewModel';
@@ -651,5 +653,73 @@ describe('orderedPlan attaches cost to every row', () => {
         const costed = orderedPlan(model(), { now: NOW, costIndex });
         expect(costed.rows.map((r) => r.id)).toEqual(bare.rows.map((r) => r.id));
         expect(costed.violations).toEqual([]);
+    });
+});
+
+// ── Name vs description (req #3119) ─────────────────────────────────────────
+// A title is a NAME. The darwin_dev seed used to load a truncated summary into
+// pipeline_steps.title, so a "name" could be a paragraph; the generator now
+// loads the plan's own short title. These two functions are what keeps the Name
+// column from becoming a second copy of the description either way.
+
+describe('stepName — the Name column', () => {
+    it('returns a short title unchanged and unflagged', () => {
+        expect(stepName({ title: 'Session Drain' }))
+            .toEqual({ text: 'Session Drain', full: 'Session Drain', truncated: false });
+    });
+
+    it('em-dashes a missing, empty or whitespace-only title', () => {
+        for (const row of [null, undefined, {}, { title: '' }, { title: '   ' }]) {
+            expect(stepName(row)).toEqual({ text: '—', full: '', truncated: false });
+        }
+    });
+
+    it('trims surrounding whitespace rather than counting it toward the cut', () => {
+        expect(stepName({ title: '  Green Baseline  ' }).full).toBe('Green Baseline');
+    });
+
+    it('cuts a prose-length legacy title at a word boundary, keeping the full text', () => {
+        const legacy = 'Seven parallel sessions on the proven substrate: house dialog '
+            + 'pattern under /agents, IntegrityError-to-409 mapping';
+        const out = stepName(legacy && { title: legacy });
+        expect(out.truncated).toBe(true);
+        expect(out.full).toBe(legacy);
+        expect(out.text.endsWith('…')).toBe(true);
+        expect(out.text.length).toBeLessThanOrEqual(48);
+        // Word boundary: nothing but the ellipsis after the last space.
+        expect(out.text.slice(0, -1).endsWith(' ')).toBe(false);
+        expect(legacy.startsWith(out.text.slice(0, -1))).toBe(true);
+    });
+
+    it('falls back to a hard cut when the first 48 chars hold no space', () => {
+        const out = stepName({ title: 'x'.repeat(80) });
+        expect(out.truncated).toBe(true);
+        expect(out.text).toBe(`${'x'.repeat(47)}…`);
+    });
+
+    it('honours an explicit max', () => {
+        expect(stepName({ title: 'Session Drain' }, 8).text).toBe('Session…');
+    });
+});
+
+describe('stepDescription — the "What this step does" column', () => {
+    it('prints the notes, never the name repeated', () => {
+        expect(stepDescription({ title: 'Session Drain', notes: 'Drain: close every session' }))
+            .toBe('Drain: close every session');
+    });
+
+    it('prints a SHORT supplementary note alone — the Name column carries the title', () => {
+        expect(stepDescription({ title: 'Green Baseline', notes: 'Blocked on the snapshot gate.' }))
+            .toBe('Blocked on the snapshot gate.');
+    });
+
+    it('falls back to the title when there is no description at all', () => {
+        expect(stepDescription({ title: 'Green Baseline', notes: null })).toBe('Green Baseline');
+        expect(stepDescription({ title: 'Green Baseline', notes: '   ' })).toBe('Green Baseline');
+    });
+
+    it('is empty, never a crash, on a row with neither', () => {
+        expect(stepDescription({})).toBe('');
+        expect(stepDescription(null)).toBe('');
     });
 });

--- a/src/SwarmView/pipelines/pipelineModel.js
+++ b/src/SwarmView/pipelines/pipelineModel.js
@@ -248,11 +248,51 @@ export function buildPlanRows(model) {
         if (d.dep_step_fk != null) bucket.depIds.push(d.dep_step_fk);
         else if (d.time_at != null) bucket.timeDeps.push(d.time_at);
     }
+    // Rule 10 attaches labels to REQUIREMENTS, so a step that links none derives
+    // no epic at all. For a gate or a baseline — the whole reason `completed_at`
+    // exists — that is technically true and visually wrong: the plan's step 7,
+    // "Green Baseline", recorded the regression baseline for the substrate work
+    // it gates, and banding it under "No epic" put a lone bead in a band of its
+    // own between the epics it belongs between.
+    //
+    // So a req-less step INHERITS the dominant label of its dependencies, walking
+    // back until it finds one. That keeps rule 10 intact where the rule has an
+    // opinion — nothing is stored, and a step with requirements still derives
+    // from them and only them — while giving a step whose whole job is to gate
+    // other work the label of the work it gates. Ambiguity resolves the same way
+    // it does everywhere else here: the first dependency, in dep order.
+    const labelCache = new Map();
+    const inheritedLabels = (stepId, seen) => {
+        if (labelCache.has(stepId)) return labelCache.get(stepId);
+        if (seen.has(stepId)) return null;   // cycle guard
+        seen.add(stepId);
+        const step = (model.steps || []).find((s) => s.id === stepId);
+        if (!step) return null;
+        const own = dominantLabels(step, model);
+        if (own.epicId != null || own.featureId != null) {
+            labelCache.set(stepId, own);
+            return own;
+        }
+        for (const depId of (depsByStep.get(stepId) || { depIds: [] }).depIds) {
+            const up = inheritedLabels(depId, seen);
+            if (up && (up.epicId != null || up.featureId != null)) {
+                // Inherited, so the FULL label sets stay empty: those drive the
+                // "spans more than one epic" tooltip, and this step spans
+                // nothing — it borrowed one label from upstream.
+                const borrowed = { ...up, epicLabels: [], featureLabels: [], inherited: true };
+                labelCache.set(stepId, borrowed);
+                return borrowed;
+            }
+        }
+        labelCache.set(stepId, own);
+        return own;
+    };
+
     return (model.steps || []).map((step) => {
         const reqIds = linkedReqIds(step.id, model);
         const linked = reqIds.map((rid) => reqsById.get(rid)).filter(Boolean);
         const unresolvedReqIds = reqIds.filter((rid) => !reqsById.has(rid));
-        const labels = dominantLabels(step, model);
+        const labels = inheritedLabels(step.id, new Set()) || dominantLabels(step, model);
         const machines = machineLabels(step, model);
         const deps = depsByStep.get(step.id) || { depIds: [], timeDeps: [] };
         return {
@@ -565,20 +605,59 @@ export function verifyOrder(rows) {
         }
     }
 
-    // Invariant 2: absolute state banding — done > running > pending.
-    let lastBand = 0;
-    for (const r of rows) {
-        const band = STATE_RANK[r.state] != null ? STATE_RANK[r.state] : 2;
-        if (band < lastBand) {
+    // Invariant 2: state banding — done > running > pending — SUBORDINATE TO
+    // TOPOLOGY.
+    //
+    // Design rule 3 orders the criteria: "topological, THEN state bands, then
+    // streams". Topology wins, and displayOrder implements exactly that — it only
+    // ever emits a row whose dependencies are already out. So when a step's GATE
+    // is in a later band than the step itself, NO ordering satisfies both rules
+    // and the one displayOrder picks (dependency first) is the right one.
+    //
+    // Checking banding as if it were absolute reported that forced case as a
+    // failure. On the live plan it fired every render: step 19 derives Running
+    // (it links the plan's own tracking requirement, #3083 — see req #3123) and
+    // it GATES step 38, which is Complete. The banner said "treat the sequence as
+    // untrustworthy" about the only sequence that was actually available.
+    //
+    // So a band inversion is a violation only when it was AVOIDABLE: the
+    // lower-band row does not depend, transitively, on the higher-band row it
+    // renders below. That keeps the regression this invariant was built for —
+    // two Running rows sinking below an UNRELATED Scheduled tail, which no
+    // dependency forced — while no longer crying wolf about the forced case.
+    const closure = new Map();
+    const dependsOn = (id) => {
+        if (closure.has(id)) return closure.get(id);
+        const out = new Set();
+        closure.set(id, out);   // cycle guard; the cycle invariant above reports it
+        const row = rows.find((r) => r.id === id);
+        for (const d of depIdsOf(row || {})) {
+            if (!posn.has(d)) continue;
+            out.add(d);
+            for (const dd of dependsOn(d)) out.add(dd);
+        }
+        return out;
+    };
+    const bandOf = (r) => (STATE_RANK[r.state] != null ? STATE_RANK[r.state] : 2);
+    for (let i = 0; i < rows.length; i++) {
+        const r = rows[i];
+        const band = bandOf(r);
+        // The earlier rows this one outranks by band but does NOT depend on.
+        const avoidable = [];
+        for (let j = 0; j < i; j++) {
+            const p = rows[j];
+            if (bandOf(p) > band && !dependsOn(r.id).has(p.id)) avoidable.push(p);
+        }
+        if (avoidable.length) {
+            const worst = avoidable[avoidable.length - 1];
             violations.push({
                 invariant: 'state-banding',
-                stepIds: [r.id],
-                message: `${r.state} step ${r.id} renders below a ` +
-                    `${lastBand === 2 ? 'pending' : 'running'} row — ` +
-                    'done>running>pending banding broken',
+                stepIds: [r.id, worst.id],
+                message: `${r.state} step ${r.id} renders below ${worst.state} step `
+                    + `${worst.id}, which it does not depend on — `
+                    + 'done>running>pending banding broken',
             });
         }
-        lastBand = band;
     }
 
     // Invariant 3: launch-batch contiguity — batch-mates render as one block.

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -78,7 +78,33 @@ const BAND_GAP = 8;
 const LANE_BASE_H = 56;         // POC horizontal pitch, before the title slot
 const TITLE_SLOT = 14;          // deviation 2 — reserved per-lane title line
 const REQ_LINE_H = 12;          // vertical layout: one requirement id per line
-const STEP_LABEL_MAX = 40;      // title label truncation above the bead
+const STEP_LABEL_MAX = 60;      // hard ceiling on a title label above the bead
+// Staggering (req #3119, the Build Visualizer's version-label pattern —
+// `d3LayoutEngine.js` offsets every odd build by `versionLaneGap`). Odd columns
+// draw their long text one line further from the bead, so a label and its
+// left/right neighbours are never on the same line and each may overflow its own
+// column. Only the SAME-PARITY columns (d±2) share a line, and the budget below
+// keeps two of those from meeting.
+const STAGGER_GAP = 14;
+// Fraction of a neighbouring column a staggered label may reach into, PER SIDE.
+// Labels are centred on their column, so the budget must bound the reach into
+// the NARROWER neighbour and then apply symmetrically — bounding the sum of both
+// neighbours does not work, because a wide left neighbour would buy half-width
+// that gets spent on the right. (That was the first version of this, and it
+// admits an overlap: with colW = [224, 64, 64, 64, 224] the labels at d=1 and
+// d=3 — the only pair that shares a line — overlapped by ~40px. Found in review,
+// with the dataset.) Two same-line labels intrude on the shared column d±1 from
+// opposite sides, so anything under 0.5 per side cannot meet; 0.4 leaves margin
+// for the mono-width estimate itself.
+const STAGGER_REACH = 0.4;
+// Minimum column width when STEP TITLES are drawn (req #3119, user directive:
+// "increase the display of the step name by 50% more characters"). The binding
+// constraint on a step name was never STEP_LABEL_MAX — it was the stagger
+// budget, which is derived from the column, and a column sized to a 4-digit
+// requirement id is ~64px, i.e. ~16 characters after the reach is added. Giving
+// the column a floor raises the budget for every title at once; STEP_LABEL_MAX
+// is only the ceiling that stops a pathological title from running forever.
+const TITLE_COL_MIN = 96;
 export const PLAN_VIZ_FONT = {
     label: 11, req: 11, title: 9.5, epic: 12, batch: 10, check: 9,
 };
@@ -92,9 +118,9 @@ const truncate = (s, n) => {
 
 // The text drawn ABOVE a bead. NO '#' anywhere — ids render bare (production
 // directive), titles render verbatim (stored plan content).
-export function stepLabelText(row, stepLabel) {
+export function stepLabelText(row, stepLabel, maxChars = STEP_LABEL_MAX) {
     return stepLabel === 'title'
-        ? truncate(row.title || `step ${row.id}`, STEP_LABEL_MAX)
+        ? truncate(row.title || `step ${row.id}`, Math.max(4, Math.min(STEP_LABEL_MAX, maxChars)))
         : String(row.id);
 }
 
@@ -146,10 +172,18 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
         const d = depthMemo.get(r.id);
         (colSteps[d] ||= []).push(r);
     }
+    // Title-mode step labels are STAGGERED, so a column no longer has to be as
+    // wide as its longest title — the label overflows into the neighbouring
+    // columns, which draw on the other line (req #3119). Sizing columns to full
+    // titles is what made the world 5800px wide on the live plan; the ids and
+    // the layout drive the width now, and the label is fitted to the room it
+    // actually has, below.
+    const staggerLabels = stepLabel === 'title';
     const colW = [];
     for (let d = 0; d <= maxD; d++) {
         const steps = colSteps[d] || [];
-        const labelW = Math.max(0, ...steps.map((r) => stepLabelText(r, stepLabel).length * CHW + 16));
+        const labelW = staggerLabels ? TITLE_COL_MIN
+            : Math.max(0, ...steps.map((r) => stepLabelText(r, stepLabel).length * CHW + 16));
         let w;
         if (reqLayout === 'horizontal') {
             w = Math.max(64, labelW, ...steps.map((r) => reqStr(r).length * CHW + 30));
@@ -159,6 +193,18 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
         }
         colW.push(w);
     }
+    // How much horizontal room a STAGGERED label at depth d may occupy: its own
+    // column plus a bounded reach into each neighbour. Ends have one neighbour.
+    // At the ends there is no neighbouring column, but there IS margin: the
+    // left gutter the lane wires start after, and the right padding the world
+    // width already reserves. Bounding by those keeps a d=0 label out of the
+    // gutter instead of letting a wide colW[1] push it off the world.
+    const staggerBudget = (d) => {
+        const left = d > 0 ? colW[d - 1] : LEFT;
+        const right = d < maxD ? colW[d + 1] : RIGHT + 40;
+        return colW[d] + 2 * STAGGER_REACH * Math.min(left, right);
+    };
+    const staggerOf = (d) => (d % 2) * STAGGER_GAP;
     const colX = [];
     {
         let acc = LEFT;
@@ -325,21 +371,62 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
         // Lane pitch (zero-overlap contract, half 2): the vertical envelope of
         // one lane — step label above, bead, req ids below, then the reserved
         // title slot — never reaches the next lane's label.
-        const pitch = (reqLayout === 'vertical'
-            ? 58 + (maxReqs - 1) * REQ_LINE_H
-            : LANE_BASE_H) + TITLE_SLOT;
+        //
+        // PER-LANE since req #3119. In 'vertical' mode a lane is as tall as ITS
+        // OWN deepest requirement stack, not as tall as the band's. One 5-req
+        // step used to set the pitch for every lane in its band: in the live
+        // Substrate plan that made all nine lanes of "Swarm Substrate Rebuild"
+        // 120px tall to accommodate step 1, when eight of them carry a single
+        // requirement and need 72 — ~380px of dead vertical space in one band,
+        // and the whole plan taller than the panel for no reason. 'horizontal'
+        // keeps a constant pitch because its req ids sit on ONE line whatever
+        // the count, so there is nothing lane-specific to measure.
+        const laneReqs = new Map();
+        for (const r of steps) {
+            const lane = laneById.get(r.id);
+            const n = (r.reqIds || []).length;
+            if (n > (laneReqs.get(lane) || 0)) laneReqs.set(lane, n);
+        }
+        // The stagger costs one extra line per lane, and it is charged ONCE
+        // because the two staggered things are mutually exclusive: in 'title'
+        // mode the step label above the bead staggers and the title slot is not
+        // drawn at all; in 'id' mode the label is a 4-digit id that never needed
+        // the room and the title slot below staggers instead.
+        const lanePitch = (lane) => (reqLayout === 'vertical'
+            ? 58 + (Math.max(1, laneReqs.get(lane) || 1) - 1) * REQ_LINE_H
+            : LANE_BASE_H) + TITLE_SLOT + STAGGER_GAP;
+        // Cumulative lane tops, so a lane's y is the SUM of the lanes above it
+        // rather than index × a single pitch. `laneY` is exported on the band:
+        // every consumer that draws per-lane furniture (the visualizer's lane
+        // wires) must use it or the wires detach from the beads.
+        const laneY = [];
+        {
+            let acc = 0;
+            for (let l = 0; l < sub; l++) { laneY.push(acc); acc += lanePitch(l); }
+            laneY.push(acc); // sentinel: total lane height
+        }
+        // Retained for consumers that want a representative pitch; band height
+        // now comes from laneY, never from sub × pitch.
+        const pitch = lanePitch(0);
         // Bands hosting batch members take a taller header: the batch letter
         // lives in a reserved header strip (below the epic label, above lane
         // 0's step label) and the box top must clear the epic label — found in
         // review as an epic-label × batch-label collision on long epic titles.
-        const headerH = BAND_HEADER
+        // The header also absorbs the stagger, but ONLY in title mode: lane 0's
+        // step label is what gets LIFTED on odd columns (req #3119), and without
+        // the extra line it rises into the epic label — and, in a band hosting a
+        // batch, into the batch letter strip. Both collisions were caught by the
+        // overlap invariant. In id mode nothing above the bead moves (the title
+        // slot staggers DOWNWARD instead), so charging the header there would be
+        // 14px of dead space per band in the default view.
+        const headerH = BAND_HEADER + (staggerLabels ? STAGGER_GAP : 0)
             + (steps.some((r) => batchOf.has(r.id)) ? BATCH_HEADER_EXTRA : 0);
-        bands.push({ ...band, steps, sub, maxReqs, pitch, headerH });
+        bands.push({ ...band, steps, sub, maxReqs, pitch, laneY, laneReqs, headerH });
     }
     let y = 8;
     for (const band of bands) {
         band.y = y;
-        band.height = band.headerH + band.sub * band.pitch;
+        band.height = band.headerH + band.laneY[band.sub];
         y += band.height + BAND_GAP;
     }
     const totalH = y + 8;
@@ -352,7 +439,7 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
             nodes.set(r.id, {
                 id: r.id,
                 x: colX[d],
-                y: band.y + band.headerH + laneById.get(r.id) * band.pitch + 10,
+                y: band.y + band.headerH + band.laneY[laneById.get(r.id)] + 10,
                 depth: d,
                 lane: laneById.get(r.id),
                 bandIndex,
@@ -424,11 +511,18 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
     const labels = [];
     for (const r of safeRows) {
         const n = nodes.get(r.id);
-        const label = stepLabelText(r, stepLabel);
+        // A staggered title label is fitted to its budget (own column + a
+        // bounded reach into each neighbour) and lifted one line on odd columns.
+        const labelMax = staggerLabels
+            ? Math.floor((staggerBudget(n.depth) - 8) / CHW)
+            : STEP_LABEL_MAX;
+        const label = stepLabelText(r, stepLabel, labelMax);
         const lw = label.length * CHW;
         labels.push({
             kind: 'step', stepId: r.id, text: label,
-            x: n.x - lw / 2, y: n.y - 26, w: lw, h: 12,
+            x: n.x - lw / 2,
+            y: n.y - 26 - (staggerLabels ? staggerOf(n.depth) : 0),
+            w: lw, h: 12,
         });
         const ids = r.reqIds || [];
         if (reqLayout === 'horizontal') {
@@ -456,12 +550,24 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
         // when the step label already IS the title — it would duplicate).
         if (stepLabel !== 'title') {
             const band = bands[n.bandIndex];
-            const maxChars = Math.max(4, Math.floor((colW[n.depth] - 8) / CHW_TITLE));
+            // Staggered too, and therefore budgeted the same way: the title may
+            // reach into its neighbours because they draw on the other line.
+            // Before req #3119 this was capped at the bare column width, which
+            // is what cut plan titles to a few characters in narrow columns.
+            const maxChars = Math.max(4, Math.floor((staggerBudget(n.depth) - 8) / CHW_TITLE));
             const t = truncate(r.title || '', maxChars);
             if (t) {
-                const slotY = reqLayout === 'vertical'
-                    ? n.y + 14 + band.maxReqs * REQ_LINE_H + 2
-                    : n.y + 28;
+                // The slot clears THIS LANE's requirement stack — the same count
+                // that sized the lane (req #3119). It used to clear the BAND's
+                // deepest stack, which was equivalent only while every lane in a
+                // band shared one pitch; with per-lane heights a one-req lane in
+                // a five-req band had its title pushed 48px past its own lane
+                // and straight onto the next lane's bead. Caught by the
+                // label-vs-bead invariant, which is why that test exists.
+                const laneN = Math.max(1, band.laneReqs.get(n.lane) || 1);
+                const slotY = (reqLayout === 'vertical'
+                    ? n.y + 14 + laneN * REQ_LINE_H + 2
+                    : n.y + 28) + staggerOf(n.depth);
                 labels.push({
                     kind: 'title', stepId: r.id, text: t,
                     x: n.x - (t.length * CHW_TITLE) / 2, y: slotY,

--- a/src/SwarmView/pipelines/pipelineViewModel.js
+++ b/src/SwarmView/pipelines/pipelineViewModel.js
@@ -478,4 +478,56 @@ export function stepProse(row) {
     return { text: title, notes };
 }
 
+/**
+ * The step's NAME, for the Name column (req #3119).
+ *
+ * A title is a name — "Session Drain", "Bounded MCP Reads" — not the opening
+ * clause of the description. The darwin_dev fixture used to load
+ * `short_title(summary)` here, so a "name" could be 256 characters of truncated
+ * prose; the seed generator now loads the plan's own short title instead.
+ *
+ * Rows written before that fix (or by any other producer) can still carry a
+ * paragraph, and this column must not become a second copy of the description.
+ * So a name that is clearly prose is CUT for display — the full string stays one
+ * hover away, and the description column still prints it in full. The cut is
+ * presentational only; nothing stored is rewritten.
+ *
+ * @param {Object} row  a PlanRow
+ * @returns {{text: string, full: string, truncated: boolean}}
+ */
+export const STEP_NAME_MAX = 48;
+
+export function stepName(row, max = STEP_NAME_MAX) {
+    const full = (row && row.title ? String(row.title) : '').trim();
+    if (!full) return { text: '—', full: '', truncated: false };
+    if (full.length <= max) return { text: full, full, truncated: false };
+    // Cut at a word boundary so a name never ends mid-token, matching the
+    // generator's own short_title().
+    const cut = full.slice(0, max - 1);
+    const space = cut.lastIndexOf(' ');
+    return { text: `${space > 0 ? cut.slice(0, space) : cut}…`, full, truncated: true };
+}
+
+/**
+ * What the "What this step does" cell should print, now that Name is its own
+ * column (req #3119): the DESCRIPTION, never the name repeated.
+ *
+ * `notes` is the full summary prose. When a row has no notes at all there is no
+ * description to show, and the title is the only thing written about the step —
+ * printing it beats printing an em-dash, so it falls back.
+ *
+ * It does NOT re-print the title alongside the notes, even when the notes are a
+ * short supplementary remark rather than a full description: the Name column
+ * carries the title on the same row, two cells to the left, and repeating it
+ * here is what the Name column was added to stop.
+ *
+ * @param {Object} row  a PlanRow
+ * @returns {string}
+ */
+export function stepDescription(row) {
+    const notes = row && row.notes ? String(row.notes).trim() : '';
+    if (!notes) return (row && row.title ? String(row.title) : '').trim();
+    return notes;
+}
+
 export { STEP_DONE, STEP_RUNNING, STEP_PENDING };

--- a/tests/tests/pipelines.spec.ts
+++ b/tests/tests/pipelines.spec.ts
@@ -169,11 +169,19 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             // V7). Asserted with the exact figure, not just the word "pipeline":
             // it is also the guard that the stale sweep worked, and therefore that
             // the DataGrid row targeted below is on page 1 of an `id: desc` sort.
+            //
+            // The call-to-action names the ACTIVE view's click target (req #3119):
+            // "click a row" is wrong advice in Cards, where the target is a card.
             await expect(page.getByTestId('pipelines-accounting'))
-                .toHaveText('3 of 3 pipelines — click a row for the plan');
+                .toHaveText('3 of 3 pipelines — click a card for the plan');
 
             await page.getByTestId('view-toggle-table').click();
             await expect(page.getByTestId('pipelines-datagrid')).toBeVisible();
+
+            // ...and it flips with the view. Asserted on BOTH sides because a
+            // one-sided check passes just as well on a hardcoded noun.
+            await expect(page.getByTestId('pipelines-accounting'))
+                .toHaveText('3 of 3 pipelines — click a row for the plan');
 
             // useViewPreference persists the choice across a reload.
             await page.reload();
@@ -384,9 +392,13 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             if (!root) return ['NO PIPELINE DETAIL ROOT'];
             const clone = root.cloneNode(true) as HTMLElement;
             // Stored plan content: the goal paragraph, the "What this step does"
-            // column (always the second-to-last cell) and its notes line.
+            // column (always the second-to-last cell) and its notes line, and —
+            // since req #3119 gave it its own column — the step NAME, which is
+            // the plan's own `title` string and just as much stored prose as the
+            // description it used to share a cell with.
             clone.querySelectorAll('[data-testid="pipeline-goal"]').forEach((n) => n.remove());
             clone.querySelectorAll('[data-testid^="pipeline-notes-"]').forEach((n) => n.remove());
+            clone.querySelectorAll('[data-testid^="pipeline-name-"]').forEach((n) => n.remove());
             clone.querySelectorAll('tr').forEach((tr) => {
                 const cells = tr.querySelectorAll('td');
                 if (cells.length > 1) cells[cells.length - 2].remove();


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3119-swarm-orchestration-final-polish-1
- wip(Darwin): 2026-07-27T10:50:30Z
- chore: init swarm session feature/3119-swarm-orchestration-final-polish-1

## Files changed
```
 src/SwarmView/detail/RequirementDetail.jsx         |  21 +-
 src/SwarmView/pipelines/PipelineCardsView.jsx      |  11 +-
 src/SwarmView/pipelines/PipelineDetail.jsx         | 249 ++++++++++++--
 src/SwarmView/pipelines/PipelinePlanTable.jsx      |  83 +++--
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx | 382 +++++++++++++++++----
 src/SwarmView/pipelines/PipelinesPage.jsx          |   8 +-
 .../pipelines/__tests__/pipelineModel.test.js      | 105 +++++-
 .../pipelines/__tests__/pipelinePlanLayout.test.js |  94 ++++-
 .../pipelines/__tests__/pipelineViewModel.test.js  |  70 ++++
 src/SwarmView/pipelines/pipelineModel.js           | 101 +++++-
 src/SwarmView/pipelines/pipelinePlanLayout.js      | 140 +++++++-
 src/SwarmView/pipelines/pipelineViewModel.js       |  52 +++
 tests/tests/pipelines.spec.ts                      |  16 +-
 13 files changed, 1131 insertions(+), 201 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)