### PR TITLE
req #3129

### DIFF
--- a/src/Agents/AgentDetail.jsx
+++ b/src/Agents/AgentDetail.jsx
@@ -60,7 +60,7 @@ import InstructionUnbindDialog from './InstructionUnbindDialog';
 import {
     byId, linksByAgent, instructionLinksByAgent, agentsByInstruction,
     isCommonInstruction, relationshipChipProps, relationshipLabel,
-    docTypeChipProps, documentHref, isAutoload,
+    docTypeChipProps, documentHref, isAutoload, isPrinciples,
     agentModelChipProps, agentModelLabel,
     nextInstructionSortOrder, planInstructionSwap, restErrorMessage,
 } from './agentRegistryUtils';
@@ -137,6 +137,14 @@ const AgentDetail = () => {
 
     const autoloadCount = myDocuments.filter(
         d => isAutoload(d.link.relationship)).length;
+
+    // req #3129: THE one guiding-principles document. The DB permits at most one
+    // per agent (uq_agent_documents_principles), so `find` is not a truncation —
+    // a second would have been refused at write time. Undefined until one is
+    // assigned, which is a legitimate state and rendered as such.
+    const principlesDoc = useMemo(
+        () => myDocuments.find(d => isPrinciples(d.link.relationship)) || null,
+        [myDocuments]);
 
     const saveOverview = async () => {
         const next = overview.trim();
@@ -295,6 +303,42 @@ const AgentDetail = () => {
                 sx={{ mb: 3 }}
                 data-testid="agent-overview-field"
             />
+
+            {/* ---------- guiding principles (req #3129) ----------
+                Rendered ABOVE instructions because load order IS precedence:
+                principles > instructions > documents > priors. This is the same
+                link that appears in the Documents table below — surfaced twice
+                on purpose, once as the agent's stance and once in the inventory.
+                Exactly one per agent, enforced by uq_agent_documents_principles. */}
+            <Box id="principles" sx={{ scrollMarginTop: 16, mb: 3 }}>
+                <Typography variant="h6" sx={{ mb: 1 }}>
+                    Guiding Principles{' '}
+                    <Typography component="span" variant="body2" color="text.secondary">
+                        — read first, before instructions
+                    </Typography>
+                </Typography>
+
+                {!principlesDoc ? (
+                    <Typography color="text.secondary" data-testid="agent-principles-empty">
+                        No guiding-principles document assigned. Tag one of this agent's documents
+                        with the <code>principles</code> role.
+                    </Typography>
+                ) : (
+                    <Stack direction="row" spacing={1} alignItems="center"
+                           data-testid={`agent-principles-${principlesDoc.row.id}`}>
+                        {documentHref(principlesDoc.row) ? (
+                            <Link href={documentHref(principlesDoc.row)} target="_blank"
+                                  rel="noopener noreferrer" underline="hover">
+                                {principlesDoc.row.name} <OpenInNewIcon sx={{ fontSize: 12 }} />
+                            </Link>
+                        ) : principlesDoc.row.name}
+                        <Chip label="principles" size="small" color="secondary" variant="filled" />
+                        <Typography variant="caption" color="text.secondary">
+                            {principlesDoc.row.location}
+                        </Typography>
+                    </Stack>
+                )}
+            </Box>
 
             {/* ---------- instructions ---------- */}
             <Box id="instructions" sx={{ scrollMarginTop: 16 }}>
@@ -459,6 +503,10 @@ const AgentDetail = () => {
                                                         {row.name} <OpenInNewIcon sx={{ fontSize: 12 }} />
                                                     </Link>
                                                 ) : row.name}
+                                                {isPrinciples(link.relationship) && (
+                                                    <Chip label="principles" size="small" color="secondary"
+                                                          variant="filled" />
+                                                )}
                                                 {autoload && (
                                                     <Chip label="autoload" size="small" color="primary"
                                                           variant="outlined" />

--- a/src/Agents/__tests__/AgentDetail.principles.test.jsx
+++ b/src/Agents/__tests__/AgentDetail.principles.test.jsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+//
+// Req #3129 — the guiding-principles slot on /agents/:id.
+//
+// The slot is a VIEW of one `agent_documents` link that also appears in the
+// Documents table below it. That double-surfacing is the whole risk, and the
+// three ways it goes wrong are each pinned here:
+//
+//   * the slot renders a document that is merely `owned` or `autoload` — the
+//     role filter is missing or matches a substring rather than a SET member;
+//   * the principles document VANISHES from the Documents table because someone
+//     "fixed" the duplication by filtering it out, so the inventory silently
+//     stops being an inventory;
+//   * the empty state renders as a crash or a blank region rather than as the
+//     actionable "no principles document assigned" prompt — the common case
+//     right after the migration, when no agent is tagged yet.
+//
+// Mounted harness with raw react-dom + act, the house pattern — same shape as
+// AgentDetail.unbind.test.jsx.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const navigateSpy = vi.fn();
+vi.mock('react-router-dom', () => ({
+    useNavigate: () => navigateSpy,
+    useParams: () => ({ id: '1' }),
+}));
+
+let agentsData = [];
+let documentsData = [];
+let agentDocsData = [];
+
+vi.mock('../../hooks/useDataQueries', () => ({
+    useAgents: () => ({ data: agentsData, isLoading: false }),
+    useInstructions: () => ({ data: [] }),
+    useArchitectureDocuments: () => ({ data: documentsData }),
+    useAgentDocuments: () => ({ data: agentDocsData }),
+    useAgentInstructions: () => ({ data: [] }),
+    agentKeys: { all: (c) => ['agents', c] },
+    instructionKeys: { all: (c) => ['instructions', c] },
+    agentInstructionKeys: { all: (c) => ['agent_instructions', c] },
+}));
+
+vi.mock('../actions/instructionsApi', () => ({
+    linkAgentInstruction: vi.fn(),
+    unlinkAgentInstruction: vi.fn(),
+    setAgentInstructionOrder: vi.fn(),
+}));
+
+vi.mock('../../RestApi/RestApi', () => ({ default: vi.fn() }));
+
+import AgentDetail from '../AgentDetail';
+import AppContext from '../../Context/AppContext';
+import AuthContext from '../../Context/AuthContext';
+
+const AGENT = {
+    id: 1, name: 'Alpha', closed: 0, ai_model: 'opus', effort: 'high',
+    overview: 'the alpha agent', location: 'alpha.md', file_name: 'alpha.md',
+};
+
+// Three documents on ONE agent. The decoys matter: `owned,autoload` carries both
+// of the roles a principles link also carries, so a filter that tests for either
+// of them instead of for `principles` picks the wrong row and still renders
+// something plausible.
+const DOCUMENTS = [
+    { id: 20, name: 'Alpha Charter', location: 'memory/alpha-charter.md',
+      doc_type: 'markdown', closed: 0 },
+    { id: 21, name: 'Alpha Reference', location: 'memory/alpha-ref.md',
+      doc_type: 'markdown', closed: 0 },
+    { id: 22, name: 'Alpha Autoloaded', location: 'memory/alpha-auto.md',
+      doc_type: 'markdown', closed: 0 },
+];
+const LINKS_WITH_PRINCIPLES = [
+    { agent_fk: 1, document_fk: 20, relationship: 'principles,owned,autoload', sort_order: 1 },
+    { agent_fk: 1, document_fk: 21, relationship: 'referenced', sort_order: 2 },
+    { agent_fk: 1, document_fk: 22, relationship: 'owned,autoload', sort_order: 3 },
+];
+const LINKS_WITHOUT_PRINCIPLES = [
+    { agent_fk: 1, document_fk: 22, relationship: 'owned,autoload', sort_order: 1 },
+];
+
+let container;
+let root;
+let queryClient;
+
+const mount = () => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider
+                        value={{ idToken: 'tok', profile: { userName: 'tester' } }}>
+                        <AgentDetail />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+};
+
+beforeEach(() => {
+    agentsData = [{ ...AGENT }];
+    documentsData = DOCUMENTS.map(d => ({ ...d }));
+    agentDocsData = LINKS_WITH_PRINCIPLES.map(l => ({ ...l }));
+    navigateSpy.mockReset();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+});
+
+describe('AgentDetail — guiding principles slot (req #3129)', () => {
+    it('renders THE principles document, not merely an owned or autoloaded one', () => {
+        mount();
+        const slot = container.querySelector('[data-testid="agent-principles-20"]');
+        expect(slot).toBeTruthy();
+        expect(slot.textContent).toContain('Alpha Charter');
+        expect(slot.textContent).toContain('memory/alpha-charter.md');
+        // The decoy carries owned+autoload but not principles.
+        expect(slot.textContent).not.toContain('Alpha Autoloaded');
+        expect(container.querySelector('[data-testid="agent-principles-22"]')).toBeNull();
+    });
+
+    it('renders the slot ABOVE the instructions section — load order is precedence', () => {
+        mount();
+        const principles = container.querySelector('#principles');
+        const instructions = container.querySelector('#instructions');
+        expect(principles).toBeTruthy();
+        expect(instructions).toBeTruthy();
+        // DOCUMENT_POSITION_FOLLOWING === 4: instructions comes after principles.
+        expect(principles.compareDocumentPosition(instructions)
+            & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it('KEEPS the principles document in the Documents table — one link, two views', () => {
+        mount();
+        const row = container.querySelector('[data-testid="agent-document-20"]');
+        expect(row).toBeTruthy();
+        expect(row.textContent).toContain('Alpha Charter');
+        // And it is flagged there too, so the two views cannot disagree.
+        expect(row.textContent).toContain('principles');
+        // All three links still listed; the slot is additive, not a filter.
+        expect(container.querySelectorAll('[data-testid^="agent-document-"]').length).toBe(3);
+    });
+
+    it('prompts rather than blanking when no principles document is assigned', () => {
+        agentDocsData = LINKS_WITHOUT_PRINCIPLES.map(l => ({ ...l }));
+        mount();
+        const empty = container.querySelector('[data-testid="agent-principles-empty"]');
+        expect(empty).toBeTruthy();
+        expect(empty.textContent).toContain('No guiding-principles document assigned');
+        // The section still exists — an unassigned agent is a legitimate state,
+        // not a reason to hide the slot and let the gap go unnoticed.
+        expect(container.querySelector('#principles')).toBeTruthy();
+    });
+});

--- a/src/Agents/agentRegistryUtils.js
+++ b/src/Agents/agentRegistryUtils.js
@@ -12,8 +12,14 @@ import { AI_MODEL_COLOR, modelFillColor } from '../SwarmView/modelChipStyles';
 // may carry several roles at once (e.g. "owned,autoload") and REST returns them
 // as a comma-joined string. These helpers parse that string. `autoload` is the
 // role marking a document the agent reads IN FULL at boot — stored, not derived.
+//
+// `principles` (req #3129) marks THE ONE document carrying an agent's guiding
+// principles. It sorts FIRST because precedence follows load order: the agent
+// reads its principles, then its instructions, then its documents. At most one
+// link per AGENT may carry it — the mirror image of the one-'owned'-per-DOCUMENT
+// rule, enforced by uq_agent_documents_principles.
 export const RELATIONSHIP_ORDER = [
-    'owned', 'curated', 'autoload', 'referenced',
+    'principles', 'owned', 'curated', 'autoload', 'referenced',
 ];
 
 // Comma-joined SET string -> array of roles, in precedence order.
@@ -24,6 +30,7 @@ export const parseRoles = (rel) => {
 
 export const hasRole = (rel, role) => parseRoles(rel).includes(role);
 export const isAutoload = (rel) => hasRole(rel, 'autoload');
+export const isPrinciples = (rel) => hasRole(rel, 'principles');
 
 /**
  * The INVERSE of `parseRoles`: roles -> the exact string the database stores.
@@ -58,6 +65,7 @@ export const relationshipRank = (rel) => {
 // primary because it is the load-bearing one — at most one per document (DB).
 export const relationshipChipProps = (rel) => {
     switch (primaryRole(rel)) {
+        case 'principles': return { color: 'secondary', variant: 'filled' };
         case 'owned':      return { color: 'primary', variant: 'filled' };
         case 'curated':    return { color: 'success', variant: 'filled' };
         case 'autoload':   return { color: 'info',    variant: 'outlined' };
@@ -605,6 +613,17 @@ export const relationshipSetError = (roles = []) => {
     // precedence rule refer to itself, so it is a hard block rather than a hint.
     if (list.includes('owned') && list.includes('referenced')) {
         return 'A link cannot be both owned and referenced — owning already outranks referencing.';
+    }
+    // req #3129: a guiding-principles document is read at boot by definition, so
+    // `principles` without `autoload` is a link that says "read this first" and
+    // "read this on demand" at the same time. The two roles are carried together
+    // deliberately — `principles` does not imply `autoload` in code, precisely so
+    // that every existing autoload consumer keeps working unchanged.
+    if (list.includes('principles') && !list.includes('autoload')) {
+        return 'A principles document must also be autoload — it is read at boot by definition.';
+    }
+    if (list.includes('principles') && list.includes('referenced')) {
+        return 'A link cannot be both principles and referenced — principles outranks every other role.';
     }
     return null;
 };


### PR DESCRIPTION
## Summary
- feat(3129): render the guiding-principles document in its own slot
- chore: init swarm session feature/3129-instructions-refactor-1

## Files changed
```
 src/Agents/AgentDetail.jsx                         |  50 +++++-
 .../__tests__/AgentDetail.principles.test.jsx      | 167 +++++++++++++++++++++
 src/Agents/agentRegistryUtils.js                   |  21 ++-
 3 files changed, 236 insertions(+), 2 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Related PRs (req #3129): DarwinAI-Config #683 · DarwinSQL #100 · Darwin #862