### PR TITLE
Epic editor page under the pipeline visualizer

### DIFF
--- a/src/Epics/EpicsPage.jsx
+++ b/src/Epics/EpicsPage.jsx
@@ -1,0 +1,538 @@
+// /swarm/epics — the Epics editor (req #3139).
+//
+// Epics are the TOP tier of Epic > Feature > Story (req #3111, migration 076).
+// Every other tier already had a page: requirements at /swarm, features at
+// /swarm/features. Epics had none — req #3115 shipped the `?epic=<id>` filter on
+// the features view as "the minimal target the requirement asked for; dedicated
+// epic pages are deliberately deferred". This is that deferred page, and it sits
+// as an L2 nav entry directly under Pipelines because an epic is what a plan is
+// made OF (design rule 10 derives a step's label by walking requirement →
+// feature → epic).
+//
+// Shape follows MachinesView (/swarm/machines): one DataGrid, a click-to-toggle
+// closed chip, no cards/trends views. Create and Edit go through one dialog
+// rather than inline editing, because `description` is multi-paragraph prose and
+// `category_fk` is a constrained choice — neither fits a grid cell.
+//
+// Deliberately NOT a `ViewerHeader` page (memory/darwin-viewer-pages.md): that
+// contract is for a dataset shown through MORE THAN ONE presentation, and it
+// mandates a ToggleButtonGroup even at length 1 — a dead control on a page with
+// a single view. The siblings this page sits beside (Machines, Customers,
+// Features) all hand-roll the same header row. Adopting ViewerHeader is the
+// right move the day this page grows a second view, not before.
+//
+// The connection to the existing epic surface is the Features count cell: it
+// navigates to /swarm/features?epic=<id>, the same target the plan visualizer's
+// epic chip ↗ uses (req #3119). The features view's epic chip links back here.
+
+import { useContext, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import Button from '@mui/material/Button';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import InputLabel from '@mui/material/InputLabel';
+import FormControl from '@mui/material/FormControl';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+import AuthContext from '../Context/AuthContext';
+import AppContext from '../Context/AppContext';
+import { useAllEpics, useAllFeatures, useAllCategories, ALL_ROWS } from '../hooks/useDataQueries';
+import { epicKeys, featureKeys, sessionKeys } from '../hooks/useQueryKeys';
+import { useSnackBarStore } from '../stores/useSnackBarStore';
+import ChipFilter from '../Components/ChipFilter/ChipFilter';
+import { formatDate } from '../utils/dateFormat';
+import { createEpic, updateEpic, deleteEpic, REST_NULL } from './epicsApi';
+
+// The same projection RequirementsTrendsView already requests, deliberately —
+// `useAllCategories` keys on `fields`, so matching it shares one cache entry
+// instead of paying for a second read of the same table. No `closed` filter:
+// this is a NAME DICTIONARY first (an epic filed under a since-closed category
+// must still render its category, not a blank), and the dialog narrows it to
+// open categories itself.
+const CATEGORY_FIELDS = 'id,category_name,color,sort_order,closed';
+
+// Explicit chipProps, not the ChipFilter palette: open/closed is a fixed
+// two-value VOCABULARY, and the palette is for dimensions whose values are data
+// (machines, projects). Left to hash, 'open' and 'closed' would pick arbitrary
+// colours that contradict the grid's own Status chip two columns away — the
+// same word in two colours on one screen.
+const CLOSED_FILTER_OPTIONS = [
+    { value: 'open', label: 'Open', chipProps: { color: 'success' } },
+    { value: 'closed', label: 'Closed', chipProps: { color: 'default' } },
+];
+
+// SMALLINT — the column's real width, not INT. 40000 is a 1264 from MySQL and
+// a 500 at the gateway, which is a worse answer than refusing it in the form.
+const SORT_ORDER_MIN = -32768;
+const SORT_ORDER_MAX = 32767;
+
+// The ENTITY ROOT of the swarm_sessions cache, and it has to be the root.
+// `sessions` is declared `byIdCreatorScoped: false`, so its two key shapes are
+// SIBLINGS rather than ancestor and descendant — ['swarm_sessions', creatorFk]
+// for the list, ['swarm_sessions', {id}] for a detail row — and they diverge at
+// element 1, where 'tester' and {id:42} fail deep equality. Neither prefix
+// reaches the other. That matters here because SwarmSessionDetail is the ONLY
+// component that renders a session's `epic_fk` at all, and it reads through the
+// byId key: invalidating the list alone refreshes every cache except the one
+// that shows the column. Derived from the factory rather than typed out, so an
+// entity rename cannot desync it.
+const SESSION_CACHE_ROOT = sessionKeys.all(null).slice(0, 1);
+
+// Collapse prose to one line for the grid cell. Epic descriptions are several
+// paragraphs (see darwin://epics) and a raw multi-line value renders as a single
+// clipped line with the newlines swallowed anyway — this at least keeps the
+// words on either side of a break from running together.
+const oneLine = (value) => (value ? String(value).replace(/\s+/g, ' ').trim() : '');
+
+// sort_order is a nullable SMALLINT fed by a text input, so there are THREE
+// answers, not two, and collapsing the last two loses data: EMPTY (clear the
+// column), a usable integer, and INVALID. `<input type="number">` keeps "4.5"
+// and "4e3" in the field rather than clearing them, so treating anything
+// non-integer as empty would silently wipe an epic's plan position on a typo.
+// Returns { value } | { empty: true } | { invalid: <reason> }.
+const parseSortOrder = (raw) => {
+    const t = (raw ?? '').trim();
+    if (t === '') return { empty: true };
+    const n = Number(t);
+    if (!Number.isInteger(n)) return { invalid: 'Sort order must be a whole number' };
+    if (n < SORT_ORDER_MIN || n > SORT_ORDER_MAX) {
+        return { invalid: `Sort order must be between ${SORT_ORDER_MIN} and ${SORT_ORDER_MAX}` };
+    }
+    return { value: n };
+};
+
+export default function EpicsPage() {
+    const { idToken, profile } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
+    const queryClient = useQueryClient();
+    const showError = useSnackBarStore(s => s.showError);
+    const navigate = useNavigate();
+
+    const creatorFk = profile?.userName;
+    const timezone = profile?.timezone;
+
+    const { data: epics = [], isLoading: epicsLoading } = useAllEpics(creatorFk);
+    // ALL_ROWS: the count is "features filed under this epic", and a closed
+    // feature is still filed under it. Counting only open ones would report 0
+    // for a finished epic and read as a data bug.
+    const { data: features = [], isLoading: featuresLoading } =
+        useAllFeatures(creatorFk, { closed: ALL_ROWS });
+    const { data: categories = [], isLoading: categoriesLoading } =
+        useAllCategories(creatorFk, { fields: CATEGORY_FIELDS });
+
+    // Every read that feeds a NUMBER OR A LABEL gates the spinner (the
+    // PipelinesPage rule). The three reads resolve independently: gating on
+    // epics alone paints a grey `0` in the Features column for every epic, and
+    // — worse — a delete confirmed in that window omits the "its N features
+    // will be unfiled" clause the confirmation exists to deliver.
+    const isLoading = epicsLoading || featuresLoading || categoriesLoading;
+
+    // Plain state, deliberately: unlike PipelinesPage's persisted filter, this
+    // page has no detail route to click into and come back from, so there is no
+    // navigation that could silently forget a chip the user turned on.
+    const [closedFilter, setClosedFilter] = useState(['open']);
+    const toggleClosedFilter = (value) => setClosedFilter(current => (
+        current.includes(value)
+            ? current.filter(v => v !== value)
+            : [...current, value]
+    ));
+
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [editTarget, setEditTarget] = useState(null);
+    const [formTitle, setFormTitle] = useState('');
+    const [formDescription, setFormDescription] = useState('');
+    const [formCategoryFk, setFormCategoryFk] = useState('');
+    const [formSortOrder, setFormSortOrder] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+
+    const featureCountByEpic = useMemo(() => {
+        const m = {};
+        for (const f of features) {
+            if (f.epic_fk == null) continue;
+            m[f.epic_fk] = (m[f.epic_fk] || 0) + 1;
+        }
+        return m;
+    }, [features]);
+
+    const categoryById = useMemo(() => {
+        const m = {};
+        for (const c of categories) m[c.id] = c;
+        return m;
+    }, [categories]);
+
+    // Open categories in the user's own order (sort_order NULLs last, then name),
+    // plus whichever one the epic being edited already carries even if it has
+    // since been closed — otherwise opening the dialog on such an epic shows an
+    // empty Select and saving would silently re-file it. The order matters
+    // beyond tidiness: `openCreate` defaults to the first entry, and "whichever
+    // row the database happened to return first" is not a default worth having.
+    const categoryOptions = useMemo(() => {
+        const open = categories.filter(c => !c.closed).sort((a, b) => {
+            const ao = a.sort_order == null ? Infinity : a.sort_order;
+            const bo = b.sort_order == null ? Infinity : b.sort_order;
+            return ao - bo || String(a.category_name).localeCompare(String(b.category_name));
+        });
+        const current = editTarget?.category_fk;
+        if (current != null && !open.some(c => c.id === current)) {
+            const row = categoryById[current];
+            if (row) return [...open, row];
+        }
+        return open;
+    }, [categories, categoryById, editTarget]);
+
+    const rows = useMemo(() => {
+        const visible = epics.filter(e => (
+            closedFilter.includes(e.closed ? 'closed' : 'open')
+        ));
+        // sort_order NULLs last, then id — the order darwin://epics itself uses.
+        // Pre-sorted rather than an initial sortModel because MUI sorts a null
+        // sort_order to the TOP in ascending order, which puts brand-new,
+        // unordered epics above the ordered plan.
+        return [...visible]
+            .map(e => ({ ...e, feature_count: featureCountByEpic[e.id] || 0 }))
+            .sort((a, b) => {
+                const ao = a.sort_order == null ? Infinity : a.sort_order;
+                const bo = b.sort_order == null ? Infinity : b.sort_order;
+                return ao - bo || a.id - b.id;
+            });
+    }, [epics, closedFilter, featureCountByEpic]);
+
+    const invalidateEpics = () =>
+        queryClient.invalidateQueries({ queryKey: epicKeys.all(creatorFk) });
+
+    const openCreate = () => {
+        setEditTarget(null);
+        setFormTitle('');
+        setFormDescription('');
+        // Pre-select the first OPEN category (the FeatureEditDialog rule).
+        // category_fk is required by the API, so an empty default is a dead Save
+        // button on a form that looks complete. `categoryOptions` was memoized
+        // for the previous `editTarget` and may still carry that epic's closed
+        // category appended at the end, so the openness test is explicit rather
+        // than positional — filing new work under a closed category is wrong
+        // even when it is the only category left.
+        setFormCategoryFk(categoryOptions.find(c => !c.closed)?.id ?? '');
+        setFormSortOrder('');
+        setDialogOpen(true);
+    };
+
+    const openEdit = (row) => {
+        setEditTarget(row);
+        setFormTitle(row.title || '');
+        setFormDescription(row.description || '');
+        setFormCategoryFk(row.category_fk ?? '');
+        setFormSortOrder(row.sort_order == null ? '' : String(row.sort_order));
+        setDialogOpen(true);
+    };
+
+    const handleSubmit = async () => {
+        const title = formTitle.trim();
+        const description = formDescription.trim();
+        const sortOrder = parseSortOrder(formSortOrder);
+        if (!title) {
+            showError('Title is required');
+            return;
+        }
+        // category_fk is ON DELETE RESTRICT and required by the API — a create
+        // without it fails at the gateway, so refuse it here with a real message.
+        if (formCategoryFk === '' || formCategoryFk == null) {
+            showError('Category is required');
+            return;
+        }
+        // An unusable sort order is REFUSED, never silently treated as "clear
+        // it": the two look identical in the payload and one of them destroys
+        // the epic's position in the plan.
+        if (sortOrder.invalid) {
+            showError(sortOrder.invalid);
+            return;
+        }
+        setSubmitting(true);
+        try {
+            if (editTarget) {
+                // Every editable column is sent, with the nullable ones cleared
+                // via the REST 'NULL' sentinel. One code path beats diffing the
+                // form against the row and getting the empty cases wrong.
+                await updateEpic(darwinUri, idToken, editTarget.id, {
+                    title,
+                    description: description || REST_NULL,
+                    category_fk: formCategoryFk,
+                    sort_order: sortOrder.empty ? REST_NULL : sortOrder.value,
+                });
+            } else {
+                await createEpic(darwinUri, idToken, {
+                    title,
+                    description: description || null,
+                    category_fk: formCategoryFk,
+                    // POST takes a real null; the 'NULL' string is a PUT-only
+                    // sentinel and would be stored as the literal text.
+                    sort_order: sortOrder.empty ? null : sortOrder.value,
+                });
+            }
+            invalidateEpics();
+            setDialogOpen(false);
+        } catch (err) {
+            // TWO-argument form on purpose. call_rest_api THROWS a bare
+            // `{data, httpStatus}` object for every gateway error, so `err.message`
+            // is undefined on exactly the failures worth reporting; the store's
+            // second argument is what renders the status code beside the text.
+            showError(err, editTarget ? 'Could not save epic' : 'Could not create epic');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const toggleClosed = async (row) => {
+        try {
+            await updateEpic(darwinUri, idToken, row.id, { closed: row.closed ? 0 : 1 });
+            invalidateEpics();
+        } catch (err) {
+            showError(err, 'Could not change epic status');
+        }
+    };
+
+    const handleDelete = async (row) => {
+        const count = row.feature_count;
+        const consequence = count
+            ? ` Its ${count} feature${count === 1 ? '' : 's'} will be unfiled (kept, but with no epic).`
+            : '';
+        if (!window.confirm(`Delete epic "${row.title}"?${consequence}`)) return;
+        try {
+            await deleteEpic(darwinUri, idToken, row.id);
+            invalidateEpics();
+            // BOTH columns that point at an epic are ON DELETE SET NULL, so both
+            // caches are now stale: features.epic_fk (the count on this page) and
+            // swarm_sessions.epic_fk (req #3186's attribution row, which would
+            // otherwise keep rendering a bare `#<id>` chip for an epic that no
+            // longer exists — the title lookup fails once the epics list refetches).
+            // The session invalidation goes to the ENTITY ROOT deliberately; see
+            // SESSION_CACHE_ROOT above for why the list key cannot reach the row
+            // that actually renders the column.
+            queryClient.invalidateQueries({ queryKey: featureKeys.all(creatorFk) });
+            queryClient.invalidateQueries({ queryKey: SESSION_CACHE_ROOT });
+        } catch (err) {
+            showError(err, 'Could not delete epic');
+        }
+    };
+
+    // Deliberately NOT memoized (the FeaturesPage / CustomersPage shape). Every
+    // action cell closes over `idToken`, which is refreshed in place by
+    // AuthContext; a memoized column array would keep firing REST calls with the
+    // token it captured on first render long after that token expired.
+    const columns = [
+        { field: 'id', headerName: 'ID', width: 70 },
+        { field: 'title', headerName: 'Epic', flex: 1, minWidth: 200 },
+        {
+            field: 'category_name', headerName: 'Category', width: 150,
+            valueGetter: (_v, row) => categoryById[row.category_fk]?.category_name || '',
+            renderCell: (params) => (
+                <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+                    <Chip label={params.value || '—'} size="small" variant="outlined"
+                          sx={categoryById[params.row.category_fk]?.color
+                              ? { borderColor: categoryById[params.row.category_fk].color }
+                              : undefined} />
+                </Box>
+            ),
+        },
+        {
+            field: 'description', headerName: 'Description', flex: 2, minWidth: 260,
+            valueGetter: (value) => oneLine(value),
+            valueFormatter: (value) => value || '—',
+        },
+        {
+            field: 'feature_count', headerName: 'Features', width: 100, type: 'number',
+            // The connection to the existing epic surface (req #3139): the same
+            // epic-filtered features view the plan visualizer's ↗ opens.
+            renderCell: (params) => (
+                <Box
+                    component="span"
+                    role="link"
+                    tabIndex={0}
+                    aria-label={`Open the features filed under ${params.row.title}`}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        navigate(`/swarm/features?epic=${params.row.id}`);
+                    }}
+                    onKeyDown={(e) => {
+                        if (e.key !== 'Enter') return;
+                        e.stopPropagation();
+                        navigate(`/swarm/features?epic=${params.row.id}`);
+                    }}
+                    sx={{
+                        cursor: 'pointer',
+                        textDecoration: params.value > 0 ? 'underline' : 'none',
+                        color: params.value > 0 ? 'primary.main' : 'text.secondary',
+                    }}
+                    data-testid={`epic-features-link-${params.row.id}`}
+                >
+                    {params.value}
+                </Box>
+            ),
+        },
+        {
+            field: 'sort_order', headerName: 'Order', width: 90, type: 'number',
+            valueFormatter: (value) => (value == null ? '—' : value),
+        },
+        {
+            field: 'closed', headerName: 'Status', width: 110, sortable: false,
+            renderCell: (params) => (
+                <Chip
+                    label={params.value ? 'Closed' : 'Open'}
+                    size="small"
+                    color={params.value ? 'default' : 'success'}
+                    variant={params.value ? 'outlined' : 'filled'}
+                    onClick={() => toggleClosed(params.row)}
+                    clickable
+                    data-testid={`epic-toggle-closed-${params.row.id}`}
+                />
+            ),
+        },
+        {
+            field: 'create_ts', headerName: 'Created', width: 120,
+            valueFormatter: (value) => formatDate(value, timezone),
+        },
+        {
+            field: 'actions', headerName: '', width: 100, sortable: false,
+            filterable: false, disableColumnMenu: true,
+            renderCell: (params) => (
+                <Stack direction="row" spacing={0.5}>
+                    <Tooltip title="Edit">
+                        <IconButton size="small"
+                                    data-testid={`epic-edit-${params.row.id}`}
+                                    onClick={(e) => { e.stopPropagation(); openEdit(params.row); }}>
+                            <EditIcon fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete">
+                        <IconButton size="small"
+                                    data-testid={`epic-delete-${params.row.id}`}
+                                    onClick={(e) => { e.stopPropagation(); handleDelete(params.row); }}>
+                            <DeleteIcon fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                </Stack>
+            ),
+        },
+    ];
+
+    return (
+        <Box sx={{ gridArea: 'content', p: 3, width: '100%', overflow: 'auto' }}>
+            <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 2 }}>
+                <Typography variant="h5">Epics</Typography>
+                <ChipFilter
+                    options={CLOSED_FILTER_OPTIONS}
+                    selected={closedFilter}
+                    onToggle={toggleClosedFilter}
+                    testId="epics-closed-filter"
+                    chipTestIdPrefix="epics-closed-chip"
+                />
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}
+                            data-testid="epics-accounting">
+                    {rows.length} of {epics.length} epic{epics.length === 1 ? '' : 's'}
+                </Typography>
+                <Box sx={{ flexGrow: 1 }} />
+                <Button variant="contained" startIcon={<AddIcon />} onClick={openCreate}
+                        data-testid="epic-add">
+                    New Epic
+                </Button>
+            </Stack>
+
+            {isLoading ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+                    <CircularProgress />
+                </Box>
+            ) : (
+                <Box sx={{ width: '100%' }} data-testid="epics-datagrid">
+                    <DataGrid
+                        autoHeight
+                        rows={rows}
+                        columns={columns}
+                        getRowId={(r) => r.id}
+                        density="compact"
+                        slots={{ toolbar: GridToolbar }}
+                        slotProps={{ toolbar: { showQuickFilter: true } }}
+                        initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
+                        pageSizeOptions={[10, 25, 50]}
+                        disableRowSelectionOnClick
+                        data-testid="epics-grid"
+                    />
+                </Box>
+            )}
+
+            <Dialog open={dialogOpen} onClose={() => !submitting && setDialogOpen(false)}
+                    maxWidth="md" fullWidth data-testid="epic-edit-dialog">
+                <DialogTitle>{editTarget ? 'Edit epic' : 'New epic'}</DialogTitle>
+                <DialogContent>
+                    <Stack spacing={2} sx={{ mt: 1 }}>
+                        <TextField
+                            label="Title"
+                            value={formTitle}
+                            onChange={(e) => setFormTitle(e.target.value)}
+                            autoFocus required fullWidth
+                            // maxLength matches the column (VARCHAR 256). Without
+                            // it a longer title reaches MySQL, fails 1406, and
+                            // comes back as an opaque 500 (the RequirementRow rule).
+                            slotProps={{ htmlInput: { 'data-testid': 'epic-title-input', maxLength: 256 } }}
+                        />
+                        <TextField
+                            label="Description"
+                            value={formDescription}
+                            onChange={(e) => setFormDescription(e.target.value)}
+                            helperText="What this epic is for — purpose, not a fact a query can answer."
+                            fullWidth multiline minRows={6}
+                            slotProps={{ htmlInput: { 'data-testid': 'epic-description-input' } }}
+                        />
+                        <FormControl fullWidth required>
+                            <InputLabel>Category</InputLabel>
+                            <Select label="Category" value={formCategoryFk}
+                                    onChange={(e) => setFormCategoryFk(e.target.value)}
+                                    data-testid="epic-category-select">
+                                {categoryOptions.map(c => (
+                                    <MenuItem key={c.id} value={c.id}>{c.category_name}</MenuItem>
+                                ))}
+                            </Select>
+                        </FormControl>
+                        <TextField
+                            label="Sort order"
+                            value={formSortOrder}
+                            onChange={(e) => setFormSortOrder(e.target.value)}
+                            helperText="Whole number, position in the plan. Leave blank for unordered (sorts last)."
+                            type="number" fullWidth
+                            // step/min/max are the spinner's manners only — a typed
+                            // "4.5" still arrives here, which is why handleSubmit
+                            // refuses it rather than trusting the field.
+                            slotProps={{ htmlInput: {
+                                'data-testid': 'epic-sort-order-input',
+                                step: 1, min: SORT_ORDER_MIN, max: SORT_ORDER_MAX,
+                            } }}
+                        />
+                    </Stack>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setDialogOpen(false)} disabled={submitting}>Cancel</Button>
+                    <Button variant="contained" onClick={handleSubmit}
+                            disabled={submitting || !formTitle.trim() || formCategoryFk === ''}
+                            data-testid="epic-save">
+                        {editTarget ? 'Save' : 'Create'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </Box>
+    );
+}

