### PR TITLE
Epic box: add a second link to that epics location on the plan visualizer

### DIFF
--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -4,6 +4,8 @@ import call_rest_api from '../../RestApi/RestApi';
 import { useSnackBarStore } from '../../stores/useSnackBarStore';
 import { useShowClosedStore, ALL_REQUIREMENT_STATUSES } from '../../stores/useShowClosedStore';
 import { useAllCategories, useMachines, useFeatureById, useEpicById } from '../../hooks/useDataQueries';
+import { useEpicPipelineLocation } from './useEpicPipelineLocation';
+import { epicLinkTo } from '../pipelines/pipelineEpicLink';
 import { siblingActiveSort } from './requirementSort';
 import { formatDateTime, formatDate } from '../../utils/dateFormat';
 import AuthContext from '../../Context/AuthContext';
@@ -38,6 +40,8 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import NorthIcon from '@mui/icons-material/North';
 import SouthIcon from '@mui/icons-material/South';
+import LayersIcon from '@mui/icons-material/Layers';
+import LanIcon from '@mui/icons-material/Lan';
 
 // Soft limit for requirement titles — the swarm terminal, status line, and iTerm tab title
 // all cap at 35 chars (see ~/.claude/statusline.sh and scripts/swarm/iterm-launch.sh). Req #2410.
