### PR TITLE
Step editor page under the pipeline visualizer

### DIFF
--- a/src/NavBar/__tests__/navConfig.test.js
+++ b/src/NavBar/__tests__/navConfig.test.js
@@ -97,6 +97,46 @@ describe('navConfig — Epics editor placement (req #3139)', () => {
     });
 });
 
+// Req #3140 — the Steps editor completes feature 37's Pipelines > Epics > Steps
+// L2 cluster. Same positional spec as #3139 ("goes where pipelines L2 is"), so
+// position is again what these pin: appending Steps to the end of the swarm group
+// would satisfy every other assertion in this file and still be wrong.
+describe('navConfig — Steps editor placement (req #3140)', () => {
+    const STEPS_PATH = '/swarm/steps';
+    const EPICS_PATH = '/swarm/epics';
+    const PIPELINES_PATH = '/swarm/pipelines';
+
+    it('registers Steps as an L2 link in the swarm group', () => {
+        const steps = NAV_LINKS.find(l => l.path === STEPS_PATH);
+        expect(steps).toBeDefined();
+        expect(steps.group).toBe('swarm');
+        expect(steps.label).toBe('Steps');
+        expect(steps.icon).toBeTruthy();
+    });
+
+    it('keeps Pipelines, Epics and Steps contiguous, in that order', () => {
+        const paths = NAV_LINKS.map(l => l.path);
+        const pipelines = paths.indexOf(PIPELINES_PATH);
+        expect(paths.indexOf(EPICS_PATH)).toBe(pipelines + 1);
+        expect(paths.indexOf(STEPS_PATH)).toBe(pipelines + 2);
+    });
+
+    it('keeps Steps a SIBLING of Pipelines, never a child of it', () => {
+        // A step is a MEMBER of a plan, not a lifecycle record OF one, so it must
+        // not acquire req #3209's nesting.
+        const steps = NAV_LINKS.find(l => l.path === STEPS_PATH);
+        expect(steps.children).toBeUndefined();
+        NAV_LINKS.forEach(parent => {
+            expect((parent.children ?? []).map(c => c.path)).not.toContain(STEPS_PATH);
+        });
+    });
+
+    it('leaves Requirements as the swarm group\'s first link', () => {
+        // Same HomePage-redirect invariant the blocks above pin.
+        expect(NAV_LINKS.find(l => l.group === 'swarm').path).toBe('/swarm');
+    });
+});
+
 describe('flattenNavLinks', () => {
     it('emits each parent immediately followed by its children', () => {
         const flat = flattenNavLinks([

--- a/src/NavBar/navConfig.js
+++ b/src/NavBar/navConfig.js
@@ -14,6 +14,7 @@ import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import LanIcon from '@mui/icons-material/Lan';
 import LayersIcon from '@mui/icons-material/Layers';
+import LinearScaleIcon from '@mui/icons-material/LinearScale';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import BusinessIcon from '@mui/icons-material/Business';
 import UndoIcon from '@mui/icons-material/Undo';
@@ -81,6 +82,14 @@ export const NAV_LINKS = [
     // hierarchy is read from, and above Sessions for the same reason Pipelines
     // is — plan views carry no session data at all (req #3080 design rule 9).
     { path: '/swarm/epics', label: 'Epics', icon: LayersIcon, group: 'swarm' },
+    // Req #3140 — the Steps editor, the third page of feature 37 "Plan Editors"
+    // and the last of the Pipelines > Epics > Steps L2 cluster. A SIBLING for the
+    // same reason Epics is: req #3209's nesting is for lifecycle records OF a
+    // thing, and a step is a MEMBER of a plan, not a record about one. It sits
+    // after Epics rather than displacing it because the cluster reads top-down as
+    // the plan itself (Pipelines) and then what it is composed of — and because
+    // #3139 pinned Epics at Pipelines + 1.
+    { path: '/swarm/steps', label: 'Steps', icon: LinearScaleIcon, group: 'swarm' },
     // Req #3209 — Sessions is the first L2 item with L3 children. Starts,
     // Completes and Undos are lifecycle records OF a session, not peers of it,
     // so they nest underneath rather than sitting as siblings. They keep their

--- a/src/Steps/StepsPage.jsx
+++ b/src/Steps/StepsPage.jsx
@@ -1,0 +1,975 @@
+// /swarm/steps — the Steps editor (req #3140).
+//
+// The third page of feature 37 "Plan Editors": formal editor pages for the plan's
+// own entities — epics (req #3139), features, and steps — reached as second-level
+// navigation under Pipelines, alongside the plan views that render them. It is an
+// L2 SIBLING of Pipelines and Epics, never a child: req #3209's nesting is for
+// lifecycle records OF a thing (Starts are of a Session), and a step is a member
+// of a plan, not a record about one.
+//
+// Shape follows EpicsPage, which follows MachinesView: one DataGrid, click-to-
+// toggle chips, one dialog for create and edit, no cards/trends views. Not a
+// `ViewerHeader` page (memory/darwin-viewer-pages.md) for the reason recorded
+// there — that contract is for a dataset shown through MORE THAN ONE
+// presentation and mandates a ToggleButtonGroup even at length 1.
+//
+// ## "connects to the existing Step editor"
+//
+// There is no step-editing component in Darwin today; every step in production
+// was written by the Primary AI through the MCP tools. The existing step SURFACE
+// is the plan table and plan visualizer at /swarm/pipeline/:id, which already
+// scroll to and highlight a `focusStepId` (the req #3115 bead-click handshake).
+// So the connection is the Pipeline cell: it deep-links to that plan FOCUSED ON
+// THIS STEP, via `pipelineStepLink.js`, which owns both halves of the URL
+// contract. Exactly the move req #3139 made with its Features count cell.
+//
+// ## What this page edits, and what it deliberately does not
+//
+// A step's OWN COLUMNS: `title`, `notes`, `run`, and `completed_at`.
+//
+// NOT `pipeline_step_requirements` and NOT `pipeline_step_deps`. Those are the
+// coordinator's, and mutating one is half of an atomic act — req #3083's
+// operating rule, *plan edit and launch are ONE action, never two*, recorded
+// after step 13's five sessions ran while the plan still read "Scheduled". A
+// browser form that unlinks a requirement while the 2.0 orchestration engine is
+// polling that plan would race the launch decision with no error anywhere, and
+// `set_step_deps` has REPLACE semantics where a lost update is silent. Links and
+// dependencies render read-only, with their ids on hover. This is the same line
+// EpicsPage draws: it edits an epic's columns and never a feature's `epic_fk`.
+//
+// NOT `pipeline_fk` on an existing step, either — the MCP's own rule: *a step's
+// plan membership is its identity; drop it and create it in the other plan, which
+// forces the dependency question to be answered rather than silently broken.*
+// Moving a step would leave its dep rows pointing across plans, which the engine
+// cannot order and `set_step_deps` rejects loudly.
+//
+// ## Reads
+//
+// Seven bounded list reads, ALL of them ones the plan pages already use, so
+// arriving from /swarm/pipelines or /swarm/pipeline/:id paints from cache with
+// zero fetches (design rule 5; memory/detail-page-interlinking.md's composition
+// rule). `useAllRequirements` is asked for PLAN_REQUIREMENT_FIELDS specifically —
+// `fields` is in that hook's cache key, so a different projection here would be a
+// second cache entry and a guaranteed refetch of the whole requirements table.
+//
+// Machines are deliberately NOT read. The engine derives a `machineLabel` for
+// every row, but a machine is a LAUNCH parameter belonging to the plan view, and
+// this page shows no such column — so the read would cost a request to populate a
+// field nothing renders.
+
+import { useContext, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import Button from '@mui/material/Button';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import InputLabel from '@mui/material/InputLabel';
+import FormControl from '@mui/material/FormControl';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+import AuthContext from '../Context/AuthContext';
+import AppContext from '../Context/AppContext';
+import {
+    ALL_ROWS,
+    useAllEpics,
+    useAllFeatures,
+    useAllPipelineStepDeps,
+    useAllPipelineStepRequirements,
+    useAllPipelineSteps,
+    useAllPipelines,
+    useAllRequirements,
+} from '../hooks/useDataQueries';
+import {
+    pipelineStepKeys,
+    pipelineStepDepKeys,
+    pipelineStepRequirementKeys,
+} from '../hooks/useQueryKeys';
+import { useSnackBarStore } from '../stores/useSnackBarStore';
+import ChipFilter from '../Components/ChipFilter/ChipFilter';
+import { formatDateTime } from '../utils/dateFormat';
+import { PLAN_REQUIREMENT_FIELDS } from '../SwarmView/pipelines/pipelineViewModel';
+import {
+    runChipProps,
+    runLabel,
+    stepStateChipProps,
+    stepStateLabel,
+} from '../SwarmView/pipelines/pipelineChipStyles';
+import { stepLinkTo } from '../SwarmView/pipelines/pipelineStepLink';
+import {
+    STEP_DONE,
+    STEP_PENDING,
+    STEP_RUNNING,
+    buildStepEditorRows,
+    completionGuard,
+    filterStepRows,
+    gatingRequirementIds,
+    stepsAccounting,
+} from './stepsModel';
+import {
+    REST_NULL,
+    VALID_RUN_MODES,
+    completeStep,
+    createStep,
+    deleteStep,
+    fetchRequirementTracking,
+    fetchStepRequirementIds,
+    isRestNullLiteral,
+    reopenStep,
+    updateStep,
+} from './stepsApi';
+
+// Explicit chipProps rather than the ChipFilter palette, for EpicsPage's reason:
+// step state is a fixed three-value VOCABULARY with colours the plan table has
+// used since req #3114, and letting the palette hash them would put the same word
+// in two colours on two pages. `stepStateChipProps` is that vocabulary.
+const STATE_FILTER_OPTIONS = [
+    { value: STEP_PENDING, label: stepStateLabel(STEP_PENDING),
+        chipProps: stepStateChipProps(STEP_PENDING) },
+    { value: STEP_RUNNING, label: stepStateLabel(STEP_RUNNING),
+        chipProps: stepStateChipProps(STEP_RUNNING) },
+    { value: STEP_DONE, label: stepStateLabel(STEP_DONE),
+        chipProps: stepStateChipProps(STEP_DONE) },
+];
+
+// VARCHAR(256) — the column's real width. Without the cap a longer title reaches
+// MySQL, fails 1406, and comes back as an opaque 500 (the RequirementRow rule).
+const TITLE_MAX = 256;
+
+// The sentinel the Pipeline filter uses for "every plan". A real pipeline id can
+// never be '' , and `filterStepRows` takes null for all — so the Select holds the
+// string and the memo below converts.
+const ALL_PIPELINES = '';
+
+// Collapse prose to one line for a grid cell. Step notes are multi-sentence (see
+// darwin://pipeline/2) and a raw multi-line value renders as a single clipped
+// line with the newlines swallowed anyway — this at least keeps the words on
+// either side of a break from running together.
+const oneLine = (value) => (value ? String(value).replace(/\s+/g, ' ').trim() : '');
+
+// Requirement ids for a hover, marking the containers. A tracking requirement is
+// linked but never gates (req #3123), and a reader looking at a step that says
+// "3 requirements — Scheduled" needs to see which of them the derivation ignored.
+const reqIdSummary = (row) => {
+    const ids = row.reqIds || [];
+    if (!ids.length) return 'No requirements linked — this step is completed by hand.';
+    const tracking = new Set(row.trackingReqIds || []);
+    const unresolved = new Set(row.unresolvedReqIds || []);
+    return ids.map((id) => {
+        if (tracking.has(id)) return `${id} (tracking)`;
+        if (unresolved.has(id)) return `${id} (not found)`;
+        return String(id);
+    }).join(', ');
+};
+
+// Why a delete is refused, as a clause. ONE place, because the tooltip and the
+// snackbar say the same thing and must not drift.
+//
+// The verb agrees. "step 10 depend on it" reads as a rendering fault, and since
+// `dropBlockers` counts a self-dependency (InnoDB does — see its docstring) the
+// worst version of that was reachable: "Step 11 cannot be deleted: step 11 depend
+// on it", which looks like a bug rather than the correct answer it is. A step
+// blocking itself gets said outright.
+const blockerClause = (row) => {
+    const ids = row.blockerStepIds || [];
+    if (ids.length === 1 && ids[0] === row.id) return 'it depends on itself';
+    return ids.length === 1
+        ? `step ${ids[0]} depends on it`
+        : `steps ${ids.join(', ')} depend on it`;
+};
+
+// "requirement 3050" / "requirements 3050, 3090", with a verb that agrees.
+//
+// A HELPER RATHER THAN A TERNARY AT THE CALL SITE, for the reason `blockerClause`
+// is one: a hand-rolled `${n === 1 ? '' : 's'}` switches the noun and leaves the
+// verb behind, and the singular is the case most readers actually see. That exact
+// slip was written twice in this file before it was factored out both times.
+const requirementClause = (ids, verb) => (
+    ids.length === 1
+        ? `requirement ${ids[0]} ${verb}s`
+        : `requirements ${ids.join(', ')} ${verb}`
+);
+
+// A step's gate, as text. One dep row = ONE condition, and a step may carry both
+// kinds (migration 076 leaves `time_at` rows out of the UNIQUE key precisely so it
+// can), so both are counted and both are named.
+const gateSummary = (row) => {
+    const parts = [];
+    if ((row.depIds || []).length) parts.push(`after step${row.depIds.length === 1 ? '' : 's'} ${row.depIds.join(', ')}`);
+    if ((row.timeDeps || []).length) parts.push(`${row.timeDeps.length} wall-clock gate${row.timeDeps.length === 1 ? '' : 's'}`);
+    return parts.length ? parts.join(' · ') : 'No gate — eligible as soon as the plan is running.';
+};
+
+export default function StepsPage() {
+    const { idToken, profile } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
+    const queryClient = useQueryClient();
+    const showError = useSnackBarStore(s => s.showError);
+    const navigate = useNavigate();
+
+    const creatorFk = profile?.userName;
+    const timezone = profile?.timezone;
+
+    const { data: pipelines = [], isLoading: pipelinesLoading } = useAllPipelines(creatorFk);
+    const { data: steps = [], isLoading: stepsLoading } = useAllPipelineSteps(creatorFk);
+    const { data: stepRequirements = [], isLoading: linksLoading, isError: linksError } =
+        useAllPipelineStepRequirements(creatorFk);
+    const { data: stepDeps = [], isLoading: depsLoading, isError: depsError } =
+        useAllPipelineStepDeps(creatorFk);
+    const { data: requirements = [], isLoading: reqsLoading, isError: reqsError } =
+        useAllRequirements(creatorFk, { fields: PLAN_REQUIREMENT_FIELDS });
+    // Labels are a DICTIONARY here, not a catalog: a closed epic or feature must
+    // still resolve or the Epic column blanks for data it has.
+    const { data: features = [], isLoading: featuresLoading, isError: featuresError } =
+        useAllFeatures(creatorFk, { closed: ALL_ROWS });
+    const { data: epics = [], isLoading: epicsLoading, isError: epicsError } =
+        useAllEpics(creatorFk);
+
+    // EVERY read that feeds a number or a label gates the spinner (the
+    // PipelinesPage rule). They resolve independently: gating on steps alone
+    // paints every State chip as Scheduled — a claim about the plan, not about the
+    // fetch — and a delete confirmed in that window would omit the "its N
+    // requirement links will be removed" clause the confirmation exists to deliver.
+    const isLoading = pipelinesLoading || stepsLoading || linksLoading || depsLoading
+        || reqsLoading || featuresLoading || epicsLoading;
+
+    // ── A FAILED READ IS NOT AN EMPTY ONE, and here that distinction is safety ──
+    //
+    // `fetchEntity` turns a 404 into `[]` and a 5xx leaves `data` undefined, so on
+    // failure the `= []` defaults above make every read look like a table with no
+    // rows. `isLoading` says nothing about it: a failed query is settled, not
+    // loading. Two consequences, and they are not the same size:
+    //
+    // PLAN DATA — the two junctions and the requirements. Their absence does not
+    // merely blank a column, it silently REVERSES design rule 1: a step whose
+    // links did not load reports zero gating requirements, so the guard reads
+    // `editable` and one click stamps `completed_at` on a requirement-backed step
+    // of a live plan. That stamp is invisible while the requirements exist
+    // (`deriveStepState` ignores it) and surfaces later as a step deriving
+    // Complete from a stamp nobody intended. So this does not just warn — it
+    // BLOCKS the two mutations that depend on knowing the link set.
+    const planDataError = linksError || depsError || reqsError;
+
+    // WHICH read failed, for the messages. One boolean is right for deciding
+    // whether to block; spending it as though it were always the links read makes
+    // the page state a falsehood about the other two — "the requirement links did
+    // not load" when the junctions read fine and the requirements list is what
+    // failed. On a page whose whole argument is *say which it is*, that is the
+    // wrong thing to be sloppy about.
+    const failedReads = [
+        linksError && 'requirement links',
+        depsError && 'dependency rows',
+        reqsError && 'requirement list',
+    ].filter(Boolean);
+    const failedReadsText = failedReads.length > 1
+        ? `${failedReads.slice(0, -1).join(', ')} and ${failedReads[failedReads.length - 1]}`
+        : (failedReads[0] || '');
+
+    // LABELS — features and epics. Nothing here is ORDERED by them (unlike the
+    // plan pages, where display order breaks ties on epic first-appearance), so
+    // the consequence really is bounded to a blank Epic column. Say so rather
+    // than let it read as "these steps have no epic".
+    const dictionaryError = featuresError || epicsError;
+
+    // Plain state, deliberately: unlike PipelinesPage's persisted filter, this
+    // page has no detail route to click into and come back from, so there is no
+    // navigation that could silently forget a chip the user turned on.
+    //
+    // `null` is the ChipFilter default and it means "every state, including ones
+    // that do not exist yet" — the pattern's rule for a dimension backed by data.
+    // Step state is a closed three-value vocabulary so that cannot bite here, but
+    // starting at null is also the honest default for an EDITOR: it opens showing
+    // the whole plan rather than a view of it.
+    const [stateFilter, setStateFilter] = useState(null);
+    const toggleStateFilter = (value) => setStateFilter(current => {
+        const selected = current === null
+            ? STATE_FILTER_OPTIONS.map(o => o.value)
+            : current;
+        return selected.includes(value)
+            ? selected.filter(v => v !== value)
+            : [...selected, value];
+    });
+    const [pipelineFilter, setPipelineFilter] = useState(ALL_PIPELINES);
+
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [editTarget, setEditTarget] = useState(null);
+    const [formPipelineFk, setFormPipelineFk] = useState('');
+    const [formTitle, setFormTitle] = useState('');
+    const [formNotes, setFormNotes] = useState('');
+    const [formRun, setFormRun] = useState('auto');
+    const [submitting, setSubmitting] = useState(false);
+    // Step ids with a completion write in flight — the dialog's `submitting` flag
+    // for a control that has no dialog to disable. `toggleComplete` is a read then
+    // a write, so a double-click starts a second round trip while the first is
+    // still deciding: two GETs, two PUTs, and two timestamps for one intent. A ref
+    // rather than state because the guard has to be seen by the SECOND call
+    // synchronously, before React has re-rendered anything.
+    const completingRef = useRef(new Set());
+
+    // The engine runs here, once, over the reads. See stepsModel.js for why this
+    // page does not derive step state itself.
+    const { rows: allRows, unrenderedStepIds } = useMemo(() => buildStepEditorRows({
+        pipelines, steps, stepRequirements, stepDeps, requirements, features, epics,
+    }), [pipelines, steps, stepRequirements, stepDeps, requirements, features, epics]);
+
+    const rows = useMemo(() => filterStepRows(allRows, {
+        pipelineIds: pipelineFilter === ALL_PIPELINES ? null : [Number(pipelineFilter)],
+        states: stateFilter,
+    }), [allRows, pipelineFilter, stateFilter]);
+
+    // The WHOLE plan, never the filtered view (view-switchable-pages § V7). The
+    // "N of M" line beside it is where the filter's effect is stated.
+    const accounting = useMemo(() => stepsAccounting(allRows), [allRows]);
+
+    // Plans in the order the Pipelines page shows them, so the Select and that
+    // page agree: `useAllPipelines` sorts id:desc, which puts the newest first.
+    const pipelineOptions = useMemo(() => pipelines.map(
+        p => ({ id: p.id, title: p.title })), [pipelines]);
+
+    const invalidateSteps = () =>
+        queryClient.invalidateQueries({ queryKey: pipelineStepKeys.all(creatorFk) });
+
+    const openCreate = () => {
+        setEditTarget(null);
+        // Pre-select the plan the grid is currently filtered to, falling back to
+        // the first plan. `pipeline_fk` is required and ON DELETE RESTRICT, so an
+        // empty default is a dead Create button on a form that looks complete.
+        setFormPipelineFk(pipelineFilter !== ALL_PIPELINES
+            ? Number(pipelineFilter)
+            : (pipelineOptions[0]?.id ?? ''));
+        setFormTitle('');
+        setFormNotes('');
+        setFormRun('auto');
+        setDialogOpen(true);
+    };
+
+    const openEdit = (row) => {
+        setEditTarget(row);
+        setFormPipelineFk(row.pipelineId);
+        setFormTitle(row.title || '');
+        setFormNotes(row.notes || '');
+        setFormRun(VALID_RUN_MODES.includes(row.run) ? row.run : 'auto');
+        setDialogOpen(true);
+    };
+
+    const handleSubmit = async () => {
+        const title = formTitle.trim();
+        const notes = formNotes.trim();
+        if (!title) {
+            showError('Title is required');
+            return;
+        }
+        // `rest_post` and `rest_put` both substitute SQL NULL for the literal
+        // string 'NULL', and `title` is NOT NULL — so this exact input becomes a
+        // MySQL 1048 and an opaque 500 at the gateway. Refuse it here, where the
+        // message can say what actually happened.
+        if (isRestNullLiteral(title)) {
+            showError(`"${REST_NULL}" is the API's clear-this-column sentinel and cannot `
+                + 'be a title. Try "Null" or another wording.');
+            return;
+        }
+        if (!editTarget && (formPipelineFk === '' || formPipelineFk == null)) {
+            showError('Pipeline is required');
+            return;
+        }
+        setSubmitting(true);
+        try {
+            if (editTarget) {
+                // Every editable column is sent, with the nullable one cleared via
+                // the REST 'NULL' sentinel. One code path beats diffing the form
+                // against the row and getting the empty case wrong. `pipeline_fk`
+                // is NOT among them — see the header.
+                await updateStep(darwinUri, idToken, editTarget.id, {
+                    title,
+                    notes: notes || REST_NULL,
+                    run: formRun,
+                });
+            } else {
+                await createStep(darwinUri, idToken, {
+                    pipeline_fk: formPipelineFk,
+                    title,
+                    // POST takes a real null; the 'NULL' string is a PUT-only
+                    // sentinel and would be stored as the literal text.
+                    notes: notes || null,
+                    run: formRun,
+                });
+            }
+            invalidateSteps();
+            setDialogOpen(false);
+        } catch (err) {
+            // TWO-argument form on purpose. call_rest_api THROWS a bare
+            // `{data, httpStatus}` object for every gateway error, so `err.message`
+            // is undefined on exactly the failures worth reporting; the store's
+            // second argument is what renders the status code beside the text.
+            showError(err, editTarget ? 'Could not save step' : 'Could not create step');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const toggleRun = async (row) => {
+        try {
+            await updateStep(darwinUri, idToken, row.id,
+                { run: row.run === 'manual' ? 'auto' : 'manual' });
+            invalidateSteps();
+        } catch (err) {
+            showError(err, 'Could not change the step run mode');
+        }
+    };
+
+    // Design rule 1, and THIS is the only place it is decided. The chip stays
+    // clickable on a derived step deliberately: a control that silently does
+    // nothing teaches nothing, and the reason a step cannot be stamped by hand is
+    // the single most useful thing this page can say about it. So the click lands,
+    // the guard refuses, and the refusal names the requirements — the same shape
+    // the MCP's `complete_pipeline_step` raises rather than a disabled tool.
+    //
+    // Deciding it here rather than in the render is also what makes it correct:
+    // the row can be re-derived between paint and click by an invalidation, and a
+    // stamp on a requirement-backed step is not recoverable by looking at the page
+    // — the plan would go on rendering the derived answer while the column quietly
+    // disagreed.
+    const toggleComplete = async (row) => {
+        // REOPENING is unguarded, matching the MCP's `reopen_pipeline_step`.
+        // Clearing the stamp can only ever move the stored column TOWARDS what a
+        // derived step already reports, so there is nothing to protect and a step
+        // marked done by mistake must always be recoverable — including while
+        // `planDataError` is blocking the other direction, which is why the State
+        // chip reports this row as `reopen` rather than `derived`.
+        if (row.completedAt) {
+            try {
+                await reopenStep(darwinUri, idToken, row.id);
+                invalidateSteps();
+            } catch (err) {
+                showError(err, 'Could not reopen the step');
+            }
+            return;
+        }
+        // One completion per step at a time. Added HERE, released in the single
+        // `finally` below, so no early return can leak the entry.
+        //
+        // The reopen path above gets no such guard, deliberately: it is a bare
+        // idempotent write with no read in front of it, so a double-click sends
+        // `completed_at = NULL` twice and the second is a no-op. What makes the
+        // completion path different is that it DECIDES first — two clicks would
+        // run two independent guard evaluations and land two different timestamps
+        // for one intent.
+        if (completingRef.current.has(row.id)) return;
+        completingRef.current.add(row.id);
+        try {
+            await completeFlow(row);
+        } finally {
+            completingRef.current.delete(row.id);
+        }
+    };
+
+    // The guarded completion itself. Split out only so `toggleComplete` can hold
+    // the in-flight entry across every exit with one try/finally instead of a
+    // release before each of five returns.
+    //
+    // WHAT IT DOES NOT CLOSE: the window between the live re-read and the PUT. The
+    // Primary AI can link a requirement in it, and no client-side check can see
+    // that — closing it needs a server-side conditional write, which is a
+    // Lambda-Rest contract change. The MCP's `complete_pipeline_step` has the
+    // identical window for the identical reason. What the re-read removes is the
+    // 30-second one, which is the reachable one.
+    const completeFlow = async (row) => {
+        if (planDataError) {
+            showError(`Step ${row.id} cannot be completed: the ${failedReadsText} did not `
+                + 'load, so there is no way to tell whether its state is derived. Reload first.');
+            return;
+        }
+        const cached = completionGuard(row);
+        if (!cached.allowed) {
+            showError(`Step ${row.id} is derived from its requirements. ${cached.reason}`);
+            return;
+        }
+
+        // THE CACHED GUARD IS NOT ENOUGH — it is the fast path, not the rule.
+        // `staleTime` is 30s and the Primary AI links requirements onto steps of
+        // the live plan while this page is open, so the grid can be showing a
+        // link set that is half a minute out of date. Re-read this one step's
+        // links before writing, exactly as `complete_pipeline_step` does.
+        //
+        // A FAILED re-read refuses the stamp. "I could not check" and "there is
+        // nothing to check" are different answers, and only one of them permits a
+        // write.
+        let liveGating;
+        let liveTracking;
+        try {
+            const liveReqIds = await fetchStepRequirementIds(darwinUri, idToken, row.id);
+            liveGating = gatingRequirementIds(liveReqIds, requirements);
+            // The complement, so the refusal's "N containers are exempt" clause
+            // describes the links that were just read rather than the stale ones
+            // the grid was drawn from — the whole reason for re-reading.
+            liveTracking = liveReqIds.filter((rid) => !liveGating.includes(rid));
+            // LIVE IDS ARE NOT ENOUGH WHEN THE FLAGS ARE STILL CACHED. The line
+            // above takes ids from the server and `tracking` from the same ≤30s
+            // cache this re-read exists to distrust. One direction is already
+            // safe: an id the cache does not know resolves to
+            // `isTrackingRequirement(undefined)` === false, so it gates. The other
+            // is not — a requirement cached as a container that has since been
+            // corrected to work would drop out of the gating set and let the stamp
+            // through, which is precisely the damage this guard prevents.
+            //
+            // So the EXEMPTIONS are re-read, and only the exemptions: that set is
+            // empty on essentially every step, costing nothing on the common path,
+            // and never larger than a step's container count. A requirement that
+            // has since been deleted comes back absent and gates, same safe
+            // direction as an unknown id.
+            if (liveTracking.length) {
+                const rows = await Promise.all(liveTracking.map(
+                    (rid) => fetchRequirementTracking(darwinUri, idToken, rid)));
+                const fresh = rows.filter(Boolean);
+                liveGating = gatingRequirementIds(liveReqIds, [...requirements, ...fresh]);
+                // AN EXEMPTION THE RE-READ COULD NOT CONFIRM GATES, whatever the
+                // cache says about it — and it has to be forced, not left to the
+                // merge. A `null` row simply contributes nothing, so the merge
+                // falls back to the CACHED row, and a cached `tracking: 1` would
+                // exempt the id anyway: a failed verification producing a write,
+                // the one outcome this whole block exists to prevent. Absent is
+                // not the same as absent-and-therefore-work.
+                //
+                // Unreachable today — `fk_psr_requirement` is ON DELETE RESTRICT,
+                // so a requirement a live junction row points at cannot be deleted,
+                // and a 5xx throws to the catch below rather than arriving here as
+                // a 404. That is a fact about the schema, not about this code, and
+                // it is not the reason this is correct.
+                for (const rid of liveTracking.filter((_r, i) => rows[i] == null)) {
+                    if (!liveGating.includes(rid)) liveGating.push(rid);
+                }
+                liveTracking = liveReqIds.filter((rid) => !liveGating.includes(rid));
+            }
+        } catch (err) {
+            showError(err, `Could not verify step ${row.id}'s requirements — not completed`);
+            return;
+        }
+        if (liveGating.length) {
+            showError(`Step ${row.id} is derived from its requirements. `
+                + `${completionGuard({
+                    ...row, gatingReqIds: liveGating, trackingReqIds: liveTracking,
+                }).reason}`);
+            // The grid was stale enough to offer a write it should not have, so
+            // repaint it from the server rather than leave the user looking at
+            // the data that misled them.
+            invalidateSteps();
+            queryClient.invalidateQueries({
+                queryKey: pipelineStepRequirementKeys.all(creatorFk) });
+            return;
+        }
+
+        try {
+            await completeStep(darwinUri, idToken, row.id);
+            invalidateSteps();
+        } catch (err) {
+            showError(err, 'Could not complete the step');
+        }
+    };
+
+    const handleDelete = async (row) => {
+        // REFUSE POLITELY — design rule 4, from cached dep rows. This is a
+        // COURTESY, not the enforcement: `dep_step_fk` is ON DELETE RESTRICT and
+        // `deleteStep` is one statement, so a stale or failed dep read costs at
+        // worst a 409 with the plan untouched. What this buys is a message that
+        // names the blocking steps instead of a gateway error code.
+        if (row.blockerStepIds.length) {
+            showError(`Step ${row.id} cannot be deleted: ${blockerClause(row)}. `
+                + 'Re-point or remove those dependencies in the plan first.');
+            return;
+        }
+        const linkCount = (row.reqIds || []).length;
+        const gateCount = (row.depIds || []).length + (row.timeDeps || []).length;
+        const consequence = [
+            linkCount && `${linkCount} requirement link${linkCount === 1 ? '' : 's'}`,
+            gateCount && `${gateCount} dependency row${gateCount === 1 ? '' : 's'}`,
+        ].filter(Boolean).join(' and ');
+        if (!window.confirm(
+            `Delete step ${row.id} "${row.title}"?`
+            // The counts come from the same reads the grid drew, so when those
+            // failed the confirmation must not state them as fact.
+            + (planDataError
+                ? ` The ${failedReadsText} could not be read, so the consequence is`
+                  + ' unknown — the database will refuse if another step depends on it.'
+                : consequence
+                    ? ` Its ${consequence} will be removed with it. The requirements themselves are not touched.`
+                    : '')
+            + ' This cannot be undone.')) return;
+        try {
+            await deleteStep(darwinUri, idToken, row.id);
+            invalidateSteps();
+            // Both junction caches held rows for this step and the DATABASE just
+            // cascaded them away, so nothing in this client knows they are gone.
+            // Without these the plan table would keep drawing a gate that points
+            // at a step that no longer exists, which `verifyOrder` reports as
+            // `dangling-dependency` — a loud, wrong alarm caused entirely by a
+            // stale cache.
+            queryClient.invalidateQueries({
+                queryKey: pipelineStepRequirementKeys.all(creatorFk) });
+            queryClient.invalidateQueries({ queryKey: pipelineStepDepKeys.all(creatorFk) });
+        } catch (err) {
+            showError(err, 'Could not delete step');
+        }
+    };
+
+    // Deliberately NOT memoized (the EpicsPage / FeaturesPage shape). Every action
+    // cell closes over `idToken`, which is refreshed in place by AuthContext; a
+    // memoized column array would keep firing REST calls with the token it
+    // captured on first render long after that token expired.
+    const columns = [
+        { field: 'id', headerName: 'ID', width: 70 },
+        { field: 'title', headerName: 'Step', flex: 1, minWidth: 180 },
+        {
+            field: 'pipelineTitle', headerName: 'Pipeline', width: 170,
+            // THE CONNECTION TO THE EXISTING STEP SURFACE (req #3140): the plan
+            // table, scrolled to and highlighting this step.
+            renderCell: (params) => {
+                const to = stepLinkTo(params.row.pipelineId, params.row.id);
+                // `#<id>` when the pipelines read did not resolve this plan. The
+                // LINK still stands in that case, and deliberately: the id is
+                // known, it is the read that failed, and the plan page says so far
+                // better than a dead chip here could.
+                const label = params.value || `#${params.row.pipelineId}`;
+                return (
+                    <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+                        <Tooltip title={`Open this step in ${label}'s plan table`}>
+                            <Chip
+                                label={label}
+                                size="small"
+                                variant="outlined"
+                                clickable={!!to}
+                                onClick={(e) => { e.stopPropagation(); if (to) navigate(to); }}
+                                data-testid={`step-plan-link-${params.row.id}`}
+                            />
+                        </Tooltip>
+                    </Box>
+                );
+            },
+        },
+        {
+            field: 'state', headerName: 'State', width: 130, sortable: false,
+            renderCell: (params) => {
+                // ── THE MARKER REPORTS WHAT THE CLICK DOES ──────────────────
+                // Not what the row's own data says, and not what the general rule
+                // is: with the link read failed every row LOOKS completable and
+                // none is, and a stamped step is REOPENABLE even then. Three
+                // outcomes, so three values — `reopen` exists because
+                // `data-guard="derived"` has to keep meaning "this click writes
+                // nothing", which is exactly what a reader of the test suite
+                // assumes it means.
+                const contradicted = params.row.completedAt
+                    && (params.row.gatingReqIds || []).length > 0;
+                const guard = params.row.completedAt
+                    ? { kind: 'reopen',
+                        // A STAMP ITS REQUIREMENTS CONTRADICT is a real row and
+                        // this page is where someone would come to clean it up, so
+                        // the tooltip must not open with "Complete —" beside a chip
+                        // reading Running. It cannot be produced from here (that is
+                        // what the live guard prevents); it arrives from pre-existing
+                        // data or an MCP-side stamp.
+                        reason: contradicted
+                            ? 'This step carries a completed_at stamp, but '
+                              + `${requirementClause(params.row.gatingReqIds, 'contradict')} `
+                              + 'it — the plan renders the DERIVED state, so the stamp is '
+                              + 'dead weight. Click to clear it; that is the fix.'
+                            : 'Complete — click to clear the stamp. Reopening is always '
+                              + 'allowed: it only ever moves the stored column towards what a '
+                              + 'derived step already reports.' }
+                    : planDataError
+                        ? { kind: 'derived',
+                            reason: `The ${failedReadsText} did not load, so there is no way `
+                                + 'to tell whether this step\'s state is derived. Completing '
+                                + 'it is disabled until the read recovers.' }
+                        : (({ allowed, reason }) => ({
+                            kind: allowed ? 'editable' : 'derived', reason }))(
+                            completionGuard(params.row));
+                return (
+                    <Tooltip title={guard.reason}>
+                        {/* Clickable even when the guard will refuse — see
+                            toggleComplete. `data-guard` is how the refusal is
+                            visible to a test without hovering the tooltip. */}
+                        <Chip
+                            label={stepStateLabel(params.value)}
+                            size="small"
+                            {...stepStateChipProps(params.value)}
+                            clickable
+                            onClick={() => toggleComplete(params.row)}
+                            // The SAME string the tooltip carries. A tooltip is
+                            // invisible to a screen reader until focus, and this
+                            // one is the only place the page explains why a click
+                            // will or will not write — the PipelineDetail
+                            // description-button rule.
+                            aria-label={guard.reason}
+                            data-guard={guard.kind}
+                            data-testid={`step-state-chip-${params.row.id}`}
+                        />
+                    </Tooltip>
+                );
+            },
+        },
+        {
+            field: 'run', headerName: 'Run', width: 110, sortable: false,
+            renderCell: (params) => (
+                <Tooltip title={params.value === 'manual'
+                    ? 'Manual — the orchestrator reports this step eligible but never launches it. Click for Auto.'
+                    : 'Auto — the orchestrator launches this step when its gate clears. Click for Manual.'}>
+                    <Chip
+                        label={runLabel(params.value)}
+                        size="small"
+                        {...runChipProps(params.value)}
+                        clickable
+                        onClick={() => toggleRun(params.row)}
+                        data-testid={`step-run-chip-${params.row.id}`}
+                    />
+                </Tooltip>
+            ),
+        },
+        {
+            field: 'reqCount', headerName: 'Reqs', width: 90, type: 'number',
+            valueGetter: (_v, row) => (row.reqIds || []).length,
+            renderCell: (params) => (
+                <Tooltip title={reqIdSummary(params.row)}>
+                    <Box component="span" data-testid={`step-req-count-${params.row.id}`}>
+                        {params.value}
+                    </Box>
+                </Tooltip>
+            ),
+        },
+        {
+            field: 'gateCount', headerName: 'Gate', width: 90, type: 'number',
+            valueGetter: (_v, row) =>
+                (row.depIds || []).length + (row.timeDeps || []).length,
+            renderCell: (params) => (
+                <Tooltip title={gateSummary(params.row)}>
+                    <Box component="span" data-testid={`step-gate-count-${params.row.id}`}>
+                        {params.value}
+                    </Box>
+                </Tooltip>
+            ),
+        },
+        {
+            field: 'epic', headerName: 'Epic', width: 160,
+            valueFormatter: (value) => value || '—',
+        },
+        {
+            field: 'notes', headerName: 'Notes', flex: 2, minWidth: 240,
+            valueGetter: (value) => oneLine(value),
+            valueFormatter: (value) => value || '—',
+        },
+        {
+            field: 'completedAt', headerName: 'Completed', width: 150,
+            valueFormatter: (value) => (value ? formatDateTime(value, timezone) : '—'),
+        },
+        {
+            field: 'actions', headerName: '', width: 100, sortable: false,
+            filterable: false, disableColumnMenu: true,
+            renderCell: (params) => (
+                <Stack direction="row" spacing={0.5}>
+                    <Tooltip title="Edit">
+                        <IconButton size="small"
+                                    data-testid={`step-edit-${params.row.id}`}
+                                    onClick={(e) => { e.stopPropagation(); openEdit(params.row); }}>
+                            <EditIcon fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                    {/* Enabled even when design rule 4 will refuse, for the same
+                        reason the State chip is: the refusal names the steps that
+                        gate on this one, which is the information the operator
+                        needs, and a disabled button delivers it only on hover. */}
+                    <Tooltip title={params.row.blockerStepIds.length
+                        ? `Blocked — ${blockerClause(params.row)}`
+                        : 'Delete'}>
+                        <IconButton size="small"
+                                    aria-label={params.row.blockerStepIds.length
+                                        ? `Blocked — ${blockerClause(params.row)}`
+                                        : `Delete step ${params.row.id}`}
+                                    data-blocked={params.row.blockerStepIds.length ? 'yes' : 'no'}
+                                    data-testid={`step-delete-${params.row.id}`}
+                                    onClick={(e) => { e.stopPropagation(); handleDelete(params.row); }}>
+                            <DeleteIcon fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                </Stack>
+            ),
+        },
+    ];
+
+    return (
+        <Box sx={{ gridArea: 'content', p: 3, width: '100%', minWidth: 0, overflow: 'auto' }}
+             data-testid="steps-page">
+            <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 2, flexWrap: 'wrap' }}
+                   useFlexGap>
+                <Typography variant="h5">Steps</Typography>
+
+                <FormControl size="small" sx={{ minWidth: 180 }}>
+                    <InputLabel>Pipeline</InputLabel>
+                    <Select label="Pipeline" value={pipelineFilter}
+                            onChange={(e) => setPipelineFilter(e.target.value)}
+                            data-testid="steps-pipeline-filter">
+                        <MenuItem value={ALL_PIPELINES}>All pipelines</MenuItem>
+                        {pipelineOptions.map(p => (
+                            <MenuItem key={p.id} value={p.id}>{p.title}</MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+
+                <ChipFilter
+                    options={STATE_FILTER_OPTIONS}
+                    selected={stateFilter}
+                    onToggle={toggleStateFilter}
+                    testId="steps-state-filter"
+                    chipTestIdPrefix="steps-state-chip"
+                />
+
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}
+                            data-testid="steps-accounting">
+                    {rows.length} of {accounting.total} step{accounting.total === 1 ? '' : 's'} —{' '}
+                    {accounting.done} complete · {accounting.running} running ·{' '}
+                    {accounting.pending} scheduled
+                </Typography>
+
+                <Box sx={{ flexGrow: 1 }} />
+
+                <Button variant="contained" startIcon={<AddIcon />} onClick={openCreate}
+                        disabled={!pipelineOptions.length}
+                        data-testid="step-add">
+                    New Step
+                </Button>
+            </Stack>
+
+            {/* A step the grouping could not place is REPORTED, never dropped
+                silently — an editor page that quietly loses a row is how a plan
+                ends up with a step nobody can see or fix. */}
+            {unrenderedStepIds.length > 0 && (
+                <Alert severity="error" variant="outlined" sx={{ mb: 2 }}
+                       data-testid="steps-unrendered-warning">
+                    {unrenderedStepIds.length} step{unrenderedStepIds.length === 1 ? '' : 's'}{' '}
+                    ({unrenderedStepIds.join(', ')}) carry no usable pipeline and are not
+                    listed below. They exist in the database and belong to no plan.
+                </Alert>
+            )}
+
+            {planDataError && (
+                <Alert severity="error" variant="outlined" sx={{ mb: 2 }}
+                       data-testid="steps-plan-data-error">
+                    The {failedReadsText} failed to load. <strong>Every State chip, Reqs
+                    count and Gate count below is computed as though those rows do not
+                    exist</strong> — a step that is Running may read Scheduled. Completing
+                    a step is disabled until this read recovers; reopening one, and edits
+                    to title, notes and run mode, are unaffected, and the database still
+                    refuses a delete that would break a dependency. Reload.
+                </Alert>
+            )}
+
+            {dictionaryError && (
+                <Alert severity="warning" variant="outlined" sx={{ mb: 2 }}
+                       data-testid="steps-dictionary-error">
+                    The epic or feature list failed to load, so the Epic column is blank for
+                    every row — that is the failed read, not the plan. Reload before reading
+                    anything into it. Step state, requirement counts and gates are unaffected.
+                </Alert>
+            )}
+
+            {isLoading ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+                    <CircularProgress />
+                </Box>
+            ) : (
+                <Box sx={{ width: '100%' }} data-testid="steps-datagrid">
+                    <DataGrid
+                        autoHeight
+                        rows={rows}
+                        columns={columns}
+                        getRowId={(r) => r.id}
+                        density="compact"
+                        slots={{ toolbar: GridToolbar }}
+                        slotProps={{ toolbar: { showQuickFilter: true } }}
+                        initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
+                        pageSizeOptions={[10, 25, 50, 100]}
+                        disableRowSelectionOnClick
+                        data-testid="steps-grid"
+                    />
+                </Box>
+            )}
+
+            <Dialog open={dialogOpen} onClose={() => !submitting && setDialogOpen(false)}
+                    maxWidth="md" fullWidth data-testid="step-edit-dialog">
+                <DialogTitle>{editTarget ? `Edit step ${editTarget.id}` : 'New step'}</DialogTitle>
+                <DialogContent>
+                    <Stack spacing={2} sx={{ mt: 1 }}>
+                        <FormControl fullWidth required disabled={!!editTarget}>
+                            <InputLabel>Pipeline</InputLabel>
+                            <Select label="Pipeline" value={formPipelineFk}
+                                    onChange={(e) => setFormPipelineFk(e.target.value)}
+                                    data-testid="step-pipeline-select">
+                                {pipelineOptions.map(p => (
+                                    <MenuItem key={p.id} value={p.id}>{p.title}</MenuItem>
+                                ))}
+                            </Select>
+                        </FormControl>
+                        {editTarget && (
+                            <Typography variant="caption" sx={{ color: 'text.secondary', mt: -1 }}>
+                                A step&apos;s plan membership is its identity. To move this step,
+                                delete it and create it in the other plan — that forces its
+                                dependencies to be answered rather than silently broken.
+                            </Typography>
+                        )}
+                        <TextField
+                            label="Title"
+                            value={formTitle}
+                            onChange={(e) => setFormTitle(e.target.value)}
+                            helperText="The step's short NAME — &quot;Session Drain&quot;, not a sentence."
+                            autoFocus required fullWidth
+                            slotProps={{ htmlInput: {
+                                'data-testid': 'step-title-input', maxLength: TITLE_MAX } }}
+                        />
+                        <TextField
+                            label="Notes"
+                            value={formNotes}
+                            onChange={(e) => setFormNotes(e.target.value)}
+                            helperText={'What this step must achieve and why. Never its dependencies, '
+                                + 'status, membership or ordinal — those are rows, and prose that '
+                                + 'restates them goes stale (design rule 11). Replaces on save; it '
+                                + 'does not append.'}
+                            fullWidth multiline minRows={5}
+                            slotProps={{ htmlInput: { 'data-testid': 'step-notes-input' } }}
+                        />
+                        <FormControl fullWidth>
+                            <InputLabel>Run</InputLabel>
+                            <Select label="Run" value={formRun}
+                                    onChange={(e) => setFormRun(e.target.value)}
+                                    data-testid="step-run-select">
+                                <MenuItem value="auto">Auto — the orchestrator launches it</MenuItem>
+                                <MenuItem value="manual">Manual — reported eligible, never launched</MenuItem>
+                            </Select>
+                        </FormControl>
+                    </Stack>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setDialogOpen(false)} disabled={submitting}>Cancel</Button>
+                    <Button variant="contained" onClick={handleSubmit}
+                            disabled={submitting || !formTitle.trim()
+                                || (!editTarget && formPipelineFk === '')}
+                            data-testid="step-save">
+                        {editTarget ? 'Save' : 'Create'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </Box>
+    );
+}

--- a/src/Steps/__tests__/StepsPage.test.jsx
+++ b/src/Steps/__tests__/StepsPage.test.jsx
@@ -1,0 +1,778 @@
+// @vitest-environment jsdom
+//
+// Req #3140 — the Steps editor.
+//
+// The DataGrid is STUBBED (see the mock below) for EpicsPage.test.jsx's reason:
+// jsdom gives every element a zero-size box, so the real grid virtualizes down to
+// no cells and a suite built on it asserts against an empty table. The stub runs
+// each column through the SAME contract the real grid uses — `valueGetter(value,
+// row)` then `valueFormatter(value, row)` then `renderCell({row, value})`, v7
+// argument order — so a column that mis-uses that signature still fails here.
+//
+// What IS pinned is the wiring this requirement is about:
+//   - the Pipeline cell deep-links to the step in its plan table, which is the
+//     "connects to the existing Step editor" clause
+//   - design rule 1: the State chip is inert on a requirement-backed step and
+//     stamps `completed_at` on a step that derives from nothing else
+//   - design rule 4: delete refuses BEFORE clearing anything when another step
+//     depends on this one, and the cascade order is deps, links, step
+//   - create / edit send the right body to the right endpoint, `pipeline_fk` is
+//     locked on edit, and the REST 'NULL' sentinel a JSON null cannot express
+//   - the junction caches are invalidated after a delete, or the plan table draws
+//     a gate pointing at a step that no longer exists
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const navigations = [];
+// Spread the real module rather than replacing it: a narrow `{ useNavigate }`
+// mock turns any future router import in the page into an undefined-export crash
+// that says nothing about the actual failure.
+vi.mock('react-router-dom', async (importOriginal) => ({
+    ...(await importOriginal()),
+    useNavigate: () => (to) => navigations.push(to),
+}));
+
+vi.mock('@mui/x-data-grid', () => ({
+    GridToolbar: () => null,
+    DataGrid: ({ rows, columns }) => (
+        <div data-testid="grid">
+            {rows.map((row, index) => (
+                <div key={row.id} data-testid={`grid-row-${row.id}`} data-index={index}>
+                    {columns.map((col) => {
+                        const raw = row[col.field];
+                        const value = col.valueGetter ? col.valueGetter(raw, row, col) : raw;
+                        const formatted = col.valueFormatter
+                            ? col.valueFormatter(value, row, col) : value;
+                        return (
+                            <span key={col.field} data-testid={`cell-${col.field}-${row.id}`}>
+                                {col.renderCell
+                                    ? col.renderCell({ row, value, id: row.id, field: col.field })
+                                    : String(formatted ?? '')}
+                            </span>
+                        );
+                    })}
+                </div>
+            ))}
+        </div>
+    ),
+}));
+
+let pipelines;
+let steps;
+let stepRequirements;
+let stepDeps;
+let requirements;
+let features;
+let epics;
+let loading;
+let errors;
+
+vi.mock('../../hooks/useDataQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        useAllPipelines: () => ({ data: pipelines, isLoading: loading.pipelines }),
+        useAllPipelineSteps: () => ({ data: steps, isLoading: loading.steps }),
+        useAllPipelineStepRequirements: () => ({ data: stepRequirements, isLoading: loading.links, isError: errors.links }),
+        useAllPipelineStepDeps: () => ({ data: stepDeps, isLoading: loading.deps, isError: errors.deps }),
+        useAllRequirements: () => ({ data: requirements, isLoading: loading.reqs, isError: errors.reqs }),
+        useAllFeatures: () => ({ data: features, isLoading: loading.features, isError: errors.features }),
+        useAllEpics: () => ({ data: epics, isLoading: loading.epics, isError: errors.epics }),
+    };
+});
+
+const restCalls = [];
+let restFail = null;
+// Rows a GET answers with — the live pre-stamp re-read of a step's requirement
+// links. `null` means "no rows", which is what Lambda-Rest expresses as a 404 and
+// `fetchEntity` turns back into [].
+let restGetRows = null;
+vi.mock('../../RestApi/RestApi', () => ({
+    default: vi.fn((uri, method, body) => {
+        restCalls.push({ uri, method, body });
+        if (restFail && restFail(uri, method)) {
+            // The shape call_rest_api THROWS for a gateway error — a bare object,
+            // never an Error, which is why the page uses showError's two-arg form.
+            // eslint-disable-next-line no-throw-literal
+            return Promise.reject({ data: null, httpStatus: { httpStatus: 409, httpMessage: 'CONFLICT' } });
+        }
+        if (method === 'GET') {
+            const rows = typeof restGetRows === 'function' ? restGetRows(uri) : restGetRows;
+            if (rows == null) {
+                // The real 404-on-zero-rows answer, which fetchEntity absorbs.
+                // eslint-disable-next-line no-throw-literal
+                return Promise.reject({ data: null, httpStatus: { httpStatus: 404, httpMessage: 'NOT FOUND' } });
+            }
+            return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: rows });
+        }
+        return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+    }),
+}));
+
+import StepsPage from '../StepsPage';
+import AuthContext from '../../Context/AuthContext';
+import AppContext from '../../Context/AppContext';
+import { useSnackBarStore } from '../../stores/useSnackBarStore';
+
+let mountedRoots = [];
+let queryClient;
+
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0, refetchOnWindowFocus: false } },
+    });
+    vi.spyOn(queryClient, 'invalidateQueries');
+    const root = createRoot(container);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local/darwin' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <StepsPage />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    mountedRoots.push(root);
+    return { container };
+}
+
+const node = (testId) => document.body.querySelector(`[data-testid="${testId}"]`);
+const click = (el) => act(() => { el.click(); });
+const type = (el, value) => act(() => {
+    const proto = el instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, 'value').set.call(el, value);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+});
+const flush = () => act(async () => { await Promise.resolve(); await Promise.resolve(); });
+const rowIds = () => [...document.body.querySelectorAll('[data-testid^="grid-row-"]')]
+    .map(el => Number(el.getAttribute('data-testid').replace('grid-row-', '')));
+const snackMessage = () => useSnackBarStore.getState().message;
+const stepPuts = () => restCalls.filter(c => c.method === 'PUT'
+    && c.uri.endsWith('/pipeline_steps'));
+
+beforeEach(() => {
+    navigations.length = 0;
+    restCalls.length = 0;
+    restFail = null;
+    restGetRows = null;
+    mountedRoots = [];
+    loading = { pipelines: false, steps: false, links: false, deps: false, reqs: false, features: false, epics: false };
+    errors = { features: false, epics: false, links: false, deps: false, reqs: false };
+    pipelines = [
+        { id: 2, title: 'Darwin', pipeline_status: 'active' },
+        { id: 1, title: 'Substrate', pipeline_status: 'draft' },
+    ];
+    steps = [
+        // Requirement-backed and RUNNING — the derived case design rule 1 protects.
+        { id: 10, pipeline_fk: 2, title: 'Session Drain', run: 'auto', notes: 'Close every\nopen session.', completed_at: null },
+        // Link-less and gated ON by step 10 — the delete-blocked case.
+        { id: 11, pipeline_fk: 2, title: 'Green Baseline', run: 'manual', notes: null, completed_at: null },
+        // In the other plan, requirement-backed and Complete — derived, so its
+        // State chip must refuse a hand stamp even though it reads Complete.
+        { id: 20, pipeline_fk: 1, title: 'Clone Canary', run: 'auto', notes: null, completed_at: null },
+        // Link-less and ALREADY stamped — the only shape that can be reopened by
+        // hand (design rule 1: no gating requirements, so its own column decides).
+        { id: 21, pipeline_fk: 1, title: 'Manual Gate', run: 'auto', notes: null, completed_at: '2026-07-28 06:00:00' },
+    ];
+    stepRequirements = [
+        { step_fk: 10, requirement_fk: 3050 },
+        { step_fk: 20, requirement_fk: 3111 },
+    ];
+    stepDeps = [
+        { id: 1, step_fk: 10, dep_step_fk: 11, time_at: null },
+    ];
+    requirements = [
+        { id: 3050, title: 'Gateway', requirement_status: 'development', feature_fk: 100, tracking: 0 },
+        { id: 3111, title: 'Schema', requirement_status: 'met', feature_fk: 101, tracking: 0 },
+    ];
+    features = [
+        { id: 100, title: 'Substrate', epic_fk: 900 },
+        { id: 101, title: 'Tables', epic_fk: 901 },
+    ];
+    epics = [
+        { id: 900, title: 'Swarm Substrate' },
+        { id: 901, title: 'Orchestration' },
+    ];
+    useSnackBarStore.setState({ open: false, message: '' });
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+});
+
+afterEach(() => {
+    act(() => { mountedRoots.forEach(r => r.unmount()); });
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+});
+
+describe('StepsPage rows', () => {
+    it('lists every step of every plan by default', () => {
+        mount();
+        expect(rowIds().sort((a, b) => a - b)).toEqual([10, 11, 20, 21]);
+    });
+
+    it('renders the state the ENGINE derived, not the completed_at column', () => {
+        mount();
+        expect(node('step-state-chip-10').textContent).toBe('Running');
+        expect(node('step-state-chip-11').textContent).toBe('Scheduled');
+        // Step 20 has a NULL completed_at and still reads Complete, because its
+        // one requirement is met — the derivation, not the column.
+        expect(node('step-state-chip-20').textContent).toBe('Complete');
+        expect(node('step-state-chip-21').textContent).toBe('Complete');
+    });
+
+    it('marks what the State chip CLICK will do — three outcomes, three values', () => {
+        mount();
+        // Requirement-backed: the click writes nothing.
+        expect(node('step-state-chip-10').getAttribute('data-guard')).toBe('derived');
+        expect(node('step-state-chip-20').getAttribute('data-guard')).toBe('derived');
+        // Derives from its own column and is unstamped: the click completes it.
+        expect(node('step-state-chip-11').getAttribute('data-guard')).toBe('editable');
+        // Already stamped: the click REOPENS. Not `editable`, because that value
+        // has to keep meaning "this click completes", and not `derived`, because
+        // that has to keep meaning "this click writes nothing".
+        expect(node('step-state-chip-21').getAttribute('data-guard')).toBe('reopen');
+    });
+
+    it('resolves the epic label through requirement -> feature -> epic', () => {
+        mount();
+        expect(node('cell-epic-10').textContent).toBe('Swarm Substrate');
+        expect(node('cell-epic-20').textContent).toBe('Orchestration');
+        // Step 11 links no requirement and inherits nothing (it depends on
+        // nothing), so it genuinely has no epic.
+        expect(node('cell-epic-11').textContent).toBe('—');
+    });
+
+    it('counts requirements and gate rows', () => {
+        mount();
+        expect(node('step-req-count-10').textContent).toBe('1');
+        expect(node('step-req-count-11').textContent).toBe('0');
+        expect(node('step-gate-count-10').textContent).toBe('1');
+        expect(node('step-gate-count-11').textContent).toBe('0');
+    });
+
+    it('collapses multi-line notes to one line', () => {
+        mount();
+        expect(node('cell-notes-10').textContent).toBe('Close every open session.');
+        expect(node('cell-notes-11').textContent).toBe('—');
+    });
+
+    it('reports the whole plan in the accounting line, and the filter beside it', () => {
+        mount();
+        expect(node('steps-accounting').textContent).toContain('4 of 4 steps');
+        expect(node('steps-accounting').textContent).toContain('2 complete');
+        expect(node('steps-accounting').textContent).toContain('1 running');
+        expect(node('steps-accounting').textContent).toContain('1 scheduled');
+    });
+
+    it('narrows to one derived state, and to nothing when every chip is off', () => {
+        mount();
+        click(node('steps-state-chip-running'));   // null -> all-but-running
+        expect(rowIds().sort((a, b) => a - b)).toEqual([11, 20, 21]);
+        click(node('steps-state-chip-done'));
+        click(node('steps-state-chip-pending'));
+        expect(rowIds()).toEqual([]);
+        expect(node('steps-accounting').textContent).toContain('0 of 4');
+    });
+
+    // Every read feeds a number or a label. Painting off the steps read alone
+    // shows every State chip as Scheduled — a claim about the plan, not about the
+    // fetch — and lets a delete be confirmed without its consequence clause.
+    it('holds the grid until the requirement read lands, not just the steps one', () => {
+        loading = { ...loading, reqs: true };
+        mount();
+        expect(node('steps-datagrid')).toBeNull();
+    });
+
+    it('says the Epic column is blank because a read FAILED, not because there is no epic', () => {
+        errors = { features: true, epics: false };
+        mount();
+        expect(node('steps-dictionary-error')).not.toBeNull();
+    });
+
+    it('reports a step it cannot place rather than dropping it silently', () => {
+        steps = [...steps, { id: 99, pipeline_fk: null, title: 'Orphan', run: 'auto' }];
+        mount();
+        expect(node('steps-unrendered-warning').textContent).toContain('99');
+        expect(rowIds()).not.toContain(99);
+    });
+});
+
+describe('StepsPage — connects to the existing step surface', () => {
+    it('deep-links the Pipeline cell to this step in its plan table', () => {
+        mount();
+        click(node('step-plan-link-10'));
+        expect(navigations).toEqual(['/swarm/pipeline/2?mode=table&step=10']);
+    });
+
+    it('labels the cell with the plan title', () => {
+        mount();
+        expect(node('step-plan-link-10').textContent).toBe('Darwin');
+        expect(node('step-plan-link-20').textContent).toBe('Substrate');
+    });
+
+    it('still links, labelled by id, when the pipelines read did not resolve the plan', () => {
+        // The id is known and the ROUTE is valid — it is the read that failed. The
+        // plan page reports a missing pipeline far better than a dead chip here
+        // could, so the link stands.
+        pipelines = [];
+        mount();
+        expect(node('step-plan-link-10').textContent).toBe('#2');
+        click(node('step-plan-link-10'));
+        expect(navigations).toEqual(['/swarm/pipeline/2?mode=table&step=10']);
+    });
+});
+
+describe('StepsPage — design rule 1 (completed_at)', () => {
+    it('stamps a step that derives from nothing else', async () => {
+        mount();
+        click(node('step-state-chip-11'));
+        await flush();
+        const put = stepPuts()[0];
+        expect(put.body[0].id).toBe(11);
+        // UTC MySQL naive form — never the ISO 'T' form, which dateFormat reads
+        // as LOCAL and would render offset-shifted everywhere it appears.
+        expect(put.body[0].completed_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    });
+
+    it('reopens a hand-stamped step', async () => {
+        mount();
+        click(node('step-state-chip-21'));
+        await flush();
+        expect(stepPuts()[0].body[0]).toEqual({ id: 21, completed_at: 'NULL' });
+    });
+
+    it('writes NOTHING for a requirement-backed step, and says why', async () => {
+        mount();
+        click(node('step-state-chip-10'));
+        await flush();
+        expect(stepPuts()).toEqual([]);
+        expect(snackMessage()).toContain('3050');
+    });
+
+    it('refuses a derived step even when it reads Complete', async () => {
+        // Step 20 is Complete because its requirement is met. Stamping it would
+        // put a stored answer beside a derived one that can still change.
+        mount();
+        click(node('step-state-chip-20'));
+        await flush();
+        expect(stepPuts()).toEqual([]);
+        expect(snackMessage()).toContain('3111');
+    });
+
+    it('does not open with "Complete" on a stamp its requirements contradict', async () => {
+        // A stamped step whose requirement is still in development renders
+        // "Running" (derived, correct). This page is where someone would come to
+        // clean that up, so the explanation must not read as though the chip
+        // agreed with the column.
+        steps = steps.map(s => (s.id === 10 ? { ...s, completed_at: '2026-07-28 06:00:00' } : s));
+        mount();
+        expect(node('step-state-chip-10').textContent).toBe('Running');
+        expect(node('step-state-chip-10').getAttribute('data-guard')).toBe('reopen');
+        const why = node('step-state-chip-10').getAttribute('aria-label');
+        // The verb agrees — the singular is the common case for a contradicted
+        // stamp, so "requirement 3050 contradict it" would be the wording most
+        // readers actually saw.
+        expect(why).toContain('requirement 3050 contradicts it');
+        expect(why.startsWith('Complete')).toBe(false);
+        // The action is still right: the click clears the dead stamp.
+        click(node('step-state-chip-10'));
+        await flush();
+        expect(stepPuts()[0].body[0]).toEqual({ id: 10, completed_at: 'NULL' });
+    });
+
+    it('pluralizes the contradiction for several requirements', () => {
+        steps = steps.map(s => (s.id === 10 ? { ...s, completed_at: '2026-07-28 06:00:00' } : s));
+        stepRequirements = [...stepRequirements, { step_fk: 10, requirement_fk: 3111 }];
+        mount();
+        expect(node('step-state-chip-10').getAttribute('aria-label'))
+            .toContain('requirements 3050, 3111 contradict it');
+    });
+
+    it('opens with "Complete" on an ordinary hand-stamped step', () => {
+        mount();
+        expect(node('step-state-chip-21').getAttribute('aria-label').startsWith('Complete'))
+            .toBe(true);
+    });
+
+    it('re-reads the step LIVE before stamping, because the cache is 30s stale', async () => {
+        mount();
+        click(node('step-state-chip-11'));
+        await flush();
+        const get = restCalls.find(c => c.method === 'GET');
+        expect(get.uri).toBe('http://test.local/darwin/pipeline_step_requirements?step_fk=11');
+        // The GET precedes the PUT — a check after the write protects nothing.
+        expect(restCalls.indexOf(get)).toBeLessThan(
+            restCalls.findIndex(c => c.method === 'PUT'));
+    });
+
+    it('refuses when the LIVE read shows a requirement the cache had not seen yet', async () => {
+        // The Primary AI links a requirement onto a manual step while this page is
+        // open. The grid still says zero links; the write path must not.
+        restGetRows = () => [{ step_fk: 11, requirement_fk: 3050 }];
+        mount();
+        click(node('step-state-chip-11'));
+        await flush();
+        expect(stepPuts()).toEqual([]);
+        expect(snackMessage()).toContain('3050');
+    });
+
+    it('still allows the stamp when the live read returns only a TRACKING container', async () => {
+        requirements = [...requirements,
+            { id: 3083, title: 'Tracker', requirement_status: 'development', feature_fk: 100, tracking: 1 }];
+        restGetRows = () => [{ step_fk: 11, requirement_fk: 3083 }];
+        mount();
+        click(node('step-state-chip-11'));
+        await flush();
+        expect(stepPuts()[0].body[0].id).toBe(11);
+    });
+
+    it('refuses when the live read FAILS — "cannot check" is not "nothing to check"', async () => {
+        restFail = (uri, method) => method === 'GET';
+        mount();
+        click(node('step-state-chip-11'));
+        await flush();
+        expect(stepPuts()).toEqual([]);
+        expect(snackMessage()).toContain('Could not verify');
+    });
+
+    it('reopens WITHOUT a live read — clearing a stamp needs no permission', async () => {
+        mount();
+        click(node('step-state-chip-21'));
+        await flush();
+        expect(restCalls.filter(c => c.method === 'GET')).toEqual([]);
+        expect(stepPuts()[0].body[0]).toEqual({ id: 21, completed_at: 'NULL' });
+    });
+
+    it('re-reads the TRACKING FLAG of anything the cache wants to exempt', async () => {
+        // Live ids with cached flags is still half a cached guard: a requirement
+        // cached as a container that has since been corrected to work would drop
+        // out of the gating set and let the stamp through.
+        requirements = [...requirements,
+            { id: 3083, title: 'Was a tracker', requirement_status: 'development', feature_fk: 100, tracking: 1 }];
+        restGetRows = (uri) => (uri.includes('pipeline_step_requirements')
+            ? [{ step_fk: 11, requirement_fk: 3083 }]
+            // The server's current truth: it is WORK now.
+            : [{ id: 3083, tracking: 0 }]);
+        mount();
+        click(node('step-state-chip-11'));
+        await flush();
+        expect(restCalls.some(c => c.uri.includes('requirements?id=3083'))).toBe(true);
+        expect(stepPuts()).toEqual([]);
+        expect(snackMessage()).toContain('3083');
+    });
+
+    it('GATES an exemption the re-read could not confirm', async () => {
+        // A 404 on the tracking re-read means NOT CONFIRMED, not "nothing to
+        // check". Letting the merge fall back to a cached `tracking: 1` would be a
+        // failed verification producing a write — the one outcome the live re-read
+        // exists to prevent. (Unreachable in production because
+        // `fk_psr_requirement` is ON DELETE RESTRICT, which is a fact about the
+        // schema, not about this code.)
+        requirements = [...requirements,
+            { id: 3083, title: 'Cached as a container', requirement_status: 'development', feature_fk: 100, tracking: 1 }];
+        restGetRows = (uri) => (uri.includes('pipeline_step_requirements')
+            ? [{ step_fk: 11, requirement_fk: 3083 }]
+            : null);   // 404 — the row was not returned
+        mount();
+        click(node('step-state-chip-11'));
+        await flush();
+        expect(stepPuts()).toEqual([]);
+        expect(snackMessage()).toContain('3083');
+    });
+
+    it('re-reads nothing extra when the cache exempts nothing', async () => {
+        restGetRows = () => [{ step_fk: 11, requirement_fk: 3050 }];
+        mount();
+        click(node('step-state-chip-11'));
+        await flush();
+        // 3050 is work in the cache, so it gates without a second look.
+        expect(restCalls.filter(c => c.method === 'GET')).toHaveLength(1);
+    });
+
+    it('issues ONE completion per step however many times the chip is clicked', async () => {
+        // toggleComplete is a read then a write, so a double-click would otherwise
+        // start a second round trip while the first is still deciding.
+        mount();
+        click(node('step-state-chip-11'));
+        click(node('step-state-chip-11'));
+        await flush();
+        expect(restCalls.filter(c => c.method === 'GET')).toHaveLength(1);
+        expect(stepPuts()).toHaveLength(1);
+    });
+});
+
+describe('StepsPage — a FAILED read is not an empty one', () => {
+    it('blocks completion and says so when the requirement links did not load', async () => {
+        // Without this the `= []` default reports zero gating requirements for
+        // every step, the guard reads `editable`, and one click stamps
+        // completed_at on a requirement-backed step of a live plan.
+        errors = { ...errors, links: true };
+        mount();
+        expect(node('steps-plan-data-error')).not.toBeNull();
+        expect(node('step-state-chip-10').getAttribute('data-guard')).toBe('derived');
+        click(node('step-state-chip-10'));
+        await flush();
+        expect(stepPuts()).toEqual([]);
+        expect(restCalls.filter(c => c.method === 'GET')).toEqual([]);
+    });
+
+    it('raises the same banner when the requirements list itself failed', () => {
+        errors = { ...errors, reqs: true };
+        mount();
+        expect(node('steps-plan-data-error')).not.toBeNull();
+    });
+
+    it('names WHICH read failed rather than always blaming the links', async () => {
+        // One boolean is right for deciding whether to block, but spending it as
+        // though it were always the links read makes the page state a falsehood
+        // about the other two.
+        errors = { ...errors, reqs: true };
+        mount();
+        expect(node('steps-plan-data-error').textContent).toContain('requirement list');
+        expect(node('steps-plan-data-error').textContent).not.toContain('requirement links');
+        click(node('step-state-chip-10'));
+        await flush();
+        expect(snackMessage()).toContain('requirement list');
+    });
+
+    it('joins several failed reads into one honest list', () => {
+        errors = { ...errors, links: true, deps: true };
+        mount();
+        expect(node('steps-plan-data-error').textContent)
+            .toContain('requirement links and dependency rows');
+    });
+
+    it('still REOPENS a stamped step, and says so, while completion is blocked', async () => {
+        // Clearing a stamp never depends on knowing the link set, so blocking it
+        // would be a rule the data does not require — but the marker and tooltip
+        // must then not claim the click is disabled.
+        errors = { ...errors, links: true };
+        mount();
+        expect(node('step-state-chip-21').getAttribute('data-guard')).toBe('reopen');
+        click(node('step-state-chip-21'));
+        await flush();
+        expect(stepPuts()[0].body[0]).toEqual({ id: 21, completed_at: 'NULL' });
+    });
+
+    it('does not state a consequence it could not compute in the delete confirmation', async () => {
+        errors = { ...errors, deps: true };
+        mount();
+        click(node('step-delete-10'));
+        await flush();
+        expect(window.confirm.mock.calls[0][0]).toContain('could not be read');
+        expect(window.confirm.mock.calls[0][0]).toContain('dependency rows');
+    });
+
+    it('leaves title / notes / run edits alone — they depend on none of it', async () => {
+        errors = { ...errors, links: true };
+        mount();
+        click(node('step-run-chip-10'));
+        await flush();
+        expect(stepPuts()[0].body[0]).toEqual({ id: 10, run: 'manual' });
+    });
+});
+
+describe('StepsPage — design rule 4 (delete)', () => {
+    it('refuses BEFORE clearing anything when another step depends on this one', async () => {
+        mount();
+        click(node('step-delete-11'));
+        await flush();
+        // Not one statement issued — reaching MySQL's RESTRICT on the third would
+        // leave step 11 alive, stripped of its links and completely UN-GATED.
+        expect(restCalls.filter(c => c.method === 'DELETE')).toEqual([]);
+        expect(snackMessage()).toContain('10');
+        expect(window.confirm).not.toHaveBeenCalled();
+    });
+
+    it('marks which rows the delete will refuse', () => {
+        mount();
+        expect(node('step-delete-11').getAttribute('data-blocked')).toBe('yes');
+        expect(node('step-delete-10').getAttribute('data-blocked')).toBe('no');
+    });
+
+    it('makes the verb agree, so a single blocker does not read as a bug', async () => {
+        mount();
+        click(node('step-delete-11'));
+        await flush();
+        expect(snackMessage()).toContain('step 10 depends on it');
+    });
+
+    it('says a self-dependency outright rather than naming the step twice', async () => {
+        // dropBlockers counts a self-dep because InnoDB does. "step 11 depend on
+        // it" for a step blocking itself reads as a rendering fault.
+        stepDeps = [{ id: 1, step_fk: 11, dep_step_fk: 11, time_at: null }];
+        mount();
+        click(node('step-delete-11'));
+        await flush();
+        expect(snackMessage()).toContain('it depends on itself');
+        expect(restCalls.filter(c => c.method === 'DELETE')).toEqual([]);
+    });
+
+    it('pluralizes correctly for several blockers', async () => {
+        stepDeps = [
+            { id: 1, step_fk: 10, dep_step_fk: 11, time_at: null },
+            { id: 2, step_fk: 20, dep_step_fk: 11, time_at: null },
+        ];
+        mount();
+        click(node('step-delete-11'));
+        await flush();
+        expect(snackMessage()).toContain('steps 10, 20 depend on it');
+    });
+
+    it('deletes with ONE statement and lets the database cascade the children', async () => {
+        // Three statements from a browser is strictly worse than one: every
+        // intermediate failure leaves the step alive and UN-GATED, which the
+        // orchestration engine reads as eligible-immediately. The links and the
+        // step's own dep rows CASCADE; `dep_step_fk` RESTRICTs. So the worst case
+        // is a clean 409 with the plan untouched.
+        mount();
+        click(node('step-delete-10'));
+        await flush();
+        expect(restCalls.filter(c => c.method === 'DELETE').map(c => [c.uri, c.body])).toEqual([
+            ['http://test.local/darwin/pipeline_steps', { id: 10 }],
+        ]);
+    });
+
+    it('is the same single statement for a step with no junction rows', async () => {
+        mount();
+        click(node('step-delete-21'));
+        await flush();
+        expect(restCalls.filter(c => c.method === 'DELETE').map(c => c.uri))
+            .toEqual(['http://test.local/darwin/pipeline_steps']);
+    });
+
+    it('names the consequence in the confirmation', async () => {
+        mount();
+        click(node('step-delete-10'));
+        await flush();
+        expect(window.confirm.mock.calls[0][0]).toContain('1 requirement link and 1 dependency row');
+    });
+
+    it('does nothing when the confirmation is declined', async () => {
+        window.confirm.mockReturnValue(false);
+        mount();
+        click(node('step-delete-10'));
+        await flush();
+        expect(restCalls.filter(c => c.method === 'DELETE')).toEqual([]);
+    });
+
+    it('invalidates BOTH junction caches, not just the steps one', async () => {
+        mount();
+        click(node('step-delete-10'));
+        await flush();
+        const keys = queryClient.invalidateQueries.mock.calls.map(c => c[0].queryKey[0]);
+        // Without these the plan table keeps drawing a gate pointing at a step
+        // that no longer exists, which verifyOrder reports as a loud, wrong
+        // `dangling-dependency`.
+        expect(keys).toContain('pipeline_steps');
+        expect(keys).toContain('pipeline_step_requirements');
+        expect(keys).toContain('pipeline_step_deps');
+    });
+});
+
+describe('StepsPage — create and edit', () => {
+    it('creates a step in the selected plan with a real null for empty notes', async () => {
+        mount();
+        click(node('step-add'));
+        type(node('step-title-input'), 'New Gate');
+        click(node('step-save'));
+        await flush();
+        const post = restCalls.find(c => c.method === 'POST');
+        expect(post.uri).toBe('http://test.local/darwin/pipeline_steps');
+        // POST takes a real null; the 'NULL' string is a PUT-only sentinel and
+        // would be stored as the literal text.
+        expect(post.body).toEqual({
+            pipeline_fk: 2, title: 'New Gate', run: 'auto', notes: null, completed_at: null,
+        });
+    });
+
+    it('never sets completed_at on a new step — a step is born incomplete', async () => {
+        mount();
+        click(node('step-add'));
+        type(node('step-title-input'), 'New Gate');
+        click(node('step-save'));
+        await flush();
+        expect(restCalls.find(c => c.method === 'POST').body.completed_at).toBeNull();
+    });
+
+    it('sends the REST NULL sentinel when an edit clears the notes', async () => {
+        mount();
+        click(node('step-edit-10'));
+        type(node('step-notes-input'), '');
+        click(node('step-save'));
+        await flush();
+        expect(stepPuts()[0].body[0]).toEqual({
+            id: 10, title: 'Session Drain', notes: 'NULL', run: 'auto',
+        });
+    });
+
+    it('never sends pipeline_fk on an edit — plan membership is identity', async () => {
+        mount();
+        click(node('step-edit-10'));
+        click(node('step-save'));
+        await flush();
+        expect(stepPuts()[0].body[0]).not.toHaveProperty('pipeline_fk');
+    });
+
+    it('refuses an empty title rather than sending a 1406 to MySQL', async () => {
+        mount();
+        click(node('step-edit-10'));
+        type(node('step-title-input'), '   ');
+        expect(node('step-save').disabled).toBe(true);
+    });
+
+    it('refuses the literal string NULL as a title rather than shipping a 1048', async () => {
+        // rest_post and rest_put BOTH substitute SQL NULL for this exact string,
+        // and `title` is NOT NULL — so it reaches the user as an opaque 500.
+        mount();
+        click(node('step-add'));
+        type(node('step-title-input'), 'NULL');
+        click(node('step-save'));
+        await flush();
+        expect(restCalls.filter(c => c.method === 'POST')).toEqual([]);
+        expect(snackMessage()).toContain('sentinel');
+    });
+
+    it('allows a title that merely resembles the sentinel', async () => {
+        mount();
+        click(node('step-add'));
+        type(node('step-title-input'), 'Null check');
+        click(node('step-save'));
+        await flush();
+        expect(restCalls.find(c => c.method === 'POST').body.title).toBe('Null check');
+    });
+
+    it('reports a gateway failure with its status rather than swallowing it', async () => {
+        restFail = (uri, method) => method === 'POST';
+        mount();
+        click(node('step-add'));
+        type(node('step-title-input'), 'New Gate');
+        click(node('step-save'));
+        await flush();
+        expect(snackMessage()).toContain('Could not create step');
+    });
+});
+
+describe('StepsPage — run mode', () => {
+    it('toggles auto to manual and back', async () => {
+        mount();
+        click(node('step-run-chip-10'));
+        await flush();
+        expect(stepPuts()[0].body[0]).toEqual({ id: 10, run: 'manual' });
+        restCalls.length = 0;
+        click(node('step-run-chip-11'));
+        await flush();
+        expect(stepPuts()[0].body[0]).toEqual({ id: 11, run: 'auto' });
+    });
+});

--- a/src/Steps/__tests__/stepsModel.test.js
+++ b/src/Steps/__tests__/stepsModel.test.js
@@ -1,0 +1,333 @@
+// Req #3140 — the Steps editor's page model.
+//
+// What is pinned here is everything the browser has to enforce that the MCP
+// service enforces in Python, plus the one property that makes this page
+// trustworthy at all: it AGREES with the plan pages about step state, because it
+// runs the same engine rather than a copy of it.
+//
+// The fixture is deliberately shaped like the live plan: a requirement-backed
+// step, a link-less manual step, a step whose only link is a TRACKING container
+// (req #3123), a step with an unresolved requirement id, a gate chain, and two
+// pipelines — so cross-plan leakage would show up as a wrong count rather than
+// as nothing.
+
+import { describe, it, expect } from 'vitest';
+
+import {
+    STEP_DONE,
+    STEP_PENDING,
+    STEP_RUNNING,
+    buildStepEditorRows,
+    completionGuard,
+    dropBlockers,
+    filterStepRows,
+    gatingRequirementIds,
+    stepsAccounting,
+} from '../stepsModel';
+
+const PIPELINES = [
+    { id: 1, title: 'Darwin', pipeline_status: 'active' },
+    { id: 2, title: 'Substrate', pipeline_status: 'draft' },
+];
+
+const STEPS = [
+    { id: 10, pipeline_fk: 1, title: 'Session Drain', run: 'auto', notes: 'Close every open session.', completed_at: null },
+    { id: 11, pipeline_fk: 1, title: 'Green Baseline', run: 'manual', notes: null, completed_at: '2026-07-28 06:00:00' },
+    { id: 12, pipeline_fk: 1, title: 'Container Only', run: 'auto', notes: null, completed_at: null },
+    { id: 13, pipeline_fk: 1, title: 'Unresolved Link', run: 'auto', notes: null, completed_at: null },
+    { id: 20, pipeline_fk: 2, title: 'Other Plan', run: 'auto', notes: null, completed_at: null },
+];
+
+const STEP_REQUIREMENTS = [
+    { step_fk: 10, requirement_fk: 3050 },   // development -> Running
+    { step_fk: 12, requirement_fk: 3083 },   // tracking container -> falls through to completed_at
+    { step_fk: 13, requirement_fk: 9999 },   // not in the requirements read
+    { step_fk: 20, requirement_fk: 3111 },   // met -> Complete
+];
+
+// step 11 gates step 10; step 10 gates nothing. Step 11 also carries a wall-clock
+// row, which is a SECOND condition on one step (migration 076 leaves `time_at`
+// rows out of the UNIQUE key precisely so it can).
+const STEP_DEPS = [
+    { id: 1, step_fk: 10, dep_step_fk: 11, time_at: null },
+    { id: 2, step_fk: 11, dep_step_fk: null, time_at: '2026-07-28 05:00:00' },
+];
+
+const REQUIREMENTS = [
+    { id: 3050, title: 'Gateway', requirement_status: 'development', feature_fk: 100, tracking: 0 },
+    { id: 3083, title: 'Plan tracker', requirement_status: 'development', feature_fk: 100, tracking: 1 },
+    { id: 3111, title: 'Schema', requirement_status: 'met', feature_fk: 101, tracking: 0 },
+];
+
+const FEATURES = [
+    { id: 100, title: 'Substrate', epic_fk: 900 },
+    { id: 101, title: 'Tables', epic_fk: 901 },
+];
+
+const EPICS = [
+    { id: 900, title: 'Swarm Substrate' },
+    { id: 901, title: 'Orchestration' },
+];
+
+const build = (overrides = {}) => buildStepEditorRows({
+    pipelines: PIPELINES,
+    steps: STEPS,
+    stepRequirements: STEP_REQUIREMENTS,
+    stepDeps: STEP_DEPS,
+    requirements: REQUIREMENTS,
+    features: FEATURES,
+    epics: EPICS,
+    ...overrides,
+});
+
+const byId = (rows) => Object.fromEntries(rows.map(r => [r.id, r]));
+
+describe('buildStepEditorRows — state comes from the engine', () => {
+    it('derives every step in every plan', () => {
+        const { rows } = build();
+        expect(rows.map(r => r.id).sort((a, b) => a - b)).toEqual([10, 11, 12, 13, 20]);
+    });
+
+    it('a gating requirement in development derives Running', () => {
+        expect(byId(build().rows)[10].state).toBe(STEP_RUNNING);
+    });
+
+    it('a link-less step derives from its OWN completed_at stamp', () => {
+        // The only place that column means anything (design rule 1).
+        expect(byId(build().rows)[11].state).toBe(STEP_DONE);
+    });
+
+    it('a step whose only link is a TRACKING container falls through to its stamp', () => {
+        // req #3123. Counting the container would pin this step Running forever:
+        // the container never leaves `development` because the plan it holds is
+        // still running, and the step waits on the plan that waits on the step.
+        const row = byId(build().rows)[12];
+        expect(row.state).toBe(STEP_PENDING);
+        expect(row.trackingReqIds).toEqual([3083]);
+        expect(row.gatingReqIds).toEqual([]);
+    });
+
+    it('an unresolved requirement id GATES — nothing was read that said otherwise', () => {
+        const row = byId(build().rows)[13];
+        expect(row.unresolvedReqIds).toEqual([9999]);
+        expect(row.gatingReqIds).toEqual([9999]);
+        expect(row.trackingReqIds).toEqual([]);
+    });
+
+    it('all-terminal requirements derive Complete', () => {
+        expect(byId(build().rows)[20].state).toBe(STEP_DONE);
+    });
+
+    it('derives the epic label through requirement -> feature -> epic (rule 10)', () => {
+        const rows = byId(build().rows);
+        expect(rows[10].epic).toBe('Swarm Substrate');
+        expect(rows[20].epic).toBe('Orchestration');
+    });
+});
+
+describe('buildStepEditorRows — plan scoping', () => {
+    it('decorates every row with its plan title and status', () => {
+        const rows = byId(build().rows);
+        expect(rows[10].pipelineId).toBe(1);
+        expect(rows[10].pipelineTitle).toBe('Darwin');
+        expect(rows[10].pipelineStatus).toBe('active');
+        expect(rows[20].pipelineTitle).toBe('Substrate');
+    });
+
+    it('never leaks one plan\'s dependency rows into another\'s step', () => {
+        // buildPipelineModel scopes deps by the OWNING step, so a step in plan 2
+        // must come back ungated even though plan 1 is full of dep rows.
+        const rows = byId(build().rows);
+        expect(rows[20].depIds).toEqual([]);
+        expect(rows[10].depIds).toEqual([11]);
+        expect(rows[11].timeDeps).toEqual(['2026-07-28 05:00:00']);
+    });
+
+    it('still derives a step whose pipeline row is missing from the read', () => {
+        // A truncated or failed pipelines read must not make steps disappear from
+        // the one page that could fix them.
+        const { rows, unrenderedStepIds } = build({ pipelines: [] });
+        expect(rows.map(r => r.id).sort((a, b) => a - b)).toEqual([10, 11, 12, 13, 20]);
+        expect(byId(rows)[10].pipelineTitle).toBeNull();
+        expect(byId(rows)[10].state).toBe(STEP_RUNNING);
+        expect(unrenderedStepIds).toEqual([]);
+    });
+
+    it('REPORTS a step it cannot place instead of dropping it', () => {
+        const { rows, unrenderedStepIds } = build({
+            steps: [...STEPS, { id: 99, pipeline_fk: null, title: 'Orphan', run: 'auto' }],
+        });
+        expect(unrenderedStepIds).toEqual([99]);
+        expect(rows.some(r => r.id === 99)).toBe(false);
+    });
+
+    it('survives empty and missing inputs', () => {
+        expect(buildStepEditorRows()).toEqual({ rows: [], unrenderedStepIds: [] });
+        expect(buildStepEditorRows({ steps: [] })).toEqual({ rows: [], unrenderedStepIds: [] });
+    });
+});
+
+describe('dropBlockers — design rule 4, refuse FIRST', () => {
+    it('names the steps whose dependency row references this one', () => {
+        expect(dropBlockers(11, STEP_DEPS)).toEqual([10]);
+    });
+
+    it('is empty for a step nothing gates on', () => {
+        expect(dropBlockers(10, STEP_DEPS)).toEqual([]);
+        expect(dropBlockers(20, STEP_DEPS)).toEqual([]);
+    });
+
+    it('de-duplicates and sorts, so a refusal never names a step twice', () => {
+        const deps = [
+            { id: 1, step_fk: 30, dep_step_fk: 11, time_at: null },
+            { id: 2, step_fk: 30, dep_step_fk: 11, time_at: null },
+            { id: 3, step_fk: 12, dep_step_fk: 11, time_at: null },
+        ];
+        expect(dropBlockers(11, deps)).toEqual([12, 30]);
+    });
+
+    it('ignores wall-clock rows, which reference no step', () => {
+        expect(dropBlockers(null, STEP_DEPS)).toEqual([]);
+    });
+
+    it('counts a self-dependency, because InnoDB does', () => {
+        // The check PREVIEWS the database's answer rather than enforcing anything
+        // (deleteStep is one statement and dep_step_fk RESTRICTs). InnoDB evaluates
+        // that RESTRICT even against a dep row inside the same cascade, so this
+        // delete really would refuse — excluding the row would produce a bare 409
+        // where a named refusal was available.
+        expect(dropBlockers(5, [{ id: 1, step_fk: 5, dep_step_fk: 5, time_at: null }]))
+            .toEqual([5]);
+    });
+
+    it('is attached to every row by buildStepEditorRows', () => {
+        const rows = byId(build().rows);
+        expect(rows[11].blockerStepIds).toEqual([10]);
+        expect(rows[10].blockerStepIds).toEqual([]);
+    });
+
+    it('survives a missing deps list', () => {
+        expect(dropBlockers(11, undefined)).toEqual([]);
+    });
+});
+
+describe('gatingRequirementIds — one rule for the grid and the live re-check', () => {
+    it('drops tracking containers and keeps real work', () => {
+        expect(gatingRequirementIds([3050, 3083], REQUIREMENTS)).toEqual([3050]);
+    });
+
+    it('keeps an id the requirements read did not return', () => {
+        // Nothing was read that said it is a container, and refusing a stamp is
+        // the recoverable direction.
+        expect(gatingRequirementIds([9999], REQUIREMENTS)).toEqual([9999]);
+    });
+
+    it('reads tracking numerically, so the string "0" is WORK', () => {
+        // `Boolean("0")` is true, which would silently stop a real requirement
+        // from gating its step — wrong in the dangerous direction.
+        const reqs = [{ id: 1, tracking: '0' }, { id: 2, tracking: '1' }, { id: 3, tracking: 0 }];
+        expect(gatingRequirementIds([1, 2, 3], reqs)).toEqual([1, 3]);
+    });
+
+    it('is what buildStepEditorRows put on every row', () => {
+        const rows = byId(build().rows);
+        expect(rows[10].gatingReqIds).toEqual(gatingRequirementIds([3050], REQUIREMENTS));
+        expect(rows[12].gatingReqIds).toEqual(gatingRequirementIds([3083], REQUIREMENTS));
+    });
+
+    it('survives empty and missing inputs', () => {
+        expect(gatingRequirementIds(undefined, undefined)).toEqual([]);
+        expect(gatingRequirementIds([], REQUIREMENTS)).toEqual([]);
+    });
+});
+
+describe('completionGuard — design rule 1, client-side', () => {
+    it('allows a link-less step to be stamped by hand', () => {
+        const guard = completionGuard(byId(build().rows)[11]);
+        expect(guard.allowed).toBe(true);
+        expect(guard.reason).toMatch(/reopen/i);
+    });
+
+    it('allows a container-only step — the exemption is what makes it completable', () => {
+        const guard = completionGuard(byId(build().rows)[12]);
+        expect(guard.allowed).toBe(true);
+        expect(guard.reason).toMatch(/mark this step complete/i);
+    });
+
+    it('REFUSES a requirement-backed step and names the requirements', () => {
+        const guard = completionGuard(byId(build().rows)[10]);
+        expect(guard.allowed).toBe(false);
+        expect(guard.reason).toContain('3050');
+    });
+
+    it('refuses on an unresolved link, and says which id', () => {
+        const guard = completionGuard(byId(build().rows)[13]);
+        expect(guard.allowed).toBe(false);
+        expect(guard.reason).toContain('9999');
+    });
+
+    it('names the exempted containers on a MIXED step so the count is explicable', () => {
+        const guard = completionGuard({
+            id: 1, reqIds: [3050, 3083], trackingReqIds: [3083], gatingReqIds: [3050],
+        });
+        expect(guard.allowed).toBe(false);
+        expect(guard.reason).toContain('3050');
+        // Verbs agree with the noun — the singular is the common case here.
+        expect(guard.reason).toContain('1 tracking container 3083 is exempt and was not counted');
+    });
+
+    it('pluralizes the exemption clause correctly for several containers', () => {
+        const guard = completionGuard({
+            id: 1, reqIds: [3050, 3083, 3090], trackingReqIds: [3083, 3090], gatingReqIds: [3050],
+        });
+        expect(guard.reason)
+            .toContain('2 tracking containers 3083, 3090 are exempt and were not counted');
+    });
+
+    it('survives a row with no arrays at all', () => {
+        expect(completionGuard({}).allowed).toBe(true);
+        expect(completionGuard(null).allowed).toBe(true);
+    });
+});
+
+describe('filterStepRows', () => {
+    const rows = build().rows;
+
+    it('null means every value — the ChipFilter contract', () => {
+        expect(filterStepRows(rows, {}).length).toBe(rows.length);
+        expect(filterStepRows(rows, { states: null, pipelineIds: null }).length).toBe(rows.length);
+    });
+
+    it('an EMPTY selection means show nothing, and is never corrected back to all', () => {
+        expect(filterStepRows(rows, { states: [] })).toEqual([]);
+        expect(filterStepRows(rows, { pipelineIds: [] })).toEqual([]);
+    });
+
+    it('narrows to one plan', () => {
+        expect(filterStepRows(rows, { pipelineIds: [2] }).map(r => r.id)).toEqual([20]);
+    });
+
+    it('narrows by derived state', () => {
+        expect(filterStepRows(rows, { states: [STEP_RUNNING] }).map(r => r.id)).toEqual([10]);
+        expect(filterStepRows(rows, { states: [STEP_DONE] }).map(r => r.id).sort((a, b) => a - b))
+            .toEqual([11, 20]);
+    });
+
+    it('ANDs the two dimensions', () => {
+        expect(filterStepRows(rows, { pipelineIds: [1], states: [STEP_DONE] }).map(r => r.id))
+            .toEqual([11]);
+    });
+});
+
+describe('stepsAccounting', () => {
+    it('counts the three derived states', () => {
+        expect(stepsAccounting(build().rows))
+            .toEqual({ total: 5, done: 2, running: 1, pending: 2 });
+    });
+
+    it('is zeroed rather than undefined for no rows', () => {
+        expect(stepsAccounting([]))
+            .toEqual({ total: 0, done: 0, running: 0, pending: 0 });
+        expect(stepsAccounting(undefined).total).toBe(0);
+    });
+});

--- a/src/Steps/stepsApi.js
+++ b/src/Steps/stepsApi.js
@@ -1,0 +1,246 @@
+// Mutation utilities for the pipeline_steps data type (req #3140).
+//
+// Steps are the members of an execution plan (req #3111, migration 076). The
+// frontend has READ them since req #3114 (`useAllPipelineSteps`) and renders
+// them in the plan table and the plan visualizer, but had no write path at all —
+// every step in production was created by the Primary AI through the MCP tools.
+// This module is the browser's write half, and it goes through the SAME gateway
+// path `darwin-mcp/services/pipelines.py` already POSTs, PUTs and DELETEs:
+// `{darwinUri}/pipeline_steps`. No new backend surface exists or is needed.
+//
+// Pattern mirrors Epics/epicsApi.js — call_rest_api directly, callers handle
+// TanStack Query cache invalidation via queryClient.invalidateQueries.
+//
+// ## The invariants this module has to carry itself
+//
+// The browser does NOT go through the MCP service, so the two design rules
+// `pipelines.py` enforces in Python are unenforced on this path unless they are
+// reproduced here. They are, and `stepsModel.js` holds the decision half as pure
+// tested functions:
+//
+//   * design rule 1 — `completed_at` is valid ONLY on a step with zero GATING
+//     requirements (tracking containers exempt, req #3123). `completeStep` is the
+//     only function here that stamps it. What DECIDES is StepsPage's
+//     `completeFlow`, from a LIVE re-read (`fetchStepRequirementIds` +
+//     `fetchRequirementTracking` below); `stepsModel`'s `completionGuard` is the
+//     cached fast path in front of it, not the rule.
+//   * design rule 4 — a step another step depends on cannot be deleted. Here the
+//     schema really is the enforcement (`dep_step_fk` is ON DELETE RESTRICT) and
+//     `deleteStep` is deliberately ONE statement so that the refusal is atomic;
+//     see its own note for why three statements from a browser would be worse
+//     than none.
+//
+// Column shape (measured against `darwin://pipeline/2` and services/pipelines.py):
+//   pipeline_fk   required, the step's plan membership — its IDENTITY, never updated
+//   title         NOT NULL, VARCHAR(256)
+//   run           'auto' | 'manual'
+//   notes         nullable TEXT
+//   completed_at  nullable DATETIME — stamped by completeStep, cleared by reopenStep
+
+import call_rest_api from '../RestApi/RestApi';
+import { fetchEntity } from '../hooks/factory/createEntityQueries';
+
+const isOk = (status) => status === 200 || status === 201 || status === 204;
+
+// Only ever reached for the status call_rest_api RETURNS rather than throws —
+// the synthetic 503 it manufactures for a transport-level failure. Every gateway
+// error (4xx/5xx) is thrown from call_rest_api as a bare `{data, httpStatus}`
+// object and never arrives here. The thrown Error carries `httpStatus` so BOTH
+// shapes read identically to useSnackBarStore's two-argument form, which renders
+// the status code beside the caller's message.
+function assertOk(result, action) {
+    const status = result.httpStatus?.httpStatus;
+    if (!isOk(status)) {
+        const msg = result.httpStatus?.httpMessage || 'unknown';
+        const error = new Error(`${action} failed: HTTP ${status} ${msg}`);
+        error.httpStatus = result.httpStatus;
+        throw error;
+    }
+    return result.data;
+}
+
+// Lambda-Rest's clear-a-column sentinel: the literal string 'NULL'. A JSON null
+// is not what it recognizes on a PUT, which is why an update that wants to empty
+// `notes` has to send this (the same rule the MCP's `update_pipeline_step` obeys
+// via its own NULL constant).
+//
+// IT IS NOT PUT-ONLY. `rest_post.py` applies the identical substitution, so a
+// POST carrying the string 'NULL' stores SQL NULL too — the create path below
+// sends a real `null` for an empty field because that is clearer at the call
+// site, not because the sentinel would be stored verbatim.
+//
+// The consequence is on BOTH verbs and it reaches free text: a user who types the
+// four characters N-U-L-L into a field gets SQL NULL stored. Harmless for `notes`
+// (nullable), fatal for `title` (NOT NULL — MySQL 1048, an opaque 500 at the
+// gateway), which is why `isRestNullLiteral` exists and StepsPage refuses it in
+// the form rather than letting the user meet that 500.
+export const REST_NULL = 'NULL';
+
+/**
+ * Whether a user-typed value would be swallowed by the REST_NULL sentinel.
+ *
+ * Compared against the TRIMMED value because that is what the page sends, and
+ * case-sensitively because the substitution in `rest_post`/`rest_put` is `v ==
+ * "NULL"` — 'null' and 'Null' reach the column as ordinary text and must not be
+ * refused.
+ */
+export const isRestNullLiteral = (value) => String(value ?? '').trim() === REST_NULL;
+
+// The MySQL naive-datetime form Darwin stores everywhere, in UTC — the same
+// expression Features/actions/validationApi.js uses for `completed_at`, and the
+// browser's equivalent of the MCP's `sql_now()`. `toISOString()` is UTC by
+// definition, so a step completed from any timezone stamps the same instant.
+// The 'T' has to go: `dateFormat.formatDateTime` reads the space-separated form
+// as UTC and the 'T' form as LOCAL, so shipping the ISO form would render the
+// stamp offset-shifted on every page that displays it.
+export const sqlNow = () => new Date().toISOString().slice(0, 19).replace('T', ' ');
+
+export const VALID_RUN_MODES = ['auto', 'manual'];
+
+/**
+ * Create a step in a plan.
+ *
+ * `completed_at` is never set here — a step is born incomplete, and a step with
+ * requirements may never carry the stamp at all (design rule 1). Requirement
+ * links and dependency rows are not created either: the MCP's
+ * `create_pipeline_step` is atomic over all three precisely because plan edit and
+ * launch are ONE action (req #3083), and this page deliberately does not own that
+ * act — see the header of StepsPage.jsx.
+ */
+export async function createStep(darwinUri, idToken,
+    { pipeline_fk, title, run = 'auto', notes = null }) {
+    const r = await call_rest_api(`${darwinUri}/pipeline_steps`, 'POST',
+        { pipeline_fk, title, run, notes, completed_at: null }, idToken);
+    return assertOk(r, 'createStep');
+}
+
+/**
+ * Update a step's own columns.
+ *
+ * `fields` is a partial update. Nullable columns the caller wants CLEARED must
+ * arrive as REST_NULL; StepsPage does that conversion where it knows which
+ * fields are nullable, rather than this transport guessing from a falsy value
+ * (an empty-string title and a cleared notes field are not the same act).
+ *
+ * `notes` REPLACES, never appends — the MCP rule, and for its reason: the
+ * transport has no append primitive, so an "append" would be a read-modify-write
+ * with the read hidden inside the call and a concurrent editor would lose an
+ * entry with no error anywhere.
+ */
+export async function updateStep(darwinUri, idToken, id, fields) {
+    const r = await call_rest_api(`${darwinUri}/pipeline_steps`, 'PUT',
+        [{ id, ...fields }], idToken);
+    return assertOk(r, 'updateStep');
+}
+
+/**
+ * Stamp `completed_at` — the manual-step completion, and the ONLY place it is
+ * ever set from the browser.
+ *
+ * DESIGN RULE 1 IS THE CALLER'S PRECONDITION, and it is not optional: this must
+ * be called only for a step whose gating set was just confirmed EMPTY BY A LIVE
+ * READ (StepsPage's `completeFlow`). `completionGuard` alone is not sufficient —
+ * it answers from the ≤30s cache. A requirement-backed step's
+ * state is DERIVED from its requirements, so a stored stamp could only ever agree
+ * with them by luck — and the plan renderers would keep showing the derived
+ * answer while this column quietly said something else.
+ */
+export async function completeStep(darwinUri, idToken, id) {
+    return updateStep(darwinUri, idToken, id, { completed_at: sqlNow() });
+}
+
+/**
+ * Clear `completed_at` — mutation honesty for a step marked done by mistake.
+ * Idempotent: reopening a step that was never completed is a no-op.
+ */
+export async function reopenStep(darwinUri, idToken, id) {
+    return updateStep(darwinUri, idToken, id, { completed_at: REST_NULL });
+}
+
+/**
+ * HARD-delete a step. Dropped stays dropped (req #3080 playbook case 8) — no
+ * tombstone, no residue.
+ *
+ * ## ONE STATEMENT, and that is the whole safety argument
+ *
+ * The MCP's `drop_pipeline_step` issues three (own deps, links, step) wrapped in
+ * a hand-written compensation, because it owes its caller a receipt counting what
+ * was removed. This page owes no receipt, and three statements from a browser is
+ * strictly worse: every intermediate failure leaves the step ALIVE and UN-GATED
+ * — which every renderer reads as eligible-immediately and the orchestration
+ * engine then launches — and a compensating restore can itself fail with nobody
+ * to tell.
+ *
+ * The database already does all of it, atomically:
+ *   * `pipeline_step_requirements.step_fk` CASCADES — the links go with the step.
+ *   * `pipeline_step_deps.step_fk` CASCADES — the step's OWN gate rows go with it.
+ *   * `pipeline_step_deps.dep_step_fk` is ON DELETE RESTRICT — MySQL REFUSES the
+ *     whole statement if another step gates on this one, which is design rule 4
+ *     enforced by the schema rather than by a check that could be stale. Nothing
+ *     is stripped on the refusal path, because nothing else was attempted.
+ *
+ * So the worst case here is a clean 409 with the plan untouched. `dropBlockers`
+ * still runs first in the page, but only to REFUSE POLITELY and name the steps
+ * responsible — correctness no longer depends on it being right.
+ *
+ * (MySQL evaluates that RESTRICT even against a dep row inside the same cascade,
+ * which is why a MULTI-step sweep needs two phases — see the note in
+ * darwin-mcp/tests/conftest.py. Deleting ONE step never hits that case: the only
+ * dep rows cascaded are its own, and those reference steps that survive.)
+ */
+export async function deleteStep(darwinUri, idToken, id) {
+    const r = await call_rest_api(`${darwinUri}/pipeline_steps`, 'DELETE', { id }, idToken);
+    return assertOk(r, 'deleteStep');
+}
+
+/**
+ * The requirement ids currently linked to a step, read LIVE.
+ *
+ * Design rule 1 cannot be enforced against a cache. `staleTime` is 30s
+ * (QueryClientSetup.jsx), and the Primary AI links requirements onto steps of the
+ * live plan while this page is open — so a guard that trusts the grid's own data
+ * can approve a stamp on a step that acquired a gating requirement seconds ago,
+ * and the resulting `completed_at` is silent: `deriveStepState` ignores it while
+ * the requirement exists, so the disagreement only surfaces later, when unlinking
+ * that requirement makes the step derive Complete from a stamp nobody intended.
+ * The MCP's `complete_pipeline_step` re-reads for exactly this reason.
+ *
+ * `fetchEntity` is the house GET helper and carries the convention that matters
+ * here: Lambda-Rest answers a filtered GET that matches nothing with a 404, which
+ * `call_rest_api` THROWS on, and `fetchEntity` turns back into `[]`. A step with
+ * no links is the common case, so getting that wrong would break the guard on
+ * precisely the steps it is meant to let through.
+ *
+ * It does NOT swallow a real failure — a 5xx propagates, and the caller must
+ * refuse the stamp rather than proceed on an unknown link set.
+ */
+export async function fetchStepRequirementIds(darwinUri, idToken, stepId) {
+    const rows = await fetchEntity(
+        `${darwinUri}/pipeline_step_requirements?step_fk=${stepId}`, idToken);
+    return (Array.isArray(rows) ? rows : []).map(r => r.requirement_fk);
+}
+
+/**
+ * One requirement's `tracking` flag, read LIVE. Returns null when the row is gone.
+ *
+ * The companion to the read above, and it exists because live IDS with cached
+ * FLAGS is still half a cached guard. Only the ids the cache wants to EXEMPT are
+ * worth re-reading — an id it does not know already gates, and an id it calls
+ * work already gates — so this is called on a set that is empty for essentially
+ * every step and never bigger than that step's container count.
+ *
+ * `null` means NOT CONFIRMED, and the caller must treat it as gating EXPLICITLY —
+ * it cannot leave that to the merge. A null row contributes nothing, so the merge
+ * falls back to whatever the cache held, and the cache holding `tracking: 1` is
+ * exactly the case this call exists to distrust. A 5xx propagates instead and
+ * refuses the stamp; this is only the quiet path.
+ *
+ * `fields` is narrowed to the two columns the decision needs. It does not share
+ * `useAllRequirements`' cache — this is a deliberate uncached read, and going
+ * through the query client would defeat its own purpose.
+ */
+export async function fetchRequirementTracking(darwinUri, idToken, requirementId) {
+    const rows = await fetchEntity(
+        `${darwinUri}/requirements?id=${requirementId}&fields=id,tracking`, idToken);
+    return (Array.isArray(rows) && rows.length) ? rows[0] : null;
+}

--- a/src/Steps/stepsModel.js
+++ b/src/Steps/stepsModel.js
@@ -1,0 +1,296 @@
+// stepsModel.js — the pure page model behind /swarm/steps (req #3140).
+//
+// PURE: plain rows in, plain rows out. No React, no MUI, no hooks, no clock. Its
+// own module so vitest can exercise it without a DOM and so StepsPage stays in
+// React Fast Refresh (the instructionSort.js lesson).
+//
+// ## It does not derive step state. It ASKS.
+//
+// A step's state is derived, never stored (req #3080 design rule 1), and Darwin
+// already has exactly two implementations of that derivation on purpose:
+// `pipelineModel.js` for the browser and `pipeline_derive.py` for the daemon,
+// kept honest by a shared 29-case conformance corpus. A third one here — even a
+// three-line one — would be a third thing to keep in step, and the failure mode
+// is an editor page that disagrees with the plan it edits about whether a step
+// is Running. So this module runs the REAL engine: `buildPipelineModel` narrows
+// the whole-table reads to one plan, `buildPlanRows` derives, and everything
+// below only decorates the result.
+//
+// COST: pure CPU over rows the app has already fetched, and no gateway read of
+// its own — the six lists are the same ones `/swarm/pipelines` and
+// `/swarm/pipeline/:id` use, so arriving from either paints from cache (design
+// rule 5, and memory/detail-page-interlinking.md's composition rule). The work
+// grows with the number of steps, never with the number of requests.
+//
+// It deliberately does NOT call `orderedPlan`: display order, launch batches,
+// eligibility and the time axis are the PLAN's concerns. This page is a grid the
+// user sorts by clicking a header, and a topologically-ordered editor that
+// silently re-sorts itself when a requirement closes would be a worse editor.
+
+import {
+    buildPipelineModel,
+} from '../SwarmView/pipelines/pipelineViewModel';
+import {
+    buildPlanRows,
+    isTrackingRequirement,
+    STEP_DONE,
+    STEP_RUNNING,
+    STEP_PENDING,
+} from '../SwarmView/pipelines/pipelineModel';
+
+const asArray = (v) => (Array.isArray(v) ? v : []);
+
+export { STEP_DONE, STEP_RUNNING, STEP_PENDING };
+
+/**
+ * The steps whose dependency row references `stepId` — design rule 4's blockers.
+ *
+ * ## This is a PREVIEW of the database's answer, not the enforcement
+ *
+ * The enforcement is `pipeline_step_deps.dep_step_fk ON DELETE RESTRICT`, and
+ * since `deleteStep` is a single statement that constraint is reached with
+ * nothing else attempted — a blocked delete is an atomic 409 with the plan
+ * untouched. So this function's whole job is to turn that 409 into a sentence
+ * naming the steps responsible, from data the page already has.
+ *
+ * That makes MATCHING THE DATABASE the only correctness criterion here. It is not
+ * a safety check that may err on the strict side; a disagreement in either
+ * direction is a wrong message. Which is why a SELF-DEPENDENCY counts: InnoDB
+ * evaluates the RESTRICT even against a dep row that is itself inside the same
+ * cascade (measured and recorded in darwin-mcp/tests/conftest.py — it is why a
+ * multi-step sweep needs two phases), so `(step_fk=X, dep_step_fk=X)` really does
+ * refuse the delete of X. Excluding it here would have been right when this check
+ * WAS the enforcement — the step would have been permanently undeletable through
+ * the page — and is wrong now that the database refuses anyway: the user would
+ * get a bare gateway code where a named refusal was available. No current write
+ * surface can create such a row (`set_step_deps` rejects self-deps loudly), so
+ * this is about the two answers agreeing, not about an input in flight.
+ *
+ * Sorted and de-duplicated so the message is stable: two dependency rows on one
+ * step (a step gate plus a wall-clock gate) must not name it twice.
+ *
+ * @param {number} stepId
+ * @param {Object[]} stepDeps  pipeline_step_deps rows
+ * @returns {number[]}
+ */
+export function dropBlockers(stepId, stepDeps) {
+    const blockers = new Set();
+    for (const dep of asArray(stepDeps)) {
+        if (!dep) continue;
+        // A WALL-CLOCK row references no step and can never block a delete. The
+        // test is on the ROW rather than only on the comparison because
+        // `dep_step_fk` is null on those rows: a nullish `stepId` reaching here
+        // would equal every one of them and refuse a legal delete, naming steps
+        // that merely carry a time gate.
+        if (dep.dep_step_fk == null || dep.dep_step_fk !== stepId) continue;
+        blockers.add(dep.step_fk);
+    }
+    return [...blockers].sort((a, b) => a - b);
+}
+
+/**
+ * The GATING subset of a link set — design rule 1's input, in one place.
+ *
+ * Used by `buildStepEditorRows` for the grid and by the page's LIVE re-read
+ * before a stamp, so the displayed guard and the enforced guard cannot be two
+ * different rules.
+ *
+ * TRACKING CONTAINERS ARE EXEMPT (req #3123): a container is not work and never
+ * gates a step, so a step whose only links are containers falls through to its
+ * own `completed_at` exactly as a link-less step does. Counting them would make
+ * such a step permanently un-completable — the exemption's own new bug.
+ *
+ * An UNRESOLVED id — one the requirements read did not return — gates, because
+ * `isTrackingRequirement(undefined)` is false. Nothing was read that said it is a
+ * container, and refusing a stamp is the recoverable direction.
+ *
+ * @param {number[]} reqIds
+ * @param {Object[]} requirements  any superset
+ * @returns {number[]}
+ */
+export function gatingRequirementIds(reqIds, requirements) {
+    const byId = new Map(asArray(requirements).map((r) => [r.id, r]));
+    return asArray(reqIds).filter((rid) => !isTrackingRequirement(byId.get(rid)));
+}
+
+/**
+ * Whether `completed_at` may be stamped on this row — design rule 1, client-side.
+ *
+ * The browser writes straight to Lambda-Rest, so the rule the MCP's
+ * `complete_pipeline_step` enforces in Python is unenforced unless the client
+ * enforces it. A requirement-backed step's state is DERIVED from its
+ * requirements; a stored stamp could only ever agree with them by luck, and the
+ * plan table would keep rendering the derived answer while the column quietly
+ * said something else.
+ *
+ * THIS FUNCTION IS THE FAST PATH, NOT THE ENFORCEMENT. It answers from whatever
+ * link set the caller's row was built from, which is a ≤30s cache. What actually
+ * decides is StepsPage's `completeFlow`, which re-reads the step's links live
+ * before any stamp and calls this again on the result. Use it to render, and to
+ * refuse early; never as the last word before a write.
+ *
+ * ## It is deliberately STRICTER than `deriveStepState` on an unresolved id
+ *
+ * `buildPlanRows` filters unresolved ids out with `.filter(Boolean)` before
+ * `deriveStepState` sees them, so a step whose only link is an unreadable
+ * requirement DERIVES from its own stamp — while this guard counts that id and
+ * refuses. The two disagree on purpose, because they answer different questions:
+ * the engine asks *what does the data say this step is*, and the safest answer
+ * for a row it cannot read is to fall back to the stored column. This asks *may a
+ * human overwrite that column*, and the honest answer while a link is unreadable
+ * is no. Such a step renders Scheduled and refuses the stamp until the read
+ * recovers — visibly stuck rather than invisibly wrong.
+ *
+ * @param {Object} row  a step editor row
+ * @returns {{allowed: boolean, reason: string}}
+ */
+export function completionGuard(row) {
+    const gating = asArray(row && row.gatingReqIds);
+    if (!gating.length) {
+        return {
+            allowed: true,
+            reason: row && row.completedAt
+                ? 'Complete — click to reopen this step'
+                : 'Scheduled — click to mark this step complete',
+        };
+    }
+    const tracking = asArray(row.trackingReqIds);
+    // The verbs agree with the noun. A `${n === 1 ? '' : 's'}` that switches only
+    // the noun produced "1 tracking container 3083 are exempt and were not
+    // counted" — and the singular is the common case, so it was the wording most
+    // readers would have seen.
+    const one = tracking.length === 1;
+    const exempt = tracking.length
+        ? ` (${tracking.length} tracking container${one ? '' : 's'} `
+          + `${tracking.join(', ')} ${one ? 'is' : 'are'} exempt and `
+          + `${one ? 'was' : 'were'} not counted)`
+        : '';
+    return {
+        allowed: false,
+        reason: `Derived from ${gating.length} gating requirement`
+            + `${gating.length === 1 ? '' : 's'} ${gating.join(', ')}${exempt} — `
+            + 'close or unlink them to control this step by hand.',
+    };
+}
+
+/**
+ * Every step in every plan, decorated for the editor grid.
+ *
+ * Steps are grouped by `pipeline_fk` and derived one plan at a time, because the
+ * engine's contract is a model scoped to ONE pipeline — the junction and dep
+ * tables carry no pipeline_fk, so there is no other way to narrow them. A step
+ * whose pipeline is missing from the pipelines read is still derived, against a
+ * synthetic `{id: <fk>}`: an unresolved plan is a fetch problem, and dropping the
+ * step would hide it from the one page that could fix it.
+ *
+ * `unrenderedStepIds` is the honesty channel. Any step the grouping could not
+ * place — a null or non-integer `pipeline_fk` — comes back here rather than
+ * vanishing, and the page says so. Silence about a dropped row on an editor page
+ * is how a plan loses a step nobody can see.
+ *
+ * @param {Object} args  the six bounded list reads plus the three dictionaries
+ * @returns {{rows: Object[], unrenderedStepIds: number[]}}
+ */
+export function buildStepEditorRows({
+    pipelines,
+    steps,
+    stepRequirements,
+    stepDeps,
+    requirements,
+    features,
+    epics,
+    machines,
+} = {}) {
+    const allSteps = asArray(steps);
+    const pipelineById = new Map(asArray(pipelines).map((p) => [p.id, p]));
+
+    // Grouped in ENCOUNTER order so the grid's default (unsorted) order follows
+    // `sort=id:asc` from the read — the order the plan pages already see.
+    const byPipeline = new Map();
+    const unrenderedStepIds = [];
+    for (const step of allSteps) {
+        if (!step) continue;
+        const fk = step.pipeline_fk;
+        if (!Number.isInteger(fk)) {
+            if (step.id != null) unrenderedStepIds.push(step.id);
+            continue;
+        }
+        if (!byPipeline.has(fk)) byPipeline.set(fk, []);
+        byPipeline.get(fk).push(step);
+    }
+
+    const rows = [];
+    for (const [fk, ownSteps] of byPipeline) {
+        const pipeline = pipelineById.get(fk) || null;
+        const planRows = buildPlanRows(buildPipelineModel({
+            // A synthetic row when the plan itself did not resolve — the engine
+            // only ever reads `pipeline.id`, and every other column it would want
+            // belongs to the pipelines page, not to a step.
+            pipeline: pipeline || { id: fk },
+            steps: ownSteps,
+            stepRequirements,
+            stepDeps,
+            requirements,
+            features,
+            epics,
+            machines,
+        }));
+        for (const planRow of planRows) {
+            rows.push({
+                ...planRow,
+                pipelineId: fk,
+                pipelineTitle: pipeline ? pipeline.title : null,
+                pipelineStatus: pipeline ? pipeline.pipeline_status : null,
+                // Design rule 1's input, through the SAME function the page's live
+                // pre-stamp re-read uses — so what the chip shows and what the
+                // write path enforces are one rule, not two that agree today.
+                gatingReqIds: gatingRequirementIds(planRow.reqIds, requirements),
+                blockerStepIds: dropBlockers(planRow.id, stepDeps),
+            });
+        }
+    }
+
+    return { rows, unrenderedStepIds };
+}
+
+/**
+ * The grid's visible rows.
+ *
+ * `null` means "every value, including ones that do not exist yet" — the
+ * ChipFilter contract (memory/chip-filter-pattern.md). An EMPTY array is a legal
+ * selection meaning "show nothing" and is never auto-corrected back to all: a
+ * user who deselects every chip gets an empty view, which is honest feedback that
+ * the filter is doing something.
+ *
+ * @param {Object[]} rows
+ * @param {{pipelineIds: ?number[], states: ?string[]}} filters
+ * @returns {Object[]}
+ */
+export function filterStepRows(rows, { pipelineIds = null, states = null } = {}) {
+    return asArray(rows).filter((row) => {
+        if (pipelineIds != null && !pipelineIds.includes(row.pipelineId)) return false;
+        if (states != null && !states.includes(row.state)) return false;
+        return true;
+    });
+}
+
+/**
+ * Complete / Running / Scheduled counts for the accounting line.
+ *
+ * Called on the FULL row set, never the filtered one (view-switchable-pages
+ * § V7 — accounting describes the data, not the current view). The page prints
+ * "N of M steps" beside it, which is where the filter's effect is stated.
+ *
+ * @param {Object[]} rows
+ * @returns {{total: number, done: number, running: number, pending: number}}
+ */
+export function stepsAccounting(rows) {
+    const out = { total: 0, done: 0, running: 0, pending: 0 };
+    for (const row of asArray(rows)) {
+        out.total += 1;
+        if (row.state === STEP_DONE) out.done += 1;
+        else if (row.state === STEP_RUNNING) out.running += 1;
+        else out.pending += 1;
+    }
+    return out;
+}

--- a/src/SwarmView/pipelines/PipelineDetail.jsx
+++ b/src/SwarmView/pipelines/PipelineDetail.jsx
@@ -72,6 +72,7 @@ import {
     findPipelineDetailMode,
 } from './pipelineDetailModes';
 import { pipelineStatusChipProps } from './pipelineChipStyles';
+import { readFocusStepParam } from './pipelineStepLink';
 import SemanticLevelControl from '../../Components/SemanticLevelControl';
 import {
     DEFAULT_COLOR_KEY, DEFAULT_PLAN_LEVEL_PREF, DEFAULT_REQ_VIEW, DEFAULT_STEP_WIDTH,
@@ -353,15 +354,29 @@ export default function PipelineDetail() {
     const requestedMode = searchParams.get('mode');
     const linkMode = PIPELINE_DETAIL_MODES.some(
         (m) => m.value === requestedMode && !m.disabled) ? requestedMode : null;
+    // ── `?step=` makes ONE STEP addressable (req #3140) ──────────────────────
+    // The receiving end of the Steps editor's row link, and the same handshake a
+    // bead click already uses: seed `focusStepId`, and the table scrolls to and
+    // highlights that row. `pipelineStepLink.js` owns both halves of the
+    // contract so the writer and this reader cannot drift on the key.
+    const linkStepId = readFocusStepParam(searchParams);
+    // A named step FORCES the table, overriding `?mode=` when the two disagree.
+    // Only the table consumes `focusStepId` — the visualizer has beads, not rows,
+    // and ignores the prop entirely — so honoring `?mode=plan&step=7` as written
+    // would land the reader on a plan with nothing highlighted and nothing to say
+    // why. Naming a row is the more specific request, so it wins.
+    const linkView = linkStepId != null ? 'table' : linkMode;
 
-    const [focusStepId, setFocusStepId] = useState(null);
-    const [modeOverride, setModeOverride] = useState(linkMode);
-    // Re-seeds when the LINK changes — a new `?mode=` or a different plan — and at
-    // no other time, so a manual pick below is never resurrected by a re-render.
+    const [focusStepId, setFocusStepId] = useState(linkStepId);
+    const [modeOverride, setModeOverride] = useState(linkView);
+    // Re-seeds when the LINK changes — a new `?mode=`, a new `?step=`, or a
+    // different plan — and at no other time, so a manual pick below is never
+    // resurrected by a re-render. A link with no `?step=` clears the focus, which
+    // is what keeps a stale highlight from surviving an unrelated navigation.
     useEffect(() => {
-        setModeOverride(linkMode);
-        setFocusStepId(null);
-    }, [linkMode, pipelineId]);
+        setModeOverride(linkView);
+        setFocusStepId(linkStepId);
+    }, [linkView, linkStepId, pipelineId]);
     const onStepFocus = useCallback((stepId) => {
         setFocusStepId(stepId);
         setModeOverride('table');

--- a/src/SwarmView/pipelines/__tests__/PipelineDetail.stepParam.test.jsx
+++ b/src/SwarmView/pipelines/__tests__/PipelineDetail.stepParam.test.jsx
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+//
+// Req #3140 — the RECEIVING end of the Steps editor's row link.
+//
+// `pipelineStepLink.test.js` pins the two pure functions. This pins the React
+// half, which is where the property that actually matters lives: a `?step=` link
+// seeds `focusStepId` and forces the table, and NEITHER of those may survive a
+// manual mode pick. The mode-override machinery is shared with the req #3115
+// bead-click handshake and with `?mode=`, so an edit to that effect's dependency
+// list would break all three at once and silently.
+//
+// The two mode panels are STUBBED: the real Plan mode is react-konva, which needs
+// a canvas jsdom does not provide, and none of this requirement's behaviour is in
+// either panel. The stub reports the props the handshake is made of.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// The panel factory lives INSIDE the factory: vi.mock is hoisted above every
+// top-level binding in this file, so a `const Panel` outside is a TDZ error.
+vi.mock('../pipelineDetailModes', () => {
+    const Panel = (name) => function ModeStub({ focusStepId }) {
+        return <div data-testid={`mode-${name}`}
+                    data-focus={focusStepId == null ? '' : String(focusStepId)} />;
+    };
+    const MODES = [
+        { value: 'table', label: 'Table', icon: () => null, Component: Panel('table') },
+        { value: 'plan', label: 'Plan', icon: () => null, Component: Panel('plan') },
+    ];
+    return {
+        PIPELINE_DETAIL_MODES: MODES,
+        PIPELINE_DETAIL_MODE_STORAGE_KEY: 'darwin-swarm-pipeline-detail-mode',
+        DEFAULT_PIPELINE_DETAIL_MODE: 'table',
+        findPipelineDetailMode: (v) => MODES.find((m) => m.value === v),
+        default: MODES,
+    };
+});
+
+vi.mock('../../../RestApi/RestApi', () => ({ default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })) }));
+
+vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    const empty = () => ({ data: [], isLoading: false, isError: false });
+    return {
+        ...actual,
+        useAllPipelines: () => ({
+            data: [{ id: 2, title: 'Darwin', pipeline_status: 'active', description: '' }],
+            isLoading: false,
+        }),
+        useAllPipelineSteps: () => ({
+            data: [{ id: 47, pipeline_fk: 2, title: 'Session Drain', run: 'auto', notes: null, completed_at: null }],
+            isLoading: false,
+        }),
+        useAllPipelineStepRequirements: empty,
+        useAllPipelineStepDeps: empty,
+        useAllRequirements: empty,
+        useAllFeatures: empty,
+        useAllEpics: empty,
+        useMachines: empty,
+        useAllRequirementSessions: empty,
+        useAllSessionCostRollups: empty,
+    };
+});
+
+import PipelineDetail from '../PipelineDetail';
+import AuthContext from '../../../Context/AuthContext';
+import AppContext from '../../../Context/AppContext';
+
+let mountedRoots = [];
+
+function mount(url) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0, refetchOnWindowFocus: false } },
+    });
+    const root = createRoot(container);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local/darwin' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <MemoryRouter initialEntries={[url]}>
+                            <Routes>
+                                <Route path="/swarm/pipeline/:id" element={<PipelineDetail />} />
+                            </Routes>
+                        </MemoryRouter>
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    mountedRoots.push(root);
+}
+
+const node = (testId) => document.body.querySelector(`[data-testid="${testId}"]`);
+const focusOf = (name) => node(`mode-${name}`)?.getAttribute('data-focus');
+const click = (el) => act(() => { el.click(); });
+
+// `useViewPreference` stores a RAW string and reads sessionStorage FIRST, falling
+// back to localStorage for a newly opened tab. A JSON-encoded value would arrive
+// as `"plan"` with the quotes, fail normalizeView, and silently fall through to
+// the default — making a preference test pass for the wrong reason.
+const storePreference = (value) => {
+    localStorage.setItem('darwin-swarm-pipeline-detail-mode', value);
+    sessionStorage.setItem('darwin-swarm-pipeline-detail-mode', value);
+};
+
+beforeEach(() => {
+    mountedRoots = [];
+    localStorage.clear();
+    sessionStorage.clear();
+});
+
+afterEach(() => {
+    act(() => { mountedRoots.forEach(r => r.unmount()); });
+    document.body.innerHTML = '';
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+});
+
+describe('PipelineDetail — ?step= (req #3140)', () => {
+    it('seeds the focus on the FIRST render, not after an effect', () => {
+        // `useState(linkStepId)` rather than a `useState(null)` an effect corrects:
+        // the table scrolls to the focused row in its own layout effect, and a
+        // focus that arrives a paint later can miss that.
+        mount('/swarm/pipeline/2?mode=table&step=47');
+        expect(focusOf('table')).toBe('47');
+    });
+
+    it('forces the TABLE even when ?mode= names the visualizer', () => {
+        // Only the table consumes focusStepId. Honouring ?mode=plan here would
+        // land the reader on a plan with nothing highlighted and nothing to say why.
+        mount('/swarm/pipeline/2?mode=plan&step=47');
+        expect(node('mode-table')).not.toBeNull();
+        expect(node('mode-plan')).toBeNull();
+        expect(focusOf('table')).toBe('47');
+    });
+
+    it('forces the table over a STORED preference of plan', () => {
+        storePreference('plan');
+        mount('/swarm/pipeline/2?step=47');
+        expect(node('mode-table')).not.toBeNull();
+        expect(focusOf('table')).toBe('47');
+    });
+
+    it('leaves the stored preference in charge when there is no ?step=', () => {
+        storePreference('plan');
+        mount('/swarm/pipeline/2');
+        expect(node('mode-plan')).not.toBeNull();
+        expect(focusOf('plan')).toBe('');
+    });
+
+    it('carries no focus when the parameter is absent or unusable', () => {
+        mount('/swarm/pipeline/2?mode=table');
+        expect(focusOf('table')).toBe('');
+    });
+
+    it('ignores a non-integer ?step=, rather than focusing NaN or 0', () => {
+        mount('/swarm/pipeline/2?mode=table&step=12abc');
+        expect(focusOf('table')).toBe('');
+        mount('/swarm/pipeline/2?mode=table&step=');
+        expect(focusOf('table')).toBe('');
+    });
+
+    // THE PROPERTY A DEPENDENCY-LIST EDIT WOULD BREAK SILENTLY. The link asks to
+    // see one thing once; picking a mode by hand must clear both the override and
+    // the focus and must never be resurrected by a re-render.
+    it('a manual mode pick clears the focus and survives re-render', () => {
+        mount('/swarm/pipeline/2?mode=table&step=47');
+        expect(focusOf('table')).toBe('47');
+        click(node('pipeline-mode-plan'));
+        expect(node('mode-plan')).not.toBeNull();
+        expect(focusOf('plan')).toBe('');
+        // Re-render via an unrelated state change on the same page — the
+        // description dialog. The URL is untouched, so the seeding effect must
+        // not fire again and drag the reader back to the table.
+        click(node('pipeline-description-btn'));
+        expect(node('mode-plan')).not.toBeNull();
+        expect(focusOf('plan')).toBe('');
+    });
+
+    it('a manual pick back to table does not resurrect the link focus', () => {
+        mount('/swarm/pipeline/2?mode=table&step=47');
+        click(node('pipeline-mode-plan'));
+        click(node('pipeline-mode-table'));
+        expect(focusOf('table')).toBe('');
+    });
+});