--- a/src/Epics/__tests__/EpicsPage.test.jsx
+++ b/src/Epics/__tests__/EpicsPage.test.jsx
@@ -1,0 +1,449 @@
+// @vitest-environment jsdom
+//
+// Req #3139 — the Epics editor.
+//
+// The DataGrid is STUBBED (see the mock below): jsdom gives every element a
+// zero-size box, so the real grid virtualizes down to no cells at all and a
+// suite built on it asserts against an empty table. The stub renders each row
+// through the SAME column contract the real grid uses — `valueGetter(value,
+// row)` then `valueFormatter(value, row)` then `renderCell({ row, value })`,
+// v7 argument order — so a column that mis-uses that signature still fails
+// here. What the stub deliberately does NOT prove is grid behaviour itself
+// (sorting by header click, pagination, quick filter); none of that is this
+// requirement's code.
+//
+// What IS pinned is the wiring the requirement is about:
+//   - the Features count cell navigates to the epic-filtered features view,
+//     which is the "connects to the existing epic editor" clause
+//   - create / edit send the right body to the right endpoint, including the
+//     REST 'NULL' sentinel that a JSON null cannot express on a PUT
+//   - the closed chip toggles the flag rather than opening a dialog
+//   - delete is gated on confirm and invalidates the FEATURES cache too,
+//     because features.epic_fk is ON DELETE SET NULL
+//   - the closed filter and the sort_order-nulls-last ordering
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const navigations = [];
+// Spread the real module rather than replacing it: a narrow `{ useNavigate }`
+// mock turns any future router import in the page into an undefined-export
+// crash that says nothing about the actual failure.
+vi.mock('react-router-dom', async (importOriginal) => ({
+    ...(await importOriginal()),
+    useNavigate: () => (to) => navigations.push(to),
+}));
+
+// Mirrors the real column contract closely enough to catch a signature error.
+vi.mock('@mui/x-data-grid', () => ({
+    GridToolbar: () => null,
+    DataGrid: ({ rows, columns }) => (
+        <div data-testid="grid">
+            {rows.map((row, index) => (
+                <div key={row.id} data-testid={`grid-row-${row.id}`} data-index={index}>
+                    {columns.map((col) => {
+                        const raw = row[col.field];
+                        const value = col.valueGetter ? col.valueGetter(raw, row, col) : raw;
+                        const formatted = col.valueFormatter
+                            ? col.valueFormatter(value, row, col) : value;
+                        return (
+                            <span key={col.field} data-testid={`cell-${col.field}-${row.id}`}>
+                                {col.renderCell
+                                    ? col.renderCell({ row, value, id: row.id, field: col.field })
+                                    : String(formatted ?? '')}
+                            </span>
+                        );
+                    })}
+                </div>
+            ))}
+        </div>
+    ),
+}));
+
+let epics;
+let features;
+let categories;
+let loading;
+
+vi.mock('../../hooks/useDataQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        useAllEpics: () => ({ data: epics, isLoading: loading.epics }),
+        useAllFeatures: () => ({ data: features, isLoading: loading.features }),
+        useAllCategories: () => ({ data: categories, isLoading: loading.categories }),
+    };
+});
+
+const restCalls = [];
+vi.mock('../../RestApi/RestApi', () => ({
+    default: vi.fn((uri, method, body) => {
+        restCalls.push({ uri, method, body });
+        return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+    }),
+}));
+
+import EpicsPage from '../EpicsPage';
+import AuthContext from '../../Context/AuthContext';
+import AppContext from '../../Context/AppContext';
+import { useSnackBarStore } from '../../stores/useSnackBarStore';
+
+let mountedRoots = [];
+let queryClient;
+
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0, refetchOnWindowFocus: false } },
+    });
+    vi.spyOn(queryClient, 'invalidateQueries');
+    const root = createRoot(container);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local/darwin' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <EpicsPage />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    mountedRoots.push(root);
+    return { container };
+}
+
+const node = (testId) => document.body.querySelector(`[data-testid="${testId}"]`);
+const click = (el) => act(() => { el.click(); });
+
+const type = (el, value) => act(() => {
+    const proto = el instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, 'value').set.call(el, value);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+});
+
+// Let the awaited REST call and the state updates that follow it settle.
+const flush = () => act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+const rowIds = () => [...document.body.querySelectorAll('[data-testid^="grid-row-"]')]
+    .map(el => Number(el.getAttribute('data-testid').replace('grid-row-', '')));
+
+beforeEach(() => {
+    navigations.length = 0;
+    restCalls.length = 0;
+    mountedRoots = [];
+    loading = { epics: false, features: false, categories: false };
+    epics = [
+        { id: 4, title: 'Pipeline', description: 'Plans as data.\n\nSecond para.', category_fk: 1, closed: 0, sort_order: 4, create_ts: '2026-07-28 05:15:14' },
+        { id: 2, title: 'Application Backlog', description: null, category_fk: 1, closed: 0, sort_order: 1, create_ts: '2026-07-28 05:15:14' },
+        { id: 9, title: 'Unordered', description: null, category_fk: 577, closed: 0, sort_order: null, create_ts: '2026-07-31 02:38:14' },
+        { id: 7, title: 'Retired', description: null, category_fk: 1, closed: 1, sort_order: 2, create_ts: '2026-07-31 10:43:32' },
+    ];
+    features = [
+        { id: 10, title: 'f1', epic_fk: 4 },
+        { id: 11, title: 'f2', epic_fk: 4 },
+        { id: 12, title: 'f3', epic_fk: null },
+        { id: 13, title: 'f4', epic_fk: 2 },
+    ];
+    // sort_order is deliberately OUT of fetch order: 'Mapping' arrives second
+    // but sorts first, so the create-default assertion below proves the page
+    // respects the user's ordering rather than whatever MySQL returned first.
+    categories = [
+        { id: 1, category_name: 'Darwin', color: '#123456', closed: 0, sort_order: 5 },
+        { id: 577, category_name: 'Mapping', color: null, closed: 0, sort_order: 1 },
+        { id: 900, category_name: 'Archived', color: null, closed: 1, sort_order: 0 },
+    ];
+    useSnackBarStore.setState({ open: false, message: '' });
+});
+
+const snackMessage = () => useSnackBarStore.getState().message;
+
+afterEach(() => {
+    act(() => { mountedRoots.forEach(r => r.unmount()); });
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+});
+
+describe('EpicsPage rows', () => {
+    it('shows open epics by default, ordered by sort_order with NULLs last', () => {
+        mount();
+        expect(rowIds()).toEqual([2, 4, 9]);
+    });
+
+    it('adds the closed epics when the Closed chip is toggled on', () => {
+        mount();
+        click(node('epics-closed-chip-closed'));
+        expect(rowIds()).toEqual([2, 7, 4, 9]);
+    });
+
+    it('shows nothing — not everything — when every filter chip is off', () => {
+        mount();
+        click(node('epics-closed-chip-open'));
+        expect(rowIds()).toEqual([]);
+        expect(node('epics-accounting').textContent).toContain('0 of 4');
+    });
+
+    it('counts the features filed under each epic, unfiled ones excluded', () => {
+        mount();
+        expect(node('epic-features-link-4').textContent).toBe('2');
+        expect(node('epic-features-link-2').textContent).toBe('1');
+        expect(node('epic-features-link-9').textContent).toBe('0');
+    });
+
+    it('collapses a multi-paragraph description to one line', () => {
+        mount();
+        expect(node('cell-description-4').textContent).toBe('Plans as data. Second para.');
+        expect(node('cell-description-2').textContent).toBe('—');
+    });
+
+    it('resolves the category name for the row', () => {
+        mount();
+        expect(node('cell-category_name-4').textContent).toContain('Darwin');
+        expect(node('cell-category_name-9').textContent).toContain('Mapping');
+    });
+
+    // The three reads land independently. Painting the grid off the epics read
+    // alone shows every Features count as 0 and lets a delete be confirmed
+    // WITHOUT the "its N features will be unfiled" clause — a wrong number is
+    // not a loading state.
+    it('holds the grid until the features read lands, not just the epics one', () => {
+        loading = { epics: false, features: true, categories: false };
+        mount();
+        expect(node('epics-datagrid')).toBeNull();
+    });
+
+    it('holds the grid until the category labels land', () => {
+        loading = { epics: false, features: false, categories: true };
+        mount();
+        expect(node('epics-datagrid')).toBeNull();
+    });
+});
+
+describe('EpicsPage — connection to the features view', () => {
+    it('navigates to the epic-filtered features view from the Features cell', () => {
+        mount();
+        click(node('epic-features-link-4'));
+        expect(navigations).toEqual(['/swarm/features?epic=4']);
+    });
+
+    it('navigates even when the epic has no features yet', () => {
+        mount();
+        click(node('epic-features-link-9'));
+        expect(navigations).toEqual(['/swarm/features?epic=9']);
+    });
+});
+
+describe('EpicsPage create', () => {
+    // The default category is the first OPEN one BY SORT ORDER (id 577), not
+    // the first row the read returned (id 1) and not the closed id 900, which
+    // sorts ahead of both.
+    it('POSTs the trimmed title with a null description and the first open category', async () => {
+        mount();
+        click(node('epic-add'));
+        type(node('epic-title-input'), '  New Epic  ');
+        click(node('epic-save'));
+        await flush();
+
+        expect(restCalls).toEqual([{
+            uri: 'http://test.local/darwin/epics',
+            method: 'POST',
+            body: { title: 'New Epic', description: null, category_fk: 577, sort_order: null },
+        }]);
+    });
+
+    it('never pre-selects a CLOSED category, even one that sorts first', () => {
+        mount();
+        click(node('epic-add'));
+        // Reached through the same dialog the save reads from, so this pins the
+        // rendered choice rather than the payload alone.
+        expect(node('epic-category-select').textContent).toContain('Mapping');
+    });
+
+    it('sends a real integer sort_order when one is given', async () => {
+        mount();
+        click(node('epic-add'));
+        type(node('epic-title-input'), 'Ordered');
+        type(node('epic-sort-order-input'), '12');
+        click(node('epic-save'));
+        await flush();
+
+        expect(restCalls[0].body.sort_order).toBe(12);
+    });
+
+    it('refuses to submit a blank title', async () => {
+        mount();
+        click(node('epic-add'));
+        type(node('epic-title-input'), '   ');
+        expect(node('epic-save').disabled).toBe(true);
+        click(node('epic-save'));
+        await flush();
+        expect(restCalls).toEqual([]);
+    });
+});
+
+describe('EpicsPage sort order validation', () => {
+    // The dangerous case: "invalid" and "empty" both look like a missing number,
+    // but only one of them should reach the wire as a clear-the-column.
+    // Both refusals assert the MESSAGE as well as the silence: "sent nothing and
+    // said nothing" is a sibling of the defect being fixed, and `restCalls === []`
+    // alone cannot tell the two apart.
+    it('refuses a fractional sort order instead of silently clearing the column', async () => {
+        mount();
+        click(node('epic-edit-4'));
+        type(node('epic-sort-order-input'), '4.5');
+        click(node('epic-save'));
+        await flush();
+        expect(restCalls).toEqual([]);
+        expect(snackMessage()).toContain('whole number');
+    });
+
+    it('refuses a value wider than the SMALLINT column', async () => {
+        mount();
+        click(node('epic-edit-4'));
+        type(node('epic-sort-order-input'), '40000');
+        click(node('epic-save'));
+        await flush();
+        expect(restCalls).toEqual([]);
+        expect(snackMessage()).toContain('32767');
+    });
+
+    it('sends 0 as a real position, never as a clear', async () => {
+        // `0` is falsy and a legitimate sort_order (a live category uses it) —
+        // the one value most likely to be lost by an `|| REST_NULL` shortcut.
+        mount();
+        click(node('epic-edit-4'));
+        type(node('epic-sort-order-input'), '0');
+        click(node('epic-save'));
+        await flush();
+        expect(restCalls[0].body[0].sort_order).toBe(0);
+    });
+
+    it('accepts a negative whole number', async () => {
+        mount();
+        click(node('epic-edit-4'));
+        type(node('epic-sort-order-input'), '-3');
+        click(node('epic-save'));
+        await flush();
+        expect(restCalls[0].body[0].sort_order).toBe(-3);
+    });
+});
+
+describe('EpicsPage edit', () => {
+    it('PUTs an array carrying the id and every editable column', async () => {
+        mount();
+        click(node('epic-edit-4'));
+        type(node('epic-title-input'), 'Pipeline v2');
+        click(node('epic-save'));
+        await flush();
+
+        expect(restCalls).toEqual([{
+            uri: 'http://test.local/darwin/epics',
+            method: 'PUT',
+            body: [{
+                id: 4,
+                title: 'Pipeline v2',
+                description: 'Plans as data.\n\nSecond para.',
+                category_fk: 1,
+                sort_order: 4,
+            }],
+        }]);
+    });
+
+    it("clears an emptied description with the REST 'NULL' sentinel, not a JSON null", async () => {
+        mount();
+        click(node('epic-edit-4'));
+        type(node('epic-description-input'), '');
+        click(node('epic-save'));
+        await flush();
+
+        expect(restCalls[0].body[0].description).toBe('NULL');
+    });
+
+    it("clears an emptied sort order with the same sentinel", async () => {
+        mount();
+        click(node('epic-edit-4'));
+        type(node('epic-sort-order-input'), '');
+        click(node('epic-save'));
+        await flush();
+
+        expect(restCalls[0].body[0].sort_order).toBe('NULL');
+    });
+
+    it('opens the dialog pre-filled from the row it was launched on', () => {
+        mount();
+        click(node('epic-edit-2'));
+        expect(node('epic-title-input').value).toBe('Application Backlog');
+        expect(node('epic-description-input').value).toBe('');
+        expect(node('epic-sort-order-input').value).toBe('1');
+    });
+});
+
+describe('EpicsPage closed toggle', () => {
+    it('closes an open epic with a one-field PUT', async () => {
+        mount();
+        click(node('epic-toggle-closed-4'));
+        await flush();
+        expect(restCalls).toEqual([{
+            uri: 'http://test.local/darwin/epics',
+            method: 'PUT',
+            body: [{ id: 4, closed: 1 }],
+        }]);
+    });
+
+    it('re-opens a closed epic', async () => {
+        mount();
+        click(node('epics-closed-chip-closed'));
+        click(node('epic-toggle-closed-7'));
+        await flush();
+        expect(restCalls[0].body).toEqual([{ id: 7, closed: 0 }]);
+    });
+});
+
+describe('EpicsPage delete', () => {
+    it('does nothing when the confirmation is declined', async () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(false);
+        mount();
+        click(node('epic-delete-4'));
+        await flush();
+        expect(restCalls).toEqual([]);
+    });
+
+    it('names the unfiling consequence in the confirmation', () => {
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+        mount();
+        click(node('epic-delete-4'));
+        expect(confirmSpy.mock.calls[0][0]).toContain('2 features will be unfiled');
+    });
+
+    it('DELETEs by id and invalidates every cache the SET NULL touches', async () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        mount();
+        click(node('epic-delete-4'));
+        await flush();
+
+        expect(restCalls).toEqual([{
+            uri: 'http://test.local/darwin/epics',
+            method: 'DELETE',
+            body: { id: 4 },
+        }]);
+        const keys = queryClient.invalidateQueries.mock.calls.map(c => c[0].queryKey);
+        expect(keys.map(k => k[0])).toContain('epics');
+        expect(keys.map(k => k[0])).toContain('features');
+        // The WHOLE key, not just its first element. req #3186's
+        // swarm_sessions.epic_fk is ON DELETE SET NULL too, and the only
+        // component that renders it reads through the byId key
+        // ['swarm_sessions', {id}] — a SIBLING of the list key
+        // ['swarm_sessions', creatorFk], not a descendant. Asserting
+        // `queryKey[0] === 'swarm_sessions'` is satisfied by the list key, which
+        // misses the detail row entirely; only the bare entity root reaches it.
+        expect(keys).toContainEqual(['swarm_sessions']);
+    });
+});

