### PR TITLE
status selector feature

### DIFF
--- a/src/SwarmView/pipelines/PipelineCardsView.jsx
+++ b/src/SwarmView/pipelines/PipelineCardsView.jsx
@@ -16,23 +16,22 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
 import { pipelineStatusChipProps } from './pipelineChipStyles';
-import { machineTitle } from './pipelineViewModel';
+import { machineTitle, pipelinesEmptyMessage } from './pipelineViewModel';
 
 const EMPTY_SUMMARY = { total: 0, done: 0, running: 0, pending: 0 };
 
 export default function PipelineCardsView({ pipelines, summaries, machines, onOpen,
-    filtered = false }) {
+    hiddenStatusCounts = [] }) {
     if (!pipelines.length) {
         // "No pipelines yet" is a claim about the DATA, and it is false whenever
         // a status filter is what emptied the view — the page's own accounting
         // line says "0 of 2" two inches above it. Distinguish the two; an empty
-        // result the user caused should say so, and say how to undo it.
+        // result the user caused should say so, and name WHICH statuses it hid
+        // (req #3220) rather than pointing at a since-removed "All" chip.
         return (
             <Typography variant="body2" color="text.secondary" sx={{ px: 1, py: 3 }}
                         data-testid="pipelines-cards-empty">
-                {filtered
-                    ? 'No pipelines match this status filter — choose All to see them.'
-                    : 'No pipelines yet.'}
+                {pipelinesEmptyMessage(hiddenStatusCounts)}
             </Typography>
         );
     }

--- a/src/SwarmView/pipelines/PipelinesPage.jsx
+++ b/src/SwarmView/pipelines/PipelinesPage.jsx
@@ -13,9 +13,7 @@ import { useContext, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Box from '@mui/material/Box';
-import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
-import Stack from '@mui/material/Stack';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
@@ -33,17 +31,69 @@ import {
 } from '../../hooks/useDataQueries';
 import { useViewPreference } from '../../hooks/useViewPreference';
 import normalizeView from '../../Components/ViewerHeader/normalizeView';
+import ChipFilter from '../../Components/ChipFilter';
 import PipelineCardsView from './PipelineCardsView';
 import PipelinesTableView from './PipelinesTableView';
-import { pipelineStatusChipProps, PIPELINE_STATUS_VALUES } from './pipelineChipStyles';
-import { PLAN_REQUIREMENT_FIELDS, pipelineSummaries } from './pipelineViewModel';
+import {
+    pipelineStatusChipProps,
+    DEFAULT_PIPELINE_STATUSES,
+    PIPELINE_STATUS_VALUES,
+} from './pipelineChipStyles';
+import {
+    PLAN_REQUIREMENT_FIELDS,
+    pipelineSummaries,
+    hiddenPipelineStatusCounts,
+} from './pipelineViewModel';
 
 const VIEW_STORAGE_KEY = 'darwin-swarm-pipelines-view';
+
+// req #3220 — per-tab only (sessionStorage), matching useViewPreference's own
+// per-tab-first rationale (memory/view-switchable-pages.md). Needed because the
+// default is no longer "show everything": before this feature, losing the
+// filter on a click-into-detail-and-back was harmless (it reset to null, i.e.
+// every pipeline). Now it resets to a NARROWER set, so silently forgetting a
+// chip the user turned back on (e.g. re-enabling `completed` to look at one)
+// would re-hide it the moment they navigate back — the exact class of surprise
+// this requirement's default-set discussion was worried about.
+const STATUS_FILTER_STORAGE_KEY = 'darwin-swarm-pipelines-status-filter';
+
+function readStoredStatusFilter() {
+    try {
+        const raw = sessionStorage.getItem(STATUS_FILTER_STORAGE_KEY);
+        if (raw == null) return null; // nothing stored yet — caller falls back to the default
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return null;
+        // A stored [] is a legal, intentional "show nothing" (ChipFilter's own
+        // contract: empty is never auto-corrected back to a default). `[]` is
+        // truthy in JS, so the caller's `|| DEFAULT_PIPELINE_STATUSES` only
+        // fires when nothing was stored at all, never on a real empty choice.
+        return parsed.filter((v) => PIPELINE_STATUS_VALUES.includes(v));
+    } catch {
+        return null;
+    }
+}
+
+function writeStoredStatusFilter(statuses) {
+    try {
+        sessionStorage.setItem(STATUS_FILTER_STORAGE_KEY, JSON.stringify(statuses));
+    } catch {
+        // Safari private mode / quota exceeded — in-memory state still updates.
+    }
+}
 
 const VIEWS = [
     { value: 'cards', label: 'Cards', icon: ViewModuleIcon },
     { value: 'table', label: 'Table', icon: TableChartIcon },
 ];
+
+// req #3220 — fixed vocabulary, so options are module-level, same pattern as
+// SwarmView's requirementStatusOptions. Colors come from pipelineStatusChipProps,
+// not the ChipFilter palette.
+const pipelineStatusOptions = PIPELINE_STATUS_VALUES.map((status) => ({
+    value: status,
+    label: status,
+    chipProps: pipelineStatusChipProps(status),
+}));
 
 export default function PipelinesPage() {
     const navigate = useNavigate();
@@ -53,7 +103,21 @@ export default function PipelinesPage() {
 
     const [view, setView] = useViewPreference(VIEW_STORAGE_KEY, 'cards');
     const activeView = normalizeView(view, VIEWS);
-    const [statusFilter, setStatusFilter] = useState(null);
+    // req #3220 — multi-select via the shared ChipFilter, not the old nullable
+    // single value. Nothing outside this page reads the filter, so a Zustand
+    // store would still be ceremony without a second consumer — but the value
+    // itself is now worth surviving a click-into-detail-and-back (see the
+    // STATUS_FILTER_STORAGE_KEY comment above), so it's seeded from and
+    // written through to sessionStorage rather than living purely in memory.
+    const [statusFilter, setStatusFilter] = useState(
+        () => readStoredStatusFilter() || DEFAULT_PIPELINE_STATUSES);
+    const toggleStatus = (status) => setStatusFilter((current) => {
+        const next = current.includes(status)
+            ? current.filter((s) => s !== status)
+            : [...current, status];
+        writeStoredStatusFilter(next);
+        return next;
+    });
 
     const { data: pipelines = [], isLoading: pipelinesLoading } = useAllPipelines(creatorFk);
     const { data: steps = [], isLoading: stepsLoading } = useAllPipelineSteps(creatorFk);
@@ -81,9 +145,13 @@ export default function PipelinesPage() {
         [pipelines, steps, stepRequirements, requirements]);
 
     const filtered = useMemo(
-        () => (statusFilter === null
-            ? pipelines
-            : pipelines.filter((p) => p.pipeline_status === statusFilter)),
+        () => pipelines.filter((p) => statusFilter.includes(p.pipeline_status)),
+        [pipelines, statusFilter]);
+
+    // Named for the empty state (req #3220 acceptance) rather than a boolean —
+    // "a filter is active" doesn't say WHICH statuses vanished.
+    const hiddenStatusCounts = useMemo(
+        () => hiddenPipelineStatusCounts(pipelines, statusFilter),
         [pipelines, statusFilter]);
 
     const open = (id) => navigate(`/swarm/pipeline/${id}`);
@@ -119,33 +187,16 @@ export default function PipelinesPage() {
                     ))}
                 </ToggleButtonGroup>
 
-                {/* Shared control — filters BOTH views (R4/R5). Local state is
-                    sufficient: nothing outside this page reads it, so a Zustand
-                    store would be ceremony without a second consumer. */}
-                <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}
-                       data-testid="pipelines-status-filter">
-                    <Chip label="All" size="small"
-                          onClick={() => setStatusFilter(null)}
-                          color={statusFilter === null ? 'primary' : 'default'}
-                          variant={statusFilter === null ? 'filled' : 'outlined'}
-                          sx={{ cursor: 'pointer' }}
-                          data-testid="pipelines-status-chip-all" />
-                    {PIPELINE_STATUS_VALUES.map((v) => {
-                        const selected = statusFilter === v;
-                        const props = pipelineStatusChipProps(v);
-                        return (
-                            <Chip key={v} label={v} size="small"
-                                  onClick={() => setStatusFilter(v)}
-                                  variant={selected ? 'filled' : 'outlined'}
-                                  sx={{ cursor: 'pointer',
-                                         ...(selected && props.sx ? props.sx : {}),
-                                         ...(!selected && props.sx
-                                             ? { borderColor: props.sx.bgcolor, opacity: 0.75 }
-                                             : {}) }}
-                                  data-testid={`pipelines-status-chip-${v}`} />
-                        );
-                    })}
-                </Stack>
+                {/* Shared control — filters BOTH views (R4/R5). Multi-select via
+                    the standardized ChipFilter (req #3220), not a second
+                    hand-rolled implementation of it. */}
+                <ChipFilter
+                    options={pipelineStatusOptions}
+                    selected={statusFilter}
+                    onToggle={toggleStatus}
+                    testId="pipelines-status-filter"
+                    chipTestIdPrefix="pipelines-status-chip"
+                />
 
                 {/* Accounting line counts the WHOLE dataset, with the filtered
                     subset named separately (V7). The call-to-action names what
@@ -169,6 +220,7 @@ export default function PipelinesPage() {
                         machines={machines}
                         timezone={timezone}
                         onOpen={open}
+                        hiddenStatusCounts={hiddenStatusCounts}
                     />
                 ) : (
                     <PipelineCardsView
@@ -176,7 +228,7 @@ export default function PipelinesPage() {
                         summaries={summaries}
                         machines={machines}
                         onOpen={open}
-                        filtered={statusFilter !== null}
+                        hiddenStatusCounts={hiddenStatusCounts}
                     />
                 )}
             </Box>

--- a/src/SwarmView/pipelines/PipelinesTableView.jsx
+++ b/src/SwarmView/pipelines/PipelinesTableView.jsx
@@ -13,10 +13,11 @@ import { DataGrid, GridToolbar } from '@mui/x-data-grid';
 
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
+import Typography from '@mui/material/Typography';
 
 import { formatDateTime } from '../../utils/dateFormat';
 import { pipelineStatusChipProps, PIPELINE_STATUS_VALUES } from './pipelineChipStyles';
-import { machineTitle } from './pipelineViewModel';
+import { machineTitle, pipelinesEmptyMessage } from './pipelineViewModel';
 
 const EMPTY_SUMMARY = { total: 0, done: 0, running: 0, pending: 0 };
 
@@ -25,7 +26,23 @@ const EMPTY_SUMMARY = { total: 0, done: 0, running: 0, pending: 0 };
 const STATUS_ORDER = PIPELINE_STATUS_VALUES.reduce(
     (acc, v, i) => ({ ...acc, [v]: i }), {});
 
-export default function PipelinesTableView({ pipelines, summaries, machines, timezone, onOpen }) {
+// req #3220 — the table view's own empty state, matching Cards: a status
+// filter that hid every pipeline must say WHICH statuses it hid rather than
+// falling through to the DataGrid's generic "No rows" placeholder.
+function PipelinesNoRowsOverlay({ hiddenStatusCounts = [] }) {
+    return (
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    height: '100%', p: 2 }}
+             data-testid="pipelines-table-empty">
+            <Typography variant="body2" color="text.secondary">
+                {pipelinesEmptyMessage(hiddenStatusCounts)}
+            </Typography>
+        </Box>
+    );
+}
+
+export default function PipelinesTableView({ pipelines, summaries, machines, timezone, onOpen,
+    hiddenStatusCounts = [] }) {
     const rows = useMemo(() => pipelines.map((p) => {
         const s = summaries.get(p.id) || EMPTY_SUMMARY;
         return {
@@ -90,8 +107,11 @@ export default function PipelinesTableView({ pipelines, summaries, machines, tim
                 columns={columns}
                 rowHeight={52}
                 density="compact"
-                slots={{ toolbar: GridToolbar }}
-                slotProps={{ toolbar: { showQuickFilter: true } }}
+                slots={{ toolbar: GridToolbar, noRowsOverlay: PipelinesNoRowsOverlay }}
+                slotProps={{
+                    toolbar: { showQuickFilter: true },
+                    noRowsOverlay: { hiddenStatusCounts },
+                }}
                 initialState={{
                     pagination: { paginationModel: { pageSize: 25 } },
                     sorting: { sortModel: [{ field: 'id', sort: 'desc' }] },

--- a/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
@@ -13,6 +13,8 @@ import {
     planRenderRows,
     pipelineSummary,
     pipelineSummaries,
+    hiddenPipelineStatusCounts,
+    pipelinesEmptyMessage,
     machineTitle,
     rowMachineLabel,
     batchMachineLabel,
@@ -334,6 +336,63 @@ describe('pipelineSummary / pipelineSummaries', () => {
 
     it('handles no pipelines at all', () => {
         expect(pipelineSummaries().size).toBe(0);
+    });
+});
+
+describe('hiddenPipelineStatusCounts — req #3220 empty-state naming', () => {
+    const PIPES = [
+        { id: 1, pipeline_status: 'active' },
+        { id: 2, pipeline_status: 'active' },
+        { id: 3, pipeline_status: 'draft' },
+        { id: 4, pipeline_status: 'paused' },
+        { id: 5, pipeline_status: 'completed' },
+        { id: 6, pipeline_status: 'completed' },
+    ];
+
+    it('names only hidden statuses that actually have matching pipelines', () => {
+        expect(hiddenPipelineStatusCounts(PIPES, ['active', 'draft', 'paused']))
+            .toEqual([{ status: 'completed', count: 2 }]);
+    });
+
+    it('returns nothing when every status is selected', () => {
+        expect(hiddenPipelineStatusCounts(PIPES, [
+            'draft', 'active', 'paused', 'completed', 'aborted',
+        ])).toEqual([]);
+    });
+
+    it('omits a hidden status with zero matching pipelines — nothing to explain', () => {
+        // 'aborted' is excluded from the filter but no pipeline is aborted, so
+        // naming it would not answer "why is this empty".
+        expect(hiddenPipelineStatusCounts(PIPES, ['active', 'draft', 'paused', 'completed']))
+            .toEqual([]);
+    });
+
+    it('orders results by PIPELINE_STATUS_VALUES, not by filter or input order', () => {
+        // completed sorts before aborted in the lifecycle order even though the
+        // fixture lists an aborted-heavy set first.
+        const pipes = [
+            { id: 1, pipeline_status: 'aborted' },
+            { id: 2, pipeline_status: 'completed' },
+        ];
+        expect(hiddenPipelineStatusCounts(pipes, []))
+            .toEqual([{ status: 'completed', count: 1 }, { status: 'aborted', count: 1 }]);
+    });
+
+    it('handles no pipelines and no filter', () => {
+        expect(hiddenPipelineStatusCounts(undefined, undefined)).toEqual([]);
+    });
+});
+
+describe('pipelinesEmptyMessage — req #3220', () => {
+    it('says "no pipelines yet" when nothing is hidden', () => {
+        expect(pipelinesEmptyMessage([])).toBe('No pipelines yet.');
+    });
+
+    it('names hidden statuses and their counts', () => {
+        expect(pipelinesEmptyMessage([
+            { status: 'paused', count: 1 },
+            { status: 'completed', count: 2 },
+        ])).toBe('No pipelines match this filter — hidden: paused (1), completed (2).');
     });
 });
 

--- a/src/SwarmView/pipelines/pipelineChipStyles.js
+++ b/src/SwarmView/pipelines/pipelineChipStyles.js
@@ -82,6 +82,13 @@ export const ELIGIBLE_MARKER_COLOR = '#4caf50';
 // the plan as a whole — deliberately NOT derived, unlike a step's state.
 export const PIPELINE_STATUS_VALUES = ['draft', 'active', 'paused', 'completed', 'aborted'];
 
+// req #3220 — default-visible statuses for the list page's status filter.
+// `paused` stays IN: pausing a plan is a normal, reversible operating state the
+// Primary or user can resume any time, not an archival one — unlike `completed`
+// and `aborted`, which are what the default is actually trying to get out of
+// the way. Excluding `paused` would hide a plan the instant someone pauses it.
+export const DEFAULT_PIPELINE_STATUSES = ['draft', 'active', 'paused'];
+
 export const pipelineStatusChipProps = (status) => {
     switch (status) {
         case 'draft':     return { sx: { bgcolor: '#546e7a', color: '#fff' } };

--- a/src/SwarmView/pipelines/pipelineViewModel.js
+++ b/src/SwarmView/pipelines/pipelineViewModel.js
@@ -27,6 +27,7 @@ import {
     STEP_PENDING,
 } from './pipelineModel';
 import { planTimeAxis } from './pipelinePlanTime';
+import { PIPELINE_STATUS_VALUES } from './pipelineChipStyles';
 
 const asArray = (v) => (Array.isArray(v) ? v : []);
 
@@ -389,6 +390,44 @@ export function pipelineSummaries({ pipelines, steps, stepRequirements, requirem
         out.set(p.id, pipelineSummary(buildPlanRows(model)));
     }
     return out;
+}
+
+/**
+ * Statuses hidden by the current multi-select filter that would otherwise show
+ * at least one pipeline (req #3220) — what the list page's empty state names so
+ * a user who filtered a page to nothing is told WHY rather than shown a blank
+ * view. A status the filter excludes but that has zero matching pipelines is
+ * left out: naming it would not explain anything the user can see.
+ *
+ * @param {Object[]} pipelines     the FULL (unfiltered) pipelines list
+ * @param {string[]} statusFilter  the currently-selected pipeline_status values
+ * @returns {{status: string, count: number}[]} in PIPELINE_STATUS_VALUES order
+ */
+export function hiddenPipelineStatusCounts(pipelines, statusFilter) {
+    const selected = asArray(statusFilter);
+    const counts = {};
+    for (const p of asArray(pipelines)) {
+        if (!p || !p.pipeline_status) continue;
+        counts[p.pipeline_status] = (counts[p.pipeline_status] || 0) + 1;
+    }
+    return PIPELINE_STATUS_VALUES
+        .filter((status) => !selected.includes(status) && counts[status])
+        .map((status) => ({ status, count: counts[status] }));
+}
+
+/**
+ * The list page's empty-state sentence. "No pipelines yet" is a claim about the
+ * DATA and is false whenever a status filter is what emptied the view — this
+ * names the hidden statuses and their counts instead (req #3220 acceptance).
+ *
+ * @param {{status: string, count: number}[]} hiddenStatusCounts
+ * @returns {string}
+ */
+export function pipelinesEmptyMessage(hiddenStatusCounts) {
+    const hidden = asArray(hiddenStatusCounts);
+    if (!hidden.length) return 'No pipelines yet.';
+    const named = hidden.map(({ status, count }) => `${status} (${count})`).join(', ');
+    return `No pipelines match this filter — hidden: ${named}.`;
 }
 
 // ── The no-'#' directive ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3220-status-selector-feature-1
- wip(Darwin): 2026-08-01T12:50:55Z
- chore: init swarm session feature/3220-status-selector-feature-1

## Files changed
```
 src/SwarmView/pipelines/PipelineCardsView.jsx      |  11 +-
 src/SwarmView/pipelines/PipelinesPage.jsx          | 124 +++++++++++++++------
 src/SwarmView/pipelines/PipelinesTableView.jsx     |  28 ++++-
 .../pipelines/__tests__/pipelineViewModel.test.js  |  59 ++++++++++
 src/SwarmView/pipelines/pipelineChipStyles.js      |   7 ++
 src/SwarmView/pipelines/pipelineViewModel.js       |  39 +++++++
 6 files changed, 222 insertions(+), 46 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)