--- a/src/SwarmView/pipelines/__tests__/pipelineStepLink.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineStepLink.test.js
@@ -1,0 +1,77 @@
+// Req #3140 — the addressable-step contract.
+//
+// Both halves live in one module precisely so they can be pinned against each
+// other: the round-trip test below is the whole point of the file. A builder that
+// emits `?stepId=` and a reader that looks for `?step=` would each pass their own
+// unit test and produce a link that navigates to the right plan and silently
+// highlights nothing.
+
+import { describe, it, expect } from 'vitest';
+import {
+    FOCUS_STEP_PARAM,
+    readFocusStepParam,
+    stepLinkTo,
+} from '../pipelineStepLink';
+
+describe('stepLinkTo', () => {
+    it('names the plan, the table mode and the step', () => {
+        expect(stepLinkTo(2, 47)).toBe('/swarm/pipeline/2?mode=table&step=47');
+    });
+
+    it('accepts numeric strings, because a grid row carries whatever the wire sent', () => {
+        expect(stepLinkTo('2', '47')).toBe('/swarm/pipeline/2?mode=table&step=47');
+    });
+
+    it('returns null rather than a link to /swarm/pipeline/undefined', () => {
+        // The caller renders a plain chip instead. A step whose pipeline did not
+        // resolve is a real state on the editor page — the pipelines read can fail
+        // independently of the steps read.
+        expect(stepLinkTo(null, 47)).toBeNull();
+        expect(stepLinkTo(undefined, 47)).toBeNull();
+        expect(stepLinkTo(2, null)).toBeNull();
+        expect(stepLinkTo('abc', 47)).toBeNull();
+        expect(stepLinkTo(2, 1.5)).toBeNull();
+    });
+});
+
+describe('readFocusStepParam', () => {
+    const params = (search) => new URLSearchParams(search);
+
+    it('reads the id a link names', () => {
+        expect(readFocusStepParam(params('mode=table&step=47'))).toBe(47);
+    });
+
+    it('is null when the parameter is absent', () => {
+        expect(readFocusStepParam(params('mode=table'))).toBeNull();
+    });
+
+    it('rejects every non-integer form rather than producing a NaN or a 0', () => {
+        // `Number('')` is 0 and `Number('12abc')` is NaN. Both would be handed to a
+        // `row.id === focusStepId` comparison and to a querySelector, matching
+        // nothing while suppressing nothing — a highlight that silently never
+        // appears is worse than no parameter at all.
+        expect(readFocusStepParam(params('step='))).toBeNull();
+        expect(readFocusStepParam(params('step=%20'))).toBeNull();
+        expect(readFocusStepParam(params('step=12abc'))).toBeNull();
+        expect(readFocusStepParam(params('step=1.5'))).toBeNull();
+        expect(readFocusStepParam(params('step=NaN'))).toBeNull();
+    });
+
+    it('survives a caller with no search params at all', () => {
+        expect(readFocusStepParam(null)).toBeNull();
+        expect(readFocusStepParam(undefined)).toBeNull();
+        expect(readFocusStepParam({})).toBeNull();
+    });
+
+    it('round-trips what stepLinkTo built', () => {
+        const to = stepLinkTo(2, 47);
+        const search = to.slice(to.indexOf('?'));
+        expect(readFocusStepParam(new URLSearchParams(search))).toBe(47);
+        expect(new URLSearchParams(search).get('mode')).toBe('table');
+    });
+
+    it('exports the key both halves agree on', () => {
+        expect(FOCUS_STEP_PARAM).toBe('step');
+        expect(stepLinkTo(1, 2)).toContain(`${FOCUS_STEP_PARAM}=2`);
+    });
+});