@@ -220,6 +224,27 @@ const RequirementDetail = () => {
     // read-only and reports what it knows, so "couldn't check" and "checked,
     // there's nothing" have to read differently.
     const epicLinkErrored = linkedFeatureErrored || (linkedEpicFk != null && linkedEpicErrored);
+
+    // Req #3235 — the epic box's SECOND link: where the epic sits on the plan
+    // visualizer, alongside the link above that opens the epic itself. Kicked
+    // off from `linkedEpicFk` directly rather than waiting on `linkedEpic` to
+    // land — the pipeline chain needs only the id, not the epic row, so the
+    // two resolve in parallel instead of one queueing behind the other.
+    // Deliberately not consuming the hook's `isLoading`/`isError`: this box's
+    // Loading/Error/No-epic states are the req #3234 contract and stay
+    // exactly as built (out of scope), so a slow or failed plan-location
+    // lookup just renders no second link — no different from "no pipeline" —
+    // rather than blocking or relabeling the first one.
+    const { pipelineId: epicPipelineId } = useEpicPipelineLocation(
+        profile?.userName, linkedEpicFk, { enabled: linkedEpicFk != null });
+    // Code review, req #3235: HOISTED rather than called inline in the JSX
+    // `to=` prop. `epicLinkTo` returns null for a non-integer epic id (a
+    // future BIGINT serialized as a string, a partial/mocked row) — the
+    // caller is documented and tested to render no link at all for that case,
+    // but `to={null}` handed straight to react-router's RouterLink throws at
+    // render instead. Mirrors `StepsPage.jsx`'s `const to = stepLinkTo(...)`
+    // guard for the sibling module.
+    const epicPlanLinkTo = linkedEpic ? epicLinkTo(epicPipelineId, linkedEpic.id) : null;
 
     // Filter chips now match DB status values directly
     const siblingStatuses = [...requirementStatusFilter];
@@ -847,24 +872,53 @@ const RequirementDetail = () => {
                             </Typography>
                         ) : linkedEpic ? (
                             <>
-                                {/* A real anchor (react-router Link), not a span with
-                                    onClick/onKeyDown — natively focusable/keyboard-activatable
-                                    and supports middle-click, ctrl-click and "copy link address"
-                                    (code review, req #3234). */}
-                                <Typography
-                                    component={RouterLink}
-                                    to={`/swarm/epics?id=${linkedEpic.id}`}
-                                    variant="body2"
-                                    aria-label={`Open epic ${linkedEpic.title}`}
-                                    sx={{ color: 'primary.main', textDecoration: 'underline', cursor: 'pointer' }}
-                                    data-testid="epic-linkage-link"
-                                >
-                                    {linkedEpic.title}
-                                </Typography>
+                                {/* Two links, distinguishable by icon + label before either is
+                                    clicked (req #3235): LayersIcon/"open the epic" matches the
+                                    Epics nav entry's own icon, LanIcon/"view on plan" matches
+                                    Pipelines' — the app's existing iconography, not a new one
+                                    invented for this box. A real anchor (react-router Link), not
+                                    a span with onClick/onKeyDown — natively focusable/keyboard-
+                                    activatable and supports middle-click, ctrl-click and "copy
+                                    link address" (code review, req #3234). */}
+                                <Stack direction="row" spacing={0.5} alignItems="center">
+                                    <Tooltip title="Open the epic editor">
+                                        <LayersIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+                                    </Tooltip>
+                                    <Typography
+                                        component={RouterLink}
+                                        to={`/swarm/epics?id=${linkedEpic.id}`}
+                                        variant="body2"
+                                        aria-label={`Open epic ${linkedEpic.title}`}
+                                        sx={{ color: 'primary.main', textDecoration: 'underline', cursor: 'pointer' }}
+                                        data-testid="epic-linkage-link"
+                                    >
+                                        {linkedEpic.title}
+                                    </Typography>
+                                </Stack>
                                 {linkedFeature && (
                                     <Typography variant="caption" color="text.secondary">
                                         via feature &quot;{linkedFeature.title}&quot;
                                     </Typography>
+                                )}
+                                {/* Req #3235 — omitted, not a dead link, when the epic is in no
+                                    pipeline (epicPlanLinkTo stays null) or the lookup is still
+                                    resolving. A dead link is worse than an absent one. */}
+                                {epicPlanLinkTo != null && (
+                                    <Stack direction="row" spacing={0.5} alignItems="center">
+                                        <Tooltip title="View this epic's location on the plan visualizer">
+                                            <LanIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+                                        </Tooltip>
+                                        <Typography
+                                            component={RouterLink}
+                                            to={epicPlanLinkTo}
+                                            variant="body2"
+                                            aria-label={`View epic ${linkedEpic.title} on the plan visualizer`}
+                                            sx={{ color: 'primary.main', textDecoration: 'underline', cursor: 'pointer' }}
+                                            data-testid="epic-linkage-plan-link"
+                                        >
+                                            View on plan
+                                        </Typography>
+                                    </Stack>
                                 )}
                             </>
                         ) : (

--- a/src/SwarmView/detail/__tests__/RequirementDetail.epicPlanLink.test.jsx
+++ b/src/SwarmView/detail/__tests__/RequirementDetail.epicPlanLink.test.jsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+//
+// Req #3235 — the epic box's SECOND link, end to end through the real page:
+// the requirement -> feature -> epic chain (req #3234, untouched) plus the
+// new epic -> pipeline chain (useEpicPipelineLocation) both resolve through
+// the real hooks, and the box renders two distinguishable links when a
+// pipeline is found, or omits the second one — never a dead link — when it
+// is not.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        useMachines: () => ({ data: [] }),
+        useAllCategories: () => ({ data: [{ id: 1, category_name: 'Swarm' }] }),
+    };
+});
+
+let requirementRow;
+let featureResponse;
+let epicResponse;
+let chain; // { features, requirements, stepLinks, steps, pipelines } -> { status, data }
+
+const emptyOk = { status: 200, data: [] };
+
+vi.mock('../../../RestApi/RestApi', () => ({
+    default: vi.fn((uri, method) => {
+        if (method !== 'GET') return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+        if (uri.includes('/requirements?id=')) {
+            return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [requirementRow] });
+        }
+        if (uri.includes('/features?id=')) {
+            return Promise.resolve({ httpStatus: { httpStatus: featureResponse.status }, data: featureResponse.data });
+        }
+        if (uri.includes('/epics?id=')) {
+            return Promise.resolve({ httpStatus: { httpStatus: epicResponse.status }, data: epicResponse.data });
+        }
+        const pick = (key) => (chain && chain[key]) || emptyOk;
+        let hit = emptyOk;
+        if (uri.includes('/features?epic_fk=')) hit = pick('features');
+        else if (uri.includes('/requirements?feature_fk=')) hit = pick('requirements');
+        else if (uri.includes('/pipeline_step_requirements?requirement_fk=')) hit = pick('stepLinks');
+        else if (uri.includes('/pipeline_steps?id=')) hit = pick('steps');
+        else if (uri.includes('/pipelines?id=')) hit = pick('pipelines');
+        return Promise.resolve({ httpStatus: { httpStatus: hit.status }, data: hit.data });
+    }),
+}));
+
+import RequirementDetail from '../RequirementDetail';
+import AuthContext from '../../../Context/AuthContext';
+import AppContext from '../../../Context/AppContext';
+
+let mountedRoots = [];
+
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0, refetchOnWindowFocus: false } },
+    });
+    const root = createRoot(container);
+    act(() => {
+        root.render(
+            <MemoryRouter initialEntries={['/swarm/requirement/42']}>
+                <QueryClientProvider client={queryClient}>
+                    <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                        <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                            <Routes>
+                                <Route path="/swarm/requirement/:id" element={<RequirementDetail />} />
+                            </Routes>
+                        </AuthContext.Provider>
+                    </AppContext.Provider>
+                </QueryClientProvider>
+            </MemoryRouter>
+        );
+    });
+    mountedRoots.push(root);
+}
+
+// Two more hops than the req #3234 epic-linkage test's three, so this needs
+// more rounds to drain: requirement -> feature -> epic, IN PARALLEL WITH
+// feature_fk -> features -> requirements -> pipeline_step_requirements ->
+// pipeline_steps -> pipelines.
+async function flush() {
+    for (let round = 0; round < 12; round++) {
+        await act(async () => {
+            for (let i = 0; i < 10; i++) await Promise.resolve();
+            await new Promise((r) => setTimeout(r, 0));
+            for (let i = 0; i < 5; i++) await Promise.resolve();
+        });
+    }
+}
+
+function baseRequirement(overrides = {}) {
+    return {
+        id: 42,
+        title: 'linked or not',
+        description: '',
+        category_fk: 1,
+        requirement_status: 'swarm_ready',
+        coordination_type: 'implemented',
+        ai_model: 'opus',
+        effort: 'xhigh',
+        machine_fk: null,
+        started_at: null, completed_at: null, deferred_at: null,
+        create_ts: null, update_ts: null,
+        ...overrides,
+    };
+}
+
+const node = (testId) => document.body.querySelector(`[data-testid="${testId}"]`);
+
+describe('RequirementDetail — epic box plan link (req #3235)', () => {
+    beforeEach(() => {
+        mountedRoots = [];
+        featureResponse = { status: 200, data: [] };
+        epicResponse = { status: 200, data: [] };
+        chain = {};
+    });
+    afterEach(() => {
+        act(() => { mountedRoots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+    });
+
+    it('renders both links, distinguishably, when the epic resolves to a pipeline', async () => {
+        requirementRow = baseRequirement({ feature_fk: 88 });
+        featureResponse = { status: 200, data: [{ id: 88, title: 'Cool Feature', epic_fk: 55 }] };
+        epicResponse = { status: 200, data: [{ id: 55, title: 'Big Epic' }] };
+        chain = {
+            features: { status: 200, data: [{ id: 88 }] },
+            requirements: { status: 200, data: [{ id: 101 }] },
+            stepLinks: { status: 200, data: [{ step_fk: 47 }] },
+            steps: { status: 200, data: [{ id: 47, pipeline_fk: 2 }] },
+            pipelines: { status: 200, data: [{ id: 2, pipeline_status: 'active' }] },
+        };
+        mount();
+        await flush();
+
+        const epicLink = node('epic-linkage-link');
+        expect(epicLink).not.toBeNull();
+        expect(epicLink.getAttribute('href')).toBe('/swarm/epics?id=55');
+
+        const planLink = node('epic-linkage-plan-link');
+        expect(planLink).not.toBeNull();
+        expect(planLink.getAttribute('href')).toBe('/swarm/pipeline/2?mode=plan&epic=55');
+        // Distinguishable text — never a second bare "Big Epic" anchor.
+        expect(planLink.textContent).not.toBe('Big Epic');
+        expect(epicLink.getAttribute('aria-label')).not.toBe(planLink.getAttribute('aria-label'));
+    });
+
+    it('omits the plan link — never a dead one — when the epic is in no pipeline', async () => {
+        requirementRow = baseRequirement({ feature_fk: 88 });
+        featureResponse = { status: 200, data: [{ id: 88, title: 'Cool Feature', epic_fk: 55 }] };
+        epicResponse = { status: 200, data: [{ id: 55, title: 'Big Epic' }] };
+        chain = { features: { status: 200, data: [] } }; // epic has no features -> chain runs dry
+        mount();
+        await flush();
+
+        expect(node('epic-linkage-link')).not.toBeNull();
+        expect(node('epic-linkage-plan-link')).toBeNull();
+    });
+});

--- a/src/SwarmView/detail/__tests__/useEpicPipelineLocation.test.jsx
+++ b/src/SwarmView/detail/__tests__/useEpicPipelineLocation.test.jsx
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+//
+// Req #3235 — the epic -> pipeline resolver behind the requirement page's
+// "view on plan" link. Pins the five-hop chain (features -> requirements ->
+// pipeline_step_requirements -> pipeline_steps -> pipelines), that a short
+// chain resolves to "no pipeline" rather than staying stuck loading, and the
+// tie-break (active pipeline first, else lowest id) reused verbatim from
+// `_resolve_pipeline` (darwin-mcp/services/requirements.py, req #3186).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let responses; // { features, requirements, stepLinks, steps, pipelines } -> { status, data }
+
+const emptyOk = { status: 200, data: [] };
+
+vi.mock('../../../RestApi/RestApi', () => ({
+    default: vi.fn((uri, method) => {
+        if (method !== 'GET') return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+        const pick = (key) => responses[key] || emptyOk;
+        let hit = emptyOk;
+        if (uri.includes('/features?epic_fk=')) hit = pick('features');
+        else if (uri.includes('/requirements?feature_fk=')) hit = pick('requirements');
+        else if (uri.includes('/pipeline_step_requirements?requirement_fk=')) hit = pick('stepLinks');
+        else if (uri.includes('/pipeline_steps?id=')) hit = pick('steps');
+        else if (uri.includes('/pipelines?id=')) hit = pick('pipelines');
+        return Promise.resolve({ httpStatus: { httpStatus: hit.status }, data: hit.data });
+    }),
+}));
+
+import { useEpicPipelineLocation } from '../useEpicPipelineLocation';
+import AuthContext from '../../../Context/AuthContext';
+import AppContext from '../../../Context/AppContext';
+
+function Host({ epicId }) {
+    const { pipelineId, isLoading, isError } = useEpicPipelineLocation('tester', epicId);
+    return (
+        <div data-testid="result"
+             data-pipeline={pipelineId == null ? '' : String(pipelineId)}
+             data-loading={String(isLoading)}
+             data-error={String(isError)} />
+    );
+}
+
+let mountedRoots = [];
+
+function mount(epicId) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0, refetchOnWindowFocus: false } },
+    });
+    const root = createRoot(container);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester' } }}>
+                        <Host epicId={epicId} />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    mountedRoots.push(root);
+}
+
+// Five hops chained through `enabled`, so this needs more rounds than the
+// three-hop epic-linkage box test.
+async function flush() {
+    for (let round = 0; round < 10; round++) {
+        await act(async () => {
+            for (let i = 0; i < 10; i++) await Promise.resolve();
+            await new Promise((r) => setTimeout(r, 0));
+            for (let i = 0; i < 5; i++) await Promise.resolve();
+        });
+    }
+}
+
+const result = () => document.body.querySelector('[data-testid="result"]');
+
+describe('useEpicPipelineLocation (req #3235)', () => {
+    beforeEach(() => {
+        mountedRoots = [];
+        responses = {};
+    });
+    afterEach(() => {
+        act(() => { mountedRoots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+    });
+
+    it('resolves null, not stuck loading, for an epic with no features', async () => {
+        responses.features = { status: 200, data: [] };
+        mount(55);
+        await flush();
+
+        const el = result();
+        expect(el.getAttribute('data-pipeline')).toBe('');
+        expect(el.getAttribute('data-loading')).toBe('false');
+        expect(el.getAttribute('data-error')).toBe('false');
+    });
+
+    it('resolves null when the chain runs dry partway through (features exist, no requirements)', async () => {
+        responses.features = { status: 200, data: [{ id: 88 }] };
+        responses.requirements = { status: 200, data: [] };
+        mount(55);
+        await flush();
+
+        const el = result();
+        expect(el.getAttribute('data-pipeline')).toBe('');
+        expect(el.getAttribute('data-loading')).toBe('false');
+    });
+
+    it('resolves the single pipeline at the end of a full chain', async () => {
+        responses.features = { status: 200, data: [{ id: 88 }] };
+        responses.requirements = { status: 200, data: [{ id: 101 }] };
+        responses.stepLinks = { status: 200, data: [{ step_fk: 47 }] };
+        responses.steps = { status: 200, data: [{ id: 47, pipeline_fk: 2 }] };
+        responses.pipelines = { status: 200, data: [{ id: 2, pipeline_status: 'active' }] };
+        mount(55);
+        await flush();
+
+        const el = result();
+        expect(el.getAttribute('data-pipeline')).toBe('2');
+        expect(el.getAttribute('data-loading')).toBe('false');
+    });
+
+    it('tie-breaks on the ACTIVE pipeline over a lower id (the _resolve_pipeline rule)', async () => {
+        responses.features = { status: 200, data: [{ id: 88 }] };
+        responses.requirements = { status: 200, data: [{ id: 101 }] };
+        responses.stepLinks = { status: 200, data: [{ step_fk: 10 }, { step_fk: 20 }] };
+        responses.steps = { status: 200, data: [{ id: 10, pipeline_fk: 1 }, { id: 20, pipeline_fk: 3 }] };
+        responses.pipelines = {
+            status: 200,
+            data: [
+                { id: 1, pipeline_status: 'draft' },
+                { id: 3, pipeline_status: 'active' },
+            ],
+        };
+        mount(55);
+        await flush();
+
+        expect(result().getAttribute('data-pipeline')).toBe('3');
+    });
+
+    it('falls back to the lowest id when no candidate pipeline is active', async () => {
+        responses.features = { status: 200, data: [{ id: 88 }] };
+        responses.requirements = { status: 200, data: [{ id: 101 }] };
+        responses.stepLinks = { status: 200, data: [{ step_fk: 10 }, { step_fk: 20 }] };
+        responses.steps = { status: 200, data: [{ id: 10, pipeline_fk: 5 }, { id: 20, pipeline_fk: 3 }] };
+        responses.pipelines = {
+            status: 200,
+            data: [
+                { id: 5, pipeline_status: 'aborted' },
+                { id: 3, pipeline_status: 'paused' },
+            ],
+        };
+        mount(55);
+        await flush();
+
+        expect(result().getAttribute('data-pipeline')).toBe('3');
+    });
+
+    it('reports an error rather than a silent "no pipeline" when a hop fails', async () => {
+        responses.features = { status: 500, data: [] };
+        mount(55);
+        await flush();
+
+        const el = result();
+        expect(el.getAttribute('data-error')).toBe('true');
+        expect(el.getAttribute('data-pipeline')).toBe('');
+    });
+
+    it('does nothing for a null epic id', async () => {
+        mount(null);
+        await flush();
+
+        const el = result();
+        expect(el.getAttribute('data-pipeline')).toBe('');
+        expect(el.getAttribute('data-loading')).toBe('false');
+        expect(el.getAttribute('data-error')).toBe('false');
+    });
+});

--- a/src/SwarmView/detail/useEpicPipelineLocation.js
+++ b/src/SwarmView/detail/useEpicPipelineLocation.js
@@ -1,0 +1,111 @@
+// useEpicPipelineLocation.js — req #3235.
+//
+// Resolves which pipeline (if any) an epic is seated in, for the requirement
+// page's epic box "view on plan" link.
+//
+// No table carries `epic_fk` — an epic reaches a pipeline only transitively:
+//   epics -> features (epic_fk) -> requirements (feature_fk)
+//         -> pipeline_step_requirements (requirement_fk) -> pipeline_steps (step_fk)
+//         -> pipelines (pipeline_fk)
+// Five hops, each a narrow FK-filtered read chained through `enabled` so a
+// hop only fires once its predecessor has resolved a non-empty id list —
+// never a whole-table read, matching the targeted-read discipline the epic
+// box itself was built on (req #3234).
+//
+// TIE-BREAK: an epic seated in more than one pipeline resolves to the
+// `active` one, else the lowest id — the EXACT rule `_resolve_pipeline` uses
+// server-side for session attribution (darwin-mcp/services/requirements.py,
+// req #3186), reused rather than reinvented per the requirement text.
+//
+// `isLoading` is simply every hop's own `isLoading` OR'd together: TanStack
+// v5 defines `isLoading` as `status === 'pending' && fetchStatus === 'fetching'`,
+// which is false for a disabled query — so a hop a shorter chain never reaches
+// (e.g. an epic with zero features) contributes `false`, not a stuck `true`,
+// and the chain resolves to "no pipeline" rather than "loading forever".
+
+import { useContext } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import AppContext from '../../Context/AppContext';
+import AuthContext from '../../Context/AuthContext';
+import { fetchEntity } from '../../hooks/factory/createEntityQueries';
+
+// SORTED, not just deduped (code review) — `_resolve_pipeline` sorts both of
+// its id sets before use, and this chain's query keys embed the id array
+// directly. An unsorted array keys two reads of the same id set differently
+// whenever the server returns them in a different row order (no `sort=` is
+// requested — there is nothing to order these projections BY), fragmenting
+// the cache: a plain refetch (`refetchOnWindowFocus`, a stale-time expiry)
+// can silently reorder the rows, miss every downstream cache entry, and the
+// "view on plan" link would blink out while the chain re-resolves.
+const dedupedIds = (rows, field) => [...new Set(
+    (rows || []).map((r) => r?.[field]).filter((v) => v != null)
+)].sort((a, b) => a - b);
+
+/**
+ * @param {?string} creatorFk
+ * @param {?number} epicId
+ * @param {{enabled?: boolean}} [options]
+ * @returns {{pipelineId: ?number, isLoading: boolean, isError: boolean}}
+ */
+export function useEpicPipelineLocation(creatorFk, epicId, { enabled = true } = {}) {
+    const { darwinUri } = useContext(AppContext);
+    const { idToken } = useContext(AuthContext);
+    const active = enabled && epicId != null && !!creatorFk && !!idToken;
+
+    const featuresQ = useQuery({
+        queryKey: ['epic_pipeline_location', 'features', creatorFk, epicId],
+        queryFn: () => fetchEntity(`${darwinUri}/features?epic_fk=${epicId}&fields=id`, idToken),
+        enabled: active,
+    });
+    const featureIds = dedupedIds(featuresQ.data, 'id');
+
+    const requirementsQ = useQuery({
+        queryKey: ['epic_pipeline_location', 'requirements', creatorFk, featureIds],
+        queryFn: () => fetchEntity(
+            `${darwinUri}/requirements?feature_fk=(${featureIds.join(',')})&fields=id`, idToken),
+        enabled: active && featuresQ.isSuccess && featureIds.length > 0,
+    });
+    const requirementIds = dedupedIds(requirementsQ.data, 'id');
+
+    const stepLinksQ = useQuery({
+        queryKey: ['epic_pipeline_location', 'step_links', creatorFk, requirementIds],
+        queryFn: () => fetchEntity(
+            `${darwinUri}/pipeline_step_requirements?requirement_fk=(${requirementIds.join(',')})&fields=step_fk`,
+            idToken),
+        enabled: active && requirementsQ.isSuccess && requirementIds.length > 0,
+    });
+    const stepIds = dedupedIds(stepLinksQ.data, 'step_fk');
+
+    const stepsQ = useQuery({
+        queryKey: ['epic_pipeline_location', 'steps', creatorFk, stepIds],
+        queryFn: () => fetchEntity(
+            `${darwinUri}/pipeline_steps?id=(${stepIds.join(',')})&fields=id,pipeline_fk`, idToken),
+        enabled: active && stepLinksQ.isSuccess && stepIds.length > 0,
+    });
+    const pipelineIds = dedupedIds(stepsQ.data, 'pipeline_fk');
+
+    const pipelinesQ = useQuery({
+        queryKey: ['epic_pipeline_location', 'pipelines', creatorFk, pipelineIds],
+        queryFn: () => fetchEntity(
+            `${darwinUri}/pipelines?id=(${pipelineIds.join(',')})&fields=id,pipeline_status`, idToken),
+        enabled: active && stepsQ.isSuccess && pipelineIds.length > 0,
+    });
+
+    let pipelineId = null;
+    if (pipelinesQ.data && pipelinesQ.data.length > 0) {
+        // Active first, then lowest id — `_resolve_pipeline`'s sort key,
+        // reused verbatim rather than a second tie-break invented here.
+        pipelineId = [...pipelinesQ.data].sort((a, b) => {
+            const aActive = a.pipeline_status === 'active' ? 0 : 1;
+            const bActive = b.pipeline_status === 'active' ? 0 : 1;
+            return aActive !== bActive ? aActive - bActive : a.id - b.id;
+        })[0].id;
+    }
+
+    const isLoading = featuresQ.isLoading || requirementsQ.isLoading
+        || stepLinksQ.isLoading || stepsQ.isLoading || pipelinesQ.isLoading;
+    const isError = featuresQ.isError || requirementsQ.isError
+        || stepLinksQ.isError || stepsQ.isError || pipelinesQ.isError;
+
+    return { pipelineId, isLoading, isError };
+}

--- a/src/SwarmView/pipelines/PipelineDetail.jsx
+++ b/src/SwarmView/pipelines/PipelineDetail.jsx
@@ -75,6 +75,7 @@ import {
 import { pipelineStatusChipProps } from './pipelineChipStyles';
 import { claimForPipeline, holderView } from './orchestrationHolder';
 import { readFocusStepParam } from './pipelineStepLink';
+import { readFocusEpicParam } from './pipelineEpicLink';
 import SemanticLevelControl from '../../Components/SemanticLevelControl';
 import {
     DEFAULT_COLOR_KEY, DEFAULT_PLAN_LEVEL_PREF, DEFAULT_REQ_VIEW, DEFAULT_STEP_WIDTH,
@@ -362,23 +363,43 @@ export default function PipelineDetail() {
     // highlights that row. `pipelineStepLink.js` owns both halves of the
     // contract so the writer and this reader cannot drift on the key.
     const linkStepId = readFocusStepParam(searchParams);
+    // ── `?epic=` makes ONE EPIC'S LOCATION addressable (req #3235) ───────────
+    // The receiving end of the requirement page's epic-box "view on plan" link.
+    // An epic band only exists in the visualizer, so a named epic FORCES the
+    // Plan mode the same way a named step forces the Table — but a `?step=`
+    // is more specific than a `?epic=` (a step names one row; an epic is a
+    // whole band a step already belongs to), so if a link somehow carried
+    // both, the step wins. `pipelineEpicLink.js` owns both halves of this
+    // contract, same split as the step link.
+    const linkEpicId = readFocusEpicParam(searchParams);
     // A named step FORCES the table, overriding `?mode=` when the two disagree.
     // Only the table consumes `focusStepId` — the visualizer has beads, not rows,
     // and ignores the prop entirely — so honoring `?mode=plan&step=7` as written
     // would land the reader on a plan with nothing highlighted and nothing to say
     // why. Naming a row is the more specific request, so it wins.
-    const linkView = linkStepId != null ? 'table' : linkMode;
+    const linkView = linkStepId != null ? 'table' : (linkEpicId != null ? 'plan' : linkMode);
 
     const [focusStepId, setFocusStepId] = useState(linkStepId);
+    // Req #3235 code review — `?epic=` needs the SAME transient-override
+    // treatment as `?step=`, not the raw searchParams value passed straight
+    // through: without a state copy, a manual mode pick can never clear it
+    // (nothing owns it to clear), so picking Table then Plan again — or
+    // navigating in-place from one `?epic=` link to another, which
+    // `pipelineId`'s own comment below notes this component survives without
+    // remounting — would keep re-focusing (or silently drop) a link the
+    // reader already left behind.
+    const [focusEpicId, setFocusEpicId] = useState(linkEpicId);
     const [modeOverride, setModeOverride] = useState(linkView);
-    // Re-seeds when the LINK changes — a new `?mode=`, a new `?step=`, or a
-    // different plan — and at no other time, so a manual pick below is never
-    // resurrected by a re-render. A link with no `?step=` clears the focus, which
-    // is what keeps a stale highlight from surviving an unrelated navigation.
+    // Re-seeds when the LINK changes — a new `?mode=`, a new `?step=`, a new
+    // `?epic=`, or a different plan — and at no other time, so a manual pick
+    // below is never resurrected by a re-render. A link with no `?step=`/
+    // `?epic=` clears the focus, which is what keeps a stale highlight (or a
+    // stale camera focus) from surviving an unrelated navigation.
     useEffect(() => {
         setModeOverride(linkView);
         setFocusStepId(linkStepId);
-    }, [linkView, linkStepId, pipelineId]);
+        setFocusEpicId(linkEpicId);
+    }, [linkView, linkStepId, linkEpicId, pipelineId]);
     const onStepFocus = useCallback((stepId) => {
         setFocusStepId(stepId);
         setModeOverride('table');
@@ -386,6 +407,7 @@ export default function PipelineDetail() {
     const handleModeChange = useCallback((_e, v) => {
         if (v == null) return;
         setFocusStepId(null);
+        setFocusEpicId(null);
         setModeOverride(null);
         setMode(v);
     }, [setMode]);
@@ -782,6 +804,7 @@ export default function PipelineDetail() {
                 24px instead of leaving a gap. */}
             <ActiveComponent plan={plan} model={model} pipeline={pipeline} timezone={timezone}
                              focusStepId={focusStepId} onStepFocus={onStepFocus}
+                             focusEpicId={focusEpicId}
                              costError={!!costError}
                              showCost={showCost}
                              reqLayout={reqLayout} stepLabel={stepLabel} colorKey={colorKey}

--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -86,6 +86,7 @@ import { zoom as d3zoom, zoomIdentity } from 'd3-zoom';
 // never fights the animation.
 import 'd3-transition';
 
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
@@ -235,7 +236,7 @@ function KeyGroup({ title, children, first = false }) {
 }
 
 export default function PipelinePlanVisualizer({
-    plan, model, pipeline, timezone, onStepFocus,
+    plan, model, pipeline, timezone, onStepFocus, focusEpicId,
     // Toolbar state is OWNED BY THE PAGE since req #3119 — the controls render in
     // the header row beside the pipeline name (the SwarmView/VisualizerToolbar
     // pattern, req #2407), so the panel is the canvas and nothing else.
@@ -782,12 +783,17 @@ export default function PipelinePlanVisualizer({
     //
     // Stores NOTHING. `band` comes from the layout the caller is already
     // rendering, the transform goes to d3, and the callback returns.
+    // Returns whether it actually moved the camera — false on every guard above
+    // (no container/behaviour yet, or a band that can't be fit). The req #3235
+    // mount-time effect below needs that signal: without it, a transient
+    // zero-size container would be recorded as "already focused" and the deep
+    // link would silently never apply once the canvas actually became ready.
     const focusEpic = useCallback((band) => {
         const el = containerEl;
         const zb = zoomRef.current;
-        if (!el || !zb) return;
+        if (!el || !zb) return false;
         const tr = epicFocusTransform(layout, band, size, kDefault);
-        if (!tr) return;
+        if (!tr) return false;
         // The world is about to slide out from under any open datacard, exactly
         // as it does on a pan.
         setCard(null);
@@ -802,7 +808,61 @@ export default function PipelinePlanVisualizer({
                 if (focusSeqRef.current === seq) focusingRef.current = false;
             })
             .call(zb.transform, zoomIdentity.translate(tr.x, tr.y).scale(tr.k));
+        return true;
     }, [containerEl, layout, size, kDefault]);
+
+    // Req #3235 — the mount-time end of the `?epic=` deep link: land on the
+    // SAME centered/zoomed view a band-header click produces, through the
+    // SAME zoom behaviour (`focusEpic`, never a direct transform write — the
+    // behaviour owns its own transform, and setting state alone would snap
+    // back on the next wheel or drag).
+    //
+    // If the plan is still loading, this component has not mounted yet
+    // (PipelineDetail's `isLoading` gate) — nothing here can fire against an
+    // empty canvas. What CAN still be empty at mount is the container's own
+    // size (the ResizeObserver hasn't measured yet) and the zoom behaviour
+    // (attached by the effect above, in the same commit but strictly earlier
+    // in hook order); `focusEpic`'s own guards return false for both, so this
+    // effect simply retries on the next render that changes one of its
+    // dependencies rather than marking a no-op "applied".
+    //
+    // `epicFocusAppliedRef` KEYS ON THE MEASURED SIZE TOO, not just the
+    // (pipeline, epic) pair (code review finding) — the panel is sized TWICE
+    // at mount (the `calc(100vh - 260px)` fallback in the JSX below, then
+    // again once `measureAvailH` resolves), and that second resize re-runs
+    // the `resetView` effect above (its deps include `size.h`), whose
+    // cleanup INTERRUPTS an in-flight focus transition and snaps the camera
+    // back to the default view — after which this effect, unkeyed on size,
+    // would see its own stale "applied" mark and never retry. Folding the
+    // measured size into the key means that second resize (and any later
+    // real one) invalidates the earlier mark and reapplies the focus, landing
+    // AFTER `resetView` in the same commit because both effects react to the
+    // same size change and this one is declared later in hook order. A
+    // genuine later browser resize reapplying the focus for the same reason
+    // matches `resetView`'s own existing contract, which already discards
+    // whatever view the reader was on whenever the container resizes.
+    const epicFocusAppliedRef = useRef(null);
+    useEffect(() => {
+        if (focusEpicId == null) return;
+        const key = `${pipeline?.id}:${focusEpicId}:${size.w}x${size.h}`;
+        if (epicFocusAppliedRef.current === key) return;
+        const band = layout.bands.find((b) => b.epicId === focusEpicId);
+        if (!band) return;
+        if (focusEpic(band)) epicFocusAppliedRef.current = key;
+    }, [focusEpicId, pipeline?.id, size, layout, focusEpic]);
+
+    // Req #3235 code review — the resolved pipeline can legitimately hold no
+    // band for this epic: the resolver answers "which pipeline hosts any of
+    // this epic's requirements", but a band is keyed on each STEP's DOMINANT
+    // epic (design rule 10), so an epic that never dominates a step of the
+    // resolved pipeline has no band here even though the resolution was
+    // correct. By the time this component has mounted, PipelineDetail's
+    // `isLoading` gate has already cleared and `layout` is final — so a miss
+    // here is a terminal fact, not a still-loading one, and needs to say so
+    // rather than silently landing on the default view (the dead-link outcome
+    // the requirement text rules out, arrived at from the other direction).
+    const focusEpicNotOnPlan = focusEpicId != null
+        && !layout.bands.some((b) => b.epicId === focusEpicId);
 
     if (!rows.length) {
         return (
@@ -1169,6 +1229,16 @@ export default function PipelinePlanVisualizer({
     return (
         <Box>
             <OrderViolationsAlert plan={plan} />
+
+            {/* Req #3235 — the `?epic=` deep link named an epic no band on THIS
+                plan carries (see focusEpicNotOnPlan above). Saying so beats a
+                default view with no explanation for why nothing focused. */}
+            {focusEpicNotOnPlan && (
+                <Alert severity="info" variant="outlined" sx={{ mb: 2 }}
+                       data-testid="pipeline-viz-epic-not-on-plan">
+                    That epic isn&apos;t shown on this plan — none of its steps are here.
+                </Alert>
+            )}
 
             {/* The layout toggles moved into the page header row (req #3119).
                 What stays with the canvas is the LEGEND — it describes the marks

--- a/src/SwarmView/pipelines/__tests__/PipelineDetail.epicParam.test.jsx
+++ b/src/SwarmView/pipelines/__tests__/PipelineDetail.epicParam.test.jsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+//
+// Req #3235 — the RECEIVING end of the requirement page's epic-box "view on
+// plan" link.
+//
+// `pipelineEpicLink.test.js` pins the two pure functions. This pins the React
+// half: a `?epic=` link forces the Plan mode (an epic band only exists there)
+// and seeds `focusEpicId` on the visualizer — mirroring
+// `PipelineDetail.stepParam.test.jsx`'s coverage of `?step=` forcing the
+// table. The two panels are stubbed for the same reason that file stubs
+// them: the real Plan mode is react-konva, which needs a canvas jsdom does
+// not provide.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../pipelineDetailModes', () => {
+    const Panel = (name) => function ModeStub({ focusStepId, focusEpicId }) {
+        return <div data-testid={`mode-${name}`}
+                    data-focus-step={focusStepId == null ? '' : String(focusStepId)}
+                    data-focus-epic={focusEpicId == null ? '' : String(focusEpicId)} />;
+    };
+    const MODES = [
+        { value: 'table', label: 'Table', icon: () => null, Component: Panel('table') },
+        { value: 'plan', label: 'Plan', icon: () => null, Component: Panel('plan') },
+    ];
+    return {
+        PIPELINE_DETAIL_MODES: MODES,
+        PIPELINE_DETAIL_MODE_STORAGE_KEY: 'darwin-swarm-pipeline-detail-mode',
+        DEFAULT_PIPELINE_DETAIL_MODE: 'table',
+        findPipelineDetailMode: (v) => MODES.find((m) => m.value === v),
+        default: MODES,
+    };
+});
+
+vi.mock('../../../RestApi/RestApi', () => ({ default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })) }));
+
+vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    const empty = () => ({ data: [], isLoading: false, isError: false });
+    return {
+        ...actual,
+        useAllPipelines: () => ({
+            data: [{ id: 2, title: 'Darwin', pipeline_status: 'active', description: '' }],
+            isLoading: false,
+        }),
+        useAllPipelineSteps: () => ({
+            data: [{ id: 47, pipeline_fk: 2, title: 'Session Drain', run: 'auto', notes: null, completed_at: null }],
+            isLoading: false,
+        }),
+        useAllPipelineStepRequirements: empty,
+        useAllPipelineStepDeps: empty,
+        useAllRequirements: empty,
+        useAllFeatures: empty,
+        useAllEpics: empty,
+        useMachines: empty,
+        useAllRequirementSessions: empty,
+        useAllSessionCostRollups: empty,
+    };
+});
+
+import PipelineDetail from '../PipelineDetail';
+import AuthContext from '../../../Context/AuthContext';
+import AppContext from '../../../Context/AppContext';
+
+let mountedRoots = [];
+
+function mount(url) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0, refetchOnWindowFocus: false } },
+    });
+    const root = createRoot(container);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local/darwin' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <MemoryRouter initialEntries={[url]}>
+                            <Routes>
+                                <Route path="/swarm/pipeline/:id" element={<PipelineDetail />} />
+                            </Routes>
+                        </MemoryRouter>
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    mountedRoots.push(root);
+}
+
+const node = (testId) => document.body.querySelector(`[data-testid="${testId}"]`);
+const focusEpicOf = (name) => node(`mode-${name}`)?.getAttribute('data-focus-epic');
+const focusStepOf = (name) => node(`mode-${name}`)?.getAttribute('data-focus-step');
+
+const storePreference = (value) => {
+    localStorage.setItem('darwin-swarm-pipeline-detail-mode', value);
+    sessionStorage.setItem('darwin-swarm-pipeline-detail-mode', value);
+};
+
+beforeEach(() => {
+    mountedRoots = [];
+    localStorage.clear();
+    sessionStorage.clear();
+});
+
+afterEach(() => {
+    act(() => { mountedRoots.forEach(r => r.unmount()); });
+    document.body.innerHTML = '';
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+});
+
+describe('PipelineDetail — ?epic= (req #3235)', () => {
+    it('forces the PLAN mode even when ?mode= names the table', () => {
+        mount('/swarm/pipeline/2?mode=table&epic=55');
+        expect(node('mode-plan')).not.toBeNull();
+        expect(node('mode-table')).toBeNull();
+        expect(focusEpicOf('plan')).toBe('55');
+    });
+
+    it('forces the plan over a STORED preference of table', () => {
+        storePreference('table');
+        mount('/swarm/pipeline/2?epic=55');
+        expect(node('mode-plan')).not.toBeNull();
+        expect(focusEpicOf('plan')).toBe('55');
+    });
+
+    it('leaves the stored preference in charge when there is no ?epic=', () => {
+        storePreference('plan');
+        mount('/swarm/pipeline/2');
+        expect(node('mode-plan')).not.toBeNull();
+        expect(focusEpicOf('plan')).toBe('');
+    });
+
+    it('carries no epic focus when the parameter is absent or unusable', () => {
+        mount('/swarm/pipeline/2?mode=plan');
+        expect(focusEpicOf('plan')).toBe('');
+        mount('/swarm/pipeline/2?mode=plan&epic=12abc');
+        expect(focusEpicOf('plan')).toBe('');
+    });
+
+    it('a named ?step= is more specific and wins over ?epic=', () => {
+        mount('/swarm/pipeline/2?step=47&epic=55');
+        expect(node('mode-table')).not.toBeNull();
+        expect(node('mode-plan')).toBeNull();
+        expect(focusStepOf('table')).toBe('47');
+    });
+
+    it('passes focusEpicId to whichever panel is active — only the REAL table ignores it', () => {
+        // Code review, req #3235: PipelineDetail hands focusEpicId to
+        // `ActiveComponent` unconditionally, same as focusStepId — it does not
+        // know or care which mode won. It is inert on the table only because
+        // `PipelinePlanTable`'s own parameter list never destructures it
+        // (unlike this stub, which exposes both props on both panels so the
+        // wiring itself is verifiable). A test that only checked "mode-plan is
+        // absent" would pass even if PipelineDetail silently dropped the prop.
+        mount('/swarm/pipeline/2?mode=table&step=47&epic=55');
+        expect(focusStepOf('table')).toBe('47');
+        expect(focusEpicOf('table')).toBe('55');
+        expect(node('mode-plan')).toBeNull();
+    });
+});

--- a/src/SwarmView/pipelines/__tests__/pipelineEpicLink.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineEpicLink.test.js
@@ -1,0 +1,71 @@
+// Req #3235 — the addressable-epic-location contract.
+//
+// Same round-trip discipline as pipelineStepLink.test.js (req #3140): the
+// writer (the requirement page's epic box) and the reader (PipelineDetail /
+// PipelinePlanVisualizer) must agree on the query-string key exactly, so this
+// pins both halves against each other rather than in isolation.
+
+import { describe, it, expect } from 'vitest';
+import {
+    FOCUS_EPIC_PARAM,
+    readFocusEpicParam,
+    epicLinkTo,
+} from '../pipelineEpicLink';
+
+describe('epicLinkTo', () => {
+    it('names the plan, the plan mode and the epic', () => {
+        expect(epicLinkTo(2, 55)).toBe('/swarm/pipeline/2?mode=plan&epic=55');
+    });
+
+    it('accepts numeric strings', () => {
+        expect(epicLinkTo('2', '55')).toBe('/swarm/pipeline/2?mode=plan&epic=55');
+    });
+
+    it('returns null rather than a link to /swarm/pipeline/undefined', () => {
+        // The caller omits the link entirely — an epic in no pipeline stays
+        // without one, and a dead link is worse than an absent one.
+        expect(epicLinkTo(null, 55)).toBeNull();
+        expect(epicLinkTo(undefined, 55)).toBeNull();
+        expect(epicLinkTo(2, null)).toBeNull();
+        expect(epicLinkTo('abc', 55)).toBeNull();
+        expect(epicLinkTo(2, 1.5)).toBeNull();
+    });
+});
+
+describe('readFocusEpicParam', () => {
+    const params = (search) => new URLSearchParams(search);
+
+    it('reads the id a link names', () => {
+        expect(readFocusEpicParam(params('mode=plan&epic=55'))).toBe(55);
+    });
+
+    it('is null when the parameter is absent', () => {
+        expect(readFocusEpicParam(params('mode=plan'))).toBeNull();
+    });
+
+    it('rejects every non-integer form rather than producing a NaN or a 0', () => {
+        expect(readFocusEpicParam(params('epic='))).toBeNull();
+        expect(readFocusEpicParam(params('epic=%20'))).toBeNull();
+        expect(readFocusEpicParam(params('epic=12abc'))).toBeNull();
+        expect(readFocusEpicParam(params('epic=1.5'))).toBeNull();
+        expect(readFocusEpicParam(params('epic=NaN'))).toBeNull();
+    });
+
+    it('survives a caller with no search params at all', () => {
+        expect(readFocusEpicParam(null)).toBeNull();
+        expect(readFocusEpicParam(undefined)).toBeNull();
+        expect(readFocusEpicParam({})).toBeNull();
+    });
+
+    it("round-trips what epicLinkTo built", () => {
+        const to = epicLinkTo(2, 55);
+        const search = to.slice(to.indexOf('?'));
+        expect(readFocusEpicParam(new URLSearchParams(search))).toBe(55);
+        expect(new URLSearchParams(search).get('mode')).toBe('plan');
+    });
+
+    it('exports the key both halves agree on', () => {
+        expect(FOCUS_EPIC_PARAM).toBe('epic');
+        expect(epicLinkTo(1, 2)).toContain(`${FOCUS_EPIC_PARAM}=2`);
+    });
+});

--- a/src/SwarmView/pipelines/pipelineDetailModes.js
+++ b/src/SwarmView/pipelines/pipelineDetailModes.js
@@ -14,15 +14,19 @@
 //   label      the switcher's tooltip / accessible name
 //   icon       an @mui/icons-material component (see view-switchable-pages § R3)
 //   Component  receives { plan, model, pipeline, timezone, focusStepId,
-//              onStepFocus, costError } and renders the panel.
+//              onStepFocus, focusEpicId, costError } and renders the panel.
 //              focusStepId/onStepFocus are the req #3115 cross-mode handshake:
 //              the visualizer calls onStepFocus(stepId) on a bead click, the
 //              page switches to the table mode, and the table scrolls to +
-//              highlights that row. `costError` (req #3117) is true when either
-//              cost read failed — a mode showing cost must say so rather than
-//              print em-dashes, which read as "no cost recorded". Every plan row
-//              already carries its own total on `row.cost`, so a mode needs no
-//              cost data of its own.
+//              highlights that row. `focusEpicId` (req #3235) is the one-shot
+//              `?epic=` deep link — only the visualizer consumes it, zooming
+//              to that epic's band once on mount via the same zoom behaviour a
+//              band-header click drives; the table ignores it entirely, same
+//              as the visualizer ignores `focusStepId`. `costError` (req #3117)
+//              is true when either cost read failed — a mode showing cost must
+//              say so rather than print em-dashes, which read as "no cost
+//              recorded". Every plan row already carries its own total on
+//              `row.cost`, so a mode needs no cost data of its own.
 //   disabled   optional — renders a disabled ToggleButton (rule V1: a
 //              not-yet-built view is disabled, never omitted, so the group holds
 //              its width)

--- a/src/SwarmView/pipelines/pipelineEpicLink.js
+++ b/src/SwarmView/pipelines/pipelineEpicLink.js
@@ -1,0 +1,67 @@
+// pipelineEpicLink.js — the addressable-epic contract (req #3235).
+//
+// ONE epic's location on a plan, named by URL: `/swarm/pipeline/<pid>?mode=plan&epic=<eid>`.
+//
+// Mirrors `pipelineStepLink.js` (req #3140) — same shape, same reasons: the
+// writer (the requirement page's epic box, `RequirementDetail.jsx`) and the
+// reader (`PipelineDetail.jsx` / `PipelinePlanVisualizer.jsx`) are files that
+// must agree on a query-string key exactly, so the key lives in one module
+// rather than as a string literal grep would have to find on both ends.
+//
+// `mode=plan` is carried explicitly, the same way a step link carries
+// `mode=table`: an epic band only exists in the Plan visualizer, so a link
+// that omitted the mode would land on whichever panel the reader's stored
+// preference happens to be and show nothing. It seeds the SAME transient
+// override `?step=`/`?mode=` already use — a link asks to see one thing once,
+// and must never rewrite what the reader chose as their default view.
+//
+// NO JSX and no React: a pure module vitest can exercise without a DOM, and a
+// component file with non-component exports drops out of Fast Refresh.
+
+export const FOCUS_EPIC_PARAM = 'epic';
+
+/**
+ * The route an epic's plan location links to.
+ *
+ * Returns null when either id is unusable, so a caller renders no link at all
+ * rather than one that navigates to `/swarm/pipeline/undefined` — the same
+ * "omit rather than render a dead link" rule the epic box already applies to
+ * an epic seated in no pipeline at all.
+ *
+ * @param {?number} pipelineId
+ * @param {?number} epicId
+ * @returns {?string}
+ */
+export function epicLinkTo(pipelineId, epicId) {
+    const pid = toId(pipelineId);
+    const eid = toId(epicId);
+    if (pid == null || eid == null) return null;
+    return `/swarm/pipeline/${pid}?mode=plan&${FOCUS_EPIC_PARAM}=${eid}`;
+}
+
+// NULLISH AND EMPTY ARE REJECTED BEFORE `Number` SEES THEM — see
+// pipelineStepLink.js's identical guard for why 0 is a legitimate id and
+// `Number(null)`/`Number('')` are not.
+function toId(value) {
+    if (value == null || value === '') return null;
+    const n = Number(value);
+    return Number.isInteger(n) ? n : null;
+}
+
+/**
+ * The epic id a `?epic=` parameter names, or null.
+ *
+ * VALIDATED, never trusted, exactly like `readFocusStepParam`. An id that
+ * names no band in this plan is not an error — the visualizer simply renders
+ * with nothing focused, the same as with no parameter at all.
+ *
+ * @param {{get: function(string): ?string}} searchParams
+ * @returns {?number}
+ */
+export function readFocusEpicParam(searchParams) {
+    const raw = searchParams && typeof searchParams.get === 'function'
+        ? searchParams.get(FOCUS_EPIC_PARAM) : null;
+    if (raw == null || String(raw).trim() === '') return null;
+    const id = Number(raw);
+    return Number.isInteger(id) ? id : null;
+}


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-01T23:33:47Z
- wip(Darwin): 2026-08-01T23:31:23Z
- chore: init swarm session feature/3235-epic-box-add-a-second-link-1

## Files changed
```
 src/SwarmView/detail/RequirementDetail.jsx         |  82 +++++++--
 .../RequirementDetail.epicPlanLink.test.jsx        | 171 +++++++++++++++++++
 .../__tests__/useEpicPipelineLocation.test.jsx     | 188 +++++++++++++++++++++
 src/SwarmView/detail/useEpicPipelineLocation.js    | 111 ++++++++++++
 src/SwarmView/pipelines/PipelineDetail.jsx         |  35 +++-
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx |  76 ++++++++-
 .../__tests__/PipelineDetail.epicParam.test.jsx    | 171 +++++++++++++++++++
 .../pipelines/__tests__/pipelineEpicLink.test.js   |  71 ++++++++
 src/SwarmView/pipelines/pipelineDetailModes.js     |  19 ++-
 src/SwarmView/pipelines/pipelineEpicLink.js        |  67 ++++++++
 10 files changed, 961 insertions(+), 30 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)