### PR TITLE
Plan visualizer: horizontal axis reads as TIME, not dependency depth — unstarted epics render right, bands stack by epic start

### DIFF
--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -138,9 +138,15 @@ export default function PipelinePlanVisualizer({
         () => new Map((model?.requirements || [])
             .map((r) => [r.id, { title: r.title, status: r.requirement_status }])),
         [model]);
+    // `plan.timeAxis` (req #3201) is what makes the horizontal axis read as a
+    // calendar and stacks the bands by epic start. It comes from `orderedPlan`
+    // rather than being derived here for the same reason cost does: two
+    // surfaces over one plan must not each derive the same fact.
     const layout = useMemo(
-        () => computePlanLayout(rows, plan.batches || [], { reqLayout, stepLabel }),
-        [rows, plan.batches, reqLayout, stepLabel]);
+        () => computePlanLayout(rows, plan.batches || [], {
+            reqLayout, stepLabel, timeAxis: plan.timeAxis || null,
+        }),
+        [rows, plan.batches, plan.timeAxis, reqLayout, stepLabel]);
 
     // ── Machine identity on the REQUIREMENT IDS (req #3119) ─────────────────
     // Machine rides the requirement ids, never the bead: the bead's fill already

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -13,7 +13,7 @@ import { SUBSTRATE_REBUILD_MODEL, MACHINES } from './substrateRebuildFixture';
 import { buildPipelineModel, orderedPlan } from '../pipelineViewModel';
 import {
     computePlanLayout, beadStyle, stepLabelText, BEAD_RADIUS,
-    PLAN_VIZ_PALETTE,
+    PLAN_VIZ_PALETTE, STEP_DONE,
 } from '../pipelinePlanLayout';
 
 const NOW = '2026-07-27T03:00:00Z';
@@ -90,7 +90,7 @@ describe('placement fundamentals (Substrate Rebuild fixture)', () => {
         for (const r of plan.rows) expect(layout.nodes.get(r.id)).toBeTruthy();
     });
 