--- a/src/SwarmView/pipelines/pipelineStepLink.js
+++ b/src/SwarmView/pipelines/pipelineStepLink.js
@@ -1,0 +1,83 @@
+// pipelineStepLink.js — the addressable-step contract (req #3140).
+//
+// ONE step of a plan, named by URL: `/swarm/pipeline/<pid>?mode=table&step=<sid>`.
+//
+// WHY BOTH HALVES LIVE IN ONE MODULE. The writer is the Steps editor
+// (`src/Steps/StepsPage.jsx`) and the reader is the plan page
+// (`PipelineDetail.jsx`) — two files in two directories that must agree on a
+// query-string key exactly. A builder in one and a `searchParams.get('step')` in
+// the other is a contract with no single definition, and the failure mode is a
+// link that navigates to the right plan and silently highlights nothing. Putting
+// the key in one place makes a rename a compile-time-shaped edit rather than a
+// grep.
+//
+// It is the SAME handshake req #3115 built for a bead click — the visualizer
+// calls `onStepFocus(stepId)`, the page switches to the table, the table scrolls
+// to and highlights that row. This only adds a way to enter that handshake from
+// outside the page. Nothing about `focusStepId` changes.
+//
+// `mode=table` is carried explicitly rather than left to the stored preference:
+// a step is a ROW, and the visualizer has no row to scroll to. Both parameters
+// seed the same TRANSIENT override — a link asks to see one thing once and must
+// never rewrite the reader's own default view (the `normalizeView` doctrine).
+//
+// NO JSX and no React: a pure module vitest can exercise without a DOM, and a
+// component file with non-component exports drops out of Fast Refresh (the
+// instructionSort.js lesson).
+
+export const FOCUS_STEP_PARAM = 'step';
+
+/**
+ * The route a step row links to.
+ *
+ * Returns null when either id is unusable, so a caller renders a plain number
+ * instead of a link that would navigate to `/swarm/pipeline/undefined`. A step
+ * whose `pipeline_fk` did not resolve is a real state on the editor page — the
+ * pipelines read can fail independently of the steps read.
+ *
+ * @param {?number} pipelineId
+ * @param {?number} stepId
+ * @returns {?string}
+ */
+export function stepLinkTo(pipelineId, stepId) {
+    const pid = toId(pipelineId);
+    const sid = toId(stepId);
+    if (pid == null || sid == null) return null;
+    return `/swarm/pipeline/${pid}?mode=table&${FOCUS_STEP_PARAM}=${sid}`;
+}
+
+// NULLISH AND EMPTY ARE REJECTED BEFORE `Number` SEES THEM, which is the whole
+// reason this is a function and not an inline `Number.isInteger(Number(x))`:
+// `Number(null)` and `Number('')` are both 0, and 0 is a perfectly good integer.
+// A step whose `pipeline_fk` did not resolve would have produced a confident link
+// to `/swarm/pipeline/0` — a plan that does not exist, rendering the page's
+// not-found alert as though the data were at fault.
+function toId(value) {
+    if (value == null || value === '') return null;
+    const n = Number(value);
+    return Number.isInteger(n) ? n : null;
+}
+
+/**
+ * The step id a `?step=` parameter names, or null.
+ *
+ * VALIDATED, never trusted. The value is user-editable address-bar text handed
+ * to a `[data-testid="pipeline-step-row-<id>"]` selector and compared against
+ * `row.id`; `Number('12abc')` is NaN and `Number('')` is 0, and both would
+ * produce a focus id that matches no row while suppressing nothing. An id that
+ * names no step in this plan is not an error — the plan simply renders with
+ * nothing highlighted, exactly as it does with no parameter at all.
+ *
+ * Accepts anything with a `.get(key)` — a URLSearchParams, or React Router's
+ * wrapper around one — so the reader can be tested without a router.
+ *
+ * @param {{get: function(string): ?string}} searchParams
+ * @returns {?number}
+ */
+export function readFocusStepParam(searchParams) {
+    const raw = searchParams && typeof searchParams.get === 'function'
+        ? searchParams.get(FOCUS_STEP_PARAM) : null;
+    if (raw == null || String(raw).trim() === '') return null;
+    const id = Number(raw);
+    return Number.isInteger(id) ? id : null;
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -60,6 +60,7 @@ import SwarmCompleteDetail from './SwarmCompletes/SwarmCompleteDetail';
 import PipelinesPage from './SwarmView/pipelines/PipelinesPage';
 import PipelineDetail from './SwarmView/pipelines/PipelineDetail';
 import EpicsPage from './Epics/EpicsPage';
+import StepsPage from './Steps/StepsPage';
 import SystemsPage2 from './Systems/SystemsPage2';
 import BuildVisualizerPage from './BuildVisualizer/BuildVisualizerPage';
 import CustomersPage from './Customers/CustomersPage';
@@ -170,6 +171,14 @@ root.render(
                         is what a plan is made of. */}
                     <Route path="swarm/epics" element= {<AuthenticatedRoute>
                                                              <EpicsPage />
+                                                         </AuthenticatedRoute>} />
+                    {/* Steps editor (req #3140) — the members of a plan, sited
+                        beside the pipeline routes for the same reason Epics is.
+                        Every row deep-links back to "swarm/pipeline/:id" with
+                        ?mode=table&step=<id>, which is the plan surface these
+                        steps are otherwise only visible on. */}
+                    <Route path="swarm/steps" element= {<AuthenticatedRoute>
+                                                             <StepsPage />
                                                          </AuthenticatedRoute>} />
                     <Route path="swarm/features" element= {<AuthenticatedRoute>
                                                              <FeaturesPage />


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-01T14:41:37Z
- chore: init swarm session feature/3140-step-editor-page-under-the-1

## Files changed
```
 src/NavBar/__tests__/navConfig.test.js             |  40 +
 src/NavBar/navConfig.js                            |   9 +
 src/Steps/StepsPage.jsx                            | 975 +++++++++++++++++++++
 src/Steps/__tests__/StepsPage.test.jsx             | 778 ++++++++++++++++
 src/Steps/__tests__/stepsModel.test.js             | 333 +++++++
 src/Steps/stepsApi.js                              | 246 ++++++
 src/Steps/stepsModel.js                            | 296 +++++++
 src/SwarmView/pipelines/PipelineDetail.jsx         |  31 +-
 .../__tests__/PipelineDetail.stepParam.test.jsx    | 196 +++++
 .../pipelines/__tests__/pipelineStepLink.test.js   |  77 ++
 src/SwarmView/pipelines/pipelineStepLink.js        |  83 ++
 src/index.jsx                                      |   9 +
 12 files changed, 3065 insertions(+), 8 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)