### PR TITLE
Reset joins the zoom controls; delete the pan/zoom hint bubble

### DIFF
--- a/src/SwarmView/pipelines/PipelineDetail.jsx
+++ b/src/SwarmView/pipelines/PipelineDetail.jsx
@@ -306,6 +306,15 @@ export default function PipelineDetail() {
     // (`onEffectiveLevel={setEffectiveLevel}`). Display only: nothing is derived
     // from it, so a late first report cannot change what is drawn.
     const [effectiveLevel, setEffectiveLevel] = useState(null);
+    // Req #3216 — Reset joins the header's zoom controls (it used to float
+    // over the canvas in the bottom-right corner). The click has to reach
+    // across the page/panel boundary, so this is `resetViewNonce`,
+    // KonvaBuildCanvas's own device (`BuildVisualizerPage.jsx`
+    // `handleResetView`): a number that only ever increments, watched by an
+    // effect inside the visualizer. 0 is the initial render, deliberately
+    // never fired at.
+    const [resetViewNonce, setResetViewNonce] = useState(0);
+    const handleResetView = useCallback(() => setResetViewNonce((n) => n + 1), []);
     // The step label is always the TITLE, and the requirement marks always
     // reserve room for their TITLE — the renderer draws the id inside that box
     // at L1/L2 and the title itself at L3 (see the `idText` note in
@@ -681,6 +690,30 @@ export default function PipelineDetail() {
                                 </ToggleButton>
                             </ToggleButtonGroup>
                         </Tooltip>
+                        {/* Req #3216 — Reset joins the zoom control group here,
+                            out of the bottom-right corner of the canvas it used
+                            to float in. FACTORY DEFAULT, not the readable
+                            landing scale the page opens on: one click always
+                            shows the whole plan's vertical extent, from any
+                            pan or zoom. Width re-centres on every change (it
+                            rescales every column), and does so onto WHICHEVER
+                            of the two scales is currently active — see
+                            `recenterModeRef` in PipelinePlanVisualizer.jsx —
+                            so clicking Width right after Reset keeps showing
+                            the whole plan instead of snapping back to the
+                            readable scale out from under its own neighbour. */}
+                        <Tooltip title={'Reset — fully zoomed out, the whole '
+                            + "plan's vertical extent visible"}>
+                            <Button
+                                size="small"
+                                className="cal-toggle-btn"
+                                variant="outlined"
+                                onClick={handleResetView}
+                                data-testid="pipeline-viz-reset"
+                            >
+                                Reset
+                            </Button>
+                        </Tooltip>
                     </>
                 )}
 
@@ -789,6 +822,7 @@ export default function PipelineDetail() {
                              levelPref={planLevelPref}
                              onChangeLevelPref={setLevelPref}
                              onEffectiveLevel={setEffectiveLevel}
+                             resetViewNonce={resetViewNonce}
                              />
         </Box>
     );

--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -18,9 +18,10 @@
 // it gained is the two properties a scroll pane has and free pan does not:
 // BOUNDED translation (d3's translateExtent — the plan cannot be dragged off the
 // panel and lost). The overlay scroll rails that shipped alongside it were
-// REMOVED on the user's directive (2026-08-01): the bound plus the `reset view`
-// control are what keep the plan reachable, and a thumb on a canvas that pans by
-// transform was chrome restating what the pan already shows.
+// REMOVED on the user's directive (2026-08-01): the bound plus the Reset
+// control (now in the header's zoom control group, req #3216) are what keep
+// the plan reachable, and a thumb on a canvas that pans by transform was
+// chrome restating what the pan already shows.
 //
 // Level-of-detail via the SAME semanticLevel() the swarm canvas uses, so the
 // three depth levels feel identical. Mapping (worker judgment, documented per