--- a/src/Epics/epicsApi.js
+++ b/src/Epics/epicsApi.js
@@ -1,0 +1,71 @@
+// Mutation utilities for the epics data type (req #3139).
+//
+// Epics are the top tier of Epic > Feature > Story (req #3111, migration 076).
+// The frontend has read them since req #3114 (`useAllEpics`, `useEpicById`) but
+// had no write path at all — the only epic surfaces were the plan visualizer's
+// epic chip and the `/swarm/features?epic=<id>` filter it navigates to. This
+// module is the write half, and it goes through the SAME gateway path the MCP
+// epic service (`darwin-mcp/services/epics.py`, req #3146) already POSTs, PUTs
+// and DELETEs: `{darwinUri}/epics`. No new backend surface exists or is needed.
+//
+// Pattern mirrors Customers/customersApi.js — call_rest_api directly, callers
+// handle TanStack Query cache invalidation via queryClient.invalidateQueries.
+//
+// Column shape (measured against the live schema via services/epics.py):
+//   title        NOT NULL
+//   description  nullable TEXT
+//   category_fk  required, ON DELETE RESTRICT — an epic always has a category
+//   sort_order   nullable INT
+//   closed       0 | 1
+
+import call_rest_api from '../RestApi/RestApi';
+
+const isOk = (status) => status === 200 || status === 201 || status === 204;
+
+// Only ever reached for the status call_rest_api RETURNS rather than throws —
+// the synthetic 503 it manufactures for a transport-level failure. Every
+// gateway error (4xx/5xx) is thrown from call_rest_api as a bare
+// `{data, httpStatus}` object and never arrives here at all. The thrown Error
+// carries `httpStatus` so that BOTH shapes read identically to
+// useSnackBarStore's two-argument form, which renders the status code beside
+// the caller's message.
+function assertOk(result, action) {
+    const status = result.httpStatus?.httpStatus;
+    if (!isOk(status)) {
+        const msg = result.httpStatus?.httpMessage || 'unknown';
+        const error = new Error(`${action} failed: HTTP ${status} ${msg}`);
+        error.httpStatus = result.httpStatus;
+        throw error;
+    }
+    return result.data;
+}
+
+// Lambda-Rest's PUT convention: the literal string 'NULL' clears a column; a
+// JSON null is not the sentinel it recognizes there (same rule the MCP
+// `update_epic` obeys). POST is different — it takes a real null — so this is
+// applied on the PUT path only.
+export const REST_NULL = 'NULL';
+
+export async function createEpic(darwinUri, idToken,
+    { title, description = null, category_fk, sort_order = null }) {
+    const r = await call_rest_api(`${darwinUri}/epics`, 'POST',
+        { title, description, category_fk, sort_order }, idToken);
+    return assertOk(r, 'createEpic');
+}
+
+// `fields` is a partial update. Nullable columns the caller wants CLEARED must
+// arrive as REST_NULL; EpicsPage's dialog does that conversion where it knows
+// which fields are nullable, rather than this transport guessing from a falsy
+// value (an empty-string title and a cleared description are not the same act).
+export async function updateEpic(darwinUri, idToken, id, fields) {
+    const r = await call_rest_api(`${darwinUri}/epics`, 'PUT', [{ id, ...fields }], idToken);
+    return assertOk(r, 'updateEpic');
+}
+
+// Hard delete. Nothing RESTRICTs an epic's own deletion: `features.epic_fk` and
+// `swarm_sessions.epic_fk` are both ON DELETE SET NULL, so the rows that pointed
+// at it are unfiled by the database, never destroyed. Callers warn accordingly.
+export async function deleteEpic(darwinUri, idToken, id) {
+    const r = await call_rest_api(`${darwinUri}/epics`, 'DELETE', { id }, idToken);
+    return assertOk(r, 'deleteEpic');
+}

