### PR TITLE
Navbar: nest Epics, Features and Steps as L3 children under Pipelines

### DIFF
--- a/src/NavBar/__tests__/NavBarSidebar.featuresNav.test.jsx
+++ b/src/NavBar/__tests__/NavBarSidebar.featuresNav.test.jsx
@@ -17,6 +17,13 @@
 // surprise. All four states are asserted; if a later change flips any of them, this
 // file says so.
 //
+// Req #3236 — Epics, Features and Steps now nest as CLOSED-by-default L3 children
+// of Pipelines. That is a second reason a link correct in NAV_LINKS could still be
+// invisible: the toggle matrix below needs the cluster OPEN to see the row at all,
+// so `mount()` defaults `initialPath` to a child route — landing there auto-opens
+// the parent (the same mechanism req #3209 shipped for Sessions) — rather than to
+// '/swarm'. A dedicated test below pins the closed-by-default state itself.
+//
 // The remaining tests pin invariants the move must not break — one row not two, the
 // right row highlighted, present on mobile — rather than the move itself.
 
@@ -61,7 +68,7 @@ function stubDesktop(isDesktop = true) {
     });
 }
 
-function mount({ profile, initialPath = '/swarm' } = {}) {
+function mount({ profile, initialPath = '/swarm/features' } = {}) {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -199,5 +206,46 @@ describe('NavBarSidebar — Features nav entry (req #3217)', () => {
         const labels = [...document.body.querySelectorAll('.MuiBottomNavigationAction-root')]
             .map(el => el.textContent);
         expect(labels.filter(l => l.includes('Features'))).toHaveLength(1);
+    });
+});
+
+// Req #3236 — Epics, Features and Steps nest as CLOSED-by-default L3 children of
+// Pipelines. These pin the two behaviors that are new here and that the tests
+// above lean on implicitly by mounting on a child route: the cluster starts
+// closed, and landing directly on ANY of the three children opens it (not just
+// Features, which the rest of this file happens to exercise).
+describe('NavBarSidebar — Pipelines cluster L3 nesting (req #3236)', () => {
+    it('starts the Pipelines cluster closed when landing away from it', () => {
+        mount({ profile: BOTH_GROUPS_ON, initialPath: '/swarm' });
+        expect(document.body.querySelector('a[href="/swarm/pipelines"]')).not.toBeNull();
+        expect(document.body.querySelector('a[href="/swarm/epics"]')).toBeNull();
+        expect(featureLinks()).toHaveLength(0);
+        expect(document.body.querySelector('a[href="/swarm/steps"]')).toBeNull();
+    });
+
+    it.each([
+        ['/swarm/epics'],
+        ['/swarm/features'],
+        ['/swarm/steps'],
+    ])('auto-opens the whole cluster landing directly on %s', (childPath) => {
+        mount({ profile: BOTH_GROUPS_ON, initialPath: childPath });
+        expect(document.body.querySelector('a[href="/swarm/epics"]')).not.toBeNull();
+        expect(featureLinks()).toHaveLength(1);
+        expect(document.body.querySelector('a[href="/swarm/steps"]')).not.toBeNull();
+    });
+
+    it('renders the icon-only collapsed rail with children flattened, same as Sessions', () => {
+        // Icon-only mode has no room for a +/- toggle, so children render flat
+        // right after their parent regardless of expanded state (the same
+        // behavior Sessions already relies on — no second mechanism for this
+        // cluster).
+        mount({ profile: BOTH_GROUPS_ON, initialPath: '/swarm' });
+        act(() => {
+            document.body.querySelector('[data-testid="navbar-collapse-toggle"]').click();
+        });
+        expect(document.body.querySelector('a[href="/swarm/epics"]')).not.toBeNull();
+        expect(featureLinks()).toHaveLength(1);
+        expect(document.body.querySelector('a[href="/swarm/steps"]')).not.toBeNull();
+        expect(document.body.querySelector(`[data-testid^="nav-expand-toggle-"]`)).toBeNull();
     });
 });

--- a/src/NavBar/__tests__/navConfig.test.js
+++ b/src/NavBar/__tests__/navConfig.test.js
@@ -60,160 +60,72 @@ describe('navConfig — Sessions sub-items', () => {
     });
 });
 