@@ -107,7 +108,7 @@ import { aiModelLabel } from '../modelChipStyles';
 import { effortLabel } from '../effortChipStyles';
 import { OrderViolationsAlert } from './PipelinePlanTable';
 import {
-    computePlanLayout, beadStyle, placeEpicChips, epicFocusTransform,
+    computePlanLayout, beadStyle, placeEpicChips, epicFocusTransform, factoryDefaultScale,
     PLAN_VIZ_PALETTE as P, PLAN_VIZ_FONT as F, BEAD_RADIUS, BEAD_HIT_RADIUS,
     CHW_EPIC, ZOOM_MIN_RATIO, ZOOM_MAX_RATIO,
     K_READABLE, DEFAULT_STEP_WIDTH, EPIC_CHIP_BG_ALPHA,
@@ -120,17 +121,20 @@ import '../../CalendarFC/swarmVisualizer.css';
 
 const MONO = '"SF Mono", "JetBrains Mono", Menlo, monospace';
 
-const LEVEL_NAME = { out: 'Overview', mid: 'Plan', in: 'Detail' };
-
 // The three requirement-mark colour scales, in the order they are reserved.
 // Every one is rendered every time (hidden when not live) so the key's footprint
 // is the MAX of the three and therefore constant — see the key's own comment.
 const REQ_KEY_SCALES = ['state', 'machine', 'none'];
 
-// Interactive chrome layered OVER the canvas (req #3168): the key and the
-// reset button. Both d3-zoom's gesture filter and the manual click hit-test
-// reject anything originating inside one, so a control can never double as a
-// pan gesture or as a click on the bead beneath it.
+// Interactive chrome layered OVER the canvas (req #3168): the key, the only
+// occupant left since the reset control and the status chip moved out (req
+// #3216 — reset joined the header's zoom controls, the chip was deleted
+// outright). d3-zoom's gesture filter and the manual click hit-test both
+// reject anything originating inside it, so a control can never double as a
+// pan gesture or as a click on the bead beneath it. Nothing else needs the
+// exclusion any more: what replaced the old bottom-right stack lives in the
+// page header, outside the container this behavior is bound to, so a
+// mousedown on it was never reachable as a pan gesture in the first place.
 const CHROME_SELECTOR = '[data-viz-chrome]';
 
 // The panel colour at the chip's declared opacity (req #3168 user directive:
@@ -242,6 +246,12 @@ export default function PipelinePlanVisualizer({
     reqLayout = 'vertical', stepLabel = 'title', colorKey = DEFAULT_COLOR_KEY,
     stepWidth = DEFAULT_STEP_WIDTH, reqLabel = 'id', levelPref = DEFAULT_PLAN_LEVEL_PREF,
     onEffectiveLevel, onChangeLevelPref,
+    // The header's Reset control (req #3216) lives outside this component, in
+    // the zoom control group PipelineDetail.jsx owns, so the click has to
+    // reach across that boundary. `resetViewNonce` is KonvaBuildCanvas's own
+    // device for exactly this (`resetViewNonce`/`frame`): a number that only
+    // ever increments, watched by an effect below. 0 is the initial render.
+    resetViewNonce = 0,
 }) {
     const navigate = useNavigate();
 
@@ -454,6 +464,13 @@ export default function PipelinePlanVisualizer({
     // 11px floor; see pipelinePlanLayout. On a plan that already fits at a legible
     // size this is inert — kFit wins and nothing about the old view changes.
     const kDefault = Math.max(kFit, K_READABLE);
+    // The zoom behavior's own configured floor, computed ONCE here so this
+    // and the `.scaleExtent` call below read the SAME number rather than two
+    // copies of a formula that only agree today because `kDefault` happens to
+    // collapse `Math.min(kFit, kDefault)` to `kFit` (req #3216 review
+    // finding — a future `kDefault` that could fall below `kFit` would
+    // silently desync a duplicated expression; a shared variable cannot).
+    const kZoomFloor = Math.min(kFit, kDefault) * ZOOM_MIN_RATIO;
     const curK = transform ? transform.k : kDefault;
     // THE LEVEL LADDER RE-ANCHORS ON THE DEFAULT, not on the fit (req #3168).
     // semanticLevel() takes a RATIO, and the ratio means "how far in from where
@@ -517,11 +534,13 @@ export default function PipelinePlanVisualizer({
             // from the view the reader actually lands in. The lower bound keeps
             // the fit scale in reach so `Overview` can still show the whole plan
             // on a plan that opens zoomed in.
-            .scaleExtent([Math.min(kFit, kDefault) * ZOOM_MIN_RATIO,
-                kDefault * ZOOM_MAX_RATIO])
+            .scaleExtent([kZoomFloor, kDefault * ZOOM_MAX_RATIO])
             .constrain(bound)
-            // A DRAG that starts on the key or the reset button belongs to
-            // that control (req #3168). Rejecting it HERE rather than calling
+            // A DRAG that starts on the key belongs to that control (req
+            // #3168; the reset button's own exclusion left with it, req
+            // #3216 — it now lives in the header, outside this container
+            // entirely, so it was never reachable as a pan gesture here to
+            // begin with). Rejecting it HERE rather than calling
             // stopPropagation on the control's React handler is the only version
             // that works: d3's listener is bound to this container and fires on
             // the way up, long before React's delegated handler at the document
@@ -567,22 +586,67 @@ export default function PipelinePlanVisualizer({
             // page to Table mode, which unmounts this component.
             sel.interrupt();
         };
-    }, [containerEl, size.w, size.h, kFit, kDefault, layout.width, layout.height]);
+    }, [containerEl, size.w, size.h, kFit, kDefault, kZoomFloor, layout.width, layout.height]);
 
-    // Reset to the default view on first size and whenever a layout toggle
-    // changes the world dimensions wholesale (the POC re-rendered from scratch on
-    // those toggles). `stepWidth` joins that list for the same reason the other
-    // two are on it: it rescales every column, so the previous pan lands
-    // somewhere unrelated on the new geometry.
+    // ── Reset = FACTORY DEFAULT (req #3216 D1) ──────────────────────────────
+    // Deliberately NOT `kDefault` above — see `factoryDefaultScale`'s own
+    // comment in pipelinePlanLayout.js for why the readable landing scale and
+    // "reset" are two different numbers now. The fit math is pure and lives
+    // there, same as `epicFocusTransform`'s; this file only draws what it
+    // returns. `kZoomFloor` (computed above, alongside `kDefault`) is the
+    // SAME number the zoom behavior's own `scaleExtent` floor uses — passed
+    // in rather than re-derived, so the two can never desync (review finding:
+    // a duplicated `kFit * ZOOM_MIN_RATIO` only agreed with the behavior's
+    // real floor by algebraic coincidence).
+    const kFactoryDefault = factoryDefaultScale(layout, size, kFit, kZoomFloor);
+
+    // WHICH base a toggle-driven recenter targets (review finding): Width
+    // rescales every column and re-centres to keep the view sane on the new
+    // geometry (the effect below), and until this ref existed that recentre
+    // was hard-coded to `kDefault` — so clicking Width right after clicking
+    // Reset, its own neighbour in the same header group, silently undid the
+    // factory reset the user had just asked for. Flipping this to 'factory'
+    // on a Reset click and reading it back here means a toggle instead
+    // preserves whichever view the reader is IN, exactly as it always
+    // preserved `kDefault` when the two scales happened to be the same
+    // number. A drag or a wheel zoom never touches this ref: those don't run
+    // through this effect at all, so which gesture last moved the camera is
+    // still irrelevant to it, same as before this fix.
+    const recenterModeRef = useRef('readable');
+
+    // Reset to the current base view on first size and whenever a layout
+    // toggle changes the world dimensions wholesale (the POC re-rendered from
+    // scratch on those toggles). `stepWidth` joins that list for the same
+    // reason the other two are on it: it rescales every column, so the
+    // previous pan lands somewhere unrelated on the new geometry.
     const resetView = useCallback(() => {
         const el = containerEl;
         const zb = zoomRef.current;
         if (!el || !zb || size.w === 0) return;
-        select(el).call(zb.transform, zoomIdentity.scale(kDefault));
-    }, [containerEl, size.w, kDefault]);
+        const k = recenterModeRef.current === 'factory' ? kFactoryDefault : kDefault;
+        select(el).call(zb.transform, zoomIdentity.scale(k));
+    }, [containerEl, size.w, kDefault, kFactoryDefault]);
     useEffect(() => {
         resetView();
     }, [resetView, size.h, reqLayout, stepLabel, stepWidth, reqLabel]);
+
+    const factoryReset = useCallback(() => {
+        recenterModeRef.current = 'factory';
+        resetView();
+    }, [resetView]);
+    // `resetViewNonce` only ever increments (the header's click handler), so
+    // the effect fires once per click. Read through a ref rather than joining
+    // the dependency list: `factoryReset`'s identity changes on every resize
+    // and every layout toggle, and depending on it directly would fire this on
+    // those too — which is the mount/toggle effect above's job, not a factory
+    // reset the user never asked for. 0 is the initial render — skip it, the
+    // mount effect above already puts the canvas at the readable default.
+    const factoryResetRef = useRef(factoryReset);
+    factoryResetRef.current = factoryReset;
+    useEffect(() => {
+        if (!resetViewNonce) return;
+        factoryResetRef.current();
+    }, [resetViewNonce]);
 
     // Manual DOM click hit-test: d3-zoom owns the pointer gesture, so a
     // non-drag click is resolved against the stage and fired as the Konva
@@ -592,9 +656,9 @@ export default function PipelinePlanVisualizer({
         if (!el) return undefined;
         const onDown = (e) => { downRef.current = { x: e.clientX, y: e.clientY }; };
         const onClick = (e) => {
-            // Same exclusion as the zoom filter: the key and the reset button
-            // are chrome over the canvas, and resolving a click through one of
-            // them would fire whichever bead it happens to be lying on top of.
+            // Same exclusion as the zoom filter: the key is chrome over the
+            // canvas, and resolving a click through it would fire whichever
+            // bead it happens to be lying on top of.
             if (e.target?.closest?.(CHROME_SELECTOR)) return;
             const d = downRef.current;
             if (d && Math.hypot(e.clientX - d.x, e.clientY - d.y) > 4) return;
@@ -1181,8 +1245,10 @@ export default function PipelinePlanVisualizer({
                 hover datacard appears, which makes a screenshot diff a weak
                 proof that the view actually moved. Publishing {x, y, k} costs one
                 attribute on a node React already re-renders per zoom event and
-                makes the interaction falsifiable (req #3118 PIPE-08/09). Same
-                purpose as the `pipeline-viz-zoom-level` chip beside it. */}
+                makes the interaction falsifiable (req #3118 PIPE-08/09).
+                `data-level` a few lines down carries the same duty for the
+                semantic level since the status chip that used to name it was
+                deleted (req #3216). */}
             <Box ref={setContainer} data-testid="pipeline-plan-visualizer"
                  data-transform={`${t.x.toFixed(2)},${t.y.toFixed(2)},${t.k.toFixed(4)}`}
                  // The WORLD the transform is applied to, for the same reason
@@ -1537,41 +1603,21 @@ export default function PipelinePlanVisualizer({
                     )}
                 </Stack>
 
-                {/* `data-viz-chrome` on the WRAPPER, not just the button: the
-                    6px flex gap between the two chips is inside this Stack and
-                    over the canvas, so a mousedown that landed in it started a
-                    pan from what looks like a control. */}
-                <Stack direction="row" spacing={0.75} alignItems="center"
-                       data-viz-chrome="hud"
-                       sx={{ position: 'absolute', bottom: 15, right: 10 }}>
-                    {/* The way home from a pan (req #3168). A bounded pan keeps
-                        the plan reachable; this makes getting back one click
-                        rather than a hunt, and it is also the only way back to
-                        the default SCALE after a zoom. */}
-                    <Box component="button" type="button" onClick={resetView}
-                         data-viz-chrome="reset"
-                         data-testid="pipeline-viz-reset"
-                         sx={{ fontSize: 11, fontFamily: MONO, color: P.text,
-                                background: 'rgba(0,0,0,0.45)', cursor: 'pointer',
-                                border: `1px solid ${P.line}`, borderRadius: '10px',
-                                px: 1, py: 0.25, userSelect: 'none',
-                                '&:hover': { color: P.accent, borderColor: P.accent } }}>
-                        reset view
-                    </Box>
-                    <Box sx={{ fontSize: 11,
-                                color: P.dim, background: 'rgba(0,0,0,0.45)',
-                                px: 1, py: 0.25, borderRadius: '10px',
-                                pointerEvents: 'none', userSelect: 'none' }}
-                         data-testid="pipeline-viz-zoom-level">
-                        {/* `· pinned` is `KonvaBuildCanvas`'s own wording, kept
-                            verbatim so a reader who knows one canvas knows this
-                            one. It matters more here than there: pinning does not
-                            move the camera, so without this the chip would name a
-                            level the zoom disagrees with and read as a bug. */}
-                        {LEVEL_NAME[level]}{pinnedLevel ? ' · pinned' : ''}
-                        {' · drag to pan · scroll to zoom'}
-                    </Box>
-                </Stack>
+                {/* The bottom-right reset button + status chip stack is GONE
+                    (req #3216). Reset moved to the header's zoom control group
+                    — see PipelineDetail.jsx and the `resetViewNonce` handshake
+                    above — and the status chip (zoom level name, "pinned", the
+                    "drag to pan, scroll to zoom" hint) was deleted outright,
+                    not just its text: drag-to-pan and scroll-to-zoom are
+                    discovered in under a second by anyone who touches the
+                    canvas, and a permanent caption teaching them cost this
+                    corner forever. The level and the pinned state are each
+                    still named elsewhere — `data-level` on the container
+                    (published for the same reason `data-transform` is, a few
+                    lines up) and the key's own `SemanticLevelControl` (the
+                    filled/outlined Auto|L1|L2|L3 chips), which was ALREADY the
+                    control a reader used to pin or clear a level, so removing
+                    this chip removes no signal that had no other home. */}
 
                 {card && (
                     <PlanDataCard card={card} timezone={timezone} level={level}

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -28,7 +28,7 @@ import {
     DEFAULT_PLAN_LEVEL_PREF, isPlanLevelPref, normalizePlanLevelPref, pinnedLevelOf,
     REQ_LINE_H,
     FOCUS_MAX_RATIO, FOCUS_MIN_RATIO, FOCUS_PAD, STEP_DONE, ZOOM_MAX_RATIO, ZOOM_MIN_RATIO, bandFitRect, epicFocusTransform,
-    RULER_H, computeRuler, slotTickText,
+    RULER_H, computeRuler, slotTickText, factoryDefaultScale,
 } from '../pipelinePlanLayout';
 
 const NOW = '2026-07-27T03:00:00Z';
@@ -2288,6 +2288,69 @@ describe('epic focus geometry', () => {
         expect(epicFocusTransform(layout, band, { w: 0, h: 0 }, kBase)).toBeNull();
         expect(epicFocusTransform(layout, band, undefined, kBase)).toBeNull();
         expect(epicFocusTransform(layout, band, { w: 800, h: 600 }, 0)).toBeNull();
+    });
+});
+
+describe('reset = factory default scale (req #3216 D1)', () => {
+    const kFit = 0.8;
+    // The caller's own configured floor, passed in rather than re-derived
+    // (review finding) — see the function's own comment for why. Computed
+    // here exactly as PipelinePlanVisualizer computes `kZoomFloor`, so these
+    // tests exercise the real contract between the two.
+    const kFloor = kFit * ZOOM_MIN_RATIO;
+
+    it('kFit wins when the plan already fits vertically at that scale', () => {
+        // width-bound: at kFit the world is 500 tall against a 900px viewport,
+        // so nothing about the vertical axis needs correcting.
+        const k = factoryDefaultScale({ height: 500 }, { w: 1000, h: 900 }, kFit, kFloor);
+        expect(k).toBe(kFit);
+    });
+
+    it('zooms out further than kFit on a plan too TALL to fit at it — the D1 bug', () => {
+        // height-bound: at kFit (0.8) a 2000-tall world needs 1600px of
+        // viewport and only 900 are on offer — the exact shape of "reset
+        // lands somewhere the user still has to zoom out from".
+        const size = { w: 1000, h: 900 };
+        const layout = { height: 2000 };
+        const k = factoryDefaultScale(layout, size, kFit, kFloor);
+        expect(k).toBeLessThan(kFit);
+        // THE ACCEPTANCE BAR ITSELF: the whole vertical extent fits at k.
+        expect(k * layout.height).toBeLessThanOrEqual(size.h + 1e-9);
+    });
+
+    it('never goes below the caller\'s own configured floor', () => {
+        // Absurdly tall — the vertical fit alone would ask for a k far below
+        // what the caller's own scaleExtent permits. The floor wins, matching
+        // what a user's own scroll-to-zoom-out is already capped at, rather
+        // than writing a transform the next wheel event would snap away from
+        // (see the function's own comment).
+        const size = { w: 1000, h: 900 };
+        const layout = { height: 400_000 };
+        const k = factoryDefaultScale(layout, size, kFit, kFloor);
+        expect(k).toBe(kFloor);
+        // Confirms the floor really is the binding constraint here, not a
+        // coincidence — the raw vertical fit is well below it.
+        expect(size.h / layout.height).toBeLessThan(kFloor);
+    });
+
+    it('honours a floor the caller derives from something other than kFit * ZOOM_MIN_RATIO', () => {
+        // The whole point of taking the floor as a parameter: this function
+        // must not assume any particular relationship between kFit and the
+        // floor, because the caller's own `Math.min(kFit, kDefault)` collapse
+        // is a fact about `kDefault`'s CURRENT formula, not a law this
+        // function may lean on. An arbitrary floor above kFit clamps the
+        // result up to it, whatever the vertical fit would have asked for.
+        const size = { w: 1000, h: 900 };
+        const layout = { height: 400_000 };
+        const oddFloor = kFit * 1.5;
+        expect(factoryDefaultScale(layout, size, kFit, oddFloor)).toBe(oddFloor);
+    });
+
+    it('falls back to kFit when the viewport or the plan has not measured yet', () => {
+        expect(factoryDefaultScale({ height: 500 }, { w: 0, h: 0 }, kFit, kFloor)).toBe(kFit);
+        expect(factoryDefaultScale({ height: 500 }, undefined, kFit, kFloor)).toBe(kFit);
+        expect(factoryDefaultScale({ height: 0 }, { w: 1000, h: 900 }, kFit, kFloor)).toBe(kFit);
+        expect(factoryDefaultScale(null, { w: 1000, h: 900 }, kFit, kFloor)).toBe(kFit);
     });
 });
 

--- a/src/SwarmView/pipelines/pipelineDetailModes.js
+++ b/src/SwarmView/pipelines/pipelineDetailModes.js
@@ -22,7 +22,10 @@
 //              cost read failed — a mode showing cost must say so rather than
 //              print em-dashes, which read as "no cost recorded". Every plan row
 //              already carries its own total on `row.cost`, so a mode needs no
-//              cost data of its own.
+//              cost data of its own. `resetViewNonce` (req #3216) is the
+//              header's Reset control reaching into the mode's own pan/zoom
+//              state, a number that only ever increments; ignored by any mode
+//              with no camera of its own.
 //   disabled   optional — renders a disabled ToggleButton (rule V1: a
 //              not-yet-built view is disabled, never omitted, so the group holds
 //              its width)

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -2268,4 +2268,52 @@ export function epicFocusTransform(layout, band, size, kBase) {
     };
 }
 
+// ── Reset = FACTORY DEFAULT (req #3216 D1) ──────────────────────────────────
+// "Reset" used to mean "back to `kDefault`", the READABLE landing scale (req
+// #3168, `K_READABLE` above) — fit-to-width floored at a legible text size.
+// The requirement redefines what the control returns to: fully zoomed out so
+// the whole plan's VERTICAL extent is visible, one click, from any pan or
+// zoom. "reset that lands somewhere the user still has to zoom out from is
+// not reset." On a plan with many epic bands the readable floor can sit
+// ABOVE the scale that needs, which is exactly the failure mode this
+// function exists to rule out — it is deliberately NOT `kDefault`, and
+// legibility is not a concern it weighs at all.
+//
+// PURE and exported for the same reason `epicFocusTransform` is (the comment
+// two functions up): this is a fit computation over `layout`/`size`, testable
+// with plain numbers, and the canvas component's job is only to draw what it
+// returns.
+/**
+ * The scale at which the WHOLE plan — both axes, not just the width `kFit`
+ * already fits — is visible in a `size.w` × `size.h` viewport.
+ *
+ * The tighter of the two axis fits, exactly `epicFocusTransform`'s own
+ * "contain" idiom applied to the whole world instead of one band's rect.
+ * Floored at `kFloor` — the CALLER's own configured `scaleExtent` minimum,
+ * taken as a parameter rather than re-derived here, because
+ * `zoom.transform` applies what it is given VERBATIM and does not clamp it
+ * (see PipelinePlanVisualizer's `scaleExtent` comment): a k below the floor
+ * would look right until the next wheel event snapped it back, the same bug
+ * class `epicFocusTransform`'s own clamp exists to avoid. A re-derived
+ * `kFit * ZOOM_MIN_RATIO` here would only agree with the real floor by
+ * algebraic coincidence (today, `Math.min(kFit, kDefault) === kFit` because
+ * `kDefault = Math.max(kFit, K_READABLE)`) — a future caller whose floor
+ * formula changes would silently desync a copy but cannot desync a value it
+ * hands in itself. Where that floor actually binds, the zoom behavior itself
+ * already refuses to scroll out any further on this plan — the honest edge
+ * of what panning it allows, not this function failing its own definition.
+ *
+ * @param {{width:number,height:number}} layout the world dimensions
+ * @param {{w:number,h:number}} size the viewport, in screen px
+ * @param {number} kFit the fit-to-width scale the caller already has
+ * @param {number} kFloor the caller's own zoom behavior's configured minimum
+ * @returns {number} `kFit` itself when the viewport or the plan has not
+ *   measured yet — the same "nothing to fit" fallback `kFit` uses.
+ */
+export function factoryDefaultScale(layout, size, kFit, kFloor) {
+    if (!(size?.h > 0) || !(layout?.height > 0) || !(kFit > 0)) return kFit || 0;
+    const kVertFit = size.h / layout.height;
+    return Math.max(Math.min(kFit, kVertFit), kFloor);
+}
+
 export { STEP_DONE, STEP_RUNNING, STEP_PENDING };

--- a/tests/tests/pipelines.spec.ts
+++ b/tests/tests/pipelines.spec.ts
@@ -585,23 +585,25 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
     test('PIPE-09: zoom crosses all three semantic levels and redraws each time',
         async ({ page }) => {
             const canvas = await openPlanVisualizer(page, fixture.batchPipelineId);
-            const chip = page.getByTestId('pipeline-viz-zoom-level');
             const container = page.getByTestId('pipeline-plan-visualizer');
             const scale = async () =>
                 Number((await container.getAttribute('data-transform'))!.split(',')[2]);
             const box = (await canvas.boundingBox())!;
             await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
 
-            // Fit-to-width is ratio 1 → 'mid' → "Plan" (konvaSwarmModel's
-            // semanticLevel, the same ladder the swarm canvas uses).
-            await expect(chip).toContainText('Plan');
+            // Fit-to-width is ratio 1 → 'mid' (konvaSwarmModel's semanticLevel,
+            // the same ladder the swarm canvas uses). `data-level` is what the
+            // bottom-right status chip used to say in words before it was
+            // deleted outright (req #3216 D2) — the canvas still publishes the
+            // fact, just not as a permanent caption over the plan.
+            await expect(container).toHaveAttribute('data-level', 'mid');
             const kMid = await scale();
             const atMid = await canvas.screenshot();
 
             // ratio < 0.5 → 'out'. d3-zoom's wheel factor is 2^(-deltaY/500),
             // so +800 more than halves; scaleExtent clamps at ratio 0.25.
             for (let i = 0; i < 3; i++) await page.mouse.wheel(0, 800);
-            await expect(chip).toContainText('Overview');
+            await expect(container).toHaveAttribute('data-level', 'out');
             const kOut = await scale();
             expect(kOut).toBeLessThan(kMid);
             const atOut = await canvas.screenshot();
@@ -610,7 +612,7 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
 
             // ratio >= 1.9 → 'in'; clamps at 8.
             for (let i = 0; i < 6; i++) await page.mouse.wheel(0, -800);
-            await expect(chip).toContainText('Detail');
+            await expect(container).toHaveAttribute('data-level', 'in');
             const kIn = await scale();
             expect(kIn).toBeGreaterThan(kMid);
             const atIn = await canvas.screenshot();
@@ -1082,20 +1084,24 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
                 'the view row is gone, not hidden').toHaveCount(0);
             for (const id of ['pipeline-detail-mode-toggle', 'pipeline-title',
                 'pipeline-accounting', 'pipeline-viz-stepwidth-toggle',
-                'pipeline-viz-colorkey-toggle', 'pipeline-description-btn']) {
+                'pipeline-viz-colorkey-toggle', 'pipeline-viz-reset',
+                'pipeline-description-btn']) {
                 await expect(page.locator(`[data-testid="pipeline-header-row"]`
                     + ` [data-testid="${id}"]`), `${id} is on the one row`)
                     .toHaveCount(1);
             }
-            // What the 2026-08-01 directives took OFF this row, asserted as gone
-            // rather than merely unlisted — an element that quietly came back
-            // would otherwise re-crowd the row with nothing to notice it by.
-            // The `Reqs:` and `Step:` controls were removed outright; the level
-            // selector MOVED INTO THE KEY on the canvas, so it is absent here and
-            // present there (PIPE-16 owns that half).
+            // What the 2026-08-01 directives (and req #3216) took OFF this row
+            // or off the canvas entirely, asserted as gone rather than merely
+            // unlisted — an element that quietly came back would otherwise
+            // re-crowd the row, or the canvas corner, with nothing to notice
+            // it by. The `Reqs:` and `Step:` controls were removed outright;
+            // the level selector MOVED INTO THE KEY on the canvas, so it is
+            // absent here and present there (PIPE-16 owns that half); the
+            // status chip (zoom level name, "pinned", the drag/scroll hint)
+            // was DELETED, not moved — nowhere replaces it, by design (D2).
             for (const id of ['pipeline-viz-reqlayout-toggle',
                 'pipeline-viz-steplabel-toggle', 'pipeline-status-chip',
-                'pipeline-machine-chip']) {
+                'pipeline-machine-chip', 'pipeline-viz-zoom-level']) {
                 await expect(page.getByTestId(id), `${id} is gone`).toHaveCount(0);
             }
             await expect(page.locator('[data-testid="pipeline-header-row"]'
@@ -1196,18 +1202,58 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             //    cannot creep back in.
             await expect(page.getByTestId('pipeline-viz-next-steps')).toHaveCount(0);
 
-            // 4. Reset returns the view to the default scale after a pan.
+            // 4. Reset is the FACTORY DEFAULT (req #3216 D1), not a return to
+            //    the readable landing scale: fully zoomed out, the whole
+            //    plan's vertical extent visible, from any pan OR zoom — "reset
+            //    that lands somewhere the user still has to zoom out from is
+            //    not reset" (the requirement's own words). It also moved into
+            //    the header's zoom control group, out of the canvas's
+            //    bottom-right corner it used to float in — the click below
+            //    reaches the same test id in its new home with no locator
+            //    change (D1 acceptance: "re-point anything asserting on the
+            //    reset button at its new home").
             const canvas = container.locator('canvas').first();
             const box = (await canvas.boundingBox())!;
+            const worldH = async () => Number(
+                (await container.getAttribute('data-world'))!.split(',')[1]);
             const atDefault = (await container.getAttribute('data-transform'))!;
             await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
             await page.mouse.down();
-            await page.mouse.move(box.x + box.width / 2 - 200, box.y + box.height / 2,
+            await page.mouse.move(box.x + box.width / 2 - 200, box.y + box.height / 2 - 150,
                 { steps: 10 });
             await page.mouse.up();
-            await expect(container).not.toHaveAttribute('data-transform', atDefault);
+            for (let i = 0; i < 2; i++) await page.mouse.wheel(0, -400);   // zoom IN too
+            await expect(container, 'the pan/zoom actually moved the view')
+                .not.toHaveAttribute('data-transform', atDefault);
             await page.getByTestId('pipeline-viz-reset').click();
-            await expect(container).toHaveAttribute('data-transform', atDefault);
+            const [rx, ry, rk] = (await container.getAttribute('data-transform'))!
+                .split(',').map(Number);
+            expect(rx, 'reset re-centres the world origin to the panel (x)').toBeCloseTo(0, 1);
+            expect(ry, 'reset re-centres the world origin to the panel (y)').toBeCloseTo(0, 1);
+            // THE ACCEPTANCE BAR ITSELF, not a proxy for it: the whole
+            // vertical extent must be ON SCREEN at the scale reset lands on,
+            // the exact property `kDefault` (fit-to-width floored for
+            // legibility) does not guarantee on a tall plan.
+            expect(rk * (await worldH()),
+                "reset shows the plan's whole vertical extent, nothing left to "
+                + 'zoom out for').toBeLessThanOrEqual(box.height + 1);
+
+            // 4b. Reset's neighbour in the same header group must not undo
+            //     it (code review finding on req #3216): Width re-centres on
+            //     every change because it rescales every column, and before
+            //     this was fixed that re-centre was hard-coded to the
+            //     readable landing scale — so clicking Width right after
+            //     Reset silently snapped the camera back to a view that may
+            //     no longer show the whole plan. The fit-to-height property
+            //     Width does not touch (only column width changes, not band
+            //     height) must survive the click.
+            await widthToggle.locator('button[value="medium"]').click();
+            const [, , rk2] = (await container.getAttribute('data-transform'))!
+                .split(',').map(Number);
+            expect(rk2 * (await worldH()),
+                'Width must recentre onto the SAME factory-default view Reset '
+                + 'landed on, not the readable landing scale')
+                .toBeLessThanOrEqual(box.height + 1);
 
             // 5. And the panel still clips — the rails are an overlay, not a
             //    scrollbar, so the PIPE-08 directive is untouched by them.
@@ -1345,11 +1391,15 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             await page.setViewportSize({ width: 1800, height: 1000 });
             const canvas = await openPlanVisualizer(page, fixture.mainPipelineId);
             const container = page.getByTestId('pipeline-plan-visualizer');
-            const chip = page.getByTestId('pipeline-viz-zoom-level');
             const control = page.getByTestId('pipeline-viz-level-control');
 
             // 1. It is the Build Visualizer's control, reused — same shape, same
             //    labels, same Auto-is-a-position behaviour, one component.
+            //    `aria-pressed` on its own chips is what NAMES the pinned state
+            //    (req #3216 D2 — the status chip that used to restate it in
+            //    words, "· pinned", was deleted outright; this control was
+            //    already the thing a reader pins or clears a level FROM, so
+            //    removing the caption removed no signal without another home).
             await expect(control).toBeVisible();
             await expect(control).toContainText('Detail:');
             for (const id of ['auto', '1', '2', '3']) {
@@ -1358,8 +1408,6 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             await expect(page.getByTestId('pipeline-viz-level-auto'))
                 .toHaveAttribute('aria-pressed', 'true');
             await expect(container).toHaveAttribute('data-level', 'mid');
-            await expect(chip).toContainText('Plan');
-            await expect(chip).not.toContainText('pinned');
 
             // 2. PINNING CHANGES WHAT IS DRAWN, NOT WHERE THE CAMERA IS. The
             //    transform must be byte-identical across a pin — that is the
@@ -1371,8 +1419,6 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             await expect(page.getByTestId('pipeline-viz-level-1'))
                 .toHaveAttribute('aria-pressed', 'true');
             await expect(container).toHaveAttribute('data-level', 'out');
-            await expect(chip).toContainText('Overview');
-            await expect(chip, 'a pinned level says so').toContainText('pinned');
             expect(await container.getAttribute('data-transform'),
                 'pinning a level must not move the camera').toBe(before);
             const atOut = await canvas.screenshot();
@@ -1380,8 +1426,9 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
                 'pinning redraws the canvas at the new level').not.toBe(0);
 
             await page.getByTestId('pipeline-viz-level-3').click();
+            await expect(page.getByTestId('pipeline-viz-level-3'))
+                .toHaveAttribute('aria-pressed', 'true');
             await expect(container).toHaveAttribute('data-level', 'in');
-            await expect(chip).toContainText('Detail');
             expect(await container.getAttribute('data-transform')).toBe(before);
 
             // 3. Clicking the pinned level again returns to Auto — the Build
@@ -1389,8 +1436,9 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             await page.getByTestId('pipeline-viz-level-3').click();
             await expect(page.getByTestId('pipeline-viz-level-auto'))
                 .toHaveAttribute('aria-pressed', 'true');
+            await expect(page.getByTestId('pipeline-viz-level-3'))
+                .toHaveAttribute('aria-pressed', 'false');
             await expect(container).toHaveAttribute('data-level', 'mid');
-            await expect(chip).not.toContainText('pinned');
 
             // 4. STEP/REQ/TITLE ARE GATED, EACH ON ITS OWN CONDITION (req #3221).
             //    `data-drawn` only ever enumerates these three kinds — the ruler's


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-01T22:56:37Z
- chore: init swarm session feature/3216-reset-joins-the-zoom-controls-1

## Files changed
```
 src/SwarmView/pipelines/PipelineDetail.jsx         |  34 ++++
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx | 172 +++++++++++++--------
 .../pipelines/__tests__/pipelinePlanLayout.test.js |  65 +++++++-
 src/SwarmView/pipelines/pipelineDetailModes.js     |   5 +-
 src/SwarmView/pipelines/pipelinePlanLayout.js      |  48 ++++++
 tests/tests/pipelines.spec.ts                      |  98 +++++++++---
 6 files changed, 332 insertions(+), 90 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)