### PR TITLE
Condensation + launch-batch grouping: epic-aware partitioning, and remaining-gate vs raw-dep keying

### DIFF
--- a/src/SwarmView/pipelines/PipelinePlanTable.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanTable.jsx
@@ -183,9 +183,13 @@ function CondensationAlert({ proposals }) {
 // /swarm-start argument list — the launch unit is explicit, not implied by
 // adjacency.
 function BatchBannerRow({ batch, colSpan, timezone }) {
+    // The REMAINING gate since req #3188 — the deps that are still open, which
+    // every member shares. So the empty case is "nothing left", not "never had
+    // one": a batch behind a Complete gate is launchable NOW, and printing the
+    // dep that closed weeks ago read as something still holding it back.
     const gate = batch.gateStepIds.length
         ? `steps ${batch.gateStepIds.join(', ')}`
-        : 'no step gate';
+        : 'no remaining step gate';
     // Through the SAME formatter the Depends-on cell uses. This banner printed
     // the raw wire value — UTC, microseconds included — while the row eight lines
     // below showed the localized one, for the same instant.

--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -511,7 +511,14 @@ export default function PipelinePlanVisualizer({
         // Konva has no independent fill/stroke opacity — the POC's 4% wash and
         // 85% dashed edge are rgba colors on one Rect.
         worldNodes.push(
-            <Rect key={`batch-${box.letter}`} x={box.x} y={box.y}
+            // Keyed on the SEGMENT, not the batch. A letter was unique per box
+            // while a batch produced one segment per BAND and could never span
+            // two — but req #3188 made batch-mates share only their REMAINING
+            // gate, so one batch legitimately produces one segment per column
+            // and `batch-A` became a duplicate React key on every such plan.
+            // React warns and reserves the right to drop a child.
+            <Rect key={`batch-${box.letter}-${box.bandIndex}-${box.depth}`}
+                  x={box.x} y={box.y}
                   width={box.width} height={box.height} cornerRadius={10}
                   fill="rgba(74, 217, 200, 0.04)"
                   stroke="rgba(74, 217, 200, 0.85)" dash={[6, 4]} strokeWidth={1.2}
@@ -794,8 +801,10 @@ function PlanDataCard({ card, timezone, level, containerW, containerH }) {
             <div className="ts-datacard">
                 <div className="ts-datacard-title">Launch batch {b.letter}</div>
                 {rowEl('Steps', b.stepIds.join(' '))}
+                {/* The REMAINING gate since req #3188 — same wording as the
+                    plan table's banner, because the two are one plan. */}
                 {rowEl('Gate', b.gateStepIds.length
-                    ? `steps ${b.gateStepIds.join(', ')}` : 'no step gate')}
+                    ? `steps ${b.gateStepIds.join(', ')}` : 'no remaining step gate')}
                 {timeGates.map((g) => <div key={g}>{rowEl('After', g)}</div>)}
                 {rowEl('Run', runLabel(b.run))}
                 {b.machineLabels.length > 0 && rowEl('Machines', batchMachineLabel(b))}

--- a/src/SwarmView/pipelines/__tests__/pipelineConformance.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineConformance.test.js
@@ -163,6 +163,13 @@ function observe(wireModel, now) {
     const observedBatches = batches.map((b) => ({
         letter: b.letter,
         step_ids: [...b.stepIds],
+        // req #3188 — the ONE dominant epic every member shares. Asserted, not
+        // merely produced: "no batch spans more than one epic" is the fix's
+        // first acceptance criterion, and a partition nothing observes can
+        // regress in silence. Both engines key the epic on its ID, so this is a
+        // plain comparison rather than another bucket count.
+        epic_id: b.epicId,
+        // The REMAINING (unsatisfied) gate since req #3188, not the raw dep set.
         gate_step_ids: [...b.gateStepIds],
         time_deps: [...b.timeDeps],
         run: b.run,

--- a/src/SwarmView/pipelines/__tests__/pipelineModel.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineModel.test.js
@@ -59,6 +59,12 @@ function row(id, state, deps = [], opts = {}) {
         id,
         state,
         run: opts.run || 'auto',
+        // req #3188 — the launch key's epic term is the epic ID, not the title,
+        // so a targeted case that means to exercise the epic partition must set
+        // `epicId`. `epic` alone is a display label here: buildPlanRows always
+        // emits both, and the POC-parity fixtures below carry titles only
+        // because the archived plan had no epic ids to carry.
+        epicId: opts.epicId !== undefined ? opts.epicId : null,
         epic: opts.epic !== undefined ? opts.epic : null,
         feature: opts.feature !== undefined ? opts.feature : null,
         reqIds: opts.reqIds || [],
@@ -517,13 +523,17 @@ describe('the four named POC ordering regressions (req #3080 rule 3)', () => {
 
 describe('launchBatches — rules 2 + 8, the launch unit is explicit', () => {
     it('letters batches in display order with the exact /swarm-start args', () => {
+        // Step 2 is PENDING, not done, and that is load-bearing since req #3188:
+        // the key's gate term is the REMAINING gate, so with step 2 also closed
+        // both pairs would have an empty gate and correctly become ONE batch —
+        // and this test would have stopped testing lettering across two.
         const stored = [
             row(1, STEP_DONE),
-            row(2, STEP_DONE, [1]),
-            // batch on gate 2 (deeper stream → launches first)
+            row(2, STEP_PENDING, [1]),
+            // batch behind the still-OPEN gate 2 (deeper stream → launches first)
             row(10, STEP_PENDING, [2], { reqIds: [3115, 3116], machines: ['Mac mini'] }),
             row(11, STEP_PENDING, [2], { reqIds: [3117], machines: ['Mac mini'] }),
-            // batch on gate 1
+            // batch whose gate 1 is already closed → remaining gate empty
             row(20, STEP_PENDING, [1], { reqIds: [3113], machines: ['Mac mini'] }),
             row(21, STEP_PENDING, [1], { reqIds: [3114], machines: ['Mac mini'] }),
         ];
@@ -538,7 +548,44 @@ describe('launchBatches — rules 2 + 8, the launch unit is explicit', () => {
         expect(batches[0].swarmStartCommand).toBe('/swarm-start 3115 3116 3117');
         expect(batches[1].letter).toBe('B');
         expect(batches[1].stepIds).toEqual([20, 21]);
+        expect(batches[1].gateStepIds).toEqual([]);
         expect(batches[1].swarmStartCommand).toBe('/swarm-start 3113 3114');
+    });
+
+    it('groups two steps whose gates differ ONLY in already-done deps (req #3188)', () => {
+        // DEFECT 2. Step 10's gate is step 1, which is Complete; step 11 has no
+        // gate at all. Their REMAINING gates are both empty, so they become
+        // eligible at the same instant and are one launch unit — under the raw
+        // dep set they hashed apart and the engine emitted two /swarm-start
+        // commands where the batching model says one.
+        const stored = [
+            row(1, STEP_DONE),
+            row(10, STEP_PENDING, [1], { reqIds: [7], epicId: 1 }),
+            row(11, STEP_PENDING, [], { reqIds: [8], epicId: 1 }),
+        ];
+        const batches = launchBatches(displayOrder(stored).rows);
+        expect(batches).toHaveLength(1);
+        expect(batches[0].stepIds.slice().sort()).toEqual([10, 11]);
+        expect(batches[0].gateStepIds).toEqual([]);
+        expect(batches[0].swarmStartArgs.slice().sort()).toEqual([7, 8]);
+        // …and the merged step keeps the RECORD of what gated each member.
+        const [proposal] = condensationProposals(stored);
+        expect(proposal.depStepIds).toEqual([1]);
+        expect(proposal.remainingDepStepIds).toEqual([]);
+    });
+
+    it('still splits when the remaining gates differ (req #3188)', () => {
+        // The other direction, in the same terms: step 1 is Complete and step 2
+        // is not, so step 10 has an empty remaining gate and step 11 does not.
+        // The fix WIDENS the grouping; it does not dissolve it.
+        const stored = [
+            row(1, STEP_DONE),
+            row(2, STEP_PENDING),
+            row(10, STEP_PENDING, [1], { reqIds: [7], epicId: 1 }),
+            row(11, STEP_PENDING, [2], { reqIds: [8], epicId: 1 }),
+        ];
+        expect(launchBatches(displayOrder(stored).rows)).toEqual([]);
+        expect(condensationProposals(stored)).toEqual([]);
     });
 
     it('run mode, machine set, and time gates all split batches', () => {
@@ -552,16 +599,82 @@ describe('launchBatches — rules 2 + 8, the launch unit is explicit', () => {
         expect(launchBatches(displayOrder(stored).rows)).toEqual([]);
     });
 
-    it('a batch may cross epics — grouping ignores labels (rule 10)', () => {
+    it('never MANUFACTURES a cross-epic batch — the group partitions by epic '
+       + '(req #3188)', () => {
+        // THIS TEST USED TO ASSERT THE OPPOSITE, citing rule 10's "a launch unit
+        // may legitimately cross epics". That permission is about a step that
+        // ALREADY spans epics — what the dominant-label tiebreak exists to
+        // resolve — and never licensed MERGING two cleanly-owned steps into one.
+        // Req #3184 made epic -> orchestrator a function: one epic, one Primary,
+        // and "two orchestrators can never select the same requirement for
+        // launch". A merged row hands one epic's requirements to the other
+        // epic's Primary, and the losing epic's work leaves its owner's slice
+        // silently. Measured live on pipeline 2 (2026-08-01): one group held
+        // four epic-6 steps together with six epic-7 steps.
         const stored = [
             row(1, STEP_DONE),
-            row(10, STEP_PENDING, [1], { epic: 'Substrate', reqIds: [7] }),
-            row(11, STEP_PENDING, [1], { epic: 'Application', reqIds: [8] }),
+            row(10, STEP_PENDING, [1], { epicId: 1, epic: 'Substrate', reqIds: [7] }),
+            row(11, STEP_PENDING, [1], { epicId: 2, epic: 'Application', reqIds: [8] }),
+        ];
+        expect(launchBatches(displayOrder(stored).rows)).toEqual([]);
+    });
+
+    it('partitions a shared key into one batch PER epic, keeping the same-epic '
+       + 'subsets (req #3188)', () => {
+        // The fix PARTITIONS; it does not suppress. On the live nine-step
+        // proposal that means two good proposals, not zero.
+        const stored = [
+            row(1, STEP_DONE),
+            row(10, STEP_PENDING, [1], { epicId: 1, epic: 'Substrate', reqIds: [7] }),
+            row(11, STEP_PENDING, [1], { epicId: 1, epic: 'Substrate', reqIds: [8] }),
+            row(12, STEP_PENDING, [1], { epicId: 2, epic: 'Application', reqIds: [9] }),
+            row(13, STEP_PENDING, [1], { epicId: 2, epic: 'Application', reqIds: [10] }),
         ];
         const batches = launchBatches(displayOrder(stored).rows);
+        expect(batches).toHaveLength(2);
+        expect(batches.map((b) => b.stepIds)).toEqual([[10, 11], [12, 13]]);
+        expect(batches.map((b) => b.epicId)).toEqual([1, 2]);
+        expect(batches.map((b) => b.swarmStartArgs)).toEqual([[7, 8], [9, 10]]);
+    });
+
+    it('a step that ALREADY spans epics keys under its DOMINANT one (rule 10)', () => {
+        // Rule 10's permission, preserved: step 12 links requirements from both
+        // epics, derives epic 1 as dominant, and joins epic 1's batch. The
+        // partition is by DOMINANT label — it does not refuse anything
+        // multi-epic, which would have been the over-correction.
+        const model = {
+            steps: [
+                { id: 10, title: 'a', run: 'auto', completed_at: null },
+                { id: 11, title: 'b', run: 'auto', completed_at: null },
+                { id: 12, title: 'spans both', run: 'auto', completed_at: null },
+            ],
+            stepRequirements: [
+                { step_fk: 10, requirement_fk: 70 },
+                { step_fk: 11, requirement_fk: 71 },
+                { step_fk: 12, requirement_fk: 72 },
+                { step_fk: 12, requirement_fk: 73 },
+                { step_fk: 12, requirement_fk: 74 },
+            ],
+            stepDeps: [],
+            requirements: [
+                { id: 70, requirement_status: 'approved', feature_fk: 1, machine_fk: null },
+                { id: 71, requirement_status: 'approved', feature_fk: 1, machine_fk: null },
+                { id: 72, requirement_status: 'approved', feature_fk: 1, machine_fk: null },
+                { id: 73, requirement_status: 'approved', feature_fk: 1, machine_fk: null },
+                { id: 74, requirement_status: 'approved', feature_fk: 2, machine_fk: null },
+            ],
+            features: [{ id: 1, title: 'F1', epic_fk: 1 }, { id: 2, title: 'F2', epic_fk: 2 }],
+            epics: [{ id: 1, title: 'E1' }, { id: 2, title: 'E2' }],
+            machines: [],
+        };
+        const rows = buildPlanRows(model);
+        const spanning = rows.find((r) => r.id === 12);
+        expect(spanning.epicId).toBe(1);
+        expect(spanning.epicLabels.map((e) => e.id)).toEqual([1, 2]);
+        const batches = launchBatches(displayOrder(rows).rows);
         expect(batches).toHaveLength(1);
-        expect(batches[0].stepIds).toEqual([10, 11]);
-        expect(batches[0].swarmStartArgs).toEqual([7, 8]);
+        expect(batches[0].stepIds).toEqual([10, 11, 12]);
+        expect(batches[0].epicId).toBe(1);
     });
 });
 
@@ -579,6 +692,7 @@ describe('condensationProposals — rule 2 proposals, UI decides', () => {
             stepIds: [10, 11],
             requirementIds: [7, 8],
             depStepIds: [1],
+            remainingDepStepIds: [],
             run: 'auto',
             machineLabels: ['Mac mini'],
         });
@@ -590,6 +704,68 @@ describe('condensationProposals — rule 2 proposals, UI decides', () => {
             row(10, STEP_PENDING, [1], { reqIds: [7] }),
             row(11, STEP_PENDING, [2], { reqIds: [8] }),
         ])).toEqual([]);
+    });
+
+    it('NEVER proposes a merge spanning more than one dominant epic, and offers '
+       + 'the same-epic subsets instead (req #3188)', () => {
+        // The live defect, reduced: one proposal held four epic-6 steps and six
+        // epic-7 steps. Acting on it would have handed one epic's requirements
+        // to the other epic's Primary. The required behaviour is to PARTITION,
+        // not to suppress — the bad proposal becomes two good ones.
+        const rows = [
+            row(1, STEP_DONE),
+            row(55, STEP_PENDING, [1], { epicId: 6, epic: 'Mapping', reqIds: [3201] }),
+            row(57, STEP_PENDING, [1], { epicId: 6, epic: 'Mapping', reqIds: [3202] }),
+            row(70, STEP_PENDING, [1], { epicId: 7, epic: 'Backlog', reqIds: [3203] }),
+            row(71, STEP_PENDING, [1], { epicId: 7, epic: 'Backlog', reqIds: [3204] }),
+        ];
+        const proposals = condensationProposals(rows);
+        expect(proposals).toHaveLength(2);
+        expect(proposals.map((p) => p.stepIds)).toEqual([[55, 57], [70, 71]]);
+        expect(proposals.map((p) => p.epicId)).toEqual([6, 7]);
+        expect(proposals.map((p) => p.requirementIds))
+            .toEqual([[3201, 3202], [3203, 3204]]);
+    });
+
+    it('no proposal over the Substrate Rebuild fixture resolves more than one '
+       + 'dominant epic — the invariant, over real plan data (req #3188)', () => {
+        // Pinned rather than observed once. The fixture's own shape is not the
+        // point: the assertion is a PROPERTY of every proposal the engine can
+        // emit from it, and it is stated over the full model rather than over a
+        // constructed pair, so a future change to the fixture cannot quietly
+        // stop exercising it.
+        //
+        // Two model variants, because the stock fixture's nearest pair differs
+        // in run mode and yields no proposal at all: flipping step 43 to auto
+        // produces the first genuine batch in the Substrate data.
+        const variants = [
+            SUBSTRATE_REBUILD_MODEL,
+            {
+                ...SUBSTRATE_REBUILD_MODEL,
+                steps: SUBSTRATE_REBUILD_MODEL.steps.map(
+                    (s) => (s.id === 43 ? { ...s, run: 'auto' } : s)),
+            },
+        ];
+        let seen = 0;
+        for (const model of variants) {
+            const rows = buildPlanRows(model);
+            const byId = new Map(rows.map((r) => [r.id, r]));
+            for (const proposal of condensationProposals(rows)) {
+                seen += 1;
+                const epics = new Set(
+                    proposal.stepIds.map((id) => byId.get(id).epicId));
+                expect(epics.size, `proposal ${proposal.stepIds}`).toBe(1);
+                expect([...epics][0]).toBe(proposal.epicId);
+            }
+            // Same invariant on the launch batches, from the same rows.
+            for (const batch of launchBatches(displayOrder(rows).rows)) {
+                const epics = new Set(batch.stepIds.map((id) => byId.get(id).epicId));
+                expect(epics.size, `batch ${batch.letter}`).toBe(1);
+                expect([...epics][0]).toBe(batch.epicId);
+            }
+        }
+        // A vacuous pass is not a pass: at least one proposal must have existed.
+        expect(seen).toBeGreaterThan(0);
     });
 });
 
@@ -797,13 +973,21 @@ describe('code-review hardenings (2026-07-26)', () => {
     });
 
     it('batch letters continue Excel-style past Z (batch 27 → AA)', () => {
+        // 27 batches split on MACHINE, not on gate. Since req #3188 the key's
+        // gate term is the REMAINING gate, and all 27 gate steps are Complete —
+        // so keying the split on the gate would collapse every pair into one
+        // 54-member batch and this test would letter one batch, not 27. The
+        // subject here is the lettering, so the split moves to the term that
+        // still distinguishes them.
         const stored = [];
         for (let g = 1; g <= 27; g++) {
             stored.push(row(g, STEP_DONE));
         }
         for (let g = 1; g <= 27; g++) {
-            stored.push(row(100 + g * 2, STEP_PENDING, [g], { reqIds: [1000 + g] }));
-            stored.push(row(101 + g * 2, STEP_PENDING, [g], { reqIds: [2000 + g] }));
+            stored.push(row(100 + g * 2, STEP_PENDING, [g],
+                { reqIds: [1000 + g], machines: [`M${g}`] }));
+            stored.push(row(101 + g * 2, STEP_PENDING, [g],
+                { reqIds: [2000 + g], machines: [`M${g}`] }));
         }
         const batches = launchBatches(displayOrder(stored).rows);
         expect(batches).toHaveLength(27);

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -373,12 +373,13 @@ describe('launch-batch box geometry', () => {
         expect(layout.batchBoxes).toEqual([]);
     });
 
-    // A genuine batch, with the two members' requirements under DIFFERENT
-    // epics: the batch renders one box SEGMENT per band (a single tall rect
-    // would also enclose whatever band lies between — review finding), and the
-    // same-gate manual step (not a batch-mate) stays outside every segment.
+    // A genuine batch — and since req #3188 its two members share an epic,
+    // because the engine's launch key includes the dominant epic and can no
+    // longer group across two. The same-gate MANUAL step is the non-member, and
+    // it sits in a second band so the plan still renders more than one.
     // Epic titles are deliberately LONG: the review found the batch letter
-    // colliding with a long epic label when both lived in the band header.
+    // colliding with a long epic label when both lived in the band header, and
+    // that collision is what the label-overlap combinations below still guard.
     const CROSS_EPIC_READS = {
         steps: [
             { id: 1, pipeline_fk: 1, title: 'gate', run: 'auto', notes: null,
@@ -402,8 +403,8 @@ describe('launch-batch box geometry', () => {
         ],
         requirements: [
             { id: 900, requirement_status: 'approved', machine_fk: 2, feature_fk: 101 },
-            { id: 901, requirement_status: 'approved', machine_fk: 2, feature_fk: 102 },
-            { id: 902, requirement_status: 'approved', machine_fk: 2, feature_fk: 101 },
+            { id: 901, requirement_status: 'approved', machine_fk: 2, feature_fk: 101 },
+            { id: 902, requirement_status: 'approved', machine_fk: 2, feature_fk: 102 },
         ],
         features: [
             { id: 101, title: 'Wave One', epic_fk: 11 },
@@ -422,7 +423,7 @@ describe('launch-batch box geometry', () => {
         }),
         { now: NOW });
 
-    it('boxes every member via per-band segments and excludes non-members', () => {
+    it('boxes every member and excludes non-members', () => {
         expect(crossPlan.batches).toHaveLength(1);
         const layout = computePlanLayout(crossPlan.rows, crossPlan.batches);
         const inSomeBox = (n) => layout.batchBoxes.some((box) =>
@@ -432,20 +433,127 @@ describe('launch-batch box geometry', () => {
         const m2 = layout.nodes.get(2);
         const m3 = layout.nodes.get(3);
         const outsider = layout.nodes.get(4);
-        // Cross-band batch → one segment per member band, one letter overall.
-        expect(m2.bandIndex).not.toBe(m3.bandIndex);
-        expect(layout.batchBoxes).toHaveLength(2);
-        expect(layout.batchBoxes.filter((b) => b.topSegment)).toHaveLength(1);
+        // Since req #3188 an ENGINE-PRODUCED batch always sits in one band —
+        // bands key on `epicId` and so does the launch key — so one segment,
+        // one letter. The non-member is in another band entirely and must stay
+        // outside the box regardless.
+        expect(m2.bandIndex).toBe(m3.bandIndex);
+        expect(outsider.bandIndex).not.toBe(m2.bandIndex);
+        expect(layout.batchBoxes).toHaveLength(1);
+        // EVERY segment carries the letter (req #3188). One label for a
+        // batch that draws two side-by-side boxes leaves the second reading
+        // as an anonymous batch of its own.
+        expect(layout.labels.filter((l) => l.kind === 'batch'))
+            .toHaveLength(layout.batchBoxes.length);
         expect(inSomeBox(m2)).toBe(true);
         expect(inSomeBox(m3)).toBe(true);
         expect(inSomeBox(outsider)).toBe(false);
         expect(layout.labels.filter((l) => l.kind === 'batch')).toHaveLength(1);
     });
 
+    it('segments a MULTI-COLUMN batch per column rather than drawing one wide rect', () => {
+        // REQ #3188 REGRESSION. Batch-mates used to share a raw dep set and
+        // therefore a depth, so one column per batch was sound; keying on the
+        // REMAINING gate makes "gated by a Complete step" and "not gated at all"
+        // one launch unit at DIFFERENT depths. A single-column box then left a
+        // member outside itself and enclosed whatever unrelated bead sat in the
+        // column it did cover.
+        const reads = {
+            steps: [
+                { id: 1, pipeline_fk: 1, title: 'closed gate', run: 'auto', notes: null,
+                    completed_at: null },
+                { id: 2, pipeline_fk: 1, title: 'behind the closed gate', run: 'auto',
+                    notes: null, completed_at: null },
+                { id: 3, pipeline_fk: 1, title: 'no gate at all', run: 'auto',
+                    notes: null, completed_at: null },
+            ],
+            stepRequirements: [
+                { step_fk: 1, requirement_fk: 950 },
+                { step_fk: 2, requirement_fk: 951 },
+                { step_fk: 3, requirement_fk: 952 },
+            ],
+            stepDeps: [{ id: 1, step_fk: 2, dep_step_fk: 1, time_at: null }],
+            requirements: [
+                { id: 950, requirement_status: 'met', machine_fk: 2, feature_fk: 301 },
+                { id: 951, requirement_status: 'approved', machine_fk: 2, feature_fk: 301 },
+                { id: 952, requirement_status: 'approved', machine_fk: 2, feature_fk: 301 },
+            ],
+            features: [{ id: 301, title: 'F1', epic_fk: 31 }],
+            epics: [{ id: 31, title: 'Epic A' }],
+            machines: MACHINES,
+        };
+        const p = orderedPlan(buildPipelineModel({
+            pipeline: { id: 1, title: 'x', pipeline_status: 'active', machine_fk: 2 },
+            ...reads,
+        }), { now: NOW });
+        expect(p.batches).toHaveLength(1);
+        expect(p.batches[0].stepIds.slice().sort()).toEqual([2, 3]);
+
+        const layout = computePlanLayout(p.rows, p.batches);
+        const m2 = layout.nodes.get(2);
+        const m3 = layout.nodes.get(3);
+        const outsider = layout.nodes.get(1);
+        expect(m2.depth).not.toBe(m3.depth);
+        expect(layout.batchBoxes).toHaveLength(2);
+        // EVERY segment carries the letter (req #3188). One label for a
+        // batch that draws two side-by-side boxes leaves the second reading
+        // as an anonymous batch of its own.
+        expect(layout.labels.filter((l) => l.kind === 'batch'))
+            .toHaveLength(layout.batchBoxes.length);
+
+        const encloses = (box, n) => n.x > box.x && n.x < box.x + box.width
+            && n.y > box.y && n.y < box.y + box.height;
+        // Every member is inside SOME segment…
+        for (const member of [m2, m3]) {
+            expect(layout.batchBoxes.some((box) => encloses(box, member)),
+                `member ${member.id} must be boxed`).toBe(true);
+        }
+        // …and the Complete step sharing step 3's column is inside NONE.
+        for (const box of layout.batchBoxes) {
+            expect(encloses(box, outsider), 'the gate must stay outside').toBe(false);
+        }
+    });
+
+    it('segments a cross-band batch per band rather than drawing one tall rect', () => {
+        // THE GEOMETRY IS TESTED DIRECTLY, with a HAND-BUILT batch, because the
+        // engine can no longer produce this input: req #3188 put the dominant
+        // epic in the launch key, and bands key on the same field. That makes
+        // this branch defensive rather than reachable — computePlanLayout takes
+        // rows and batches as arguments and cannot know they were derived
+        // together, so a stale or hand-assembled batch must still not enclose a
+        // band it has no member in (the original review finding). Deleting the
+        // segmentation instead would trade a tested defence for an untested
+        // assumption about every caller, forever.
+        const batch = { letter: 'A', stepIds: [2, 4], swarmStartArgs: [900, 902] };
+        const layout = computePlanLayout(crossPlan.rows, [batch]);
+        const m2 = layout.nodes.get(2);
+        const m4 = layout.nodes.get(4);
+        expect(m2.bandIndex).not.toBe(m4.bandIndex);
+        expect(layout.batchBoxes).toHaveLength(2);
+        // EVERY segment carries the letter (req #3188). One label for a
+        // batch that draws two side-by-side boxes leaves the second reading
+        // as an anonymous batch of its own.
+        expect(layout.labels.filter((l) => l.kind === 'batch'))
+            .toHaveLength(layout.batchBoxes.length);
+        expect(layout.batchBoxes.map((b) => b.stepIds)).toEqual([[2], [4]]);
+        // The non-member sharing band 2's neighbourhood is never swallowed.
+        const outsider = layout.nodes.get(3);
+        for (const box of layout.batchBoxes) {
+            const inside = outsider.x > box.x && outsider.x < box.x + box.width
+                && outsider.y > box.y && outsider.y < box.y + box.height;
+            expect(inside).toBe(false);
+        }
+    });
+
     it('never encloses a bead from an unrelated band between two members', () => {
         // Review dataset: members in the first and third bands, a NON-member in
         // the band between them, all sharing the gate. The POC's single tall
         // rect read step 3 as launching in batch A; segments must not.
+        //
+        // The batch is HAND-BUILT for the same reason as the segmentation test
+        // above: since req #3188 the engine's launch key carries the dominant
+        // epic, so it can no longer emit a batch whose members sit in different
+        // bands. The geometry still has to survive one.
         const reads = {
             steps: [
                 { id: 1, pipeline_fk: 1, title: 'gate', run: 'auto', notes: null,
@@ -489,9 +597,13 @@ describe('launch-batch box geometry', () => {
                 ...reads,
             }),
             { now: NOW });
-        expect(p.batches).toHaveLength(1);
-        expect(p.batches[0].stepIds.sort()).toEqual([2, 4]);
-        const layout = computePlanLayout(p.rows, p.batches);
+        // Each of the three steps derives its own epic, so the engine correctly
+        // proposes NO batch at all — the input this geometry has to survive is
+        // constructed, not derived.
+        expect(p.batches).toEqual([]);
+        const batch = { letter: 'A', stepIds: [2, 4], swarmStartArgs: [900, 902] };
+        const layout = computePlanLayout(p.rows, [batch]);
+        expect(layout.batchBoxes).toHaveLength(2);
         const outsider = layout.nodes.get(3);
         for (const box of layout.batchBoxes) {
             const inside = outsider.x > box.x && outsider.x < box.x + box.width

--- a/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
@@ -201,7 +201,12 @@ describe('launch batches (design rule 8)', () => {
     });
 
     it('names the gate and the run mode the banner prints', () => {
-        expect(plan.batches[0].gateStepIds).toEqual([1]);
+        // The REMAINING gate since req #3188, and step 1 carries a completed_at
+        // stamp — so the honest banner text is "no step gate", not "steps 1".
+        // The batch is eligible NOW; naming a dep that closed on 2026-07-01
+        // read as something still holding it back.
+        expect(plan.batches[0].gateStepIds).toEqual([]);
+        expect(plan.batches[0].epicId).toBe(11);
         expect(plan.batches[0].run).toBe('auto');
         expect(plan.batches[0].machineLabels).toEqual(['Mac mini']);
     });

--- a/src/SwarmView/pipelines/pipelineModel.js
+++ b/src/SwarmView/pipelines/pipelineModel.js
@@ -97,9 +97,13 @@
 //
 // @typedef {Object} LaunchBatch
 // @property {string} letter             A = launches first (display order)
-// @property {string} key                canonical (dep set, time gates, run, machines)
+// @property {string} key                canonical (epic, REMAINING gate, time gates,
+//                                       run, machines) — req #3188
 // @property {number[]} stepIds          display order
-// @property {number[]} gateStepIds
+// @property {?number} epicId            the ONE dominant epic every member shares
+// @property {?string} epic
+// @property {number[]} gateStepIds      the REMAINING (unsatisfied) step gate — shared
+//                                       by every member by construction (req #3188)
 // @property {string[]} timeDeps
 // @property {('auto'|'manual')} run
 // @property {string[]} machineLabels
@@ -113,11 +117,16 @@
 //
 // @typedef {Object} CondensationProposal  rule 2 — proposal only; UI decides
 // @property {number[]} stepIds
+// @property {?number} epicId                  the ONE dominant epic every member
+// @property {?string} epic                    shares (req #3188)
 // @property {number[]} requirementIds         launchable only (rule 8)
 // @property {number[]} trackingRequirementIds containers — carried over on a merge,
 //                                             never launched (req #3123)
-// @property {number[]} depStepIds
-// @property {string[]} timeDeps
+// @property {number[]} depStepIds             the UNION of the members' step gates —
+//                                             what the MERGED step must carry
+// @property {number[]} remainingDepStepIds    the unsatisfied subset, shared by every
+//                                             member by construction (req #3188)
+// @property {string[]} timeDeps               union, same reasoning as depStepIds
 // @property {('auto'|'manual')} run
 // @property {string[]} machineLabels
 // @property {string} reason
@@ -425,22 +434,78 @@ function idCmp(a, b) {
     return String(a) < String(b) ? -1 : String(a) > String(b) ? 1 : 0;
 }
 
-// Canonical launch-unit identity: identical (dep set + time gates, run mode,
-// machine set) — the batch key of rules 2 and 8. Time gates are part of the
-// gate; machine set comes from the requirement-derived labels.
-function launchKey(row) {
-    const deps = [...new Set(depIdsOf(row))].sort(idCmp).join(',');
+// The step gate that is still UNSATISFIED: the deps whose row is not done
+// (req #3188). A dep missing from the row set counts as unsatisfied — the safe
+// direction, and verifyOrder reports it as `dangling-dependency` separately.
+//
+// @param {PlanRow} row
+// @param {Map<number, PlanRow>} byId
+// @returns {number[]}  in the row's own dep order
+export function remainingGate(row, byId) {
+    return depIdsOf(row).filter((d) => {
+        const dep = byId.get(d);
+        return !dep || dep.state !== STEP_DONE;
+    });
+}
+
+// Canonical launch-unit identity: identical (dominant epic, REMAINING step gate,
+// time gates, run mode, machine set) — the batch key of rules 2 and 8. Machine
+// set comes from the requirement-derived labels.
+//
+// EPIC IS A TERM IN THE KEY (req #3188). Rule 10 gives a step exactly ONE
+// dominant epic, and req #3184's concurrency model makes epic -> orchestrator a
+// function: one epic, one Primary, and two orchestrators can never select the
+// same requirement for launch. A batch spanning two epics therefore hands one
+// epic's requirements to the other epic's Primary, and the losing epic's work
+// silently leaves its owner's slice. Measured on live pipeline 2 (2026-08-01,
+// 68 steps): ONE group held steps 55/57/59/60 (epic 6, Mapping Aggregator Card)
+// together with 70/71/72/73/74/85 (epic 7, Swarm Backlog) — ten steps, two
+// epics, rendered to the user as a single condensation suggestion.
+//
+// Rule 10's "a launch unit may legitimately cross epics" is about a step that
+// ALREADY spans epics — which is what the dominant-label tiebreak exists to
+// resolve — and is not licence to MANUFACTURE one out of steps that are each
+// cleanly owned. Partitioning at the KEY rather than at either consumer is what
+// makes launchBatches, condensationProposals, displayOrder's batch clustering
+// and verifyOrder's contiguity check agree by construction.
+//
+// The epic ID, not the title — unlike machineLabels, whose title/id split is the
+// one deliberate divergence from pipeline_derive.py. Both engines carry the id,
+// so keying on it adds no second divergence, and two epics sharing a title stay
+// correctly apart.
+//
+// THE GATE TERM IS THE REMAINING GATE, NOT THE RAW DEP SET (req #3188). Two
+// pending steps whose gates differ only in deps that are already done become
+// eligible at the SAME INSTANT and can genuinely launch together; keying on the
+// raw set hashed them apart and emitted two /swarm-start commands where the
+// batching model says one. The remaining gate is a function of PLAN STATE ALONE,
+// so this module stays pure and the same plan always renders the same way.
+//
+// TIME GATES STAY RAW, deliberately. Deciding whether a time gate has passed
+// needs a clock, and a clock in the batch key would make the partition — and
+// therefore display order and the batch-contiguity invariant — a function of
+// wall time: the same unmutated plan would render differently at two instants,
+// which is a worse instability than the one this fix removes. A time gate is
+// also a scheduled gate the plan author wrote; two steps carrying different ones
+// are different launch units by intent until both pass.
+function launchKey(row, byId) {
+    const epic = row.epicId != null ? row.epicId : '';
+    const deps = [...new Set(remainingGate(row, byId))].sort(idCmp).join(',');
     const times = [...(row.timeDeps || [])].sort().join(',');
     const machines = [...(row.machineLabels || [])].sort().join(',');
-    return `${deps}|${times}|${row.run || 'auto'}|${machines}`;
+    return `${epic}|${deps}|${times}|${row.run || 'auto'}|${machines}`;
 }
 
 // Pending launch groups keyed by launchKey; only groups of >=2 form a batch.
+// The row set is needed to resolve the remaining gate, so it is indexed here
+// once rather than by every caller — every caller already passes the FULL row
+// set, which is what makes the key self-contained.
 function pendingGroups(rows) {
+    const byId = new Map(rows.map((r) => [r.id, r]));
     const groups = new Map();
     for (const r of rows) {
         if (r.state !== STEP_PENDING) continue;
-        const k = launchKey(r);
+        const k = launchKey(r, byId);
         if (!groups.has(k)) groups.set(k, []);
         groups.get(k).push(r);
     }
@@ -848,23 +913,30 @@ function launchableReqIds(row) {
     return (row.reqIds || []).filter((id) => !tracking.has(id));
 }
 
-// Rules 2 + 8: pending steps sharing an identical (dep set + time gates, run,
-// machine set) launch together in ONE /swarm-start. Batches of >=2 steps get a
-// letter — A launches first — following display order, and each carries the
-// EXACT /swarm-start argument list (requirement ids in display order, tracking
-// containers excluded). A batch with nothing launchable — req-less gate steps,
-// or steps linked only to containers — has no launchable command:
-// swarmStartCommand is null, never an argument-less string.
+// Rules 2 + 8: pending steps sharing an identical (dominant epic, remaining step
+// gate + time gates, run, machine set) launch together in ONE /swarm-start.
+// Batches of >=2 steps get a letter — A launches first — following display
+// order, and each carries the EXACT /swarm-start argument list (requirement ids
+// in display order, tracking containers excluded). A batch with nothing
+// launchable — req-less gate steps, or steps linked only to containers — has no
+// launchable command: swarmStartCommand is null, never an argument-less string.
+//
+// `gateStepIds` is the REMAINING gate (req #3188), which every member shares by
+// construction now that it is the key's gate term. It is also the better answer
+// for the banner it renders into: a batch that is eligible NOW reports no step
+// gate rather than naming deps that closed long ago, and one that is still
+// waiting names exactly what it waits on.
 //
 // @param {PlanRow[]} orderedRows  display order (letters follow it)
 // @returns {LaunchBatch[]}
 export function launchBatches(orderedRows) {
+    const byId = new Map(orderedRows.map((r) => [r.id, r]));
     const groups = pendingGroups(orderedRows);
     const batches = [];
     const seen = new Set();
     for (const r of orderedRows) {
         if (r.state !== STEP_PENDING) continue;
-        const k = launchKey(r);
+        const k = launchKey(r, byId);
         const members = groups.get(k);
         if (members.length < 2 || seen.has(k)) continue;
         seen.add(k);
@@ -877,7 +949,9 @@ export function launchBatches(orderedRows) {
             letter: batchLetter(batches.length),
             key: k,
             stepIds: members.map((m) => m.id),
-            gateStepIds: [...depIdsOf(members[0])].sort(idCmp),
+            epicId: members[0].epicId != null ? members[0].epicId : null,
+            epic: members[0].epic != null ? members[0].epic : null,
+            gateStepIds: [...new Set(remainingGate(members[0], byId))].sort(idCmp),
             timeDeps: [...(members[0].timeDeps || [])].sort(),
             run: members[0].run || 'auto',
             machineLabels: labels,
@@ -900,13 +974,25 @@ export function launchBatches(orderedRows) {
 }
 
 // Rule 2: A STEP IS A SWARM-START (LAUNCH UNIT). Pending steps sharing an
-// identical (gate, run, machine) tuple are proposed for condensation into ONE
-// multi-requirement step. Proposal objects only — the UI decides presentation.
-// Order: first appearance in the given rows.
+// identical (epic, remaining gate, run, machine) tuple are proposed for
+// condensation into ONE multi-requirement step. Proposal objects only — the UI
+// decides presentation. Order: first appearance in the given rows.
+//
+// THIS LIVES IN THE VIEWER AND NOT IN `pipeline_derive.py` — a decision, not an
+// oversight (req #3188, extending req #3184's ruling). It is an advisory with no
+// server consumer: the Pipeline Engine acts on eligibility and launch batches,
+// never on a suggestion. Porting it would be speculative code, which is exactly
+// the cost a second implementation cannot carry. What COULD have drifted — the
+// pendingGroups/launchKey partition it shares with launchBatches — is not
+// viewer-only: it is already dual-implemented and pinned by the shared
+// conformance corpus through launch_batches, so a proposal inherits the epic
+// partition and the remaining-gate key by construction rather than by a copy
+// somebody has to remember to update.
 //
 // @param {PlanRow[]} rows  any order
 // @returns {CondensationProposal[]}
 export function condensationProposals(rows) {
+    const byId = new Map(rows.map((r) => [r.id, r]));
     const proposals = [];
     for (const [, members] of pendingGroups(rows)) {
         if (members.length < 2) continue;
@@ -915,10 +1001,23 @@ export function condensationProposals(rows) {
         for (const m of members) {
             for (const l of m.machineLabels || []) if (!labels.includes(l)) labels.push(l);
         }
-        const gate = depIdsOf(first).length
-            ? `steps ${[...depIdsOf(first)].sort(idCmp).join(', ')}` : 'no step gate';
+        // UNION, not members[0]'s copy. Under the remaining-gate key (req #3188)
+        // members may hold DIFFERENT raw dep sets that merely agree on what is
+        // still unsatisfied, and a caller acting on this proposal builds the
+        // merged step from these ids: taking one member's set would silently
+        // drop another member's already-satisfied dep edge and erase the plan's
+        // record of what gated that work. The union is identical to the old
+        // value whenever the members' raw sets agree, which is every case the
+        // previous key could produce.
+        const depStepIds = [...new Set(members.flatMap(depIdsOf))].sort(idCmp);
+        const timeDeps = [...new Set(members.flatMap((m) => m.timeDeps || []))].sort();
+        const remaining = [...new Set(remainingGate(first, byId))].sort(idCmp);
+        const gate = remaining.length
+            ? `steps ${remaining.join(', ')}` : 'no remaining step gate';
         proposals.push({
             stepIds: members.map((m) => m.id),
+            epicId: first.epicId != null ? first.epicId : null,
+            epic: first.epic != null ? first.epic : null,
             // Tracking containers excluded for the same reason as in
             // launchBatches: a condensed step's requirement set is what the
             // merged /swarm-start would launch. They are reported SEPARATELY
@@ -928,13 +1027,15 @@ export function condensationProposals(rows) {
             requirementIds: members.flatMap(launchableReqIds),
             trackingRequirementIds: [...new Set(
                 members.flatMap((m) => m.trackingReqIds || []))],
-            depStepIds: [...depIdsOf(first)].sort(idCmp),
-            timeDeps: [...(first.timeDeps || [])].sort(),
+            depStepIds,
+            remainingDepStepIds: remaining,
+            timeDeps,
             run: first.run || 'auto',
             machineLabels: labels,
-            reason: `steps ${members.map((m) => m.id).join(', ')} share the same gate ` +
-                `(${gate}), run mode '${first.run || 'auto'}' and machine set — ` +
-                'candidates to condense into one multi-requirement step (design rule 2)',
+            reason: `steps ${members.map((m) => m.id).join(', ')} share the same ` +
+                `remaining gate (${gate}), epic (${first.epic || 'none'}), run mode ` +
+                `'${first.run || 'auto'}' and machine set — candidates to condense ` +
+                'into one multi-requirement step (design rule 2)',
         });
     }
     return proposals;

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -22,9 +22,17 @@
 //     column widths account for whichever is drawn. Zero label overlap holds in
 //     all four combinations BY CONSTRUCTION, and the exported label rects let
 //     tests assert it rather than trust it.
-//   - Launch-batch dashed boxes around batch-mates (identical gate + run +
-//     machines — the engine's launchKey). Identical dep sets mean identical
-//     depth, so a batch is one column; a box may legitimately span epic bands.
+//   - Launch-batch dashed boxes around batch-mates (identical epic + remaining
+//     gate + run + machines — the engine's launchKey), drawn as ONE SEGMENT PER
+//     (BAND, COLUMN). Both axes matter and for different reasons. Since req
+//     #3188 the key carries the dominant epic — the same field these bands are
+//     keyed on — so an ENGINE-PRODUCED box always sits in exactly one BAND; that
+//     segmentation stays as a tested defence, because this module takes rows and
+//     batches as arguments and cannot know they were derived together. The
+//     COLUMN axis is the live one: #3188 also keys on the REMAINING gate, so a
+//     step gated by an already-Complete dep and a gate-less step are one launch
+//     unit at different dependency depths. A rect spanning either axis would
+//     enclose a non-member, which is the review finding this shape exists for.
 //
 // Two deliberate deviations from the POC, both documented for the PR:
 //   1. Band header height 40 (POC 34): the POC's epic label and a lane-0 step
@@ -591,26 +599,49 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
         }
     }
 
-    // ── Launch-batch boxes (identical gate ⇒ identical column) ──────────────
-    // One box SEGMENT per epic band the batch touches, not one tall rect: a
-    // single rect spanning bands would also enclose whatever unrelated band
-    // lies between two members (review finding) — a user would read a
+    // ── Launch-batch boxes ─────────────────────────────────────────────────
+    // One box SEGMENT per (epic band, column) the batch touches, not one rect:
+    // a single rect spanning either axis also encloses whatever unrelated band
+    // or column lies between two members (review finding) — a user would read a
     // non-member as launching in the batch. Segments share the letter and the
     // hover payload, so the launch unit stays one visible thing.
+    //
+    // Since req #3188 an engine-produced batch cannot span BANDS (the launch key
+    // and the band key are both the dominant epic); that half is kept as a
+    // DEFENCE on an argument this module does not derive — see the module
+    // header. The COLUMN half is live and reachable: #3188 keys on the remaining
+    // gate, so batch-mates legitimately sit at different dependency depths.
     const batchBoxes = [];
     for (const b of safeBatches) {
         const members = (b.stepIds || []).map((id) => nodes.get(id)).filter(Boolean);
         if (members.length < 2) continue;
-        const d = members[0].depth;
-        const w = Math.max((colW[d] || 110) - 8, 56);
-        const x = members[0].x - w / 2;
-        const byBand = new Map();
+        // ONE SEGMENT PER (BAND, COLUMN) — req #3188 made the column half of that
+        // load-bearing, and getting it wrong is the SAME defect the band half was
+        // built for, on the other axis. Until #3188 batch-mates shared a raw dep
+        // set, so they shared a depth, so one column and one x/width for the
+        // whole batch was sound. Now they share the REMAINING gate: a step gated
+        // by an already-Complete dep and a step with no gate at all are one
+        // launch unit at DIFFERENT depths. Measured on the corpus's own
+        // `batch-groups-on-remaining-gate` case — batch A is [3, 5, 2] with 3
+        // and 5 at depth 0 and 2 at depth 1 — a single-column box left member 2
+        // outside it and enclosed the unrelated Complete step 1.
+        const byCell = new Map();
         for (const n of members) {
-            if (!byBand.has(n.bandIndex)) byBand.set(n.bandIndex, []);
-            byBand.get(n.bandIndex).push(n);
+            const cell = `${n.bandIndex}|${n.depth}`;
+            if (!byCell.has(cell)) byCell.set(cell, []);
+            byCell.get(cell).push(n);
         }
-        [...byBand.keys()].sort((p, q) => p - q).forEach((bandIndex, i) => {
-            const ms = byBand.get(bandIndex);
+        // Band first, then column: the letter goes on the FIRST segment, and the
+        // plan reads top-to-bottom before left-to-right.
+        const cells = [...byCell.keys()].sort((p, q) => {
+            const [pb, pd] = p.split('|').map(Number);
+            const [qb, qd] = q.split('|').map(Number);
+            return (pb - qb) || (pd - qd);
+        });
+        for (const cell of cells) {
+            const ms = byCell.get(cell);
+            const [bandIndex, depth] = cell.split('|').map(Number);
+            const w = Math.max((colW[depth] || 110) - 8, 56);
             const yTop = Math.min(...ms.map((n) => n.y)) - 40;
             const yBot = Math.max(...ms.map((n) => {
                 const row = byId.get(n.id);
@@ -620,11 +651,14 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
             }));
             batchBoxes.push({
                 letter: b.letter, stepIds: ms.map((n) => n.id),
-                batchStepIds: b.stepIds, x, y: yTop,
+                batchStepIds: b.stepIds, x: ms[0].x - w / 2, y: yTop,
                 width: w, height: yBot - yTop,
-                bandIndex, topSegment: i === 0,
+                // `(bandIndex, depth)` identifies the segment — the renderer's
+                // React key, since `letter` alone stopped being unique per box
+                // when a batch acquired more than one segment (req #3188).
+                bandIndex, depth,
             });
-        });
+        }
     }
 
     // ── Label rectangles — every piece of text the canvas draws, as world
@@ -704,14 +738,23 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
             x: 12, y: band.y + 6, w: band.epic.length * CHW_EPIC, h: 16,
         });
     }
-    // Batch letters live in the reserved header strip of the top segment's
-    // band — below the epic label (ends at band.y+19), above lane 0's step
-    // label (starts at band.y + headerH − 16 = band.y + 40 with the extended
-    // header) — so the letter can never collide with either, whatever the epic
-    // title length. Letters sharing a band stagger rightward.
+    // Batch letters live in the reserved header strip of a segment's band —
+    // below the epic label (ends at band.y+19), above lane 0's step label
+    // (starts at band.y + headerH − 16 = band.y + 40 with the extended header)
+    // — so the letter can never collide with either, whatever the epic title
+    // length. Letters sharing a band stagger rightward.
+    //
+    // EVERY SEGMENT IS LABELLED, not just the first (req #3188). While a batch
+    // could only segment across BANDS — which the engine can no longer produce
+    // at all — one letter for the whole batch read as one launch unit stacked
+    // vertically. Column segments sit SIDE BY SIDE and are reachable on any plan
+    // where mates share only their remaining gate, and an unlabelled dashed box
+    // beside a labelled one reads as a second, anonymous batch. Repeating
+    // "batch A" is the honest rendering: both boxes ARE batch A. The stagger
+    // loop already keeps two letters in one band apart, and segments in
+    // different columns start far enough apart that it rarely has to.
     const placedLetters = new Map(); // bandIndex -> [{x, w}]
     for (const box of batchBoxes) {
-        if (!box.topSegment) continue;
         const text = `batch ${box.letter}`;
         const w = text.length * 6;
         const band = bands[box.bandIndex];


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-01T02:07:37Z
- chore: init swarm session feature/3188-condensation-launch-batch-grouping-1

## Files changed
```
 src/SwarmView/pipelines/PipelinePlanTable.jsx      |   6 +-
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx |  13 +-
 .../__tests__/pipelineConformance.test.js          |   7 +
 .../pipelines/__tests__/pipelineModel.test.js      | 204 ++++++++++++++++++++-
 .../pipelines/__tests__/pipelinePlanLayout.test.js | 142 ++++++++++++--
 .../pipelines/__tests__/pipelineViewModel.test.js  |   7 +-
 src/SwarmView/pipelines/pipelineModel.js           | 161 +++++++++++++---
 src/SwarmView/pipelines/pipelinePlanLayout.js      |  91 ++++++---
 8 files changed, 548 insertions(+), 83 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)