### PR TITLE
Requirement page: read-only epic linkage box beside AI Settings

### DIFF
--- a/src/Epics/EpicsPage.jsx
+++ b/src/Epics/EpicsPage.jsx
@@ -25,8 +25,8 @@
 // navigates to /swarm/features?epic=<id>, the same target the plan visualizer's
 // epic chip ↗ uses (req #3119). The features view's epic chip links back here.
 
-import { useContext, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
 import Box from '@mui/material/Box';
@@ -125,6 +125,7 @@ export default function EpicsPage() {
     const queryClient = useQueryClient();
     const showError = useSnackBarStore(s => s.showError);
     const navigate = useNavigate();
+    const [searchParams, setSearchParams] = useSearchParams();
 
     const creatorFk = profile?.userName;
     const timezone = profile?.timezone;
@@ -266,6 +267,36 @@ export default function EpicsPage() {
         setFormSortOrder(row.sort_order == null ? '' : String(row.sort_order));
         setDialogOpen(true);
     };
+
+    // Deep-link via ?id=<id> (req #3234): the requirement detail page's Epic
+    // linkage box links here. A flat DataGrid has no per-row route to land on,
+    // so "click through to it" means open the same edit dialog the Edit icon
+    // opens — the page's own presentation of one epic's full detail (title,
+    // description, category) that a grid row cannot show. Mirrors the
+    // `?epic=<id>` param FeaturesPage already reads from this page's own
+    // Features-count link. Fires once per param (autoOpenedIdRef) and clears
+    // the param on success so reopening the dialog and hitting Back doesn't
+    // re-trigger it; an id with no matching row is silently ignored — the
+    // grid still renders normally rather than blocking on a bad link.
+    const autoOpenedIdRef = useRef(null);
+    useEffect(() => {
+        // Gated on the PAGE's loading flag, not `epicsLoading` alone (code review,
+        // req #3234): the dialog this opens needs `categoryOptions`, which is built
+        // from `categories` — opening it while that read is still in flight put a
+        // real category id into a Select with no matching MenuItem yet.
+        if (isLoading) return;
+        const raw = searchParams.get('id');
+        if (!raw || !/^\d+$/.test(raw.trim())) return;
+        const targetId = Number(raw.trim());
+        if (autoOpenedIdRef.current === targetId) return;
+        const target = epics.find(e => e.id === targetId);
+        if (!target) return;
+        autoOpenedIdRef.current = targetId;
+        openEdit(target);
+        const next = new URLSearchParams(searchParams);
+        next.delete('id');
+        setSearchParams(next, { replace: true });
+    }, [isLoading, epics, searchParams]);
 
     const handleSubmit = async () => {
         const title = formTitle.trim();

--- a/src/Epics/__tests__/EpicsPage.test.jsx
+++ b/src/Epics/__tests__/EpicsPage.test.jsx
@@ -27,6 +27,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -104,7 +105,10 @@ import { useSnackBarStore } from '../../stores/useSnackBarStore';
 let mountedRoots = [];
 let queryClient;
 
-function mount() {
+// `initialEntries` defaults to a bare route — req #3234's `?id=<id>` deep-link
+// tests pass `['/swarm/epics?id=<id>']`. `useSearchParams` (req #3234) needs a
+// real Router in the tree; `useNavigate` stays mocked above regardless.
+function mount(initialEntries = ['/swarm/epics']) {
     const container = document.createElement('div');
     document.body.appendChild(container);
     queryClient = new QueryClient({
@@ -114,13 +118,15 @@ function mount() {
     const root = createRoot(container);
     act(() => {
         root.render(
-            <QueryClientProvider client={queryClient}>
-                <AppContext.Provider value={{ darwinUri: 'http://test.local/darwin' }}>
-                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
-                        <EpicsPage />
-                    </AuthContext.Provider>
-                </AppContext.Provider>
-            </QueryClientProvider>
+            <MemoryRouter initialEntries={initialEntries}>
+                <QueryClientProvider client={queryClient}>
+                    <AppContext.Provider value={{ darwinUri: 'http://test.local/darwin' }}>
+                        <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                            <EpicsPage />
+                        </AuthContext.Provider>
+                    </AppContext.Provider>
+                </QueryClientProvider>
+            </MemoryRouter>
         );
     });
     mountedRoots.push(root);
@@ -499,5 +505,48 @@ describe('EpicsPage delete', () => {
         // `queryKey[0] === 'swarm_sessions'` is satisfied by the list key, which
         // misses the detail row entirely; only the bare entity root reaches it.
         expect(keys).toContainEqual(['swarm_sessions']);
+    });
+});
+
+// req #3234 — the requirement detail page's Epic linkage box links here via
+// `?id=<id>`. This flat grid + dialog page has no per-row route, so "landing
+// on" a specific epic means auto-opening the same edit dialog the Edit icon
+// opens — the page's own presentation of one epic's full detail.
+describe('EpicsPage — ?id=<id> deep-link (req #3234)', () => {
+    it('opens the edit dialog for the epic named in the id param once epics have loaded', async () => {
+        mount(['/swarm/epics?id=2']);
+        await flush();
+
+        expect(node('epic-edit-dialog').className).toContain('MuiDialog');
+        expect(node('epic-title-input').value).toBe('Application Backlog');
+    });
+
+    it('does not keep re-opening (and resetting) the form on later renders', async () => {
+        mount(['/swarm/epics?id=2']);
+        await flush();
+        expect(node('epic-title-input').value).toBe('Application Backlog');
+
+        // The param is cleared and the ref guards against re-firing — if either
+        // failed, a later render would call `openEdit` again and stomp this.
+        type(node('epic-title-input'), 'Renamed');
+        await flush();
+        await flush();
+        expect(node('epic-title-input').value).toBe('Renamed');
+    });
+
+    it('ignores an id with no matching row — the grid still renders normally', async () => {
+        mount(['/swarm/epics?id=999']);
+        await flush();
+
+        expect(node('epic-title-input')).toBeNull();
+        expect(rowIds()).toEqual([2, 4, 9]);
+    });
+
+    it('does not open the dialog while categories are still loading', async () => {
+        loading = { epics: false, features: false, categories: true };
+        mount(['/swarm/epics?id=2']);
+        await flush();
+
+        expect(node('epic-title-input')).toBeNull();
     });
 });

--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect, useContext, useMemo, useRef } from 'react';
-import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Link as RouterLink } from 'react-router-dom';
 import call_rest_api from '../../RestApi/RestApi';
 import { useSnackBarStore } from '../../stores/useSnackBarStore';
 import { useShowClosedStore, ALL_REQUIREMENT_STATUSES } from '../../stores/useShowClosedStore';
-import { useAllCategories, useMachines } from '../../hooks/useDataQueries';
+import { useAllCategories, useMachines, useFeatureById, useEpicById } from '../../hooks/useDataQueries';
 import { siblingActiveSort } from './requirementSort';
 import { formatDateTime, formatDate } from '../../utils/dateFormat';
 import AuthContext from '../../Context/AuthContext';
@@ -191,6 +191,36 @@ const RequirementDetail = () => {
             }),
         [machinesData]
     );
+    // Req #3234 — Epic linkage (read-only): requirement -> feature -> epic.
+    // Targeted single-row reads (`useFeatureById`/`useEpicById`, existing in
+    // useDataQueries.js but previously unused anywhere) rather than the plan
+    // view's whole-table `useAllFeatures`/`useAllEpics` label dictionaries —
+    // this page needs at most one feature row and one epic row, not the whole
+    // account's features/epics just to resolve one requirement's chain.
+    // `!isNew` is implied by `linkedFeatureFk != null`: the new-draft literal above
+    // has no `feature_fk` key at all, so a brand-new requirement never reaches here.
+    const linkedFeatureFk = requirement?.feature_fk ?? null;
+    const { data: linkedFeatureRaw, isLoading: linkedFeatureLoading, isError: linkedFeatureErrored } =
+        useFeatureById(profile?.userName, linkedFeatureFk, { enabled: linkedFeatureFk != null });
+    const linkedFeature = Array.isArray(linkedFeatureRaw) ? linkedFeatureRaw[0] : linkedFeatureRaw;
+    const linkedEpicFk = linkedFeature?.epic_fk ?? null;
+    const { data: linkedEpicRaw, isLoading: linkedEpicLoading, isError: linkedEpicErrored } =
+        useEpicById(profile?.userName, linkedEpicFk, { enabled: linkedEpicFk != null });
+    const linkedEpic = Array.isArray(linkedEpicRaw) ? linkedEpicRaw[0] : linkedEpicRaw;
+    // Still resolving if the feature fetch hasn't landed yet, or it has and named
+    // an epic whose fetch hasn't landed yet. NOT loading when there is simply no
+    // feature (or no epic) to resolve — that is an answer, not a pending one.
+    const epicLinkResolving = linkedFeatureFk != null &&
+        (linkedFeatureLoading || (linkedEpicFk != null && linkedEpicLoading));
+    // Code review, req #3234: a failed fetch is NOT "no epic" — `isLoading` alone
+    // (TanStack v5: pending && fetching) goes false once retries exhaust on an
+    // error, same as on a real resolve, and rendering "No epic" there asserts a
+    // wrong fact the user can't tell apart from the true unlinked case. Kept
+    // distinct from `epicLinkResolving` rather than folded in: this box is
+    // read-only and reports what it knows, so "couldn't check" and "checked,
+    // there's nothing" have to read differently.
+    const epicLinkErrored = linkedFeatureErrored || (linkedEpicFk != null && linkedEpicErrored);
+
     // Filter chips now match DB status values directly
     const siblingStatuses = [...requirementStatusFilter];
 
@@ -251,6 +281,12 @@ const RequirementDetail = () => {
 
     useEffect(() => {
         if (isNew) return;  // no fetch — local draft only
+        // Re-arm the loading gate on every id change (code review, req #3234): without
+        // this, navigating from one requirement straight to another (duplicate, the
+        // sessions grid's Source link, browser Back/Forward) left the OLD requirement's
+        // data — including its resolved Epic link — rendered and clickable throughout
+        // the new GET, since `loading` was already false from the previous mount.
+        setLoading(true);
         const fetchData = async () => {
             try {
                 const requirementUri = `${darwinUri}/requirements?id=${id}`;
@@ -705,14 +741,17 @@ const RequirementDetail = () => {
                 const labelColor = isFaded ? 'text.disabled' : 'text.secondary';
 
                 return (
-                    // A real <fieldset>/<legend> pair so the "AI Settings" caption sits ON the
-                    // border line at top-left with the line notched behind the text.
+                    // Row pairing AI Settings with the Epic linkage box (req #3234) — the
+                    // same flex-row idiom the Requirement/Session timings pair below uses.
+                    <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start', flexWrap: 'wrap', mb: 2 }}>
+                    {/* A real <fieldset>/<legend> pair so the "AI Settings" caption sits ON the
+                        border line at top-left with the line notched behind the text. */}
                     <Box
                         component="fieldset"
                         data-testid="launch-settings-group"
                         sx={{
                             width: 'fit-content', maxWidth: '100%',
-                            m: 0, mb: 2, px: 1.5, pt: 0.25, pb: 1.25,
+                            m: 0, px: 1.5, pt: 0.25, pb: 1.25,
                             display: 'flex', flexDirection: 'column', gap: 1.5,
                             border: 1, borderColor: 'common.white', borderRadius: 2,
                             opacity: isFaded ? 0.4 : 1,
@@ -772,6 +811,68 @@ const RequirementDetail = () => {
                                 })}
                             </Stack>
                         </Box>
+                    </Box>
+
+                    {/* Epic linkage (req #3234) — READ-ONLY: reports the derived
+                        requirement -> feature -> epic chain and navigates, nothing more.
+                        Deliberately NOT the edit-in-place cell pattern the rest of the page
+                        uses; matching AI Settings' LOOK is the requirement, its editable
+                        BEHAVIOUR is not. Same fieldset/legend/border/radius so the two read
+                        as a pair; no editability fade since there is nothing here to edit. */}
+                    <Box
+                        component="fieldset"
+                        data-testid="requirement-epic-linkage-group"
+                        sx={{
+                            width: 'fit-content', maxWidth: '100%',
+                            m: 0, px: 1.5, pt: 0.25, pb: 1.25,
+                            display: 'flex', flexDirection: 'column', gap: 0.5,
+                            border: 1, borderColor: 'common.white', borderRadius: 2,
+                            ...(isNew && { visibility: 'hidden', pointerEvents: 'none' }),
+                        }}
+                    >
+                        <Box component="legend" sx={{ ml: 1, px: 0.5 }}>
+                            <Typography variant="subtitle2" color="text.secondary">
+                                Epic
+                            </Typography>
+                        </Box>
+                        {epicLinkResolving ? (
+                            <Typography variant="body2" color="text.secondary" data-testid="epic-linkage-loading">
+                                Loading…
+                            </Typography>
+                        ) : epicLinkErrored ? (
+                            // Code review, req #3234: distinct from "No epic" — a failed
+                            // fetch is not the same fact as a confirmed-absent link.
+                            <Typography variant="body2" color="text.secondary" data-testid="epic-linkage-error">
+                                Epic unavailable
+                            </Typography>
+                        ) : linkedEpic ? (
+                            <>
+                                {/* A real anchor (react-router Link), not a span with
+                                    onClick/onKeyDown — natively focusable/keyboard-activatable
+                                    and supports middle-click, ctrl-click and "copy link address"
+                                    (code review, req #3234). */}
+                                <Typography
+                                    component={RouterLink}
+                                    to={`/swarm/epics?id=${linkedEpic.id}`}
+                                    variant="body2"
+                                    aria-label={`Open epic ${linkedEpic.title}`}
+                                    sx={{ color: 'primary.main', textDecoration: 'underline', cursor: 'pointer' }}
+                                    data-testid="epic-linkage-link"
+                                >
+                                    {linkedEpic.title}
+                                </Typography>
+                                {linkedFeature && (
+                                    <Typography variant="caption" color="text.secondary">
+                                        via feature &quot;{linkedFeature.title}&quot;
+                                    </Typography>
+                                )}
+                            </>
+                        ) : (
+                            <Typography variant="body2" color="text.secondary" data-testid="epic-linkage-none">
+                                No epic
+                            </Typography>
+                        )}
+                    </Box>
                     </Box>
                 );
             })()}

--- a/src/SwarmView/detail/__tests__/RequirementDetail.epicLinkage.test.jsx
+++ b/src/SwarmView/detail/__tests__/RequirementDetail.epicLinkage.test.jsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+//
+// Req #3234 — the read-only Epic linkage box beside AI Settings on the
+// requirement detail page. Pins the derived requirement -> feature -> epic
+// chain: no feature, a feature with no epic, and a resolved epic all render
+// distinctly, a resolved epic links to `/swarm/epics?id=<id>`, and a failed
+// fetch reads as "unavailable" rather than the same "No epic" a genuinely
+// absent link renders (code review finding — the two must not look alike).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// `useFeatureById`/`useEpicById` are the real hooks (not stubbed) — the whole
+// point of these tests is pinning their wiring into the page. Only the two
+// unrelated data hooks the page also calls are stubbed, mirroring
+// RequirementDetail.machine.test.jsx.
+vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        useMachines: () => ({ data: [] }),
+        useAllCategories: () => ({ data: [{ id: 1, category_name: 'Swarm' }] }),
+    };
+});
+
+let requirementRow;
+let featureResponse;   // { status, data } for GET /features?id=...
+let epicResponse;      // { status, data } for GET /epics?id=...
+
+vi.mock('../../../RestApi/RestApi', () => ({
+    default: vi.fn((uri, method) => {
+        if (method !== 'GET') return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+        if (uri.includes('/requirements?id=')) {
+            return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [requirementRow] });
+        }
+        if (uri.includes('/features?id=')) {
+            return Promise.resolve({ httpStatus: { httpStatus: featureResponse.status }, data: featureResponse.data });
+        }
+        if (uri.includes('/epics?id=')) {
+            return Promise.resolve({ httpStatus: { httpStatus: epicResponse.status }, data: epicResponse.data });
+        }
+        return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+    }),
+}));
+
+import RequirementDetail from '../RequirementDetail';
+import AuthContext from '../../../Context/AuthContext';
+import AppContext from '../../../Context/AppContext';
+
+let mountedRoots = [];
+
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0, refetchOnWindowFocus: false } },
+    });
+    const root = createRoot(container);
+    act(() => {
+        root.render(
+            <MemoryRouter initialEntries={['/swarm/requirement/42']}>
+                <QueryClientProvider client={queryClient}>
+                    <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                        <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                            <Routes>
+                                <Route path="/swarm/requirement/:id" element={<RequirementDetail />} />
+                            </Routes>
+                        </AuthContext.Provider>
+                    </AppContext.Provider>
+                </QueryClientProvider>
+            </MemoryRouter>
+        );
+    });
+    mountedRoots.push(root);
+    return { container };
+}
+
+// Deeper than RequirementDetail.machine.test.jsx's `flush`: this page chains
+// THREE round-trips through the mocked REST client (the requirement GET, then
+// — once it lands and re-renders with `feature_fk` — the real `useFeatureById`
+// query, then — once THAT lands with `epic_fk` — the real `useEpicById` query).
+// Those are real TanStack Query fetches, not stubbed hooks, so each hop costs
+// its own micro/macrotask round beyond what a single `setTimeout(0)` covers.
+async function flush() {
+    for (let round = 0; round < 6; round++) {
+        await act(async () => {
+            for (let i = 0; i < 10; i++) await Promise.resolve();
+            await new Promise((r) => setTimeout(r, 0));
+            for (let i = 0; i < 5; i++) await Promise.resolve();
+        });
+    }
+}
+
+function baseRequirement(overrides = {}) {
+    return {
+        id: 42,
+        title: 'linked or not',
+        description: '',
+        category_fk: 1,
+        requirement_status: 'swarm_ready',
+        coordination_type: 'implemented',
+        ai_model: 'opus',
+        effort: 'xhigh',
+        machine_fk: null,
+        started_at: null, completed_at: null, deferred_at: null,
+        create_ts: null, update_ts: null,
+        ...overrides,
+    };
+}
+
+const node = (testId) => document.body.querySelector(`[data-testid="${testId}"]`);
+
+describe('RequirementDetail — Epic linkage box (req #3234)', () => {
+    beforeEach(() => {
+        mountedRoots = [];
+        featureResponse = { status: 200, data: [] };
+        epicResponse = { status: 200, data: [] };
+    });
+    afterEach(() => {
+        act(() => { mountedRoots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+    });
+
+    it('says "No epic" when the requirement has no feature — never an empty box', async () => {
+        requirementRow = baseRequirement();   // no feature_fk at all
+        mount();
+        await flush();
+
+        expect(node('epic-linkage-none')).not.toBeNull();
+        expect(node('epic-linkage-none').textContent).toBe('No epic');
+        expect(node('epic-linkage-link')).toBeNull();
+    });
+
+    it('says "No epic" when the feature exists but has no epic — same treatment, not a differentiated message', async () => {
+        requirementRow = baseRequirement({ feature_fk: 88 });
+        featureResponse = { status: 200, data: [{ id: 88, title: 'Orphan Feature', epic_fk: null }] };
+        mount();
+        await flush();
+
+        expect(node('epic-linkage-none').textContent).toBe('No epic');
+        expect(node('epic-linkage-link')).toBeNull();
+    });
+
+    it('links a resolved epic to /swarm/epics?id=<id> and shows the feature as context', async () => {
+        requirementRow = baseRequirement({ feature_fk: 88 });
+        featureResponse = { status: 200, data: [{ id: 88, title: 'Cool Feature', epic_fk: 55 }] };
+        epicResponse = { status: 200, data: [{ id: 55, title: 'Big Epic' }] };
+        mount();
+        await flush();
+
+        const link = node('epic-linkage-link');
+        expect(link).not.toBeNull();
+        expect(link.textContent).toBe('Big Epic');
+        expect(link.getAttribute('href')).toBe('/swarm/epics?id=55');
+        expect(document.body.textContent).toContain('via feature "Cool Feature"');
+        expect(node('epic-linkage-none')).toBeNull();
+    });
+
+    it('reads as "Epic unavailable", not "No epic", when the feature fetch fails', async () => {
+        requirementRow = baseRequirement({ feature_fk: 88 });
+        featureResponse = { status: 500, data: [] };
+        mount();
+        await flush();
+
+        expect(node('epic-linkage-error')).not.toBeNull();
+        expect(node('epic-linkage-error').textContent).toBe('Epic unavailable');
+        expect(node('epic-linkage-none')).toBeNull();
+    });
+
+    it('reads as "Epic unavailable" when the feature resolves but the epic fetch fails', async () => {
+        requirementRow = baseRequirement({ feature_fk: 88 });
+        featureResponse = { status: 200, data: [{ id: 88, title: 'Cool Feature', epic_fk: 55 }] };
+        epicResponse = { status: 500, data: [] };
+        mount();
+        await flush();
+
+        expect(node('epic-linkage-error')).not.toBeNull();
+        expect(node('epic-linkage-none')).toBeNull();
+        expect(node('epic-linkage-link')).toBeNull();
+    });
+
+    it('is hidden (kept in layout) in "new" draft mode, before any feature_fk can exist', async () => {
+        // "new" mode never issues the requirement GET — RequirementDetail reads
+        // `id === 'new'` from the route param.
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        const queryClient = new QueryClient({
+            defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0, refetchOnWindowFocus: false } },
+        });
+        const root = createRoot(container);
+        act(() => {
+            root.render(
+                <MemoryRouter initialEntries={['/swarm/requirement/new']}>
+                    <QueryClientProvider client={queryClient}>
+                        <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                            <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                                <Routes>
+                                    <Route path="/swarm/requirement/:id" element={<RequirementDetail />} />
+                                </Routes>
+                            </AuthContext.Provider>
+                        </AppContext.Provider>
+                    </QueryClientProvider>
+                </MemoryRouter>
+            );
+        });
+        mountedRoots.push(root);
+        await flush();
+
+        const group = node('requirement-epic-linkage-group');
+        expect(group).not.toBeNull();
+        expect(getComputedStyle(group).visibility).toBe('hidden');
+    });
+});

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -535,7 +535,12 @@ export function useEpicById(creatorFk, id, { enabled = true } = {}) {
     return useQuery({
         queryKey,
         queryFn: () => fetchEntity(uri, idToken),
-        enabled: enabled && !!id && !!idToken,
+        // `creatorFk` in the enabled gate matches every other hook in this file
+        // (code review, req #3234) — it is already in `queryKey`, so firing
+        // without it would cache a row under `['epics', undefined, {id}]`, a
+        // key the `epicKeys.all(creatorFk)` prefix invalidation used elsewhere
+        // can never reach.
+        enabled: enabled && !!creatorFk && !!id && !!idToken,
     });
 }
 
@@ -586,7 +591,8 @@ export function useFeatureById(creatorFk, id, { enabled = true } = {}) {
     return useQuery({
         queryKey,
         queryFn: () => fetchEntity(uri, idToken),
-        enabled: enabled && !!id && !!idToken,
+        // See useEpicById's identical comment (code review, req #3234).
+        enabled: enabled && !!creatorFk && !!id && !!idToken,
     });
 }
 


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3234-requirement-epic-linkage-1
- wip(Darwin): 2026-08-01T22:16:42Z
- chore: init swarm session feature/3234-requirement-epic-linkage-1

## Files changed
```
 src/Epics/EpicsPage.jsx                            |  35 +++-
 src/Epics/__tests__/EpicsPage.test.jsx             |  65 +++++-
 src/SwarmView/detail/RequirementDetail.jsx         | 111 ++++++++++-
 .../RequirementDetail.epicLinkage.test.jsx         | 219 +++++++++++++++++++++
 src/hooks/useDataQueries.js                        |  10 +-
 5 files changed, 423 insertions(+), 17 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)