### PR TITLE
L1 not display step name

### DIFF
--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -703,20 +703,28 @@ export default function PipelinePlanVisualizer({
     // Every label kind asks this and nothing else, and the container publishes
     // the answer as `data-drawn`. Two reasons, both learned here:
     //
-    //   · The canvas is a bitmap, so "Overview now draws step labels" is
-    //     otherwise unfalsifiable — a screenshot at L1 looks the same whether the
-    //     labels are there or not unless you already have the other version to
+    //   · The canvas is a bitmap, so "Overview omits step labels" is otherwise
+    //     unfalsifiable — a screenshot at L1 looks the same whether the labels
+    //     are there or not unless you already have the other version to
     //     compare against, and a test that pins L1 twice and compares proves
     //     nothing. Same argument as `data-transform`, which exists because a pan
     //     is only observable as changed pixels.
     //   · The three early returns it replaces were three places to get the ladder
     //     wrong, and the attribute would have been a fourth.
     //
-    // STEP LABELS DRAW AT EVERY LEVEL (user directive 2026-08-01) — Overview used
-    // to be beads and arcs with nothing naming them, which is the one level a
-    // reader opens to see the shape of a plan.
+    // STEP LABELS ARE GATED LIKE REQUIREMENT MARKS (req #3221) — a step name is
+    // per-step detail the same as a requirement id, so it shares that gate
+    // rather than drawing unconditionally. This does not clear Overview down to
+    // bare beads and arcs: the ruler's slot ticks, the batch letters and the
+    // epic band names are drawn elsewhere in this component and are not asked
+    // through `drawsKind` at all, so they keep drawing at every level — the
+    // `return true` fallback below exists for THEM, not as a default nobody
+    // reaches. This gate is draw-only: `computePlanLayout` reserves the step
+    // label's rect at every level regardless (the zero-overlap invariant is
+    // asserted against it unconditionally), so hiding it here never moves
+    // anything else.
     const drawsKind = useCallback((kind) => {
-        if (kind === 'req') return level !== 'out';
+        if (kind === 'step' || kind === 'req') return level !== 'out';
         if (kind === 'title') return level === 'in';
         return true;
     }, [level]);

--- a/tests/tests/pipelines.spec.ts
+++ b/tests/tests/pipelines.spec.ts
@@ -1332,7 +1332,7 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             await expect(reqScale).toBeVisible();
         });
 
-    // ── PIPE-16: step labels at every level, and the L1/L2/L3/Auto selector ──
+    // ── PIPE-16: what's drawn is gated by level, and the L1/L2/L3/Auto selector ──
 
     test('PIPE-16: the level selector pins what is DRAWN without moving the camera',
         async ({ page }) => {
@@ -1386,25 +1386,28 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             await expect(container).toHaveAttribute('data-level', 'mid');
             await expect(chip).not.toContainText('pinned');
 
-            // 4. STEP LABELS DRAW AT EVERY LEVEL, Overview included (user
-            //    directive 2026-08-01). The canvas is a bitmap, so the component
-            //    publishes which label kinds it drew — `data-drawn`, the same
+            // 4. STEP/REQ/TITLE ARE GATED, EACH ON ITS OWN CONDITION (req #3221).
+            //    `data-drawn` only ever enumerates these three kinds — the ruler's
+            //    slot ticks, the batch letters and the epic band names are NOT
+            //    level-gated and draw at every level regardless (see `drawsKind`'s
+            //    `return true` fallback), so this attribute proves the ladder for
+            //    the three kinds it tracks, not "Overview draws nothing" in
+            //    absolute terms. The canvas is a bitmap, so the component
+            //    publishes which of the three it drew — `data-drawn`, the same
             //    device as `data-transform` beside it and for the same reason: a
-            //    screenshot at Overview looks identical whether the labels are
+            //    screenshot at Overview looks identical whether the step label is
             //    there or not unless you already hold the other version, so a
             //    pixel comparison here would prove nothing.
             //
-            //    The ladder itself is asserted whole, because "step at every
-            //    level" is only meaningful next to the kinds that ARE gated.
-            const drawnAt = async (lvl: string) => {
+            //    The ladder itself is asserted whole, because "gated at L1" is
+            //    only meaningful next to the kinds that draw at every level.
+            const drawnAt = async (lvl: string, expected: string, message: string) => {
                 await page.getByTestId(`pipeline-viz-level-${lvl}`).click();
-                return container.getAttribute('data-drawn');
+                await expect(container, message).toHaveAttribute('data-drawn', expected);
             };
-            expect(await drawnAt('1'), 'Overview draws step labels').toBe('step');
-            expect(await drawnAt('2'), 'Plan adds the requirement marks')
-                .toBe('step,req');
-            expect(await drawnAt('3'), 'Detail adds the per-step title slot')
-                .toBe('step,req,title');
+            await drawnAt('1', '', 'Overview draws none of the three gated kinds');
+            await drawnAt('2', 'step,req', 'Plan adds the step name and requirement marks');
+            await drawnAt('3', 'step,req,title', 'Detail adds the per-step title slot');
             // And the plan really has step labels to draw, or the attribute
             // above would be describing an empty set.
             const layout = computePlanLayout(plan.rows, plan.batches,


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-01T13:25:27Z
- chore: init swarm session feature/3221-l1-not-display-step-name-1

## Files changed
```
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx | 22 ++++++++++-----
 tests/tests/pipelines.spec.ts                      | 31 ++++++++++++----------
 2 files changed, 32 insertions(+), 21 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)