-// Req #3139 — the Epics editor is an L2 entry directly under Pipelines. The
-// spec is positional ("goes where pipelines L2 is"), so position is what these
-// pin: a later nav edit that appends Epics to the end of the swarm group would
-// satisfy every other assertion in this file and still be wrong.
-describe('navConfig — Epics editor placement (req #3139)', () => {
-    const EPICS_PATH = '/swarm/epics';
+// Req #3236 — Epics, Features and Steps nest as L3 children of Pipelines,
+// reusing the exact mechanism the Sessions block above pins. This SUPERSEDES
+// #3139, #3140 and #3217, each of which pinned "sibling, never a child of
+// Pipelines" for one of these three — the earlier assertions are inverted here
+// on purpose, not merely deleted.
+describe('navConfig — Epics/Features/Steps nest under Pipelines (req #3236)', () => {
     const PIPELINES_PATH = '/swarm/pipelines';
+    const CHILD_PATHS = ['/swarm/epics', '/swarm/features', '/swarm/steps'];
 
-    it('registers Epics as an L2 link in the swarm group', () => {
-        const epics = NAV_LINKS.find(l => l.path === EPICS_PATH);
-        expect(epics).toBeDefined();
-        expect(epics.group).toBe('swarm');
-        expect(epics.label).toBe('Epics');
-        expect(epics.icon).toBeTruthy();
+    const pipelines = NAV_LINKS.find(l => l.path === PIPELINES_PATH);
+
+    it('keeps Pipelines as a top-level link in the swarm group', () => {
+        expect(pipelines).toBeDefined();
+        expect(pipelines.group).toBe('swarm');
+        expect(pipelines.label).toBe('Pipelines');
     });
 
-    it('places Epics immediately after Pipelines', () => {
-        const paths = NAV_LINKS.map(l => l.path);
-        expect(paths.indexOf(EPICS_PATH)).toBe(paths.indexOf(PIPELINES_PATH) + 1);
+    it('nests Epics / Features / Steps under Pipelines, in hierarchy order', () => {
+        // Epic > Feature > Step — not arrival order (Epics shipped #3139, Steps
+        // #3140, Features #3217 last).
+        expect(pipelines.children.map(c => c.path)).toEqual(CHILD_PATHS);
+        expect(pipelines.children.map(c => c.label)).toEqual(['Epics', 'Features', 'Steps']);
     });
 
-    it('keeps Epics a SIBLING of Pipelines, never a child of it', () => {
-        // An epic is not a lifecycle record OF a pipeline the way Starts are of
-        // a Session, so it must not acquire req #3209's nesting.
-        const epics = NAV_LINKS.find(l => l.path === EPICS_PATH);
-        expect(epics.children).toBeUndefined();
-        NAV_LINKS.forEach(parent => {
-            expect((parent.children ?? []).map(c => c.path)).not.toContain(EPICS_PATH);
-        });
+    it('every child carries an icon so the collapsed sidebar can render it', () => {
+        pipelines.children.forEach(child => expect(child.icon).toBeTruthy());
     });
 
-    it('leaves Requirements as the swarm group\'s first link', () => {
-        // Same HomePage-redirect invariant the Sessions block above pins.
-        expect(NAV_LINKS.find(l => l.group === 'swarm').path).toBe('/swarm');
-    });
-});
+    // Group-inheritance and single-level nesting are already pinned GLOBALLY by
+    // the Sessions block above (it iterates every NAV_LINKS parent, not just
+    // Sessions), so Pipelines is already covered — no per-parent duplicate here.
 
-// Req #3140 — the Steps editor joins feature 37's Pipelines > Epics > Steps L2
-// cluster. Same positional spec as #3139 ("goes where pipelines L2 is"), so
-// position is again what these pin: appending Steps to the end of the swarm group
-// would satisfy every other assertion in this file and still be wrong.
-describe('navConfig — Steps editor placement (req #3140)', () => {
-    const STEPS_PATH = '/swarm/steps';
-    const FEATURES_PATH = '/swarm/features';
-    const EPICS_PATH = '/swarm/epics';
-    const PIPELINES_PATH = '/swarm/pipelines';
-
-    it('registers Steps as an L2 link in the swarm group', () => {
-        const steps = NAV_LINKS.find(l => l.path === STEPS_PATH);
-        expect(steps).toBeDefined();
-        expect(steps.group).toBe('swarm');
-        expect(steps.label).toBe('Steps');
-        expect(steps.icon).toBeTruthy();
-    });
-
-    it('keeps Pipelines, Epics, Features and Steps contiguous, in that order', () => {
-        // Req #3217 seated Features between Epics and Steps, so Steps moved from
-        // Pipelines + 2 to Pipelines + 3. Everything #3140 actually pinned — Steps
-        // inside the cluster, after Epics, with no gap — is asserted here still;
-        // only the constant it was measured against changed.
-        const paths = NAV_LINKS.map(l => l.path);
-        const pipelines = paths.indexOf(PIPELINES_PATH);
-        expect(paths.indexOf(EPICS_PATH)).toBe(pipelines + 1);
-        expect(paths.indexOf(FEATURES_PATH)).toBe(pipelines + 2);
-        expect(paths.indexOf(STEPS_PATH)).toBe(pipelines + 3);
-    });
-
-    it('keeps Steps a SIBLING of Pipelines, never a child of it', () => {
-        // A step is a MEMBER of a plan, not a lifecycle record OF one, so it must
-        // not acquire req #3209's nesting.
-        const steps = NAV_LINKS.find(l => l.path === STEPS_PATH);
-        expect(steps.children).toBeUndefined();
-        NAV_LINKS.forEach(parent => {
-            expect((parent.children ?? []).map(c => c.path)).not.toContain(STEPS_PATH);
-        });
-    });
-
-    it('leaves Requirements as the swarm group\'s first link', () => {
-        // Same HomePage-redirect invariant the blocks above pin.
-        expect(NAV_LINKS.find(l => l.group === 'swarm').path).toBe('/swarm');
-    });
-});
-
-// Req #3217 — the Features editor, the last page of feature 37. Unlike its two
-// siblings this one is a MOVE, not an addition: /swarm/features has existed since
-// #2380 and was filed under SWARM VALIDATE, a group gated behind a profile toggle
-// that ships disabled. Two failure modes are specific to a move and to nothing
-// else in this file, so both get their own assertion: leaving the old entry behind
-// (a duplicate route in the tree) and moving it somewhere other than the cluster.
-describe('navConfig — Features editor placement (req #3217)', () => {
-    const FEATURES_PATH = '/swarm/features';
-    const STEPS_PATH = '/swarm/steps';
-    const EPICS_PATH = '/swarm/epics';
-    const PIPELINES_PATH = '/swarm/pipelines';
-
-    it('registers Features as an L2 link in the swarm group', () => {
-        const features = NAV_LINKS.find(l => l.path === FEATURES_PATH);
-        expect(features).toBeDefined();
-        expect(features.group).toBe('swarm');
-        expect(features.label).toBe('Features');
-        expect(features.icon).toBeTruthy();
-    });
-
-    it('places Features between Epics and Steps', () => {
-        // Epic > Feature is the plan hierarchy design rule 10 walks (requirement →
-        // feature → epic), and feature 37 enumerates its pages in that order.
-        const paths = NAV_LINKS.map(l => l.path);
-        expect(paths.indexOf(FEATURES_PATH)).toBe(paths.indexOf(EPICS_PATH) + 1);
-        expect(paths.indexOf(STEPS_PATH)).toBe(paths.indexOf(FEATURES_PATH) + 1);
+    it('no longer lists the child paths at the top level', () => {
+        const topLevel = NAV_LINKS.map(l => l.path);
+        CHILD_PATHS.forEach(p => expect(topLevel).not.toContain(p));
     });
 
     it('no longer files Features under the swarm-validate group', () => {
         const validatePaths = NAV_LINKS.filter(l => l.group === 'swarm-validate')
                                        .map(l => l.path);
-        expect(validatePaths).not.toContain(FEATURES_PATH);
+        expect(validatePaths).not.toContain('/swarm/features');
     });
 
     it('lists Features exactly once across the whole tree', () => {
-        // The move's own failure mode: adding the swarm entry without deleting the
-        // swarm-validate one. Both rows would light up as active on /swarm/features
-        // and the mobile bottom nav would show the page twice.
+        // The collision the requirement calls out: a Features/test-cases app
+        // lives elsewhere in Darwin, and there must be exactly one nav row for
+        // this /swarm/features editor, nested and nowhere else.
         const occurrences = flattenNavLinks(NAV_LINKS)
-            .filter(l => l.path === FEATURES_PATH).length;
+            .filter(l => l.path === '/swarm/features').length;
         expect(occurrences).toBe(1);
     });
 
-    it('leaves the rest of the swarm-validate group intact', () => {
-        // Moving one entry out must not empty or reorder the group it left.
+    it('leaves the swarm-validate group intact', () => {
         expect(NAV_LINKS.filter(l => l.group === 'swarm-validate').map(l => l.path))
             .toEqual(['/swarm/testcases', '/swarm/testplans', '/swarm/testruns']);
         expect(NAV_GROUPS.map(g => g.id)).toContain('swarm-validate');
     });
 
-    it('keeps Features a SIBLING of Pipelines, never a child of it', () => {
-        // A feature is a tier the plan is composed FROM, not a lifecycle record OF
-        // a pipeline, so it must not acquire req #3209's nesting.
-        const features = NAV_LINKS.find(l => l.path === FEATURES_PATH);
-        expect(features.children).toBeUndefined();
-        NAV_LINKS.forEach(parent => {
-            expect((parent.children ?? []).map(c => c.path)).not.toContain(FEATURES_PATH);
-        });
-    });
-
-    it('keeps the whole plan-editor cluster in one unbroken run', () => {
-        const paths = NAV_LINKS.map(l => l.path);
-        const start = paths.indexOf(PIPELINES_PATH);
-        expect(paths.slice(start, start + 4)).toEqual([
-            PIPELINES_PATH, EPICS_PATH, FEATURES_PATH, STEPS_PATH,
-        ]);
+    it('exposes the new L3 routes in the flattened list', () => {
+        const flat = flattenNavLinks(NAV_LINKS).map(l => l.path);
+        CHILD_PATHS.forEach(p => expect(flat).toContain(p));
+        expect(flat).toContain(PIPELINES_PATH);
     });
 
     it('leaves Requirements as the swarm group\'s first link', () => {
-        // Same HomePage-redirect invariant the blocks above pin — Features must not
-        // land ahead of /swarm and become the redirect target.
+        // Same HomePage-redirect invariant the Sessions block above pins.
         expect(NAV_LINKS.find(l => l.group === 'swarm').path).toBe('/swarm');
     });
 });

--- a/src/NavBar/navConfig.js
+++ b/src/NavBar/navConfig.js
@@ -69,44 +69,24 @@ export const NAV_LINKS = [
         { path: '/customer-releases', label: 'Customer Releases', icon: BusinessIcon, group: 'systems' },
     ] : []),
     { path: '/swarm', label: 'Requirements', icon: MapIcon, group: 'swarm' },
-    // Req #3114 — Swarm Orchestration: durable multi-requirement execution plans.
-    // Sits directly under Requirements because a pipeline is the layer ABOVE them
-    // (Epic > Feature > Story, sequenced into steps), and above Sessions because
-    // plan views carry no session data at all (req #3080 design rule 9).
-    { path: '/swarm/pipelines', label: 'Pipelines', icon: LanIcon, group: 'swarm' },
-    // Req #3139 — the Epics editor. An L2 SIBLING of Pipelines, not a child of
-    // it: an epic is not a lifecycle record OF a pipeline the way Starts are of
-    // a Session (req #3209's nesting rule), it is the tier the plan is composed
-    // FROM (design rule 10 walks requirement -> feature -> epic for a step's
-    // label). It sits directly under Pipelines because that is where the plan
-    // hierarchy is read from, and above Sessions for the same reason Pipelines
-    // is — plan views carry no session data at all (req #3080 design rule 9).
-    { path: '/swarm/epics', label: 'Epics', icon: LayersIcon, group: 'swarm' },
-    // Req #3217 — the Features editor, the last page of feature 37 "Plan Editors".
-    // The page itself already existed (/swarm/features, req #2380); what it lacked
-    // was a formal entry. It was filed under SWARM VALIDATE, a group gated behind
-    // `app_swarm_validate`, which ships DISABLED — so of the three tiers of Epic >
-    // Feature > Story, the middle one was the only one whose nav entry sat outside
-    // the plan group, behind a toggle a user had to go find before the page existed
-    // for them. MOVED here, never duplicated: two rows for one path would both
-    // light up as active and appear twice in the mobile bottom nav (the
-    // no-duplicate-paths invariant in navConfig.test.js pins it).
-    //
-    // Between Epics and Steps because the cluster reads top-down as the plan
-    // hierarchy — Epic > Feature (design rule 10 walks requirement → feature →
-    // epic for a step's label) — and feature 37 enumerates its own pages in that
-    // order. Steps therefore moves to Pipelines + 3; Epics keeps the Pipelines + 1
-    // slot #3139 pinned. FactCheckIcon is deliberately kept: it is the icon this
-    // page has always carried, and the entry moving is not the page changing.
-    { path: '/swarm/features', label: 'Features', icon: FactCheckIcon, group: 'swarm' },
-    // Req #3140 — the Steps editor, the second page of feature 37 "Plan Editors"
-    // to ship. A SIBLING for the same reason Epics is: req #3209's nesting is for
-    // lifecycle records OF a thing, and a step is a MEMBER of a plan, not a record
-    // about one. It sits after Epics rather than displacing it because the cluster
-    // reads top-down as the plan itself (Pipelines) and then what it is composed
-    // of — and because #3139 pinned Epics at Pipelines + 1.
-    { path: '/swarm/steps', label: 'Steps', icon: LinearScaleIcon, group: 'swarm' },
-    // Req #3209 — Sessions is the first L2 item with L3 children. Starts,
+    // Req #3236 — Epics, Features and Steps are the plan's own entities (Epic >
+    // Feature > Step, sequenced into a pipeline's steps — design rule 10 walks
+    // that chain for a step's label), so they nest as L3 children of Pipelines
+    // rather than standing beside it as L2 siblings. Reuses the collapsible L3
+    // mechanism req #3209 shipped for Sessions verbatim — no second mechanism.
+    // Order is hierarchy order (Epic, then Feature, then Step), not the order
+    // the pages happened to ship in (#3139 Epics, #3140 Steps, #3217 Features).
+    // FactCheckIcon/LayersIcon/LinearScaleIcon are unchanged: the entries moved,
+    // not the pages, so each keeps the icon it always carried.
+    {
+        path: '/swarm/pipelines', label: 'Pipelines', icon: LanIcon, group: 'swarm',
+        children: [
+            { path: '/swarm/epics', label: 'Epics', icon: LayersIcon, group: 'swarm' },
+            { path: '/swarm/features', label: 'Features', icon: FactCheckIcon, group: 'swarm' },
+            { path: '/swarm/steps', label: 'Steps', icon: LinearScaleIcon, group: 'swarm' },
+        ],
+    },
+    // Req #3209 — Sessions is an L2 item with L3 children. Starts,
     // Completes and Undos are lifecycle records OF a session, not peers of it,
     // so they nest underneath rather than sitting as siblings. They keep their
     // own routes; only their position in the nav tree changed.

--- a/tests/tests/navigation.spec.ts
+++ b/tests/tests/navigation.spec.ts
@@ -71,6 +71,31 @@ test.describe('Navigation', () => {
     await page.getByRole('menuitem', { name: /categories/i }).click();
     await expect(page).toHaveURL(/\/categoryedit/);
 
+    // Scoped to the sidebar so a page-body link of the same name can't satisfy
+    // an assertion below — used by both the Pipelines and Sessions L3 checks.
+    const navbar = page.locator('.app-navbar');
+
+    // Navigate to Pipelines
+    await page.getByRole('link', { name: /pipelines/i }).click();
+    await expect(page).toHaveURL(/\/swarm\/pipelines/);
+
+    // Req #3236 — Epics, Features and Steps nest under Pipelines the same way
+    // Sessions' L3s nest under it (req #3209): hidden until the +/- is clicked.
+    // Assert absent first so a regression that renders them unconditionally
+    // still fails here.
+    const epicsLink = navbar.getByRole('link', { name: /^epics$/i });
+    await expect(epicsLink).toHaveCount(0);
+    await page.getByTestId('nav-expand-toggle-swarm-pipelines').click();
+    // Wait explicitly rather than leaning on Playwright's actionability check to
+    // ride out MUI's Collapse timeout="auto" animation.
+    await expect(epicsLink).toHaveCount(1);
+    await epicsLink.click();
+    await expect(page).toHaveURL(/\/swarm\/epics/);
+
+    // Collapsing hides them again — the toggle is not one-way.
+    await page.getByTestId('nav-expand-toggle-swarm-pipelines').click();
+    await expect(epicsLink).toHaveCount(0);
+
     // Navigate to Sessions
     await page.getByRole('link', { name: /sessions/i }).click();
     await expect(page).toHaveURL(/\/swarm\/sessions/);
@@ -78,8 +103,6 @@ test.describe('Navigation', () => {
     // Req #3209 — Sessions is an expandable L2: its L3s (Starts / Completes /
     // Undos) are hidden until the +/- is clicked. Assert they are absent first,
     // so a regression that renders them unconditionally still fails here.
-    // Scoped to the sidebar so a page-body link of the same name can't satisfy it.
-    const navbar = page.locator('.app-navbar');
     const startsLink = navbar.getByRole('link', { name: /^starts$/i });
     await expect(startsLink).toHaveCount(0);
     await page.getByTestId('nav-expand-toggle-swarm-sessions').click();


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3236-navbar-nest-epics-features-1
- wip(Darwin): 2026-08-01T23:28:01Z
- chore: init swarm session feature/3236-navbar-nest-epics-features-1

## Files changed
```
 .../__tests__/NavBarSidebar.featuresNav.test.jsx   |  50 ++++++-
 src/NavBar/__tests__/navConfig.test.js             | 160 +++++----------------
 src/NavBar/navConfig.js                            |  56 +++-----
 tests/tests/navigation.spec.ts                     |  27 +++-
 4 files changed, 128 insertions(+), 165 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)