### PR TITLE
Plan visualizer: draw the TIME RULER — the axis is ordered by date but reads as nothing

### DIFF
--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -860,6 +860,61 @@ export default function PipelinePlanVisualizer({
         }
     });
 
+    // ── The time ruler (req #3207) ──────────────────────────────────────────
+    // Drawn AFTER the band washes and BEFORE the arcs and beads: the rules and
+    // the future tint are background furniture that must sit over the band fill
+    // (a 6% wash would otherwise swallow them) and under everything a reader
+    // actually reads. The label TEXT is not here — it rides `layout.labels` as
+    // `kind: 'slot'` so the zero-overlap contract covers it, and is drawn in the
+    // label loop below with every other piece of text on the surface.
+    {
+        const R = layout.ruler || { h: 0, slots: [], futureX: null };
+        // The FUTURE REGION, first, so the rules draw on top of its edge. A rule
+        // alone says where the boundary is; it does not say which side of it has
+        // not happened yet.
+        if (R.futureX != null && R.futureX < layout.width) {
+            worldNodes.push(
+                <Rect key="ruler-future" x={R.futureX} y={0}
+                      width={layout.width - R.futureX} height={layout.height}
+                      fill={P.wire} opacity={0.07} listening={false} />);
+        }
+        // The strip's baseline — what makes the ticks read as one ruler rather
+        // than as a row of unrelated marks.
+        worldNodes.push(
+            <Line key="ruler-baseline"
+                  points={[0, R.h - 2, layout.width, R.h - 2]}
+                  stroke={P.line} strokeWidth={1} opacity={0.7}
+                  listening={false} />);
+        R.slots.forEach((s, i) => {
+            // A GAPPED boundary is DASHED and brighter. Slots are dense in
+            // COLUMNS but sparse in TIME — 07-28 and 07-31 are adjacent columns
+            // three days apart — and the dashes are how the ruler says so
+            // without spending a second label on it. `gapDays` is null on the
+            // first dated slot and on the undated/future ones, where there is no
+            // predecessor to have skipped anything.
+            const gapped = s.gapDays != null && s.gapDays > 1;
+            // The first slot's rule would land in the left gutter, where it
+            // marks nothing: there is no earlier slot for it to divide from.
+            if (i > 0) {
+                worldNodes.push(
+                    <Line key={`ruler-rule-${s.key}`}
+                          points={[s.x, 6, s.x, layout.height - 6]}
+                          stroke={gapped ? P.dim : P.line} strokeWidth={1}
+                          dash={gapped ? [5, 5] : undefined}
+                          opacity={gapped ? 0.5 : 0.55} listening={false} />);
+            }
+            // The tick itself, in the strip, at every slot — including the ones
+            // whose LABEL was thinned away. The tick is 1px of geometry and can
+            // never collide, so a degraded ruler still shows every boundary it
+            // has; only the dates thin out.
+            worldNodes.push(
+                <Line key={`ruler-tick-${s.key}`}
+                      points={[s.x, R.h - 9, s.x, R.h - 2]}
+                      stroke={P.dim} strokeWidth={1} opacity={0.8}
+                      listening={false} />);
+        });
+    }
+
     layout.arcs.forEach((arc, i) => {
         if (arc.straight) {
             worldNodes.push(
@@ -989,6 +1044,20 @@ export default function PipelinePlanVisualizer({
                 <Text key={`lbl-${i}`} x={label.x} y={label.y} text={label.text}
                       fontSize={F.title} fontFamily={MONO} fill={P.dim}
                       listening={false} />);
+        } else if (label.kind === 'slot') {
+            // The FUTURE tick is the accent: it names the tinted REGION beside
+            // it rather than a boundary, and it is the mark the plan is most
+            // often opened to find. A DATE and an UNDATED tick are both dim —
+            // `undated` is the absence of a claim, and giving it the accent
+            // would make a plan with no timestamps read as a plan that is
+            // entirely in the future, which is the opposite claim.
+            const accented = label.slotKind === 'future';
+            worldNodes.push(
+                <Text key={`lbl-${i}`} x={label.x} y={label.y} text={label.text}
+                      fontSize={F.slot} fontFamily={MONO}
+                      fill={accented ? P.accent : P.dim}
+                      opacity={accented ? 0.9 : 0.95}
+                      listening={false} />);
         } else if (label.kind === 'epic') {
             // Drawn as an HTML overlay below, not in the world — see
             // `floatingEpics`. Nothing is pushed here.
@@ -1043,6 +1112,14 @@ export default function PipelinePlanVisualizer({
                  // evidence than the key ever was: it is what the canvas actually
                  // drew rather than a second thing derived from the same flag.
                  data-batch-boxes={layout.batchBoxes.length}
+                 // `slots,labelled` — the time ruler (req #3207), published for
+                 // the same reason the batch-box count is: canvas geometry is
+                 // otherwise only observable as pixels, and the DEGRADATION rule
+                 // is the half that a screenshot cannot distinguish from a plan
+                 // that simply has fewer days. The two numbers differing IS the
+                 // proof that thinning ran.
+                 data-ruler={`${layout.ruler.slots.length},${
+                     layout.ruler.slots.filter((s) => s.showLabel).length}`}
                  data-level={level}
                  data-drawn={drawnKinds}
                  // Full-page canvas (req #3119), the KonvaSwarmCanvas figure

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -28,6 +28,7 @@ import {
     DEFAULT_PLAN_LEVEL_PREF, isPlanLevelPref, normalizePlanLevelPref, pinnedLevelOf,
     REQ_LINE_H,
     FOCUS_MAX_RATIO, FOCUS_MIN_RATIO, FOCUS_PAD, STEP_DONE, ZOOM_MAX_RATIO, ZOOM_MIN_RATIO, bandFitRect, epicFocusTransform,
+    RULER_H, computeRuler, slotTickText,
 } from '../pipelinePlanLayout';
 
 const NOW = '2026-07-27T03:00:00Z';
@@ -1950,7 +1951,14 @@ const timedPlan = orderedPlan(buildPipelineModel(TIMED_MODEL),
     { now: '2026-07-28T12:00:00Z' });
 const timedLayout = computePlanLayout(timedPlan.rows, timedPlan.batches,
     { timeAxis: timedPlan.timeAxis });
-const timedSubstratePlan = orderedPlan(buildPipelineModel(TIMED_SUBSTRATE), { now: NOW });
+// NO `buildPipelineModel` here, and that is the whole point of this line.
+// SUBSTRATE_REBUILD_MODEL is a MODEL, not a raw payload — line 34 feeds it to
+// `orderedPlan` directly — and its steps carry no `pipeline_fk`, so rebuilding
+// it filtered all 34 rows away and every plan-scale test below ran on an EMPTY
+// plan, asserting nothing. Shipped that way with req #3201; found in the #3207
+// review, which is when it mattered: these are the tests that prove the ruler
+// did not break the zero-overlap contract at scale.
+const timedSubstratePlan = orderedPlan(TIMED_SUBSTRATE, { now: NOW });
 const colOfStep = (layout, id) => layout.nodes.get(id).depth;
 
 // ── Epic focus (req #3204) ──────────────────────────────────────────────────
@@ -2379,6 +2387,23 @@ describe('time axis — review regressions', () => {
 });
 
 describe('time axis — the zero-overlap contract still holds at plan scale', () => {
+    // THE GUARD ON THE GUARD. Every assertion below is a for-all over
+    // `layout.labels`, and a for-all over nothing passes. This block ran on an
+    // empty plan from req #3201 until the #3207 review caught it, so the
+    // preconditions are asserted rather than assumed: PLAN SCALE is the point of
+    // these tests, and "plan scale" is a claim about the data, not the code.
+    it('runs on a real, multi-slot, multi-band plan — not on an empty one', () => {
+        expect(timedSubstratePlan.rows.length)
+            .toBe(SUBSTRATE_REBUILD_MODEL.steps.length);
+        const layout = computePlanLayout(timedSubstratePlan.rows,
+            timedSubstratePlan.batches, { timeAxis: timedSubstratePlan.timeAxis });
+        expect(layout.empty).toBe(false);
+        expect(layout.slots.length).toBeGreaterThan(2);
+        expect(layout.bands.length).toBeGreaterThan(1);
+        expect(layout.labels.filter((l) => l.kind === 'slot').length)
+            .toBeGreaterThan(1);
+    });
+
     for (const combo of COMBOS) {
         const name = `${combo.reqLayout}/${combo.stepLabel}`;
         const layout = computePlanLayout(timedSubstratePlan.rows, timedSubstratePlan.batches,
@@ -2415,4 +2440,237 @@ describe('time axis — the zero-overlap contract still holds at plan scale', ()
             }
         });
     }
+});
+
+// ── The TIME RULER (req #3207) ─────────────────────────────────────────────
+// #3201 ordered the columns by date and drew nothing; this is the strip that
+// makes them READABLE as dates. Two claims are load-bearing and both are
+// asserted from layout OUTPUT rather than from the inputs:
+//
+//   1. the ruler's rects are ordinary `layout.labels` entries, so the
+//      zero-overlap contract in all four reqLayout × stepLabel combinations
+//      already covers them — no second, untested class of text;
+//   2. the reserved height is UNCONDITIONAL, so no level, plan shape or label
+//      mode relayouts the plan and zoom stays a pure transform.
+describe('time ruler (req #3207)', () => {
+    const rulerLabels = (layout) => layout.labels.filter((l) => l.kind === 'slot');
+
+    it('emits one ruler slot per axis slot, in the same order', () => {
+        expect(timedLayout.ruler.slots.map((s) => s.key))
+            .toEqual(timedLayout.slots.map((s) => s.key));
+        expect(timedLayout.ruler.slots.map((s) => s.origin))
+            .toEqual(timedLayout.slots.map((s) => s.origin));
+    });
+
+    it('gives every slot a strictly increasing, gapless x-extent covering the world', () => {
+        const rs = timedLayout.ruler.slots;
+        expect(rs[0].x).toBeLessThanOrEqual(timedLayout.colX[0]);
+        for (let i = 1; i < rs.length; i++) {
+            expect(rs[i].x).toBeGreaterThan(rs[i - 1].x);
+            // A slot ends exactly where the next begins: the columns BETWEEN
+            // two origins belong to the earlier slot, so a region bounded by
+            // its own origin column would draw a five-column day one column
+            // wide.
+            expect(rs[i - 1].x + rs[i - 1].w).toBeCloseTo(rs[i].x, 6);
+        }
+        const last = rs[rs.length - 1];
+        expect(last.x + last.w).toBeLessThanOrEqual(timedLayout.width);
+    });
+
+    it('puts every step inside the x-extent of its OWN slot', () => {
+        // The one claim a reader makes from the strip: this bead is under this
+        // date. It is a property of two independently-derived numbers (the
+        // slot's origin column and the step's column), so it is worth checking.
+        for (const r of timedPlan.rows) {
+            const s = timedLayout.ruler.slots[timedLayout.slotOf.get(r.id)];
+            const n = timedLayout.nodes.get(r.id);
+            expect(n.x).toBeGreaterThanOrEqual(s.x);
+            expect(n.x).toBeLessThanOrEqual(s.x + s.w);
+        }
+    });
+
+    it('labels the dated slots as calendar days and the future slot as future', () => {
+        const texts = timedLayout.ruler.slots.map((s) => s.label);
+        expect(texts).toEqual([
+            "Jul 25 '26", 'Jul 26', 'Jul 27', 'Jul 28', 'future',
+        ]);
+        expect(timedLayout.ruler.futureX)
+            .toBe(timedLayout.ruler.slots[timedLayout.ruler.slots.length - 1].x);
+    });
+
+    it('carries the calendar GAP so adjacent columns two days apart can say so', () => {
+        // Slots are dense in COLUMNS and sparse in TIME. Every gap here is 1
+        // (consecutive days); the gapped case gets its own plan below.
+        const gaps = timedLayout.ruler.slots.filter((s) => s.kind === 'dated')
+            .map((s) => s.gapDays);
+        expect(gaps).toEqual([null, 1, 1, 1]);
+    });
+
+    it('measures a real gap in DAYS, not in slots', () => {
+        const gapped = {
+            ...TIMED_MODEL,
+            requirements: TIMED_MODEL.requirements.map((r) => (r.id === 102
+                // 102 was 07-26. Push it past the plan's last day (07-28) to
+                // 07-31, so the ruler's final two dated slots are ADJACENT
+                // columns three calendar days apart — the sparse-in-time,
+                // dense-in-columns case the requirement names.
+                ? { ...r, completed_at: '2026-07-31T09:00:00' } : r)),
+        };
+        const p = orderedPlan(buildPipelineModel(gapped), { now: '2026-08-01T12:00:00Z' });
+        const L = computePlanLayout(p.rows, p.batches, { timeAxis: p.timeAxis });
+        const days = L.ruler.slots.filter((s) => s.kind === 'dated');
+        const gap = days.find((s) => s.day === '2026-07-31');
+        expect(gap).toBeDefined();
+        // Its predecessor on the AXIS is 07-28, not 07-30: the distance is
+        // measured in calendar days between the two slots that are actually
+        // adjacent, which is the whole point — a slot-count would say 1.
+        expect(days[days.indexOf(gap) - 1].day).toBe('2026-07-28');
+        expect(gap.gapDays).toBe(3);
+        // …and the FIRST dated slot has no predecessor to have skipped
+        // anything, so it reports null rather than a fabricated 0.
+        expect(days[0].gapDays).toBeNull();
+    });
+
+    it('disambiguates a year boundary rather than drawing two identical dates', () => {
+        const spanning = {
+            ...TIMED_MODEL,
+            requirements: TIMED_MODEL.requirements.map((r) => {
+                if (r.id === 101) return { ...r, completed_at: '2025-07-25T09:00:00' };
+                if (r.id === 107) return { ...r, completed_at: '2025-07-25T10:00:00' };
+                if (r.id === 102) return { ...r, completed_at: '2026-07-25T09:00:00' };
+                return r;
+            }),
+        };
+        const p = orderedPlan(buildPipelineModel(spanning), { now: '2026-07-28T12:00:00Z' });
+        const L = computePlanLayout(p.rows, p.batches, { timeAxis: p.timeAxis });
+        const days = L.ruler.slots.filter((s) => s.kind === 'dated');
+        expect(days[0].label).toBe("Jul 25 '25");
+        // The same calendar day one year on must NOT render as a second bare
+        // 'Jul 25' — two identical labels on one axis is the lie the ruler
+        // exists to prevent.
+        const y26 = days.find((s) => s.day === '2026-07-25');
+        expect(y26.label).toBe("Jul 25 '26");
+        expect(new Set(days.map((s) => s.label)).size).toBe(days.length);
+    });
+
+    it('degrades by THINNING labels, never by overlapping them', () => {
+        // A 200-slot axis on columns too narrow to carry 200 dates. The greedy
+        // pass must drop labels; what it may never do is emit two that meet.
+        const slots = Array.from({ length: 200 }, (_, i) => ({
+            key: `1:2026-01-${String((i % 28) + 1).padStart(2, '0')}`,
+            kind: 'dated',
+            day: `2026-${String(Math.floor(i / 28) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}`,
+            origin: i,
+        }));
+        const colW = slots.map(() => 22);
+        const colX = [];
+        { let acc = 66; for (const w of colW) { colX.push(acc + w / 2); acc += w; } }
+        const ruler = computeRuler(slots, colX, colW, 66 + 200 * 22 + 54);
+        const shown = ruler.slots.filter((s) => s.showLabel);
+        expect(shown.length).toBeGreaterThan(0);
+        expect(shown.length).toBeLessThan(slots.length);   // it really thinned
+        for (let i = 1; i < shown.length; i++) {
+            expect(shown[i].labelX)
+                .toBeGreaterThanOrEqual(shown[i - 1].labelX + shown[i - 1].labelW);
+        }
+    });
+
+    it('always labels the FUTURE tick, displacing a date if it has to', () => {
+        // The boundary a plan is opened to find. Built so the future slot's
+        // origin sits a few px past a dated one — the exact case the greedy
+        // left-to-right pass would otherwise drop.
+        const slots = [
+            { key: '1:2026-01-01', kind: 'dated', day: '2026-01-01', origin: 0 },
+            { key: '1:2026-01-02', kind: 'dated', day: '2026-01-02', origin: 1 },
+            { key: '2:future', kind: 'future', day: null, origin: 2 },
+        ];
+        const colW = [200, 8, 200];
+        const colX = [];
+        { let acc = 66; for (const w of colW) { colX.push(acc + w / 2); acc += w; } }
+        const ruler = computeRuler(slots, colX, colW, 66 + 408 + 54);
+        const fut = ruler.slots[2];
+        expect(fut.showLabel).toBe(true);
+        // …and nothing it displaced is still drawn on top of it.
+        for (const s of ruler.slots) {
+            if (s === fut || !s.showLabel) continue;
+            const meets = s.labelX < fut.labelX + fut.labelW
+                && fut.labelX < s.labelX + s.labelW;
+            expect(meets).toBe(false);
+        }
+    });
+
+    it('keeps the last tick inside the world it is measured against', () => {
+        for (const l of rulerLabels(timedLayout)) {
+            expect(l.x).toBeGreaterThanOrEqual(0);
+            expect(l.x + l.w).toBeLessThanOrEqual(timedLayout.width);
+        }
+    });
+
+    it('puts the ruler text in `labels`, so the overlap contract covers it', () => {
+        // The requirement's own acceptance constraint. Not a separate class of
+        // text with its own private checks.
+        expect(rulerLabels(timedLayout).length)
+            .toBe(timedLayout.ruler.slots.filter((s) => s.showLabel).length);
+        for (const l of rulerLabels(timedLayout)) {
+            expect(l.h).toBeGreaterThan(0);
+            expect(l.w).toBeGreaterThan(0);
+            expect(l.prose).toBe(false);   // generated from a date, not stored prose
+        }
+        assertNoLabelOverlap(timedLayout, 'timed plan with ruler');
+    });
+
+    it('never lets a ruler tick reach a band, a bead or any other label', () => {
+        for (const opts of COMBOS) {
+            const layout = computePlanLayout(timedPlan.rows, timedPlan.batches,
+                { ...opts, timeAxis: timedPlan.timeAxis });
+            assertNoLabelOverlap(layout, `${opts.reqLayout} × ${opts.stepLabel} + ruler`);
+            for (const l of rulerLabels(layout)) {
+                // Above every band, by construction: the reservation is what
+                // the first band's y is offset by.
+                expect(l.y + l.h).toBeLessThanOrEqual(layout.bands[0].y);
+                for (const n of layout.nodes.values()) {
+                    expect(rectsOverlap(l, beadRect(n))).toBe(false);
+                }
+            }
+        }
+    });
+
+    it('reserves its height UNCONDITIONALLY — a level or mode change never relayouts', () => {
+        // Zoom is a pure transform (pipelinePlanLayout deviation 2). The ruler
+        // takes the same room in every combination, on a timed plan and on an
+        // untimed one, so nothing a reader can toggle moves a bead because of
+        // the strip.
+        const heights = new Set();
+        for (const opts of COMBOS) {
+            heights.add(computePlanLayout(timedPlan.rows, timedPlan.batches,
+                { ...opts, timeAxis: timedPlan.timeAxis }).ruler.h);
+            heights.add(computePlanLayout(plan.rows, plan.batches, opts).ruler.h);
+        }
+        expect(heights.size).toBe(1);
+        expect([...heights][0]).toBe(RULER_H);
+        // …and it is genuinely charged: the first band sits below it.
+        expect(timedLayout.bands[0].y).toBeGreaterThanOrEqual(RULER_H);
+    });
+
+    it('degenerates honestly with no time axis: one slot, labelled undated', () => {
+        // The no-timeAxis path is a real path (computeTimeColumns' degenerate
+        // case), and a plan with no dates must not render a blank strip that
+        // reads as a rendering fault.
+        const untimed = computePlanLayout(plan.rows, plan.batches);
+        expect(untimed.ruler.slots).toHaveLength(1);
+        expect(untimed.ruler.slots[0].kind).toBe('unknown');
+        expect(untimed.ruler.slots[0].label).toBe('undated');
+        expect(untimed.ruler.slots[0].showLabel).toBe(true);
+        expect(untimed.ruler.futureX).toBeNull();
+        assertNoLabelOverlap(untimed, 'untimed plan with ruler');
+    });
+
+    it('returns an INERT ruler for the empty plan rather than omitting it', () => {
+        const empty = computePlanLayout([], []);
+        expect(empty.ruler).toEqual({ h: RULER_H, slots: [], futureX: null });
+    });
+
+    it('renders a tick with no # — the production directive covers generated text', () => {
+        for (const l of rulerLabels(timedLayout)) expect(l.text).not.toContain('#');
+    });
 });

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -494,7 +494,7 @@ const STAGGER_REACH = 0.4;
 // is only the ceiling that stops a pathological title from running forever.
 const TITLE_COL_MIN = 144;
 export const PLAN_VIZ_FONT = {
-    label: 16.5, req: 13.75, title: 9.5, epic: 15, batch: 10, check: 9,
+    label: 16.5, req: 13.75, title: 9.5, epic: 15, batch: 10, check: 9, slot: 13,
 };
 
 export const BEAD_RADIUS = BEAD_R;
@@ -760,6 +760,169 @@ export function computeTimeColumns(rows, byId, depsOf, timeAxis) {
     return { colOf, maxCol, slotKeys, slotOf, origins, spans };
 }
 
+// ── The TIME RULER (req #3207) ─────────────────────────────────────────────
+// #3201 made the columns a calendar and stopped there: `layout.slots` was
+// exported and tested, and nothing drew it. The columns were ORDERED by time
+// and a reader could not READ them as dates.
+//
+// Three marks, because each answers a different question and none of them is a
+// restatement of another (the ONE FACT, ONE CHANNEL rule above):
+//
+//   · the STRIP says WHICH day a column is. It is world text at the top of the
+//     plan, so it scrolls off when you pan down — which is exactly why it is
+//     not the only mark.
+//   · the SEPARATORS say WHERE a day begins. Full-height rules at slot origins,
+//     readable at any vertical pan.
+//   · the FUTURE TINT says where the not-yet-begun region starts. That boundary
+//     is the single thing a plan is most often opened to find, and a rule alone
+//     does not say which SIDE of it is the future.
+//
+// THE HEIGHT IS RESERVED UNCONDITIONALLY. Zoom is a pure transform on this
+// surface (deviation 2) — no semantic level and no plan shape may change the
+// geometry — so the strip costs `RULER_H` on every plan including the
+// degenerate no-time-axis one, where the single slot is honestly labelled
+// `undated` rather than the reservation being conditionally skipped.
+export const RULER_H = 36;
+const RULER_LABEL_Y = 12;
+const RULER_LABEL_H = 15;
+// px per mono char at font 13. Derived from the module's own ~0.61 px/pt mono
+// metric (CHW_REQ 8.4/13.75, CHW_LABEL 10.05/16.5, CHW_EPIC 9.15/15 are all
+// 0.609–0.611), not eyeballed separately — a ruler metric that drifted from the
+// others would make the overlap contract narrower for this one class of text.
+const CHW_SLOT = 7.93;
+// The clear gap two consecutive ruler labels must leave. Drives the degradation
+// pass below; a plan with more slots than room simply draws fewer labels.
+const RULER_LABEL_GAP = 10;
+const MONTH_ABBR = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// Whole days between two ISO 'YYYY-MM-DD' strings. Parsed as UTC midnights on
+// purpose: a slot key IS a calendar day with no time and no zone, and
+// `new Date('2026-07-28')` in a browser west of UTC is the 27th locally — which
+// would make a same-day pair read as a one-day gap.
+const dayNumber = (iso) => {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(iso || ''));
+    if (!m) return null;
+    return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])) / 86400000;
+};
+
+/**
+ * The text one ruler tick draws.
+ *
+ * `showYear` is decided by the CALLER, not by this function, because it is a
+ * property of the SEQUENCE rather than of the date. `computeRuler` sets it on
+ * the FIRST dated slot and on every slot whose year differs from its
+ * predecessor — so a plan that never crosses a year reads
+ * `Jul 21 '26, Jul 22, Jul 23…`: ONE anchored label, bare days after it.
+ *
+ * The anchor is not free — it costs the first tick ~40px, and on a tight ruler
+ * that is enough to thin the tick beside it (measured: `Jul 22` on the timed
+ * Substrate fixture). It is still the right trade. Two ambiguous `Jul 28`s a
+ * year apart on one axis is the lie this exists to prevent, and an axis with
+ * no year ANYWHERE is a date strip a reader cannot resolve at all — the year
+ * has to be on the first tick to anchor the whole sequence, not only the half
+ * that follows a boundary.
+ */
+export function slotTickText(slot, showYear = false) {
+    if (!slot) return '';
+    if (slot.kind === 'future') return 'future';
+    if (slot.kind !== 'dated' || !slot.day) return 'undated';
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(slot.day);
+    if (!m) return String(slot.day);
+    const base = `${MONTH_ABBR[Number(m[2]) - 1] || m[2]} ${Number(m[3])}`;
+    return showYear ? `${base} '${m[1].slice(2)}` : base;
+}
+
+/**
+ * Turn the ordered slots into drawable ruler geometry.
+ *
+ * PURE, and separated from `computePlanLayout` so the degradation rule is
+ * testable on a synthetic 200-slot axis without building a 200-column plan.
+ *
+ * @param {Object[]} slots   `layout.slots` shape — {key, kind, day, origin}
+ * @param {number[]} colX    column centres
+ * @param {number[]} colW    column widths
+ * @param {number} totalW    world width
+ * @returns {{h: number, slots: Object[], futureX: ?number}}
+ */
+export function computeRuler(slots, colX, colW, totalW) {
+    const out = [];
+    let prevDay = null;
+    let prevYear = null;
+    for (let i = 0; i < slots.length; i++) {
+        const s = slots[i];
+        const d = colX[s.origin] === undefined
+            ? 0 : colX[s.origin] - colW[s.origin] / 2;
+        // The slot's right edge is where the NEXT slot begins — not the right
+        // edge of its own last column. Columns between two origins belong to
+        // this slot (that is what `origin` means), so bounding by the origin
+        // column alone would draw a day one column wide on a day that ran five.
+        const next = slots[i + 1];
+        const nx = next && colX[next.origin] !== undefined
+            ? colX[next.origin] - colW[next.origin] / 2
+            : Math.max(d, totalW - RIGHT);
+        const dn = s.kind === 'dated' ? dayNumber(s.day) : null;
+        const year = s.kind === 'dated' && s.day ? s.day.slice(0, 4) : null;
+        out.push({
+            key: s.key, kind: s.kind, day: s.day, origin: s.origin,
+            x: d, w: Math.max(0, nx - d),
+            // Sparse in TIME though dense in COLUMNS: 07-28 and 07-31 are
+            // adjacent slots two days apart. `gapDays` is that distance, and the
+            // renderer draws a gapped boundary DASHED — the dashes are the gap.
+            // null on a non-dated slot and on the first dated one: there is no
+            // predecessor to measure from, and 0 would claim there was.
+            gapDays: (dn != null && prevDay != null) ? dn - prevDay : null,
+            label: slotTickText(s, year != null && year !== prevYear),
+            showLabel: true,
+        });
+        if (dn != null) prevDay = dn;
+        if (year != null) prevYear = year;
+    }
+    // The drawn rect, decided HERE and not by the renderer, because the
+    // degradation pass below has to thin the boxes that actually get drawn. The
+    // last tick is clamped off the right edge of the world it is measured
+    // against; clamping in the caller instead would move a box the pass had
+    // already cleared, which is how a "checked" invariant stops being one.
+    for (const r of out) {
+        r.labelW = r.label.length * CHW_SLOT;
+        r.labelX = Math.max(0, Math.min(r.x + 4, totalW - RIGHT - r.labelW));
+    }
+    // ── Degradation, measured rather than counted ───────────────────────────
+    // "Every Nth day" is the obvious rule and it is the wrong one here: columns
+    // have VARIABLE widths (a column is as wide as the widest thing drawn in
+    // it), so a fixed stride drops a label in front of 300px of empty ruler and
+    // keeps two that collide. A greedy left-to-right pass against the actual
+    // rects degrades exactly as much as the room requires and no more.
+    let lastRight = -Infinity;
+    for (const r of out) {
+        if (r.labelX < lastRight + RULER_LABEL_GAP) { r.showLabel = false; continue; }
+        r.showLabel = true;
+        lastRight = r.labelX + r.labelW;
+    }
+    // The FUTURE tick is forced back on if the pass dropped it. It is the one
+    // boundary a plan is opened to find, so it outranks whatever dated label
+    // happens to precede it — that label is displaced, not shrunk. Safe to do
+    // after the pass because FUTURE always sorts last (SLOT_FUTURE is '2:'), so
+    // nothing downstream of it needs re-thinning.
+    const fut = out.length > 0 && out[out.length - 1].kind === 'future'
+        ? out[out.length - 1] : null;
+    if (fut && !fut.showLabel) {
+        fut.showLabel = true;
+        for (const r of out) {
+            if (r === fut || !r.showLabel) continue;
+            if (r.labelX < fut.labelX + fut.labelW + RULER_LABEL_GAP
+                && fut.labelX < r.labelX + r.labelW + RULER_LABEL_GAP) {
+                r.showLabel = false;
+            }
+        }
+    }
+    return {
+        h: RULER_H,
+        slots: out,
+        futureX: fut ? fut.x : null,
+    };
+}
+
 const truncate = (s, n) => {
     const str = String(s == null ? '' : s);
     return str.length > n ? `${str.slice(0, n - 1)}…` : str;
@@ -844,6 +1007,11 @@ export function computePlanLayout(rows, batches, {
             width: MIN_WORLD_W, height: 120, bands: [], nodes: new Map(),
             arcs: [], batchBoxes: [], labels: [], colW: [], colX: [],
             slots: [], slotOf: new Map(),
+            // An INERT ruler, not a missing one: `layout.ruler.h` is the
+            // reservation and every consumer reads it unconditionally, so an
+            // absent key here would be the one shape that makes the renderer
+            // need a null check the other path never exercises.
+            ruler: { h: RULER_H, slots: [], futureX: null },
             reqLayout, stepLabel, stepWidth, reqLabel, empty: true,
         };
     }
@@ -940,6 +1108,19 @@ export function computePlanLayout(rows, batches, {
         }
     }
     const totalW = Math.max(MIN_WORLD_W, colX[maxCol] + colW[maxCol] / 2 + RIGHT + 40);
+
+    // ── The time ruler (req #3207) ──────────────────────────────────────────
+    // Built HERE, before the bands, because its height is what the first band's
+    // y is offset by. The slot descriptors are the same objects `layout.slots`
+    // exports — one derivation, not two, so the drawn ruler and the tested axis
+    // can never disagree about where a day begins.
+    const slots = slotKeys.map((key, i) => ({
+        key,
+        kind: key === SLOT_UNKNOWN ? 'unknown' : key === SLOT_FUTURE ? 'future' : 'dated',
+        day: key === SLOT_UNKNOWN || key === SLOT_FUTURE ? null : key.slice(2),
+        origin: slotOrigins[i],
+    }));
+    const ruler = computeRuler(slots, colX, colW, totalW);
 
     // ── Epic bands (dominant label), stacked by DERIVED START (req #3201) ───
     // The vertical axis reads as time too: the epic whose work began first sits
@@ -1283,7 +1464,10 @@ export function computePlanLayout(rows, batches, {
             headerH, epicLaneH });
         bandUsed.push(used);
     }
-    let y = 8;
+    // The ruler's reservation, charged ONCE and unconditionally (see RULER_H).
+    // Every band, node, arc and batch box is derived from this y, so the whole
+    // plan shifts by one constant and nothing below has to know about the strip.
+    let y = 8 + ruler.h;
     for (const band of bands) {
         band.y = y;
         band.height = band.headerH + band.laneY[band.sub];
@@ -1610,6 +1794,28 @@ export function computePlanLayout(rows, batches, {
             }
         }
     }
+    // ── Ruler ticks join `labels` (req #3207 constraint) ────────────────────
+    // Deliberately NOT a second, separately-checked class of text. The
+    // zero-overlap contract is asserted over `layout.labels` in all four
+    // reqLayout × stepLabel combinations, and a date strip that carried its own
+    // rects would be text on this surface that no invariant covers — which is
+    // how the epic label × batch letter collision got shipped once already.
+    // Left-anchored just inside the tick, because a ruler label belongs to a
+    // BOUNDARY, not to the middle of a region whose width is an accident of how
+    // many columns that day happened to need.
+    for (const r of ruler.slots) {
+        if (!r.showLabel) continue;
+        labels.push({
+            kind: 'slot', slotKey: r.key, slotKind: r.kind, day: r.day,
+            text: r.label,
+            // Generated from a date, never stored user content — so the no-'#'
+            // audit governs it (see the `prose` note on requirement marks).
+            prose: false,
+            // Clamped off the right edge so the last tick's text stays in the
+            // world it is measured against.
+            x: r.labelX, y: RULER_LABEL_Y, w: r.labelW, h: RULER_LABEL_H,
+        });
+    }
     for (const band of bands) {
         labels.push({
             kind: 'epic', epicId: band.epicId, text: band.epic,
@@ -1684,13 +1890,14 @@ export function computePlanLayout(rows, batches, {
         // this module's output — "slot k begins right of everything in slot
         // k-1" is the property the whole design rests on, and a test that
         // re-derives it from the input would be a second implementation.
-        slots: slotKeys.map((key, i) => ({
-            key,
-            kind: key === SLOT_UNKNOWN ? 'unknown' : key === SLOT_FUTURE ? 'future' : 'dated',
-            day: key === SLOT_UNKNOWN || key === SLOT_FUTURE ? null : key.slice(2),
-            origin: slotOrigins[i],
-        })),
+        slots,
         slotOf,
+        // The DRAWN axis (req #3207): the same slots with world x-extents, the
+        // calendar gap at each boundary, and which ticks survived degradation.
+        // The text rects are ALSO in `labels` above — this carries the rules,
+        // the ticks and the future region, which are not text and therefore not
+        // subject to the overlap contract.
+        ruler,
         reqLayout,
         reqLabel,
         stepLabel,

--- a/tests/tests/pipelines.spec.ts
+++ b/tests/tests/pipelines.spec.ts
@@ -660,6 +660,34 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             // regression in either.
         });
 
+    test('PIPE-10b: the time ruler draws a tick per slot, thinning labels not overlapping them',
+        async ({ page }) => {
+            // Req #3207. Same device and same reasoning as `data-batch-boxes`
+            // above: the ruler is canvas geometry, so the DOM carries what the
+            // canvas actually drew rather than a second thing derived from the
+            // same flag.
+            //
+            // TWO numbers, because the DEGRADATION rule is the half a screenshot
+            // cannot check. A pixel diff cannot tell a ruler that thinned three
+            // dates away from a plan that simply had three fewer days; `slots`
+            // against `labelled` can, and their being EQUAL here is itself the
+            // assertion — these fixtures are short enough that nothing should
+            // thin, so a labelled count below the slot count would mean the pass
+            // is firing where there is room.
+            for (const pipelineId of [fixture.batchPipelineId, fixture.mainPipelineId]) {
+                const p = pipelineId === fixture.batchPipelineId ? batchPlan : plan;
+                const L = computePlanLayout(p.rows, p.batches,
+                    { ...PLAN_VIEW_OPTIONS, timeAxis: p.timeAxis || null });
+                expect(L.ruler.slots.length).toBeGreaterThan(0);
+                const labelled = L.ruler.slots.filter(
+                    (s: { showLabel: boolean }) => s.showLabel).length;
+
+                await openPlanVisualizer(page, pipelineId);
+                await expect(page.getByTestId('pipeline-plan-visualizer'))
+                    .toHaveAttribute('data-ruler', `${L.ruler.slots.length},${labelled}`);
+            }
+        });
+
     test('PIPE-11: bead, requirement and epic click targets navigate', async ({ page }) => {
         // The BATCH plan, on purpose. Canvas hit targets are world-space and the
         // stage is fit to width, so the screen-space tolerance is


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3207-plan-visualizer-draw-the-time-ruler-1
- wip(Darwin): 2026-08-01T13:05:44Z
- chore: init swarm session feature/3207-plan-visualizer-draw-the-time-ruler-1

## Files changed
```
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx |  77 ++++++
 .../pipelines/__tests__/pipelinePlanLayout.test.js | 260 ++++++++++++++++++++-
 src/SwarmView/pipelines/pipelinePlanLayout.js      | 223 +++++++++++++++++-
 tests/tests/pipelines.spec.ts                      |  28 +++
 4 files changed, 579 insertions(+), 9 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Related PRs: BillWilliams79/DarwinAI-Config#738