--- a/src/Features/FeaturesPage.jsx
+++ b/src/Features/FeaturesPage.jsx
@@ -9,7 +9,7 @@
 //   - Coverage dot (green ≥1 link / red 0 links) computed client-side
 
 import { useState, useMemo, useContext, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
 import AuthContext from '../Context/AuthContext';
@@ -71,6 +71,7 @@ export default function FeaturesPage() {
     const { darwinUri } = useContext(AppContext);
     const queryClient = useQueryClient();
     const showError = useSnackBarStore(s => s.showError);
+    const navigate = useNavigate();
 
     const [view, setView] = useViewPreference(VIEW_KEY, 'cards');
     const [dialogOpen, setDialogOpen] = useState(false);
@@ -249,10 +250,17 @@ export default function FeaturesPage() {
                 </ToggleButtonGroup>
 
                 {epicFilter !== null && (
+                    // Req #3139 — the chip is now the way BACK to the epic that
+                    // filtered this view. Clicking the body opens the Epics
+                    // editor; the ✕ keeps its original job of clearing the
+                    // filter, and MUI routes the delete icon's click to
+                    // onDelete alone, so the two never fire together.
                     <Chip size="small" color="secondary"
                           label={`Epic: ${epics.find(e => e.id === epicFilter)?.title || epicFilter}`}
+                          onClick={() => navigate('/swarm/epics')}
+                          title="Open the Epics editor"
                           onDelete={clearEpicFilter}
-                          sx={{ flexShrink: 0 }}
+                          sx={{ flexShrink: 0, cursor: 'pointer' }}
                           data-testid="epic-filter-chip" />
                 )}
 

--- a/src/Features/__tests__/FeaturesPage.epicChip.test.jsx
+++ b/src/Features/__tests__/FeaturesPage.epicChip.test.jsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+//
+// Req #3139 — the epic filter chip on /swarm/features is now the way BACK to
+// the Epics editor.
+//
+// One chip, two controls: the body navigates, the ✕ clears the filter. That
+// split rests entirely on MUI stopping propagation inside its own delete-icon
+// handler before calling onDelete — a library internal, not our code. If a MUI
+// upgrade ever drops it, dismissing the filter would silently navigate away
+// from the page the user is standing on instead, and nothing else in the suite
+// would notice. Hence a test that owns the assumption rather than inheriting it.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const navigations = [];
+let searchParams;
+const setSearchParams = vi.fn((next) => { searchParams = next; });
+
+vi.mock('react-router-dom', async (importOriginal) => ({
+    ...(await importOriginal()),
+    useNavigate: () => (to) => navigations.push(to),
+    useSearchParams: () => [searchParams, setSearchParams],
+}));
+
+vi.mock('../../hooks/useDataQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        useAllFeatures: () => ({ data: [], isLoading: false }),
+        useAllEpics: () => ({ data: [{ id: 4, title: 'Pipeline' }] }),
+        useAllCategories: () => ({ data: [] }),
+        useFeatureTestCaseLinks: () => ({ data: [] }),
+    };
+});
+
+vi.mock('../../RestApi/RestApi', () => ({
+    default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })),
+}));
+
+import FeaturesPage from '../FeaturesPage';
+import AuthContext from '../../Context/AuthContext';
+import AppContext from '../../Context/AppContext';
+
+let mountedRoots = [];
+
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0, refetchOnWindowFocus: false } },
+    });
+    const root = createRoot(container);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local/darwin' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <FeaturesPage />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    mountedRoots.push(root);
+}
+
+const chip = () => document.body.querySelector('[data-testid="epic-filter-chip"]');
+
+beforeEach(() => {
+    navigations.length = 0;
+    setSearchParams.mockClear();
+    mountedRoots = [];
+    searchParams = new URLSearchParams('epic=4');
+    // 'cards' is the default view; keep the DataGrid out of jsdom entirely.
+    localStorage.clear();
+});
+
+afterEach(() => {
+    act(() => { mountedRoots.forEach(r => r.unmount()); });
+    document.body.innerHTML = '';
+});
+
+describe('FeaturesPage epic filter chip (req #3139)', () => {
+    it('renders the filtering epic by title', () => {
+        mount();
+        expect(chip()).not.toBeNull();
+        expect(chip().textContent).toContain('Epic: Pipeline');
+    });
+
+    it('opens the Epics editor when the chip body is clicked', () => {
+        mount();
+        act(() => { chip().click(); });
+        expect(navigations).toEqual(['/swarm/epics']);
+    });
+
+    it('clears the filter — and does NOT navigate — when the ✕ is clicked', () => {
+        mount();
+        const deleteIcon = chip().querySelector('.MuiChip-deleteIcon');
+        expect(deleteIcon).not.toBeNull();
+        act(() => { deleteIcon.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+        expect(navigations).toEqual([]);
+        expect(setSearchParams).toHaveBeenCalledTimes(1);
+        expect(setSearchParams.mock.calls[0][0].get('epic')).toBeNull();
+    });
+
+    it('renders no chip at all when no epic filter is applied', () => {
+        searchParams = new URLSearchParams('');
+        mount();
+        expect(chip()).toBeNull();
+    });
+});

--- a/src/NavBar/__tests__/navConfig.test.js
+++ b/src/NavBar/__tests__/navConfig.test.js
@@ -60,6 +60,43 @@ describe('navConfig — Sessions sub-items', () => {
     });
 });
 
