### PR TITLE
Swarm-start eligibility must exclude pipelined requirements — aggregator card and every skill

### DIFF
--- a/src/SwarmView/RequirementsTableView.jsx
+++ b/src/SwarmView/RequirementsTableView.jsx
@@ -22,7 +22,7 @@ import { DataGrid, GridToolbar } from '@mui/x-data-grid';
 import AuthContext from '../Context/AuthContext';
 import AppContext from '../Context/AppContext';
 import call_rest_api from '../RestApi/RestApi';
-import { useAllRequirements, useAllCategories, useSessions, useMachines } from '../hooks/useDataQueries';
+import { useAllRequirements, useAllCategories, useSessions, useMachines, usePipelinedRequirementIds } from '../hooks/useDataQueries';
 import { requirementKeys } from '../hooks/useQueryKeys';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
 import { requirementStatusChipProps, requirementStatusLabel } from './statusChipStyles';
@@ -80,6 +80,8 @@ const RequirementsTableView = () => {
     const creatorFk = profile?.userName;
 
     const requirementStatusFilter = useShowClosedStore(s => s.requirementStatusFilter);
+    // req #3180 — user-controlled, and it answers STEP association (see the store).
+    const hidePipelined = useShowClosedStore(s => s.hidePipelinedRequirements);
     const drill = useRequirementDrillStore(s => s.drill);
     const clearDrill = useRequirementDrillStore(s => s.clearDrill);
     const showError = useSnackBarStore(s => s.showError);
@@ -95,6 +97,12 @@ const RequirementsTableView = () => {
     // a since-retired machine must still resolve to a name here rather than
     // falling back to the raw id.
     const { data: machines = [] } = useMachines(creatorFk);
+
+    // req #3180 — THE membership answer, shared with the SwarmStartCard. Read
+    // unconditionally (hooks are not conditional) but consulted only while the
+    // toggle is ON; the junction read is small and the plan pages already hold
+    // it, so the cache entry is normally warm either way.
+    const pipelinedIds = usePipelinedRequirementIds(creatorFk);
 
     const categoryMap = useMemo(() => {
         const m = new Map();
@@ -130,12 +138,22 @@ const RequirementsTableView = () => {
     // Filter out:
     //  - Requirements whose status isn't in the chip filter
     //  - Requirements linked to closed categories (categoryMap only has open ones)
+    //  - req #3180 — when the pipeline toggle is ON, every requirement a pipeline
+    //    STEP carries, leaving the unscheduled residue.
+    //
+    // The pipeline toggle applies to the NORMAL branch only, exactly like the
+    // status chips: a Trends drill-down bypasses both. The drill's contract (see
+    // req #2850 below) is that the row set EQUALS the bar that was clicked, and
+    // RequirementsTrendsView charts from an unfiltered `useAllRequirements` — so
+    // filtering here would make the pill under the table contradict the bar
+    // above it, by most of the bucket on a plan-heavy month.
     //
     // req #2850 — when a Trends drill-down is active, the chips are bypassed entirely:
     // the table shows exactly the Met requirements in the clicked time bucket (and
     // category, if a split segment was clicked). Matching reuses the chart's bucket
     // keying (`requirementBucketKey`) so the row set equals the bar that was clicked.
     const filteredRequirements = useMemo(() => {
+        const notPipelined = (r) => !hidePipelined || !pipelinedIds.has(Number(r.id));
         if (drill) {
             // categoryIds: explicit set the chart showed (a split segment → one id, or
             // a narrowed chip selection → that subset). Honored even for closed
@@ -156,9 +174,10 @@ const RequirementsTableView = () => {
         }
         return requirements.filter(r =>
             requirementStatusFilter.includes(r.requirement_status) &&
-            categoryMap.has(r.category_fk)
+            categoryMap.has(r.category_fk) &&
+            notPipelined(r)
         );
-    }, [requirements, requirementStatusFilter, categoryMap, drill]);
+    }, [requirements, requirementStatusFilter, categoryMap, drill, hidePipelined, pipelinedIds]);
 
     // Multi-select state (v8 DataGrid shape: include=only these ids, exclude=all except these).
     // Both selectedCount and getSelectedIds are intersected with `filteredRequirements`

--- a/src/SwarmView/SwarmView.jsx
+++ b/src/SwarmView/SwarmView.jsx
@@ -36,6 +36,7 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import BubbleChartIcon from '@mui/icons-material/BubbleChart';
@@ -74,6 +75,12 @@ const SwarmView = () => {
     const setWorkingProject = useWorkingProjectStore(s => s.setWorkingProject);
     const requirementStatusFilter = useShowClosedStore(s => s.requirementStatusFilter);
     const toggleRequirementStatus = useShowClosedStore(s => s.toggleRequirementStatus);
+    // req #3180 — Table view only. The requirements BROWSE page is the one place
+    // where both populations (scheduled / unscheduled) are legitimate to look at,
+    // so pipeline membership is a user CONTROL here rather than the automatic
+    // exclusion the launch-offering surfaces apply.
+    const hidePipelined = useShowClosedStore(s => s.hidePipelinedRequirements);
+    const toggleHidePipelined = useShowClosedStore(s => s.toggleHidePipelinedRequirements);
     const showSwarmStartCard = useSwarmStartCardStore(s => s.show);
     const toggleSwarmStartCard = useSwarmStartCardStore(s => s.toggle);
     // Model/Effort column display preference (req #3029) — surfaced in the gear
@@ -315,6 +322,36 @@ const SwarmView = () => {
                                 onToggle={toggleRequirementStatus}
                                 testId="requirement-status-filter"
                             />
+                        )}
+                        {/* req #3180 — the label names the question it answers:
+                            PIPELINE STEP association ("is this scheduled"), not
+                            epic association ("does this belong to a body of
+                            work"). A requirement can carry a feature, and so an
+                            epic, while sitting in no plan at all; a label that
+                            didn't distinguish them would be read as answering
+                            whichever one the user had in mind. */}
+                        {/* `!drill` for the same reason the status chips carry it:
+                            a Trends drill-down bypasses both filters, so leaving
+                            the control on screen would show an ON toggle that is
+                            not applying. */}
+                        {view === 'table' && !drill && (
+                            <Tooltip title={hidePipelined
+                                ? 'Showing only requirements NO pipeline step carries — click to show all'
+                                : 'Hide requirements carried by a pipeline step'}>
+                                <IconButton
+                                    size="small"
+                                    onClick={toggleHidePipelined}
+                                    color={hidePipelined ? 'primary' : 'default'}
+                                    aria-label={hidePipelined
+                                        ? 'Show requirements carried by a pipeline step'
+                                        : 'Hide requirements carried by a pipeline step'}
+                                    aria-pressed={hidePipelined}
+                                    data-testid="hide-pipelined-toggle"
+                                    sx={{ flexShrink: 0 }}
+                                >
+                                    <AccountTreeIcon />
+                                </IconButton>
+                            </Tooltip>
                         )}
                         {view === 'cards' && (
                             <Tooltip title={showSwarmStartCard ? 'Hide Swarm-Start Card' : 'Show Swarm-Start Card'}>

--- a/src/TaskPlanView/SwarmStartCard.jsx
+++ b/src/TaskPlanView/SwarmStartCard.jsx
@@ -1,7 +1,8 @@
 // SwarmStartCard — cross-category requirement aggregator in the requirement view.
 //   • Header is a row of status chips (same styling as the requirements page filter chips).
 //   • Single-select: exactly one status is active at a time.
-//   • Card shows all requirements with the selected status across all categories.
+//   • Card shows all requirements with the selected status across all categories,
+//     MINUS the ones a pipeline step carries (req #3180 — see below).
 //   • Template row at the bottom (req #2414): typing a title + Enter/blur navigates
 //     the user to the requirement editor in "new" mode — nothing is saved until the
 //     user picks a category in the editor (the aggregator has no default category).
@@ -14,7 +15,9 @@ import RequirementRow from '../SwarmView/RequirementRow';
 import RequirementDeleteDialog from '../SwarmView/RequirementDeleteDialog';
 import call_rest_api from '../RestApi/RestApi';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
-import { useRequirementsByStatus, useRequirementsDone, useSessions, useCategoryColors, useAllRequirements } from '../hooks/useDataQueries';
+import { useRequirementsByStatus, useRequirementsDone, useSessions, useCategoryColors, useAllRequirements, usePipelinedRequirementIds } from '../hooks/useDataQueries';
+import { excludePipelined } from '../utils/pipelineMembership';
+import { PIPELINE_FILTERED_STATUSES, tallyRequirementStatuses } from './swarmStartCardUtils';
 import { requirementKeys } from '../hooks/useQueryKeys';
 import { useCrudCallbacks } from '../hooks/useCrudCallbacks';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
@@ -139,8 +142,27 @@ const SwarmStartCard = () => {
         { fields: 'id,title,requirement_status,coordination_type,ai_model,effort,category_fk,completed_at' },
     );
 
+    // req #3180 — this card OFFERS requirements for a direct swarm-start, so the
+    // ones a pipeline step already carries do not belong on its launch chips:
+    // their launch is the coordinator's to make, at the point the plan says so.
+    //
+    // The exclusion is UNCONDITIONAL — not a user preference. Offering an
+    // ineligible launch is a defect, not a viewing choice, so there is no toggle
+    // here; the user-controlled version of the question lives on the
+    // requirements BROWSE table, where both populations are legitimate to look
+    // at. It applies to PIPELINE_FILTERED_STATUSES only (see above).
+    const pipelinedIds = usePipelinedRequirementIds(profile?.userName);
+    const chipOffersLaunch = PIPELINE_FILTERED_STATUSES.includes(effectiveStatus);
+
+    // Memoized because this feeds a useEffect dependency and a useMemo below —
+    // `excludePipelined` mints a new array whenever it actually drops something,
+    // so an unmemoized call would re-seed local state on every render.
+    const eligibleRequirements = React.useMemo(
+        () => excludePipelined(serverRequirements, pipelinedIds, chipOffersLaunch),
+        [serverRequirements, pipelinedIds, chipOffersLaunch]);
+
     // The array that drives the card body for the currently selected chip.
-    const currentRequirements = isMet ? serverMetRequirements : serverRequirements;
+    const currentRequirements = isMet ? serverMetRequirements : eligibleRequirements;
 
     // Fetch sessions for status badges (same as CategoryCard)
     const { data: serverSessions } = useSessions(profile?.userName);
@@ -164,20 +186,33 @@ const SwarmStartCard = () => {
     // The 'met' count is overlaid from the trailing-24h Met query (req #2584), since
     // useAllRequirements doesn't carry completed_at and can't be filtered to the
     // 24-hour window here. Returns { authoring, approved, swarm_ready, development, met }.
-    const statusCountMap = React.useMemo(() => {
-        const counts = {};
-        SWARM_START_STATUSES.forEach(s => { counts[s] = 0; });
-        if (Array.isArray(allRequirementsForCounts)) {
-            for (const r of allRequirementsForCounts) {
-                if (!r || r.id === '' || r.id === undefined || r.id === null) continue;
-                if (counts[r.requirement_status] !== undefined) counts[r.requirement_status] += 1;
-            }
-        }
+    //
+    // req #3180 — a launch chip's count applies the SAME rule as its list, from
+    // the same Set, so the header can never disagree with the rows beneath it.
+    // `hidden` tallies what the exclusion removed per status, so a chip that
+    // drops to zero can SAY why (see the card body) instead of reading as
+    // "there is no work" while the requirements table plainly shows some.
+    //
+    // LOAD-BEARING: `hidden[s]` is the count dropped from that chip's LIST only
+    // because both sources are the same population — `useAllRequirements` here
+    // and `useRequirementsByStatus` above both read /requirements with NO
+    // category predicate and NO closed-category guard. RequirementsTableView
+    // does filter through `categoryMap`, and copying that here would look like
+    // an improvement while desynchronizing the count from the list AND
+    // overcounting the note, in one edit. See `tallyRequirementStatuses`.
+    const { statusCountMap, hiddenCountMap } = React.useMemo(() => {
+        const { counts, hidden } = tallyRequirementStatuses(
+            allRequirementsForCounts, SWARM_START_STATUSES, pipelinedIds);
         if (Array.isArray(serverMetRequirements)) {
             counts.met = serverMetRequirements.length;
         }
-        return counts;
-    }, [allRequirementsForCounts, serverMetRequirements]);
+        return { statusCountMap: counts, hiddenCountMap: hidden };
+    }, [allRequirementsForCounts, serverMetRequirements, pipelinedIds]);
+
+    // How many rows the exclusion removed from the chip currently on screen.
+    // Surfaced in the card body — a hidden row the user is never told about is
+    // the defect this requirement is about.
+    const hiddenCount = chipOffersLaunch ? (hiddenCountMap[effectiveStatus] ?? 0) : 0;
 
     // Template rows (id === '') always sort last so they stay anchored at the
     // bottom of the card on every re-sort.
@@ -507,6 +542,31 @@ const SwarmStartCard = () => {
                         {requirementsArray.filter(r => r.id !== '').length === 0 && (
                             <Typography variant="body2" sx={{ color: 'text.disabled', p: 1 }}>
                                 No {requirementStatusLabel(effectiveStatus).toLowerCase()} requirements
+                            </Typography>
+                        )}
+                        {/* req #3180 — a chip that hides work must SAY SO. On the
+                            live plan every swarm-ready requirement is plan-carried,
+                            so without this the card reads "No swarm ready
+                            requirements" while the requirements table plainly shows
+                            fifteen — the same "shrinking pool with no explanation
+                            reads as a bug" failure /swarm-start's STOP message
+                            exists to prevent. Rendered whether or not the list is
+                            empty, because a partly-filtered chip is just as
+                            misleading as an empty one.
+
+                            The wording must READ CORRECTLY AT ZERO. "N more …"
+                            was the first attempt and it presupposes rows above it,
+                            which is exactly wrong in the guaranteed opening state:
+                            the default chip is Swarm-Ready, and today that chip is
+                            15 of 15 hidden. */}
+                        {hiddenCount > 0 && (
+                            <Typography variant="body2"
+                                        sx={{ color: 'text.secondary', px: 1, pb: 1, fontStyle: 'italic' }}
+                                        data-testid="swarm-start-pipelined-note">
+                                {hiddenCount} {requirementStatusLabel(effectiveStatus).toLowerCase()}{' '}
+                                requirement{hiddenCount === 1 ? ' is' : 's are'} carried by a pipeline
+                                step — launched from the plan, not from here. See Pipelines, or launch
+                                one directly by id.
                             </Typography>
                         )}
                         {requirementsArray.map((requirement, requirementIndex) => (

--- a/src/TaskPlanView/__tests__/swarmStartCardUtils.test.js
+++ b/src/TaskPlanView/__tests__/swarmStartCardUtils.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { sortSwarmReadyItems, getCoordLabel } from '../swarmStartCardUtils';
+import {
+    sortSwarmReadyItems,
+    getCoordLabel,
+    PIPELINE_FILTERED_STATUSES,
+    tallyRequirementStatuses,
+} from '../swarmStartCardUtils';
 
 const req = (id, overrides = {}) => ({
     id,
@@ -67,5 +72,111 @@ describe('getCoordLabel', () => {
 
     it('returns No autonomy for unknown value', () => {
         expect(getCoordLabel('unknown')).toBe('No autonomy');
+    });
+});
+
+// req #3180 — the aggregator's pipeline exclusion. These pin the decision a
+// future reader is likeliest to "simplify": WHICH chips filter. The card offers
+// requirements for a direct swarm-start, so a requirement a pipeline step
+// carries is excluded from the launch chips — but `development` and `met` are
+// observation surfaces, not offers, and filtering them empties the two chips the
+// user watches work through.
+
+const ALL_CHIPS = ['authoring', 'approved', 'swarm_ready', 'development', 'met'];
+
+describe('PIPELINE_FILTERED_STATUSES', () => {
+    it('is the three PRE-LAUNCH statuses — the chips that offer a launch', () => {
+        expect(PIPELINE_FILTERED_STATUSES).toEqual(['authoring', 'approved', 'swarm_ready']);
+    });
+
+    it('excludes development and met — observation surfaces, not offers', () => {
+        // Measured on the live plan, 7 of 7 `development` requirements are
+        // plan-carried; filtering that chip would blank it entirely.
+        expect(PIPELINE_FILTERED_STATUSES).not.toContain('development');
+        expect(PIPELINE_FILTERED_STATUSES).not.toContain('met');
+    });
+});
+
+describe('tallyRequirementStatuses', () => {
+    const rows = [
+        req(1, { requirement_status: 'authoring' }),
+        req(2, { requirement_status: 'authoring' }),
+        req(3, { requirement_status: 'approved' }),
+        req(4, { requirement_status: 'swarm_ready' }),
+        req(5, { requirement_status: 'development' }),
+        req(6, { requirement_status: 'met' }),
+    ];
+
+    it('counts every chip and hides nothing when no requirement is pipelined', () => {
+        const { counts, hidden } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set());
+        expect(counts).toEqual({
+            authoring: 2, approved: 1, swarm_ready: 1, development: 1, met: 1,
+        });
+        expect(Object.values(hidden).every(n => n === 0)).toBe(true);
+    });
+
+    it('moves a pipelined launch-chip requirement from counts into hidden', () => {
+        const { counts, hidden } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([2, 4]));
+        expect(counts.authoring).toBe(1);
+        expect(hidden.authoring).toBe(1);
+        expect(counts.swarm_ready).toBe(0);
+        expect(hidden.swarm_ready).toBe(1);
+    });
+
+    it('leaves development and met counted even when pipelined', () => {
+        // THE decision. If this test starts failing because someone made the
+        // exclusion uniform, the Development chip has just gone blank.
+        const { counts, hidden } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([5, 6]));
+        expect(counts.development).toBe(1);
+        expect(counts.met).toBe(1);
+        expect(hidden.development).toBe(0);
+        expect(hidden.met).toBe(0);
+    });
+
+    it('keeps count + hidden summing to the population, so the note is exact', () => {
+        // `hidden[s]` is the number of rows dropped from that chip's LIST, which
+        // is only true while count and list read the same population.
+        const { counts, hidden } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([1, 2, 3, 4]));
+        for (const s of ALL_CHIPS) {
+            const total = rows.filter(r => r.requirement_status === s).length;
+            expect(counts[s] + hidden[s]).toBe(total);
+        }
+    });
+
+    it('never counts the template row', () => {
+        // id === '' is the "type a title here" row, not a requirement — and
+        // Number('') is 0, which must never reach the Set lookup.
+        const withTemplate = [...rows, { id: '', requirement_status: 'authoring' }];
+        const { counts } = tallyRequirementStatuses(withTemplate, ALL_CHIPS, new Set([0]));
+        expect(counts.authoring).toBe(2);
+    });
+
+    it('matches a numeric Set against string row ids', () => {
+        const { counts, hidden } = tallyRequirementStatuses(
+            [{ id: '4', requirement_status: 'swarm_ready' }], ALL_CHIPS, new Set([4]));
+        expect(counts.swarm_ready).toBe(0);
+        expect(hidden.swarm_ready).toBe(1);
+    });
+
+    it('ignores statuses outside the chip vocabulary', () => {
+        const { counts } = tallyRequirementStatuses(
+            [...rows, req(9, { requirement_status: 'wontfix' })], ALL_CHIPS, new Set());
+        expect(counts.wontfix).toBeUndefined();
+        expect(Object.keys(counts)).toEqual(ALL_CHIPS);
+    });
+
+    it('returns zeroed maps for a missing read, hiding nothing', () => {
+        // The in-flight state. Showing MORE than we eventually will is the
+        // deliberate direction — never hide eligible work behind a pending fetch.
+        const { counts, hidden } = tallyRequirementStatuses(undefined, ALL_CHIPS, new Set([1]));
+        expect(counts).toEqual({
+            authoring: 0, approved: 0, swarm_ready: 0, development: 0, met: 0,
+        });
+        expect(hidden.authoring).toBe(0);
+    });
+
+    it('tolerates a missing pipelined Set', () => {
+        const { counts } = tallyRequirementStatuses(rows, ALL_CHIPS, undefined);
+        expect(counts.swarm_ready).toBe(1);
     });
 });

--- a/src/TaskPlanView/swarmStartCardUtils.js
+++ b/src/TaskPlanView/swarmStartCardUtils.js
@@ -6,6 +6,65 @@ export const sortSwarmReadyItems = (items) => {
     return [...items].sort((a, b) => a.id - b.id);
 };
 
+// req #3180 — the chips that OFFER a launch, and therefore the only ones the
+// pipeline exclusion applies to.
+//
+// `development` and `met` are deliberately NOT here, and this is the decision a
+// future reader is likeliest to "simplify" back to uniform. Neither is an offer:
+// a `development` requirement cannot be launched by any path (/swarm-start's
+// per-item gate prompts on it), and `met` is req #2584's trailing-24h
+// recent-completions list. Measured against the live plan, 7 of 7 `development`
+// requirements are plan-carried — filtering uniformly would empty the chip the
+// user watches in-flight work through, and the Met chip would converge on
+// permanently blank as the plan completes.
+//
+// This is per-chip, not per-card, and it does NOT reintroduce the "filtered list
+// under an unfiltered count" defect: that defect is a list and a count
+// disagreeing FOR ONE CHIP, and `tallyRequirementStatuses` below applies exactly
+// this predicate to the count that the card applies to the list.
+export const PIPELINE_FILTERED_STATUSES = ['authoring', 'approved', 'swarm_ready'];
+
+/**
+ * Per-status counts for the chip badges, plus what the pipeline exclusion removed.
+ *
+ * Pure so the "which chips filter" decision is pinned by tests rather than only
+ * by a rendered card.
+ *
+ * INVARIANT THIS DEPENDS ON: the card counts from `useAllRequirements` while it
+ * lists from `useRequirementsByStatus`, and applies NO closed-category filter to
+ * EITHER — unlike RequirementsTableView, which filters its rows through
+ * `categoryMap`. That is what makes `hidden[status]` exactly the number of rows
+ * dropped from that chip's list. Adding a closed-category guard to one source and
+ * not the other would desynchronize the count from the list AND overcount the
+ * note, in the same edit. Today the pipelined-in-closed-category population is 0.
+ *
+ * @param {Array<{id: number, requirement_status: string}>} requirements
+ * @param {string[]} statuses      the chip vocabulary; every key is initialized to 0
+ * @param {Set<number>} pipelinedIds  from `pipelinedRequirementIds`
+ * @returns {{counts: Object, hidden: Object}}
+ */
+export const tallyRequirementStatuses = (requirements, statuses, pipelinedIds) => {
+    const counts = {};
+    const hidden = {};
+    statuses.forEach(s => { counts[s] = 0; hidden[s] = 0; });
+    if (!Array.isArray(requirements)) return { counts, hidden };
+
+    for (const r of requirements) {
+        // The template row (id === '') is not a requirement and must never be
+        // counted — nor reach the Set lookup, where Number('') would be 0.
+        if (!r || r.id === '' || r.id === undefined || r.id === null) continue;
+        const status = r.requirement_status;
+        if (counts[status] === undefined) continue;
+        if (PIPELINE_FILTERED_STATUSES.includes(status)
+                && pipelinedIds && pipelinedIds.has(Number(r.id))) {
+            hidden[status] += 1;
+            continue;
+        }
+        counts[status] += 1;
+    }
+    return { counts, hidden };
+};
+
 // Map coordination_type to a display label for tooltips / aria.
 export const getCoordLabel = (coordType) => {
     switch (coordType) {

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -1,5 +1,5 @@
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
 import { domainKeys, areaKeys, taskKeys, projectKeys, categoryKeys, requirementKeys, priorityCardOrderKeys, recurringTaskKeys, mapRunKeys, mapRouteKeys, mapCoordinateKeys, mapViewKeys, mapPartnerKeys, mapRunPartnerKeys, epicKeys, featureKeys, testCaseKeys, featureTestCaseKeys, testPlanKeys, testPlanCaseKeys, testRunKeys, testResultKeys, customerKeys, buildProjectKeys, branchKeys, buildKeys, customerReleaseKeys } from './useQueryKeys';
@@ -7,6 +7,8 @@ import { devServers, sessions, swarmStarts, swarmStartSessions, swarmUndos, swar
 // `fetchEntity` is shared with the factory so both layers handle REST errors
 // identically (req #2593).
 import { fetchEntity } from './factory/createEntityQueries';
+// req #3180 — THE browser's one derivation of pipeline-step membership.
+import { pipelinedRequirementIds } from '../utils/pipelineMembership';
 
 export function useDomains(creatorFk, { closed, fields = 'id,domain_name,sort_order', enabled = true } = {}) {
     const { darwinUri } = useContext(AppContext);
@@ -864,6 +866,20 @@ export const useAllPipelines                = pipelines.useAll;
 export const useAllPipelineSteps            = pipelineSteps.useAll;
 export const useAllPipelineStepRequirements = pipelineStepRequirements.useAll;
 export const useAllPipelineStepDeps         = pipelineStepDeps.useAll;
+
+// Req #3180 — the requirement ids a pipeline STEP carries, as a Set.
+//
+// One shared hook over the junction read above, so the two surfaces that need
+// this (the SwarmStartCard aggregator, the requirements-page filter) consult ONE
+// query cache entry and ONE derivation. It costs no extra fetch on the plan
+// pages, which already hold this exact read.
+//
+// The Set is memoized on the query data, so it is referentially stable between
+// refetches that change nothing — consumers use it as a useMemo dependency.
+export function usePipelinedRequirementIds(creatorFk, { enabled = true } = {}) {
+    const { data } = useAllPipelineStepRequirements(creatorFk, { enabled });
+    return useMemo(() => pipelinedRequirementIds(data), [data]);
+}
 
 // Req #3117 — the plan page's Cost column. TWO more bounded list reads, never a
 // per-requirement fetch: the junction maps requirements to their sessions, the

--- a/src/stores/__tests__/useShowClosedStore.pipelined.test.js
+++ b/src/stores/__tests__/useShowClosedStore.pipelined.test.js
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+//
+// req #3180 — `hidePipelinedRequirements`, the requirements-page pipeline filter.
+// Exercises the REAL store action. The default is the load-bearing part: OFF must
+// be exactly today's behaviour, because this control ships to users who have a
+// persisted blob that predates it.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useShowClosedStore } from '../useShowClosedStore';
+
+const flag = () => useShowClosedStore.getState().hidePipelinedRequirements;
+const toggle = () => useShowClosedStore.getState().toggleHidePipelinedRequirements();
+
+describe('hidePipelinedRequirements', () => {
+    beforeEach(() => {
+        useShowClosedStore.setState({ hidePipelinedRequirements: false });
+    });
+
+    it('defaults to OFF — everything shown, exactly today\'s behaviour', () => {
+        expect(flag()).toBe(false);
+    });
+
+    it('toggles ON and back OFF', () => {
+        toggle();
+        expect(flag()).toBe(true);
+        toggle();
+        expect(flag()).toBe(false);
+    });
+
+    it('leaves the status chip filter alone — the two are independent dimensions', () => {
+        const before = useShowClosedStore.getState().requirementStatusFilter;
+        toggle();
+        expect(useShowClosedStore.getState().requirementStatusFilter).toBe(before);
+    });
+
+    it('an older persisted blob with no key keeps the OFF default', () => {
+        // No persist version bump was taken: zustand merges the persisted object
+        // over the initializer, so a missing key falls through to `false`. This
+        // pins that assumption rather than leaving it implicit.
+        const merged = { ...useShowClosedStore.getInitialState(),
+                         ...{ requirementStatusFilter: ['met'] } };
+        expect(merged.hidePipelinedRequirements).toBe(false);
+    });
+});

--- a/src/stores/useShowClosedStore.js
+++ b/src/stores/useShowClosedStore.js
@@ -23,6 +23,29 @@ export const useShowClosedStore = create(
             sessionStatusFilter: DEFAULT_SESSION_STATUSES,
             sessionMachineFilter: DEFAULT_SESSION_MACHINES,
 
+            // req #3180 — the requirements TABLE's pipeline filter. ON hides every
+            // requirement a pipeline STEP carries, leaving the residue: work
+            // nobody has scheduled. Note which question it answers — STEP
+            // association (a `pipeline_step_requirements` row, "is this
+            // scheduled"), NOT epic association ("does this belong to a body of
+            // work"), which a requirement can carry while sitting in no plan at
+            // all. Exposing that gap is the point of the ON state.
+            //
+            // A CONTROL, not an automatic exclusion, because on a BROWSE page
+            // both populations are legitimate to look at and only the user knows
+            // which they want. The surfaces that OFFER a launch (SwarmStartCard,
+            // /swarm-start's auto-discovery) exclude unconditionally instead —
+            // there, showing an ineligible launch is a defect, not a preference.
+            //
+            // OFF is today's behaviour, so no persist version bump is needed: an
+            // older persisted blob simply lacks the key and zustand's default
+            // merge leaves this `false` in place.
+            hidePipelinedRequirements: false,
+            toggleHidePipelinedRequirements: () =>
+                set((state) => ({
+                    hidePipelinedRequirements: !state.hidePipelinedRequirements,
+                })),
+
             toggleRequirementStatus: (status) =>
                 set((state) => {
                     const current = state.requirementStatusFilter;

--- a/src/utils/__tests__/pipelineMembership.test.js
+++ b/src/utils/__tests__/pipelineMembership.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { pipelinedRequirementIds, excludePipelined } from '../pipelineMembership';
+
+// req #3180. This module is the browser's ONE answer to "does a pipeline step
+// carry this requirement" — both the SwarmStartCard aggregator and the
+// requirements-page filter read it. The tests that matter are the ones pinning
+// the shape it must survive in real data (a junction with no id column, ids that
+// arrive as strings from a REST payload) and the direction it must fail in
+// (show more, never hide eligible work).
+
+describe('pipelinedRequirementIds', () => {
+    it('collects requirement_fk from junction rows', () => {
+        const ids = pipelinedRequirementIds([
+            { step_fk: 1, requirement_fk: 3074 },
+            { step_fk: 2, requirement_fk: 3172 },
+        ]);
+        expect(ids).toEqual(new Set([3074, 3172]));
+    });
+
+    it('collapses a requirement carried by several steps', () => {
+        // Membership is "at least one step" — the Set is the right shape for it.
+        const ids = pipelinedRequirementIds([
+            { step_fk: 1, requirement_fk: 3074 },
+            { step_fk: 9, requirement_fk: 3074 },
+        ]);
+        expect(ids.size).toBe(1);
+        expect(ids.has(3074)).toBe(true);
+    });
+
+    it('normalizes string ids so a REST payload matches a numeric row id', () => {
+        // Lambda-Rest can hand back either; a Set keyed on '3074' would never
+        // match a row whose id is 3074, and the filter would silently no-op.
+        const ids = pipelinedRequirementIds([{ step_fk: '1', requirement_fk: '3074' }]);
+        expect(ids.has(3074)).toBe(true);
+    });
+
+    it('never seeds the set from a row with no requirement_fk', () => {
+        // A null in the set makes `has(Number(undefined))`-adjacent lookups
+        // unpredictable; drop the row instead.
+        const ids = pipelinedRequirementIds([
+            { step_fk: 1, requirement_fk: null },
+            { step_fk: 2 },
+            null,
+            { step_fk: 3, requirement_fk: 3074 },
+        ]);
+        expect(ids).toEqual(new Set([3074]));
+    });
+
+    it('returns an empty set for a missing or non-array read', () => {
+        // The in-flight state of the junction query. Empty means "nothing known
+        // to be pipelined", so nothing is hidden — see the direction test below.
+        expect(pipelinedRequirementIds(undefined).size).toBe(0);
+        expect(pipelinedRequirementIds(null).size).toBe(0);
+        expect(pipelinedRequirementIds({}).size).toBe(0);
+    });
+});
+
+describe('excludePipelined', () => {
+    const rows = [{ id: 3074 }, { id: 3180 }, { id: 3172 }];
+
+    it('drops exactly the requirements a step carries', () => {
+        const kept = excludePipelined(rows, new Set([3074, 3172]));
+        expect(kept.map(r => r.id)).toEqual([3180]);
+    });
+
+    it('returns the input unchanged when disabled', () => {
+        // Same reference, so an opted-out caller cannot trip a referential
+        // -equality dependency into re-running.
+        expect(excludePipelined(rows, new Set([3074]), false)).toBe(rows);
+    });
+
+    it('returns the input unchanged when nothing is pipelined', () => {
+        expect(excludePipelined(rows, new Set())).toBe(rows);
+        expect(excludePipelined(rows, undefined)).toBe(rows);
+    });
+
+    it('shows MORE, never less, while the junction read is in flight', () => {
+        // The deliberate failure direction: an unresolved (or failed) membership
+        // read must not blank a launch surface, and must never hide eligible
+        // work behind a fetch error.
+        expect(excludePipelined(rows, pipelinedRequirementIds(undefined))).toBe(rows);
+    });
+
+    it('matches a numeric set against string row ids', () => {
+        const kept = excludePipelined([{ id: '3074' }, { id: '3180' }], new Set([3074]));
+        expect(kept.map(r => r.id)).toEqual(['3180']);
+    });
+
+    it('passes a non-array through untouched', () => {
+        expect(excludePipelined(undefined, new Set([3074]))).toBe(undefined);
+    });
+});

--- a/src/utils/pipelineMembership.js
+++ b/src/utils/pipelineMembership.js
@@ -1,0 +1,63 @@
+// Pipeline membership — req #3180.
+//
+// THE browser's one answer to "does a pipeline step carry this requirement".
+// Both consumers (the SwarmStartCard aggregator and the requirements page
+// filter) read it from here; computing it a second way is how the two surfaces
+// start disagreeing, which is the same defect class this requirement removes at
+// the data layer.
+//
+// WHICH QUESTION THIS ANSWERS: STEP association — a direct
+// `pipeline_step_requirements` junction row, i.e. "is this scheduled". It is NOT
+// epic association (requirement -> feature -> epic), which answers "does this
+// belong to a body of work" and is true of plenty of requirements no step will
+// ever run. Those two populations differ, and the gap between them — work
+// correctly filed under an epic that no step will run — is exactly what the
+// requirements-page filter exists to expose. Every label built on this says
+// "pipeline step" so it cannot be read as answering the other question.
+//
+// The daemon derives the same fact server-side as `requirement.pipelined`
+// (darwin-mcp/services/requirements.py). The two cannot share code — the browser
+// reaches Lambda-Rest, the daemon reaches it from a localhost process — so they
+// are deliberate duplicates of one rule, exactly like pipelineModel.js and
+// pipeline_derive.py.
+
+/**
+ * @param {Array<{requirement_fk: number}>} stepRequirements  rows from
+ *        `useAllPipelineStepRequirements` (the junction, whole-table read).
+ * @returns {Set<number>} requirement ids at least one pipeline step carries.
+ */
+export const pipelinedRequirementIds = (stepRequirements) => {
+    const ids = new Set();
+    if (!Array.isArray(stepRequirements)) return ids;
+    for (const link of stepRequirements) {
+        // A junction row with no requirement_fk cannot name a requirement. Skip
+        // it rather than seeding the set with null/undefined, which would make
+        // `has(r.id)` answer true for any row whose own id was missing.
+        if (!link || link.requirement_fk === null || link.requirement_fk === undefined) continue;
+        ids.add(Number(link.requirement_fk));
+    }
+    return ids;
+};
+
+/**
+ * Drop every requirement a pipeline step carries.
+ *
+ * `enabled === false` returns the input array UNCHANGED (same reference), so a
+ * caller that has not opted in — or whose junction read has not resolved — pays
+ * nothing and cannot trip a referential-equality dependency.
+ *
+ * WHILE THE JUNCTION READ IS IN FLIGHT the set is empty, so nothing is dropped
+ * and the surface shows MORE than it eventually will. That direction is the
+ * deliberate one: the alternative (treat unknown as pipelined) would blank a
+ * launch surface on every page load and, worse, would hide eligible work behind
+ * a fetch failure.
+ *
+ * @param {Array<{id: number}>} requirements
+ * @param {Set<number>} pipelinedIds  from `pipelinedRequirementIds`
+ * @param {boolean} [enabled=true]
+ */
+export const excludePipelined = (requirements, pipelinedIds, enabled = true) => {
+    if (!enabled || !Array.isArray(requirements)) return requirements;
+    if (!pipelinedIds || pipelinedIds.size === 0) return requirements;
+    return requirements.filter(r => !pipelinedIds.has(Number(r?.id)));
+};


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3180-swarm-start-eligibility-must-1
- wip(Darwin): 2026-08-01T13:09:08Z
- chore: init swarm session feature/3180-swarm-start-eligibility-must-1

## Files changed
```
 src/SwarmView/RequirementsTableView.jsx            |  25 ++++-
 src/SwarmView/SwarmView.jsx                        |  37 +++++++
 src/TaskPlanView/SwarmStartCard.jsx                |  88 +++++++++++++---
 .../__tests__/swarmStartCardUtils.test.js          | 113 ++++++++++++++++++++-
 src/TaskPlanView/swarmStartCardUtils.js            |  59 +++++++++++
 src/hooks/useDataQueries.js                        |  18 +++-
 .../__tests__/useShowClosedStore.pipelined.test.js |  44 ++++++++
 src/stores/useShowClosedStore.js                   |  23 +++++
 src/utils/__tests__/pipelineMembership.test.js     |  92 +++++++++++++++++
 src/utils/pipelineMembership.js                    |  63 ++++++++++++
 10 files changed, 543 insertions(+), 19 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)