-    it('assigns dependency-depth columns: a dep always sits left of its dependent', () => {
+    it('every arc points forward: a dep always sits left of its dependent', () => {
         for (const r of plan.rows) {
             const n = layout.nodes.get(r.id);
             for (const d of r.depIds) {
@@ -119,13 +119,32 @@ describe('placement fundamentals (Substrate Rebuild fixture)', () => {
         }
     });
 
-    it('groups bands by dominant epic in first-appearance order over display order', () => {
-        const expected = [];
-        for (const r of plan.rows) {
-            const key = r.epicId != null ? r.epicId : null;
-            if (!expected.includes(key)) expected.push(key);
-        }
+    // With no time axis supplied every epic is undated, so req #3201's band
+    // rule falls through to its documented tie-break: epic id ascending, the
+    // label-less band last. (The fixture carries no timestamps at all — the
+    // timed axis is exercised in its own describe block below.)
+    it('stacks bands by epic id when no epic has a derived start', () => {
+        const expected = [...new Set(plan.rows.map((r) => (r.epicId != null ? r.epicId : null)))]
+            .sort((a, b) => (a === b ? 0 : a === null ? 1 : b === null ? -1 : a - b));
         expect(layout.bands.map((b) => b.epicId)).toEqual(expected);
+    });
+
+    // The degenerate axis IS the old axis. Without this, "one code path" is a
+    // claim in a comment rather than a property.
+    it('degenerates to pure dependency depth with no time axis', () => {
+        const byId = new Map(plan.rows.map((r) => [r.id, r]));
+        const memo = new Map();
+        const depth = (r) => {
+            if (memo.has(r.id)) return memo.get(r.id);
+            memo.set(r.id, 0);
+            const v = 1 + Math.max(-1, ...(r.depIds || [])
+                .filter((d) => byId.has(d)).map((d) => depth(byId.get(d))));
+            memo.set(r.id, v);
+            return v;
+        };
+        for (const r of plan.rows) {
+            expect(layout.nodes.get(r.id).depth).toBe(depth(r));
+        }
     });
 });
 
@@ -716,4 +735,326 @@ describe('empty plan', () => {
         expect(layout.nodes.size).toBe(0);
         expect(layout.labels).toEqual([]);
     });
+});
+
+// ── The TIME AXIS (req #3201) ───────────────────────────────────────────────
+// A purpose-built model rather than the Substrate fixture, because the shapes
+// under test are shapes that fixture does not contain: an epic that has never
+// started at all, an UNGATED step whose work began late (the live step-97
+// shape, which is the acceptance case a per-band origin cannot satisfy), a
+// dependency that crosses an epic boundary, and a dependency edge that runs
+// BACKWARD in time. Every requirement here carries `completed_at` and no
+// `started_at`, which is what the live table overwhelmingly looks like.
+const TIMED_MODEL = {
+    pipeline: { id: 500, title: 'Time axis' },
+    epics: [
+        { id: 1, title: 'Shipped' },
+        { id: 2, title: 'In flight' },
+        { id: 3, title: 'Backlog' },
+    ],
+    features: [
+        { id: 11, title: 'F-shipped', epic_fk: 1 },
+        { id: 12, title: 'F-flight', epic_fk: 2 },
+        { id: 13, title: 'F-backlog', epic_fk: 3 },
+    ],
+    machines: [],
+    steps: [
+        { id: 1, pipeline_fk: 500, title: 'Ship A', run: 'auto', completed_at: null },
+        { id: 2, pipeline_fk: 500, title: 'Ship B', run: 'auto', completed_at: null },
+        { id: 3, pipeline_fk: 500, title: 'Flight A', run: 'auto', completed_at: null },
+        // The step-97 shape: no dep edges at all, work begun on the LATEST day.
+        { id: 4, pipeline_fk: 500, title: 'Flight late, ungated', run: 'auto', completed_at: null },
+        { id: 5, pipeline_fk: 500, title: 'Backlog A', run: 'auto', completed_at: null },
+        { id: 6, pipeline_fk: 500, title: 'Backlog B', run: 'auto', completed_at: null },
+        // Backward in time: its own work completed on day 1, but it is gated on
+        // step 3, whose work began on day 3.
+        { id: 7, pipeline_fk: 500, title: 'Ship C, late gate', run: 'auto', completed_at: null },
+    ],
+    stepDeps: [
+        { id: 1, step_fk: 2, dep_step_fk: 1, time_at: null },
+        { id: 2, step_fk: 3, dep_step_fk: 2, time_at: null },   // crosses epic 1 -> 2
+        { id: 3, step_fk: 6, dep_step_fk: 5, time_at: null },
+        { id: 4, step_fk: 7, dep_step_fk: 3, time_at: null },   // backward in time
+    ],
+    stepRequirements: [
+        { step_fk: 1, requirement_fk: 101 },
+        { step_fk: 2, requirement_fk: 102 },
+        { step_fk: 3, requirement_fk: 103 },
+        { step_fk: 4, requirement_fk: 104 },
+        { step_fk: 5, requirement_fk: 105 },
+        { step_fk: 6, requirement_fk: 106 },
+        { step_fk: 7, requirement_fk: 107 },
+    ],
+    requirements: [
+        // `met` with NO started_at — 820 of 960 live `met` rows look like this.
+        {
+            id: 101, title: 'r101', requirement_status: 'met', feature_fk: 11,
+            machine_fk: null, coordination_type: 'implemented', tracking: 0,
+            started_at: null, completed_at: '2026-07-25T09:00:00',
+        },
+        {
+            id: 102, title: 'r102', requirement_status: 'met', feature_fk: 11,
+            machine_fk: null, coordination_type: 'implemented', tracking: 0,
+            started_at: null, completed_at: '2026-07-26T09:00:00',
+        },
+        {
+            id: 103, title: 'r103', requirement_status: 'development', feature_fk: 12,
+            machine_fk: null, coordination_type: 'implemented', tracking: 0,
+            started_at: '2026-07-27T09:00:00', completed_at: null,
+        },
+        {
+            id: 104, title: 'r104', requirement_status: 'development', feature_fk: 12,
+            machine_fk: null, coordination_type: 'implemented', tracking: 0,
+            started_at: '2026-07-28T09:00:00', completed_at: null,
+        },
+        {
+            id: 105, title: 'r105', requirement_status: 'authoring', feature_fk: 13,
+            machine_fk: null, coordination_type: 'implemented', tracking: 0,
+            started_at: null, completed_at: null,
+        },
+        {
+            id: 106, title: 'r106', requirement_status: 'approved', feature_fk: 13,
+            machine_fk: null, coordination_type: 'implemented', tracking: 0,
+            started_at: null, completed_at: null,
+        },
+        {
+            id: 107, title: 'r107', requirement_status: 'met', feature_fk: 11,
+            machine_fk: null, coordination_type: 'implemented', tracking: 0,
+            started_at: null, completed_at: '2026-07-25T10:00:00',
+        },
+    ],
+};
+
+const timedPlan = orderedPlan(buildPipelineModel(TIMED_MODEL),
+    { now: '2026-07-28T12:00:00Z' });
+const timedLayout = computePlanLayout(timedPlan.rows, timedPlan.batches,
+    { timeAxis: timedPlan.timeAxis });
+const colOfStep = (layout, id) => layout.nodes.get(id).depth;
+
+describe('time axis — vertical band order (req #3201)', () => {
+    it('stacks bands by derived epic start, never-started last', () => {
+        expect(timedLayout.bands.map((b) => b.epic))
+            .toEqual(['Shipped', 'In flight', 'Backlog']);
+    });
+
+    it('derives an epic start from completed_at when started_at was never stamped', () => {
+        expect(timedPlan.timeAxis.bandStarts.get(1)).toBe('2026-07-25T09:00:00');
+        expect(timedPlan.timeAxis.bandStarts.get(2)).toBe('2026-07-27T09:00:00');
+        expect(timedPlan.timeAxis.bandStarts.get(3)).toBe(null);
+    });
+});
+
+describe('time axis — horizontal position (req #3201)', () => {
+    it('every arc still points forward — no step renders left of a dependency', () => {
+        for (const r of timedPlan.rows) {
+            for (const d of r.depIds) {
+                expect(colOfStep(timedLayout, d)).toBeLessThan(colOfStep(timedLayout, r.id));
+                expect(timedLayout.nodes.get(d).x).toBeLessThan(timedLayout.nodes.get(r.id).x);
+            }
+        }
+    });
+
+    it('renders a NEVER-STARTED epic right of every started epic, with no dep edge', () => {
+        const started = timedPlan.rows
+            .filter((r) => r.epicId !== 3).map((r) => colOfStep(timedLayout, r.id));
+        const never = timedPlan.rows
+            .filter((r) => r.epicId === 3).map((r) => colOfStep(timedLayout, r.id));
+        expect(Math.min(...never)).toBeGreaterThan(Math.max(...started));
+        // …and it got there without borrowing anybody's dependency edge.
+        for (const r of timedPlan.rows.filter((x) => x.epicId === 3)) {
+            for (const d of r.depIds) expect(timedPlan.rows.find((x) => x.id === d).epicId).toBe(3);
+        }
+    });
+
+    it('puts an UNGATED late step right of the epic that finished before it', () => {
+        // The live step-97 case: step 4 has NO dependencies at all, and must
+        // still render right of everything whose work happened earlier. This is
+        // what removes the need for a synthetic dep edge.
+        const late = colOfStep(timedLayout, 4);
+        for (const id of [1, 2, 3]) expect(colOfStep(timedLayout, id)).toBeLessThan(late);
+        expect(timedPlan.rows.find((r) => r.id === 4).depIds).toEqual([]);
+    });
+
+    it('monotonizes a BACKWARD-IN-TIME edge rather than drawing the arc backwards', () => {
+        // Step 7's own work completed on day 1, but it is gated on step 3
+        // (day 3). Its column follows the gate, not the stamp.
+        expect(colOfStep(timedLayout, 7)).toBeGreaterThan(colOfStep(timedLayout, 3));
+        expect(timedLayout.slotOf.get(7)).toBe(timedLayout.slotOf.get(3));
+    });
+
+    it('orders the slots chronologically, with the future slot last', () => {
+        expect(timedLayout.slots.map((s) => s.day)).toEqual([
+            '2026-07-25', '2026-07-26', '2026-07-27', '2026-07-28', null,
+        ]);
+        expect(timedLayout.slots[timedLayout.slots.length - 1].kind).toBe('future');
+        for (let i = 1; i < timedLayout.slots.length; i++) {
+            expect(timedLayout.slots[i].origin)
+                .toBeGreaterThan(timedLayout.slots[i - 1].origin);
+        }
+    });
+
+    it('starts every slot strictly right of the last column any earlier slot reaches', () => {
+        // The property the whole design rests on, asserted from OUTPUT: it is
+        // what makes "unstarted renders right of started" true in general, not
+        // just for this fixture's epics.
+        const maxColInSlot = timedLayout.slots.map(() => -1);
+        for (const r of timedPlan.rows) {
+            const k = timedLayout.slotOf.get(r.id);
+            const c = colOfStep(timedLayout, r.id);
+            if (c > maxColInSlot[k]) maxColInSlot[k] = c;
+        }
+        for (let k = 1; k < timedLayout.slots.length; k++) {
+            expect(timedLayout.slots[k].origin).toBeGreaterThan(maxColInSlot[k - 1]);
+        }
+    });
+});
+
+// ── Review regressions (req #3201) ─────────────────────────────────────────
+// Three shapes the first cut of the axis got wrong. Each one is asserted from
+// LAYOUT OUTPUT, not from the classifier, because the classifier being right is
+// only half the claim — the column is what the user sees.
+describe('time axis — review regressions', () => {
+    const build = (rows, reqs) => {
+        const model = {
+            pipeline: { id: 900, title: 'r' },
+            epics: [{ id: 1, title: 'E' }, { id: 2, title: 'F' }],
+            features: [{ id: 21, title: 'fe', epic_fk: 1 }, { id: 22, title: 'ff', epic_fk: 2 }],
+            machines: [],
+            steps: rows.map((r) => ({
+                id: r.id, pipeline_fk: 900, title: `s${r.id}`, run: 'auto',
+                completed_at: r.completedAt || null,
+            })),
+            stepDeps: rows.flatMap((r) => (r.depIds || []).map((d, i) => ({
+                id: r.id * 100 + i, step_fk: r.id, dep_step_fk: d, time_at: null,
+            }))),
+            stepRequirements: rows.flatMap((r) => (r.reqIds || [])
+                .map((q) => ({ step_fk: r.id, requirement_fk: q }))),
+            requirements: reqs,
+        };
+        const p = orderedPlan(buildPipelineModel(model), { now: '2026-07-10T00:00:00Z' });
+        return {
+            plan: p,
+            layout: computePlanLayout(p.rows, p.batches, { timeAxis: p.timeAxis }),
+        };
+    };
+    const r = (o) => ({
+        id: 1, title: 't', requirement_status: 'met', feature_fk: 21, machine_fk: null,
+        coordination_type: 'implemented', tracking: 0, started_at: null,
+        completed_at: null, ...o,
+    });
+
+    // Critical: `deferred` is TERMINAL, so the engine derives `done` from it.
+    // Calling it not-yet-started put a done step in the future zone AND, since
+    // the monotone max propagates FUTURE, dragged its whole subtree there —
+    // step 2 finished 07-01 rendered right of step 3 which finished 07-02.
+    it('keeps a DONE step derived from a deferred requirement out of the future zone', () => {
+        const { plan, layout } = build(
+            [
+                { id: 1, depIds: [], reqIds: [1] },
+                { id: 2, depIds: [1], reqIds: [2] },
+                { id: 3, depIds: [], reqIds: [3] },
+            ],
+            [
+                r({ id: 1, requirement_status: 'deferred' }),
+                r({ id: 2, completed_at: '2026-07-01T00:00:00' }),
+                r({ id: 3, completed_at: '2026-07-02T00:00:00' }),
+            ],
+        );
+        for (const row of plan.rows) expect(row.state).toBe(STEP_DONE);
+        expect(layout.slots.some((s) => s.kind === 'future')).toBe(false);
+        // Step 2 finished BEFORE step 3, so it may not render to its right.
+        expect(layout.nodes.get(2).depth).toBeLessThan(layout.nodes.get(3).depth);
+    });
+
+    // Warning: UNKNOWN means "no claim", so it must not be handed the leftmost
+    // column — that is the claim "earliest of all". The un-run manual gate here
+    // used to render LEFT of finished work.
+    it('does not push an UNKNOWN step left of dated work', () => {
+        const { layout } = build(
+            [
+                { id: 1, depIds: [], reqIds: [1] },
+                { id: 2, depIds: [], reqIds: [] },   // req-less, not complete
+            ],
+            [r({ id: 1, completed_at: '2026-07-01T00:00:00' })],
+        );
+        expect(layout.nodes.get(2).depth).not.toBeLessThan(layout.nodes.get(1).depth);
+        expect(layout.slots.some((s) => s.kind === 'unknown')).toBe(false);
+    });
+
+    // Warning: a NULL start meant both "not begun" and "begun but unstamped",
+    // so a pure BACKLOG epic could stack above an ACTIVE one on an id tie-break.
+    it('stacks an unstamped ACTIVE epic above a never-started backlog epic', () => {
+        const { layout } = build(
+            [
+                { id: 1, depIds: [], reqIds: [1] },   // epic 2 — in flight, unstamped
+                { id: 2, depIds: [], reqIds: [2] },   // epic 1 — untouched backlog
+            ],
+            [
+                r({ id: 1, requirement_status: 'development', feature_fk: 22 }),
+                r({ id: 2, requirement_status: 'authoring', feature_fk: 21 }),
+            ],
+        );
+        expect(layout.bands.map((b) => b.epic)).toEqual(['F', 'E']);
+    });
+});
+
+// The zero-overlap contract is metric-derived, and req #3201 changed the thing
+// the metrics are indexed by (columns are time positions now, so a plan has
+// MORE of them and they are sparser). Re-running the four-combination invariant
+// under a real-scale timed axis is what keeps that contract from rotting
+// silently — the Substrate fixture's 34 steps, with timestamps synthesized from
+// each requirement's status so the plan spreads over several day slots and
+// acquires backward-in-time edges of its own.
+const TIMED_SUBSTRATE = {
+    ...SUBSTRATE_REBUILD_MODEL,
+    requirements: SUBSTRATE_REBUILD_MODEL.requirements.map((r) => {
+        const day = `2026-07-${String(21 + (r.id % 6)).padStart(2, '0')}`;
+        if (r.requirement_status === 'met' || r.requirement_status === 'wontfix') {
+            return { ...r, started_at: null, completed_at: `${day}T08:00:00` };
+        }
+        if (r.requirement_status === 'development') {
+            return { ...r, started_at: `${day}T08:00:00`, completed_at: null };
+        }
+        return { ...r, started_at: null, completed_at: null };
+    }),
+};
+const timedSubstratePlan = orderedPlan(buildPipelineModel(TIMED_SUBSTRATE), { now: NOW });
+
+describe('time axis — the zero-overlap contract still holds at plan scale', () => {
+    for (const combo of COMBOS) {
+        const name = `${combo.reqLayout}/${combo.stepLabel}`;
+        const layout = computePlanLayout(timedSubstratePlan.rows, timedSubstratePlan.batches,
+            { ...combo, timeAxis: timedSubstratePlan.timeAxis });
+
+        it(`no two labels intersect (${name})`, () => {
+            assertNoLabelOverlap(layout, name);
+        });
+
+        it(`no label intersects any bead (${name})`, () => {
+            for (const label of layout.labels) {
+                for (const n of layout.nodes.values()) {
+                    if (rectsOverlap(label, beadRect(n))) {
+                        throw new Error(`label ${JSON.stringify(label)} overlaps bead ${n.id}`);
+                    }
+                }
+            }
+        });
+
+        it(`every arc points forward (${name})`, () => {
+            for (const r of timedSubstratePlan.rows) {
+                for (const d of r.depIds) {
+                    expect(layout.nodes.get(d).depth).toBeLessThan(layout.nodes.get(r.id).depth);
+                }
+            }
+        });
+
+        it(`never stacks two beads on one (band, column, lane) cell (${name})`, () => {
+            const seen = new Set();
+            for (const n of layout.nodes.values()) {
+                const cell = `${n.bandIndex}|${n.depth}|${n.lane}`;
+                expect(seen.has(cell)).toBe(false);
+                seen.add(cell);
+            }
+        });
+    }
 });

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanTime.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanTime.test.js
@@ -1,0 +1,148 @@
+// pipelinePlanTime.test.js — the derived START rules behind the Plan
+// visualizer's time axis (req #3201).
+//
+// These are the DECISIONS the requirement asked to be made explicitly rather
+// than left to whatever the data happened to do, so each one is pinned here:
+// which requirements count as started, what "not started" positively means,
+// and the difference between FUTURE (a claim) and UNKNOWN (no claim).
+
+import { describe, it, expect } from 'vitest';
+
+import {
+    requirementStart, stepStart, planTimeAxis, isNotYetStarted,
+    TIME_DATED, TIME_FUTURE, TIME_UNKNOWN,
+} from '../pipelinePlanTime';
+import { TERMINAL_REQUIREMENT_STATUSES } from '../pipelineModel';
+
+const req = (o) => ({
+    id: 1, title: 't', requirement_status: 'met', feature_fk: null,
+    machine_fk: null, coordination_type: 'implemented', tracking: 0,
+    started_at: null, completed_at: null, ...o,
+});
+const row = (o) => ({ id: 1, reqIds: [], completedAt: null, epicId: 1, ...o });
+const index = (reqs) => new Map(reqs.map((r) => [r.id, r]));
+
+describe('requirementStart', () => {
+    it('prefers started_at', () => {
+        expect(requirementStart(req({ started_at: 'A', completed_at: 'B' }))).toBe('A');
+    });
+
+    // THE decision this requirement asked for. 820 of 960 live `met`
+    // requirements have no `started_at` at all; treating them as never-started
+    // banishes finished work to the right-hand future, which is the defect the
+    // axis exists to fix, inverted.
+    it('falls back to completed_at — terminal-without-a-start COUNTS as started', () => {
+        expect(requirementStart(req({ completed_at: 'B' }))).toBe('B');
+    });
+
+    it('is null when neither stamp exists', () => {
+        expect(requirementStart(req({}))).toBe(null);
+        expect(requirementStart(null)).toBe(null);
+    });
+});
+
+describe('stepStart', () => {
+    it('takes the MINIMUM over the step\'s requirements', () => {
+        const reqs = [
+            req({ id: 1, completed_at: '2026-07-26T00:00:00' }),
+            req({ id: 2, started_at: '2026-07-24T00:00:00' }),
+        ];
+        expect(stepStart(row({ reqIds: [1, 2] }), index(reqs)))
+            .toEqual({ at: '2026-07-24T00:00:00', kind: TIME_DATED });
+    });
+
+    it('falls back to the STEP\'s own completed_at — the req-less gate step', () => {
+        expect(stepStart(row({ reqIds: [], completedAt: '2026-07-25T00:00:00' }), new Map()))
+            .toEqual({ at: '2026-07-25T00:00:00', kind: TIME_DATED });
+    });
+
+    it('is FUTURE when every requirement is positively not-yet-started', () => {
+        const reqs = [
+            req({ id: 1, requirement_status: 'authoring' }),
+            req({ id: 2, requirement_status: 'approved' }),
+            req({ id: 3, requirement_status: 'swarm_ready' }),
+        ];
+        expect(stepStart(row({ reqIds: [1, 2, 3] }), index(reqs)).kind).toBe(TIME_FUTURE);
+    });
+
+    // THE review finding. `deferred` is TERMINAL — deriveStepState returns
+    // `done` for a step whose requirements are all terminal — so calling it
+    // not-yet-started put a green checked bead in the not-yet-begun region and,
+    // because the monotone max propagates FUTURE downstream, dragged that
+    // step's whole subtree with it. Live case: pipeline 2 step 35 "Messaging
+    // Design", requirement 3108, deferred with no stamps.
+    it.each(TERMINAL_REQUIREMENT_STATUSES)(
+        'never calls a step FUTURE on a terminal requirement (%s)', (status) => {
+            const reqs = [req({ id: 1, requirement_status: status })];
+            expect(stepStart(row({ reqIds: [1] }), index(reqs)).kind).toBe(TIME_UNKNOWN);
+        });
+
+    it('classifies not-yet-started from the ENGINE\'s terminal set, not a local list', () => {
+        for (const s of TERMINAL_REQUIREMENT_STATUSES) expect(isNotYetStarted(s)).toBe(false);
+        expect(isNotYetStarted('development')).toBe(false);
+        for (const s of ['authoring', 'approved', 'swarm_ready']) {
+            expect(isNotYetStarted(s)).toBe(true);
+        }
+    });
+
+    it('is UNKNOWN, not FUTURE, when a met requirement lost both stamps', () => {
+        const reqs = [
+            req({ id: 1, requirement_status: 'met' }),
+            req({ id: 2, requirement_status: 'authoring' }),
+        ];
+        expect(stepStart(row({ reqIds: [1, 2] }), index(reqs)).kind).toBe(TIME_UNKNOWN);
+    });
+
+    it('ignores links whose requirement is missing from the read', () => {
+        expect(stepStart(row({ reqIds: [999] }), new Map()).kind).toBe(TIME_UNKNOWN);
+    });
+});
+
+describe('planTimeAxis', () => {
+    it('gives every band the MINIMUM start of its own steps, null when none started', () => {
+        const reqs = [
+            req({ id: 1, completed_at: '2026-07-26T00:00:00' }),
+            req({ id: 2, completed_at: '2026-07-24T00:00:00' }),
+            req({ id: 3, requirement_status: 'authoring' }),
+        ];
+        const rows = [
+            row({ id: 10, epicId: 5, reqIds: [1] }),
+            row({ id: 11, epicId: 5, reqIds: [2] }),
+            row({ id: 12, epicId: 6, reqIds: [3] }),
+            row({ id: 13, epicId: null, reqIds: [] }),
+        ];
+        const { stepStarts, bandStarts, bandKinds } = planTimeAxis(rows, reqs);
+        expect(bandStarts.get(5)).toBe('2026-07-24T00:00:00');
+        expect(bandStarts.get(6)).toBe(null);
+        expect(bandStarts.get(null)).toBe(null);
+        expect(stepStarts.get(12).kind).toBe(TIME_FUTURE);
+        expect(stepStarts.get(13).kind).toBe(TIME_UNKNOWN);
+        expect(bandKinds.get(5)).toBe(TIME_DATED);
+        expect(bandKinds.get(6)).toBe(TIME_FUTURE);
+        expect(bandKinds.get(null)).toBe(TIME_UNKNOWN);
+    });
+
+    // A NULL start used to mean both "has not begun" and "began, but nobody
+    // stamped it", which sorted an ACTIVE epic into the backlog tier.
+    it('separates an unstamped-but-active epic from a never-started one', () => {
+        const reqs = [
+            req({ id: 1, requirement_status: 'development' }),   // in flight, unstamped
+            req({ id: 2, requirement_status: 'authoring' }),     // untouched backlog
+        ];
+        const rows = [
+            row({ id: 1, epicId: 7, reqIds: [1] }),
+            row({ id: 2, epicId: 6, reqIds: [2] }),
+        ];
+        const { bandStarts, bandKinds } = planTimeAxis(rows, reqs);
+        expect(bandStarts.get(7)).toBe(null);
+        expect(bandStarts.get(6)).toBe(null);
+        expect(bandKinds.get(7)).toBe(TIME_UNKNOWN);
+        expect(bandKinds.get(6)).toBe(TIME_FUTURE);
+    });
+
+    it('tolerates junk input rather than throwing on a mid-fetch render', () => {
+        const { stepStarts, bandStarts } = planTimeAxis(null, null);
+        expect(stepStarts.size).toBe(0);
+        expect(bandStarts.size).toBe(0);
+    });
+});

--- a/src/SwarmView/pipelines/pipelineDetailModes.js
+++ b/src/SwarmView/pipelines/pipelineDetailModes.js
@@ -46,9 +46,11 @@ export const PIPELINE_DETAIL_MODES = [
         Component: PipelinePlanTable,
     },
     {
-        // The req #3115 Plan visualizer: epic bands, chain-aware swim lanes,
-        // dependency-depth columns, launch-batch boxes, drag-pan + three-level
-        // zoom (react-konva + d3-zoom, the Swarm Visualizer's feel).
+        // The req #3115 Plan visualizer: epic bands stacked by derived start,
+        // chain-aware swim lanes, TIME-SLOT columns floored by dependency depth
+        // (req #3201 — they were raw dependency depth), launch-batch boxes,
+        // drag-pan + three-level zoom (react-konva + d3-zoom, the Swarm
+        // Visualizer's feel).
         value: 'plan',
         label: 'Plan',
         icon: AccountTreeIcon,

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -8,10 +8,16 @@
 //
 // The layout language (POC, kept verbatim unless noted):
 //   - Epic bands stacked vertically, one per DOMINANT epic (design rule 10), in
-//     first-appearance order over the given rows (callers pass display order, so
-//     completed epics surface first exactly as the POC page read).
-//   - Dependency-depth columns left-to-right; a step's column is
-//     1 + max(dep columns).
+//     DERIVED-START order since req #3201: earliest-starting epic on top,
+//     never-started epics last, epic id ascending as the tie-break. (Was
+//     first-appearance over display order, which had two problems: it made a
+//     band's position move whenever a step was appended, and it said nothing at
+//     all about time.)
+//   - TIME-SLOT columns left-to-right (req #3201). A column is a position on a
+//     calendar proxy, no longer raw dependency depth — see the block comment
+//     above `computeTimeColumns` for the whole model. Dependency depth survives
+//     as the HARD FLOOR: a step's column is never less than 1 + the maximum of
+//     its dependencies', so every arc still points forward.
 //   - Chain-aware swim lanes inside each band: a step takes its first same-epic
 //     dependency's lane when free, and that lane is RESERVED across the columns
 //     the chain spans, so no unrelated bead sits on an arc's path.
@@ -124,6 +130,168 @@ export const PLAN_VIZ_FONT = {
 
 export const BEAD_RADIUS = BEAD_R;
 
+// ── The time axis (req #3201) ───────────────────────────────────────────────
+// Sentinel slot prefixes. Sorting the composed keys lexicographically IS the
+// chronological order: '0' < '1' < '2', and ISO days sort as strings.
+const SLOT_UNKNOWN = '0:unknown';
+const SLOT_FUTURE = '2:future';
+const slotOfDay = (at) => `1:${String(at).slice(0, 10)}`;
+
+// Comparable rank for a step's derived start. UNKNOWN sorts BEFORE every date
+// and FUTURE AFTER every date, which is what makes the monotone max below mean
+// "the latest thing this step is downstream of".
+const TIME_RANK = { unknown: 0, dated: 1, future: 2 };
+const rankOf = (t) => TIME_RANK[t && t.kind] || 0;
+function timeCmp(a, b) {
+    const ra = rankOf(a);
+    const rb = rankOf(b);
+    if (ra !== rb) return ra - rb;
+    const xa = (a && a.at) || '';
+    const xb = (b && b.at) || '';
+    return xa === xb ? 0 : (xa < xb ? -1 : 1);
+}
+
+/**
+ * Turn derived START TIMES into COLUMNS, with dependency depth as a hard floor.
+ *
+ * The axis is a sequence of TIME SLOTS: one leading slot for steps whose start
+ * is UNKNOWN, one per distinct calendar DAY that carries work, and one trailing
+ * slot for steps that have positively not begun. Day granularity is a choice: a
+ * slot per distinct timestamp degenerates the drawing into a one-step-per-column
+ * diagonal and hides every bit of parallelism, while a slot per day puts the
+ * work of one day side by side, which is how the plan is actually read.
+ *
+ * Four steps, and the order matters:
+ *
+ * 1. **Monotonize.** A step's effective time is `max(its own, every
+ *    dependency's)`. A step cannot begin before its gate; where the stored
+ *    timestamps disagree — and they DO, twice, in live pipeline 2 — the gate
+ *    wins. This is the same "topology outranks presentation" ruling design rule
+ *    3 makes, applied to the DATA so that step 4 below needs no special case.
+ *    It also resolves UNKNOWN for free: a req-less step inherits the time of the
+ *    work it gates, exactly as it already inherits that work's epic label.
+ * 2. **Local depth.** Inside one slot, a step's offset is its dependency depth
+ *    counting only same-slot dependencies. A chain done in one day reads as
+ *    consecutive columns.
+ * 3. **Origins.** `origin[k] = Σ (span[i] + 1)` over earlier slots, where
+ *    `span[i]` is slot i's deepest local chain. Every slot therefore starts at
+ *    least one column past the last column any earlier slot can reach.
+ * 4. **Columns.** `col(r) = max(origin[slot] + localDepth, 1 + max col(deps))`.
+ *
+ * TWO PROPERTIES FALL OUT, and both are asserted in the tests:
+ *
+ * - **Every arc points forward**, unconditionally, from the second term. No
+ *   step can render left of something it depends on because a date said so —
+ *   the constraint this requirement was told not to break.
+ * - **Slot k renders strictly right of slot j < k.** Proof: by induction, a
+ *   same-slot dep contributes `1 + col(d) ≤ origin[k] + localDepth(r)`, and an
+ *   earlier-slot dep contributes `1 + col(d) ≤ origin[j] + span[j] + 1 ≤
+ *   origin[k]`. Step 1 is what guarantees there is no LATER-slot dep to break
+ *   the induction. So a never-started epic renders right of every started one
+ *   with no synthetic dependency edge anywhere.
+ *
+ * DEGENERATE CASE, and it is the reason there is no second code path: with no
+ * time axis supplied every step is UNKNOWN, so there is ONE slot, local depth is
+ * global dependency depth and `col` is exactly the pre-#3201 depth column.
+ *
+ * @param {Object[]} rows                 PlanRows
+ * @param {Map<number, Object>} byId
+ * @param {(r: Object) => number[]} depsOf  in-set dependency ids
+ * @param {?Object} timeAxis              planTimeAxis() output, or null
+ * @returns {{colOf: Map<number, number>, maxCol: number,
+ *            slotKeys: string[], slotOf: Map<number, number>,
+ *            origins: number[], spans: number[]}}
+ */
+export function computeTimeColumns(rows, byId, depsOf, timeAxis) {
+    const starts = (timeAxis && timeAxis.stepStarts) || new Map();
+    const own = (r) => starts.get(r.id) || { at: null, kind: 'unknown' };
+
+    // 1. Monotonize along the dep graph.
+    const effMemo = new Map();
+    const eff = (r) => {
+        if (effMemo.has(r.id)) return effMemo.get(r.id);
+        effMemo.set(r.id, own(r)); // cycle guard — a cycle keeps its own time
+        let best = own(r);
+        for (const d of depsOf(r)) {
+            const up = eff(byId.get(d));
+            if (timeCmp(up, best) > 0) best = up;
+        }
+        effMemo.set(r.id, best);
+        return best;
+    };
+    const slotKeyOf = (r) => {
+        const t = eff(r);
+        if (t.kind === 'dated' && t.at) return slotOfDay(t.at);
+        return t.kind === 'future' ? SLOT_FUTURE : SLOT_UNKNOWN;
+    };
+    // UNKNOWN GETS NO SLOT OF ITS OWN when any dated slot exists (review
+    // finding). A dedicated leading slot put every UNKNOWN step one column
+    // LEFT of all dated work — "earlier than everything", which is precisely
+    // the claim UNKNOWN means we cannot make, and the opposite of this
+    // module's own rule that topology alone should place it. Sharing the
+    // EARLIEST dated slot gives it the weakest lower bound there is (that
+    // slot's origin is 0), so its column comes from its dependencies and
+    // nothing else. It keeps a slot of its own only when there is no dated
+    // slot to share — otherwise it would fall into FUTURE, which is a claim
+    // in the other direction.
+    const rawKeys = new Set(rows.map(slotKeyOf));
+    const hasUnknown = rawKeys.delete(SLOT_UNKNOWN);
+    const slotKeys = [...rawKeys].sort();
+    if (hasUnknown && (slotKeys.length === 0 || slotKeys[0] === SLOT_FUTURE)) {
+        slotKeys.unshift(SLOT_UNKNOWN);
+    }
+    const slotIndex = new Map(slotKeys.map((k, i) => [k, i]));
+    const slotFor = (r) => {
+        const k = slotKeyOf(r);
+        const i = slotIndex.get(k);
+        return i === undefined ? 0 : i;   // UNKNOWN folded into the first slot
+    };
+    const slotOf = new Map(rows.map((r) => [r.id, slotFor(r)]));
+
+    // 2. Local depth, counting only same-slot dependencies.
+    const ldMemo = new Map();
+    const slotIdx = (id) => {
+        const i = slotOf.get(id);
+        return i === undefined ? 0 : i;   // a caller's byId may exceed rows
+    };
+    const ld = (r) => {
+        if (ldMemo.has(r.id)) return ldMemo.get(r.id);
+        ldMemo.set(r.id, 0); // cycle guard
+        const v = 1 + Math.max(-1, ...depsOf(r)
+            .filter((d) => slotIdx(d) === slotIdx(r.id))
+            .map((d) => ld(byId.get(d))));
+        ldMemo.set(r.id, v);
+        return v;
+    };
+    rows.forEach(ld);
+
+    // 3. Slot spans and cumulative origins.
+    const spans = slotKeys.map(() => 0);
+    for (const r of rows) {
+        const k = slotIdx(r.id);
+        if (ldMemo.get(r.id) > spans[k]) spans[k] = ldMemo.get(r.id);
+    }
+    const origins = [];
+    {
+        let acc = 0;
+        for (let k = 0; k < slotKeys.length; k++) { origins.push(acc); acc += spans[k] + 1; }
+    }
+
+    // 4. Columns — the time position, floored by topology.
+    const colOf = new Map();
+    const col = (r) => {
+        if (colOf.has(r.id)) return colOf.get(r.id);
+        colOf.set(r.id, 0); // cycle guard — a cycle collapses toward column 0
+        const v = Math.max(origins[slotIdx(r.id)] + ldMemo.get(r.id),
+            ...depsOf(r).map((d) => 1 + col(byId.get(d))));
+        colOf.set(r.id, v);
+        return v;
+    };
+    rows.forEach(col);
+    const maxCol = Math.max(0, ...rows.map((r) => colOf.get(r.id)));
+    return { colOf, maxCol, slotKeys, slotOf, origins, spans };
+}
+
 const truncate = (s, n) => {
     const str = String(s == null ? '' : s);
     return str.length > n ? `${str.slice(0, n - 1)}…` : str;
@@ -142,39 +310,36 @@ const reqStr = (row) => (row.reqIds || []).join(' ');
 /**
  * Compute the full Plan-mode layout.
  *
- * @param {Object[]} rows      engine PlanRows, DISPLAY order (band order follows
- *                             first appearance, so pass displayOrder output)
+ * @param {Object[]} rows      engine PlanRows, DISPLAY order (steps sort within
+ *                             a band by column, so pass displayOrder output)
  * @param {Object[]} batches   engine LaunchBatch[] (launchBatches output)
  * @param {Object} [opts]
  * @param {('horizontal'|'vertical')} [opts.reqLayout]
  * @param {('id'|'title')} [opts.stepLabel]
+ * @param {?Object} [opts.timeAxis]  planTimeAxis() output (req #3201). Omitted,
+ *                             the axis degenerates to pure dependency depth and
+ *                             bands stack by epic id — see computeTimeColumns.
  * @returns {Object} layout — see the shape assembled at the bottom
  */
-export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', stepLabel = 'id' } = {}) {
+export function computePlanLayout(rows, batches, {
+    reqLayout = 'horizontal', stepLabel = 'id', timeAxis = null,
+} = {}) {
     const safeRows = Array.isArray(rows) ? rows : [];
     const safeBatches = Array.isArray(batches) ? batches : [];
     if (safeRows.length === 0) {
         return {
             width: MIN_WORLD_W, height: 120, bands: [], nodes: new Map(),
             arcs: [], batchBoxes: [], labels: [], colW: [], colX: [],
-            reqLayout, stepLabel, empty: true,
+            slots: [], slotOf: new Map(), reqLayout, stepLabel, empty: true,
         };
     }
 
     const byId = new Map(safeRows.map((r) => [r.id, r]));
     const depsOf = (r) => (r.depIds || []).filter((d) => byId.has(d));
 
-    // ── Dependency-depth columns ────────────────────────────────────────────
-    const depthMemo = new Map();
-    const depth = (r) => {
-        if (depthMemo.has(r.id)) return depthMemo.get(r.id);
-        depthMemo.set(r.id, 0); // cycle guard — a cycle collapses to column 0
-        const v = 1 + Math.max(-1, ...depsOf(r).map((d) => depth(byId.get(d))));
-        depthMemo.set(r.id, v);
-        return v;
-    };
-    safeRows.forEach(depth);
-    const maxD = Math.max(...safeRows.map((r) => depthMemo.get(r.id)));
+    // ── Time-slot columns, floored by dependency depth (req #3201) ──────────
+    const { colOf, maxCol, slotKeys, slotOf, origins: slotOrigins } =
+        computeTimeColumns(safeRows, byId, depsOf, timeAxis);
 
     // ── Column widths (the zero-overlap contract, half 1) ───────────────────
     // A column is as wide as the widest thing DRAWN in it: the one-line req-id
@@ -182,7 +347,7 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
     // label — id or truncated title — in either mode.
     const colSteps = [];
     for (const r of safeRows) {
-        const d = depthMemo.get(r.id);
+        const d = colOf.get(r.id);
         (colSteps[d] ||= []).push(r);
     }
     // Title-mode step labels are STAGGERED, so a column no longer has to be as
@@ -193,7 +358,7 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
     // actually has, below.
     const staggerLabels = stepLabel === 'title';
     const colW = [];
-    for (let d = 0; d <= maxD; d++) {
+    for (let d = 0; d <= maxCol; d++) {
         const steps = colSteps[d] || [];
         const labelW = staggerLabels ? TITLE_COL_MIN
             : Math.max(0, ...steps.map((r) => stepLabelText(r, stepLabel).length * CHW_LABEL + 16));
@@ -214,35 +379,79 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
     // gutter instead of letting a wide colW[1] push it off the world.
     const staggerBudget = (d) => {
         const left = d > 0 ? colW[d - 1] : LEFT;
-        const right = d < maxD ? colW[d + 1] : RIGHT + 40;
+        const right = d < maxCol ? colW[d + 1] : RIGHT + 40;
         return colW[d] + 2 * STAGGER_REACH * Math.min(left, right);
     };
     const staggerOf = (d) => (d % 2) * STAGGER_GAP;
     const colX = [];
     {
         let acc = LEFT;
-        for (let d = 0; d <= maxD; d++) {
+        for (let d = 0; d <= maxCol; d++) {
             colX.push(acc + colW[d] / 2);
             acc += colW[d];
         }
     }
-    const totalW = Math.max(MIN_WORLD_W, colX[maxD] + colW[maxD] / 2 + RIGHT + 40);
+    const totalW = Math.max(MIN_WORLD_W, colX[maxCol] + colW[maxCol] / 2 + RIGHT + 40);
 
-    // ── Epic bands (dominant label, first-appearance order) ─────────────────
+    // ── Epic bands (dominant label), stacked by DERIVED START (req #3201) ───
+    // The vertical axis reads as time too: the epic whose work began first sits
+    // on top. An epic's start is the minimum over its requirements — there is no
+    // `epics.started_at` and design rule 1 says there never will be — and
+    // `pipelinePlanTime.js` owns the derivation, including the ruling that a
+    // requirement which completed without ever being stamped `started_at`
+    // counts as started.
+    //
+    // THREE TIERS, then tie-breaks, stated rather than left to sort stability:
+    //   1. `dated`   — sort ascending on the derived start;
+    //   2. `unknown` — no start, but evidence of work whose timing was never
+    //                  recorded. A NULL start alone used to mean both this and
+    //                  tier 3, which let a pure BACKLOG epic stack above an
+    //                  ACTIVE one on an id tie-break (review finding);
+    //   3. `future`  — every step positively has not begun. Sorts LAST.
+    // Within a tier: EPIC ID ascending, the label-less "No epic" band last of
+    // all. Id rather than first appearance on purpose — first appearance moved
+    // a band down the stack whenever a step was appended to another epic, a
+    // documented wart of the old rule, and it carried no time meaning.
+    const bandStarts = (timeAxis && timeAxis.bandStarts) || new Map();
+    const bandKinds = (timeAxis && timeAxis.bandKinds) || new Map();
+    const BAND_TIER = { dated: 0, unknown: 1, future: 2 };
+    const bandTierOf = (key) => {
+        const t = BAND_TIER[bandKinds.get(key)];
+        return t === undefined ? BAND_TIER.future : t;
+    };
     const bandKeys = [];
     const bandByKey = new Map();
     for (const r of safeRows) {
         const key = r.epicId != null ? r.epicId : null;
         if (!bandByKey.has(key)) {
-            bandByKey.set(key, {
-                key, epicId: key, epic: r.epic || 'No epic',
-                color: EPIC_PALETTE[bandKeys.length % EPIC_PALETTE.length],
-                steps: [],
-            });
+            bandByKey.set(key, { key, epicId: key, epic: r.epic || 'No epic', steps: [] });
             bandKeys.push(key);
         }
         bandByKey.get(key).steps.push(r);
     }
+    const bandStartOf = (key) => {
+        const v = bandStarts.get(key);
+        return v == null ? null : String(v);
+    };
+    bandKeys.sort((a, b) => {
+        const ta = bandTierOf(a);
+        const tb = bandTierOf(b);
+        if (ta !== tb) return ta - tb;
+        const sa = bandStartOf(a);
+        const sb = bandStartOf(b);
+        if ((sa === null) !== (sb === null)) return sa === null ? 1 : -1;
+        if (sa !== null && sa !== sb) return sa < sb ? -1 : 1;
+        if (a === b) return 0;
+        if (a === null) return 1;
+        if (b === null) return -1;
+        return a < b ? -1 : 1;
+    });
+    // Colour AFTER the sort: the palette cycles on the band's position in the
+    // stack, so assigning at discovery time would hand two adjacent bands the
+    // same hue once the order stopped being discovery order.
+    bandKeys.forEach((key, i) => {
+        bandByKey.get(key).color = EPIC_PALETTE[i % EPIC_PALETTE.length];
+    });
 
     // Batch letters, for adjacency inside a band (a box must never enclose a
     // non-member — POC sorted batch-mates together within the band).
@@ -285,7 +494,7 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
     for (const key of bandKeys) {
         const band = bandByKey.get(key);
         const steps = [...band.steps].sort((a, b) =>
-            (depthMemo.get(a.id) - depthMemo.get(b.id)) ||
+            (colOf.get(a.id) - colOf.get(b.id)) ||
             ((batchOf.has(a.id) ? 0 : 1) - (batchOf.has(b.id) ? 0 : 1)) ||
             String(batchOf.get(a.id) || '').localeCompare(String(batchOf.get(b.id) || '')));
         const used = new Map(); // depth -> Map(lane -> step id | RESERVED)
@@ -305,7 +514,7 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
             (used.has(d) ? used.get(d).get(lane) : undefined);
         const free = (d, lane) => occupant(d, lane) === undefined;
         const corridorOk = (a, r, lane) => {
-            for (let dd = depthMemo.get(a.id) + 1; dd < depthMemo.get(r.id); dd++) {
+            for (let dd = colOf.get(a.id) + 1; dd < colOf.get(r.id); dd++) {
                 const o = occupant(dd, lane);
                 if (o === undefined) continue;
                 if (o === RESERVED) return false;
@@ -356,7 +565,7 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
                 if (ds >= d || rDeps.has(sid)) continue;
                 for (const tid of dependentsInBand.get(sid) || []) {
                     if (tid === r.id) continue;
-                    if (depthMemo.get(tid) <= d) continue;
+                    if (colOf.get(tid) <= d) continue;
                     if (reach(r.id).has(sid) && reach(tid).has(r.id)) continue;
                     return false;
                 }
@@ -375,7 +584,7 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
         // occupied lane, boxing unrelated steps in ~15% of multi-batch plans.)
         const batchRunNext = new Map(); // letter -> next lane in this band's run
         for (const r of steps) {
-            const d = depthMemo.get(r.id);
+            const d = colOf.get(r.id);
             const letter = batchOf.get(r.id);
             let lane = null;
             if (letter !== undefined) {
@@ -439,7 +648,7 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
             // identity for later corridorOk checks.
             for (const a of sameEpicDepsOf(r)) {
                 if (laneById.get(a.id) === lane) {
-                    for (let dd = depthMemo.get(a.id) + 1; dd < d; dd++) {
+                    for (let dd = colOf.get(a.id) + 1; dd < d; dd++) {
                         take(dd, lane, RESERVED);
                     }
                 }
@@ -529,7 +738,7 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
     const nodes = new Map();
     bands.forEach((band, bandIndex) => {
         for (const r of band.steps) {
-            const d = depthMemo.get(r.id);
+            const d = colOf.get(r.id);
             nodes.set(r.id, {
                 id: r.id,
                 x: colX[d],
@@ -801,6 +1010,18 @@ export function computePlanLayout(rows, batches, { reqLayout = 'horizontal', ste
         labels,
         colW,
         colX,
+        // The time axis as GEOMETRY (req #3201): the ordered slots and the
+        // column each one starts at. Exported so the axis is assertable from
+        // this module's output — "slot k begins right of everything in slot
+        // k-1" is the property the whole design rests on, and a test that
+        // re-derives it from the input would be a second implementation.
+        slots: slotKeys.map((key, i) => ({
+            key,
+            kind: key === SLOT_UNKNOWN ? 'unknown' : key === SLOT_FUTURE ? 'future' : 'dated',
+            day: key === SLOT_UNKNOWN || key === SLOT_FUTURE ? null : key.slice(2),
+            origin: slotOrigins[i],
+        })),
+        slotOf,
         reqLayout,
         stepLabel,
         empty: false,

--- a/src/SwarmView/pipelines/pipelinePlanTime.js
+++ b/src/SwarmView/pipelines/pipelinePlanTime.js
@@ -1,0 +1,177 @@
+// pipelinePlanTime.js — the plan's DERIVED TIME AXIS (req #3201).
+//
+// PURE: plain rows in, plain time facts out. No React, no clock, no DOM. It is
+// its own module because it answers a DATA question ("when did this step's work
+// begin?") that `pipelinePlanLayout.js` — pure geometry — must not be the place
+// to answer, and that `pipelineModel.js` must not answer either: that engine is
+// mirrored line for line by `darwin-mcp/services/pipeline_derive.py` under a
+// shared conformance corpus, and the orchestration engine has no use for a
+// rendering axis. Adding this there would grow the parity surface for a fact
+// only a canvas reads.
+//
+// ── WHY THE AXIS EXISTS ─────────────────────────────────────────────────────
+// The visualizer's horizontal position used to be dependency DEPTH alone, so a
+// brand-new epic — whose steps have no dep edges, because nothing existed to
+// gate them on — landed in column 0 and visually claimed it runs FIRST. The
+// live workaround was to attach a dependency edge that does not exist purely to
+// push the row rightwards (pipeline 2, step 97 -> 88, 2026-08-01). A layout
+// that can only be corrected by lying in the data is the bug.
+//
+// ── THERE IS NO STORED START ────────────────────────────────────────────────
+// `epics` has no `started_at` and never will (design rule 1 — derive, don't
+// store). `requirements.started_at` exists, so an epic's start is a MINIMUM
+// over its requirements. Two decisions the raw column forces, both recorded in
+// `memory/pipeline-plan-visualizer.md`:
+//
+// 1. **A requirement that completed without ever being stamped `started_at`
+//    COUNTS AS STARTED.** This is not a courtesy. Measured against the whole
+//    live requirements table on 2026-08-01: 820 of 960 `met` requirements have
+//    `started_at` NULL, and only 2 of the 32 requirements in live pipeline 2's
+//    "Pipeline" epic carry one. A literal MIN(started_at) rule classified FIVE
+//    of that plan's SIX epics as never-started — including two that are 100%
+//    done — and would have banished finished work to the right-hand future.
+//    That is the same defect this axis fixes, inverted. `completed_at` is
+//    populated, and it is a strict upper bound on a start: work that finished
+//    demonstrably began no later than it finished.
+// 2. **No TERMINAL status ever votes FUTURE**, and the set is IMPORTED from the
+//    engine rather than re-listed here. This is the review finding that made
+//    the rule derived instead of hand-written: `deferred` is terminal —
+//    `deriveStepState` returns `done` for a step whose requirements are all
+//    terminal — so listing it as not-yet-started put a GREEN CHECKED BEAD in
+//    the not-yet-begun region. Live pipeline 2, step 35 "Messaging Design"
+//    (requirement 3108, `deferred`, no stamps) moved from column 18 to the
+//    FUTURE slot origin, the only done step among 21 pending ones. Worse, the
+//    monotone max propagates: every step downstream of a deferred-only step is
+//    dragged into the future regardless of its OWN stamps. Deriving the set
+//    from `TERMINAL_REQUIREMENT_STATUSES` makes that class of drift
+//    unrepresentable — a status the engine calls finished can never be one this
+//    module calls future.
+
+import { TERMINAL_REQUIREMENT_STATUSES } from './pipelineModel';
+
+// A status positively asserts "this work has not begun" only if the engine
+// neither calls it finished nor calls it in flight. Today that is `authoring`,
+// `approved` and `swarm_ready` — but it is computed, so a new status is
+// classified by what the engine already says about it.
+export const isNotYetStarted = (status) =>
+    !TERMINAL_REQUIREMENT_STATUSES.includes(status) && status !== 'development';
+
+// The three answers a step's start can have. FUTURE and UNKNOWN are NOT the
+// same thing and collapsing them is the mistake this enum exists to prevent:
+// FUTURE is a positive claim ("every requirement here is still queued"), so it
+// earns the rightmost slot; UNKNOWN is the absence of a claim ("this ran, but
+// no stamp survives"), so it must NOT be pushed anywhere — topology alone
+// positions it. Treating UNKNOWN as FUTURE would fling a done-but-unstamped
+// step past its own dependents.
+export const TIME_DATED = 'dated';
+export const TIME_FUTURE = 'future';
+export const TIME_UNKNOWN = 'unknown';
+
+/**
+ * The effective start of ONE requirement, or null when it has neither stamp.
+ *
+ * @param {?Object} req  a requirement row from the plan's light projection
+ * @returns {?string} ISO-ish datetime string, lexicographically comparable
+ */
+export function requirementStart(req) {
+    if (!req) return null;
+    if (req.started_at) return String(req.started_at);
+    if (req.completed_at) return String(req.completed_at);
+    return null;
+}
+
+/**
+ * The derived start of ONE step: `{at, kind}`.
+ *
+ * Resolution order, first hit wins:
+ *   1. the MINIMUM `requirementStart` over its linked requirements → dated;
+ *   2. the step's own `completedAt` → dated. This is the req-less GATE step
+ *      (the "Green Baseline" shape) whose whole existence is its stamp;
+ *   3. every classifiable linked requirement is not-yet-started → FUTURE;
+ *   4. otherwise UNKNOWN.
+ *
+ * Tracking CONTAINERS are included deliberately, unlike everywhere the flag is
+ * consulted for GATING (req #3123) or for LAUNCH ARGUMENTS (design rule 8).
+ * Time is neither: a container's stamps are real facts about when the plan it
+ * holds began, and a step is not misplaced by knowing them.
+ *
+ * @param {Object} row                 a PlanRow (needs `reqIds`, `completedAt`)
+ * @param {Map<number, Object>} reqsById
+ * @returns {{at: ?string, kind: string}}
+ */
+export function stepStart(row, reqsById) {
+    const ids = (row && row.reqIds) || [];
+    let min = null;
+    let sawFuture = false;
+    let sawUnclassifiable = false;
+    for (const id of ids) {
+        const req = reqsById.get(id);
+        if (!req) continue;                 // unresolved link — says nothing
+        const at = requirementStart(req);
+        if (at !== null) {
+            if (min === null || at < min) min = at;
+        } else if (isNotYetStarted(req.requirement_status)) {
+            sawFuture = true;
+        } else {
+            sawUnclassifiable = true;       // terminal or in flight, but unstamped
+        }
+    }
+    if (min !== null) return { at: min, kind: TIME_DATED };
+    if (row && row.completedAt) return { at: String(row.completedAt), kind: TIME_DATED };
+    if (sawFuture && !sawUnclassifiable) return { at: null, kind: TIME_FUTURE };
+    return { at: null, kind: TIME_UNKNOWN };
+}
+
+/**
+ * The whole axis: a start for every step, and a start for every epic band.
+ *
+ * BAND START IS THE RAW MINIMUM, not the monotonized one the layout computes.
+ * An epic's own first start is a fact about that epic; letting another epic's
+ * gate push it later would make a band's position in the stack depend on work
+ * it does not own. The layout monotonizes only the HORIZONTAL axis, where the
+ * forward-arc invariant makes it necessary.
+ *
+ * The band key matches the layout's: the row's DOMINANT epic id (rule 10), with
+ * `null` for a step that resolves no epic at all.
+ *
+ * `bandKinds` exists because a NULL start was doing two incompatible jobs
+ * (review finding). An epic with active, in-flight work whose requirements
+ * simply never got stamped has no derived start — and so did an epic that is
+ * pure untouched backlog, which sorted them together and let the BACKLOG stack
+ * above the ACTIVE epic on an id tie-break. The three tiers separate them:
+ *   - `dated`   — at least one step has a real start; sort on it;
+ *   - `unknown` — no start, but at least one step is not FUTURE, i.e. there is
+ *                 EVIDENCE of work whose timing was not recorded;
+ *   - `future`  — every step positively has not begun.
+ *
+ * @param {Object[]} rows          PlanRows (any order)
+ * @param {Object[]} requirements  the plan's requirement rows
+ * @returns {{stepStarts: Map<number, {at: ?string, kind: string}>,
+ *            bandStarts: Map<?number, ?string>,
+ *            bandKinds: Map<?number, string>}}
+ */
+export function planTimeAxis(rows, requirements) {
+    const safeRows = Array.isArray(rows) ? rows : [];
+    const reqsById = new Map(
+        (Array.isArray(requirements) ? requirements : []).map((r) => [r.id, r]));
+    const stepStarts = new Map();
+    const bandStarts = new Map();
+    const bandKinds = new Map();
+    for (const row of safeRows) {
+        const start = stepStart(row, reqsById);
+        stepStarts.set(row.id, start);
+        const key = row.epicId != null ? row.epicId : null;
+        if (!bandStarts.has(key)) {
+            bandStarts.set(key, null);
+            bandKinds.set(key, TIME_FUTURE);
+        }
+        const prev = bandStarts.get(key);
+        if (start.kind === TIME_DATED) {
+            if (prev === null || start.at < prev) bandStarts.set(key, start.at);
+            bandKinds.set(key, TIME_DATED);
+        } else if (start.kind === TIME_UNKNOWN && bandKinds.get(key) === TIME_FUTURE) {
+            bandKinds.set(key, TIME_UNKNOWN);
+        }
+    }
+    return { stepStarts, bandStarts, bandKinds };
+}

--- a/src/SwarmView/pipelines/pipelineViewModel.js
+++ b/src/SwarmView/pipelines/pipelineViewModel.js
@@ -26,6 +26,7 @@ import {
     STEP_RUNNING,
     STEP_PENDING,
 } from './pipelineModel';
+import { planTimeAxis } from './pipelinePlanTime';
 
 const asArray = (v) => (Array.isArray(v) ? v : []);
 
@@ -41,8 +42,17 @@ const asArray = (v) => (Array.isArray(v) ? v : []);
 // its cache key, so two pages asking for different projections are two cache
 // entries and the second one refetches the whole requirements table. One
 // constant means list -> detail navigation reuses the read it already paid for.
+//
+// `started_at` / `completed_at` (req #3201) carry the plan's TIME AXIS. The
+// visualizer's horizontal position is a calendar proxy and its bands stack by
+// epic start, and there is no `epics.started_at` column to read — an epic's
+// start is DERIVED as a minimum over its requirements (design rule 1), so the
+// two stamps have to travel with the projection. They are two DATETIME columns
+// on rows already being read; the blob columns req #3078 keeps out of list
+// reads are a different thing entirely.
 export const PLAN_REQUIREMENT_FIELDS =
-    'id,title,requirement_status,machine_fk,feature_fk,coordination_type,tracking';
+    'id,title,requirement_status,machine_fk,feature_fk,coordination_type,tracking,'
+    + 'started_at,completed_at';
 
 /**
  * Narrow the whole-table reads to ONE pipeline, in the shape req #3112 fixed.
@@ -192,7 +202,7 @@ export function buildCostIndex({ requirementSessions, sessionCosts } = {}) {
 
 /**
  * Run the engine end to end over a model: derive → order → SELF-CHECK → batch →
- * propose → mark eligibility → attach cost.
+ * propose → mark eligibility → attach cost → derive the time axis.
  *
  * The verifyOrder() call is on the RENDERED order, which is design rule 3's whole
  * point: the renderer checks its own output and the caller renders any violation
@@ -243,9 +253,19 @@ export function orderedPlan(model, { now, costIndex = null } = {}) {
     // input, so there is nothing outside this function to surprise.
     for (const r of rows) r.cost = aggregateRowCost(r, costIndex);
 
+    // The visualizer's TIME AXIS (req #3201). Derived here rather than in the
+    // canvas for the same reason cost is: the plan table and the plan
+    // visualizer are two surfaces over one plan, and a fact they each derive
+    // independently is a fact that can disagree. Like cost, and for the same
+    // reason, it is computed AFTER ordering and is never an ordering input —
+    // display order stays topological-then-state-banded (rule 3), and only the
+    // canvas's column origins and band stacking read this.
+    const timeAxis = planTimeAxis(rows, (model && model.requirements) || []);
+
     return {
         rows,
         violations,
+        timeAxis,
         batches,
         batchLetterByStepId,
         proposals,


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-01T08:50:53Z
- chore: init swarm session feature/3201-plan-visualizer-horizontal-axis-1

## Files changed
```
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx |  10 +-
 .../pipelines/__tests__/pipelinePlanLayout.test.js | 355 ++++++++++++++++++++-
 .../pipelines/__tests__/pipelinePlanTime.test.js   | 148 +++++++++
 src/SwarmView/pipelines/pipelineDetailModes.js     |   8 +-
 src/SwarmView/pipelines/pipelinePlanLayout.js      | 293 ++++++++++++++---
 src/SwarmView/pipelines/pipelinePlanTime.js        | 177 ++++++++++
 src/SwarmView/pipelines/pipelineViewModel.js       |  24 +-
 7 files changed, 965 insertions(+), 50 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)