+// Req #3139 — the Epics editor is an L2 entry directly under Pipelines. The
+// spec is positional ("goes where pipelines L2 is"), so position is what these
+// pin: a later nav edit that appends Epics to the end of the swarm group would
+// satisfy every other assertion in this file and still be wrong.
+describe('navConfig — Epics editor placement (req #3139)', () => {
+    const EPICS_PATH = '/swarm/epics';
+    const PIPELINES_PATH = '/swarm/pipelines';
+
+    it('registers Epics as an L2 link in the swarm group', () => {
+        const epics = NAV_LINKS.find(l => l.path === EPICS_PATH);
+        expect(epics).toBeDefined();
+        expect(epics.group).toBe('swarm');
+        expect(epics.label).toBe('Epics');
+        expect(epics.icon).toBeTruthy();
+    });
+
+    it('places Epics immediately after Pipelines', () => {
+        const paths = NAV_LINKS.map(l => l.path);
+        expect(paths.indexOf(EPICS_PATH)).toBe(paths.indexOf(PIPELINES_PATH) + 1);
+    });
+
+    it('keeps Epics a SIBLING of Pipelines, never a child of it', () => {
+        // An epic is not a lifecycle record OF a pipeline the way Starts are of
+        // a Session, so it must not acquire req #3209's nesting.
+        const epics = NAV_LINKS.find(l => l.path === EPICS_PATH);
+        expect(epics.children).toBeUndefined();
+        NAV_LINKS.forEach(parent => {
+            expect((parent.children ?? []).map(c => c.path)).not.toContain(EPICS_PATH);
+        });
+    });
+
+    it('leaves Requirements as the swarm group\'s first link', () => {
+        // Same HomePage-redirect invariant the Sessions block above pins.
+        expect(NAV_LINKS.find(l => l.group === 'swarm').path).toBe('/swarm');
+    });
+});
+
 describe('flattenNavLinks', () => {
     it('emits each parent immediately followed by its children', () => {
         const flat = flattenNavLinks([

--- a/src/NavBar/navConfig.js
+++ b/src/NavBar/navConfig.js
@@ -13,6 +13,7 @@ import PlayCircleIcon from '@mui/icons-material/PlayCircle';
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import LanIcon from '@mui/icons-material/Lan';
+import LayersIcon from '@mui/icons-material/Layers';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import BusinessIcon from '@mui/icons-material/Business';
 import UndoIcon from '@mui/icons-material/Undo';
@@ -72,6 +73,14 @@ export const NAV_LINKS = [
     // (Epic > Feature > Story, sequenced into steps), and above Sessions because
     // plan views carry no session data at all (req #3080 design rule 9).
     { path: '/swarm/pipelines', label: 'Pipelines', icon: LanIcon, group: 'swarm' },
+    // Req #3139 — the Epics editor. An L2 SIBLING of Pipelines, not a child of
+    // it: an epic is not a lifecycle record OF a pipeline the way Starts are of
+    // a Session (req #3209's nesting rule), it is the tier the plan is composed
+    // FROM (design rule 10 walks requirement -> feature -> epic for a step's
+    // label). It sits directly under Pipelines because that is where the plan
+    // hierarchy is read from, and above Sessions for the same reason Pipelines
+    // is — plan views carry no session data at all (req #3080 design rule 9).
+    { path: '/swarm/epics', label: 'Epics', icon: LayersIcon, group: 'swarm' },
     // Req #3209 — Sessions is the first L2 item with L3 children. Starts,
     // Completes and Undos are lifecycle records OF a session, not peers of it,
     // so they nest underneath rather than sitting as siblings. They keep their

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -59,6 +59,7 @@ import SwarmCompletesPage from './SwarmCompletes/SwarmCompletesPage';
 import SwarmCompleteDetail from './SwarmCompletes/SwarmCompleteDetail';
 import PipelinesPage from './SwarmView/pipelines/PipelinesPage';
 import PipelineDetail from './SwarmView/pipelines/PipelineDetail';
+import EpicsPage from './Epics/EpicsPage';
 import SystemsPage2 from './Systems/SystemsPage2';
 import BuildVisualizerPage from './BuildVisualizer/BuildVisualizerPage';
 import CustomersPage from './Customers/CustomersPage';
@@ -163,6 +164,12 @@ root.render(
                                                          </AuthenticatedRoute>} />
                     <Route path="swarm/pipeline/:id" element= {<AuthenticatedRoute>
                                                              <PipelineDetail />
+                                                         </AuthenticatedRoute>} />
+                    {/* Epics editor (req #3139) — the top tier of Epic > Feature
+                        > Story, sited beside the pipeline routes because an epic
+                        is what a plan is made of. */}
+                    <Route path="swarm/epics" element= {<AuthenticatedRoute>
+                                                             <EpicsPage />
                                                          </AuthenticatedRoute>} />
                     <Route path="swarm/features" element= {<AuthenticatedRoute>
                                                              <FeaturesPage />


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3139-epic-editor-page-under-the-1
- wip(Darwin): 2026-08-01T13:32:57Z
- chore: init swarm session feature/3139-epic-editor-page-under-the-1

## Files changed
```
 src/Epics/EpicsPage.jsx                            | 538 +++++++++++++++++++++
 src/Epics/__tests__/EpicsPage.test.jsx             | 449 +++++++++++++++++
 src/Epics/epicsApi.js                              |  71 +++
 src/Features/FeaturesPage.jsx                      |  12 +-
 .../__tests__/FeaturesPage.epicChip.test.jsx       | 118 +++++
 src/NavBar/__tests__/navConfig.test.js             |  37 ++
 src/NavBar/navConfig.js                            |   9 +
 src/index.jsx                                      |   7 +
 8 files changed, 1239 insertions(+), 2 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)