### PR TITLE
Met/total counts beside plan and epic names, behind a toggle

### DIFF
--- a/src/SwarmView/pipelines/PipelineCardsView.jsx
+++ b/src/SwarmView/pipelines/PipelineCardsView.jsx
@@ -22,8 +22,8 @@ import { claimForPipeline, holderView } from './orchestrationHolder';
 
 const EMPTY_SUMMARY = { total: 0, done: 0, running: 0, pending: 0 };
 
-export default function PipelineCardsView({ pipelines, summaries, machines, claims = [],
-    onOpen, hiddenStatusCounts = [] }) {
+export default function PipelineCardsView({ pipelines, summaries, reqCounts,
+    showReqCounts = false, machines, claims = [], onOpen, hiddenStatusCounts = [] }) {
     if (!pipelines.length) {
         // "No pipelines yet" is a claim about the DATA, and it is false whenever
         // a status filter is what emptied the view — the page's own accounting
@@ -45,6 +45,15 @@ export default function PipelineCardsView({ pipelines, summaries, machines, clai
                 const pct = s.total ? Math.round((s.done / s.total) * 100) : 0;
                 // req #3224 — the whole-plan reservation, if one is held.
                 const holder = holderView(claimForPipeline(claims, p.id), machines);
+                // req #3225 — behind the shared toggle. `pipelineRequirementCounts`
+                // sets an entry for EVERY pipeline, even {met:0,total:0}. Contrast
+                // the per-epic buckets, which `requirementCounts` (pipelineModel.js)
+                // builds lazily and leaves absent for an epic with no counted
+                // requirement — pipelinePlanLayout.js's `epicBandLabelText`
+                // degrades that miss to the plain name. So a plan legitimately
+                // shows "0/0" rather than the name alone: at the plan level, "no
+                // counted requirements" IS an answer, not a missing one.
+                const counts = showReqCounts ? reqCounts?.get(p.id) : null;
                 return (
                     <Card key={p.id} variant="outlined" data-testid={`pipeline-card-${p.id}`}>
                         <CardActionArea onClick={() => onOpen(p.id)}>
@@ -54,6 +63,7 @@ export default function PipelineCardsView({ pipelines, summaries, machines, clai
                                     <Typography variant="subtitle1" sx={{ flex: 1,
                                                                           fontWeight: 600 }}>
                                         {p.title}
+                                        {counts ? ` ${counts.met}/${counts.total}` : ''}
                                     </Typography>
                                     <Chip size="small" label={p.pipeline_status}
                                           {...pipelineStatusChipProps(p.pipeline_status)} />

--- a/src/SwarmView/pipelines/PipelineDetail.jsx
+++ b/src/SwarmView/pipelines/PipelineDetail.jsx
@@ -268,6 +268,17 @@ export default function PipelineDetail() {
     // canvas and the page owns the chrome. That is what buys the visualizer a
     // full-height canvas: every row of chrome it used to carry is now shared.
     const [showCost, setShowCost] = useState(false);
+    // req #3225 — persisted (unlike showCost above) because the SAME toggle
+    // also governs the plan list page's Cards/Table titles, a different page
+    // component that must read the same choice on its own next mount rather
+    // than default back to off. `useViewPreference`'s per-tab sessionStorage
+    // is exactly that: this page writes it, the list page's own hook reads it
+    // fresh when React Router mounts that page. Off by default (the
+    // requirement's own recommendation) so the header row's default width is
+    // unchanged.
+    const [showReqCountsPref, setShowReqCountsPref] = useViewPreference(
+        'darwin-pipeline-req-counts', 'off');
+    const showReqCounts = showReqCountsPref === 'on';
     // Req #3179 — the goal text is behind the header's info button now. Shut it
     // when the route changes plans: this component is re-rendered, not remounted,
     // on an :id change, so an open dialog would otherwise stay open and re-title
@@ -500,6 +511,9 @@ export default function PipelineDetail() {
         () => orderedPlan(model, { now: new Date(), costIndex }),
         [model, costIndex]);
     const summary = useMemo(() => pipelineSummary(plan.rows), [plan.rows]);
+    // req #3225 — the whole-plan met/total, read straight off `orderedPlan`'s
+    // own derivation (no second pass over `model`).
+    const planReqCounts = plan.requirementCounts?.overall;
 
     // req #3224 — the WHOLE-PLAN reservation. An epic-scoped one is a different
     // and weaker claim ("a slice of this plan is being orchestrated") and is the
@@ -573,7 +587,11 @@ export default function PipelineDetail() {
                       data-testid="pipeline-breadcrumb-list">
                     Pipelines
                 </Link>
-                <Typography variant="body2" color="text.primary">{pipeline.title}</Typography>
+                <Typography variant="body2" color="text.primary">
+                    {pipeline.title}
+                    {showReqCounts && planReqCounts
+                        ? ` ${planReqCounts.met}/${planReqCounts.total}` : ''}
+                </Typography>
             </Breadcrumbs>
 
             {/* ── ONE ROW (user directive 2026-08-01) ─────────────────────────
@@ -621,6 +639,8 @@ export default function PipelineDetail() {
 
                 <Typography variant="h6" sx={{ flexShrink: 0 }} data-testid="pipeline-title">
                     {pipeline.title}
+                    {showReqCounts && planReqCounts
+                        ? ` ${planReqCounts.met}/${planReqCounts.total}` : ''}
                 </Typography>
 
                 {/* Accounting — the whole plan, never a filtered view
@@ -637,6 +657,23 @@ export default function PipelineDetail() {
                 </Typography>
 
                 <Box sx={{ flexGrow: 1 }} />
+
+                {/* req #3225 — visible in EITHER mode (the plan name reads it
+                    here, the epic band label reads it in Plan mode), so it
+                    lives outside the mode-conditional block below rather than
+                    joining one side of it. */}
+                <Tooltip title={'Show requirements met / total beside the plan '
+                    + 'name and every epic band label'}>
+                    <Button
+                        size="small"
+                        className="cal-toggle-btn"
+                        variant={showReqCounts ? 'contained' : 'outlined'}
+                        onClick={() => setShowReqCountsPref(showReqCounts ? 'off' : 'on')}
+                        data-testid="pipeline-reqcounts-toggle"
+                    >
+                        Counts
+                    </Button>
+                </Tooltip>
 
                 {activeMode === 'table' ? (
                     <Button
@@ -840,6 +877,7 @@ export default function PipelineDetail() {
                              focusEpicId={focusEpicId}
                              costError={!!costError}
                              showCost={showCost}
+                             showReqCounts={showReqCounts}
                              reqLayout={reqLayout} stepLabel={stepLabel} colorKey={colorKey}
                              stepWidth={stepWidth} reqLabel={reqLabel}
                              levelPref={planLevelPref}

--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -241,6 +241,10 @@ export default function PipelinePlanVisualizer({
     reqLayout = 'vertical', stepLabel = 'title', colorKey = DEFAULT_COLOR_KEY,
     stepWidth = DEFAULT_STEP_WIDTH, reqLabel = 'id', levelPref = DEFAULT_PLAN_LEVEL_PREF,
     onEffectiveLevel, onChangeLevelPref,
+    // req #3225 — the page's own persisted toggle. Governs the epic band
+    // label's count suffix here and the plan-name suffix on the page's own
+    // header, from one shared preference.
+    showReqCounts = false,
     // The header's Reset control (req #3216) lives outside this component, in
     // the zoom control group PipelineDetail.jsx owns, so the click has to
     // reach across that boundary. `resetViewNonce` is KonvaBuildCanvas's own
@@ -278,6 +282,18 @@ export default function PipelinePlanVisualizer({
     // `reqLabelText` in the layout module.
     const reqTitles = useMemo(
         () => new Map([...reqInfo].map(([id, info]) => [id, info.title])), [reqInfo]);
+    // req #3225 — the epic->{met,total} lookup `computePlanLayout` measures
+    // into the band label. Built from `plan.requirementCounts.byEpic`, the
+    // SAME derivation `orderedPlan` already ran (design rule 5: no second
+    // pass over the model just to feed this component). `null` while the
+    // toggle is off, so an unlit toggle costs the layout nothing beyond the
+    // one extra memo dependency — every band's label reads exactly as it did
+    // before this requirement.
+    const epicCounts = useMemo(() => {
+        if (!showReqCounts) return null;
+        return new Map((plan.requirementCounts?.byEpic || [])
+            .map((c) => [c.epicId, c]));
+    }, [showReqCounts, plan.requirementCounts]);
     // `plan.timeAxis` (req #3201) is what makes the horizontal axis read as a
     // calendar and stacks the bands by epic start. It comes from `orderedPlan`
     // rather than being derived here for the same reason cost does: two
@@ -285,10 +301,10 @@ export default function PipelinePlanVisualizer({
     const layout = useMemo(
         () => computePlanLayout(rows, plan.batches || [], {
             reqLayout, stepLabel, stepWidth, reqLabel, reqTitles,
-            timeAxis: plan.timeAxis || null,
+            timeAxis: plan.timeAxis || null, epicCounts,
         }),
         [rows, plan.batches, plan.timeAxis, reqLayout, stepLabel, stepWidth,
-            reqLabel, reqTitles]);
+            reqLabel, reqTitles, epicCounts]);
 
     // ── The REQUIREMENT-ID channel (req #3119, tri-state req #3168) ─────────
     // Whatever the key, it rides the requirement ids and never the bead: the

--- a/src/SwarmView/pipelines/PipelinesPage.jsx
+++ b/src/SwarmView/pipelines/PipelinesPage.jsx
@@ -43,6 +43,7 @@ import {
 import {
     PLAN_REQUIREMENT_FIELDS,
     pipelineSummaries,
+    pipelineRequirementCounts,
     hiddenPipelineStatusCounts,
 } from './pipelineViewModel';
 
@@ -104,6 +105,15 @@ export default function PipelinesPage() {
 
     const [view, setView] = useViewPreference(VIEW_STORAGE_KEY, 'cards');
     const activeView = normalizeView(view, VIEWS);
+    // req #3225 — the SAME preference the plan detail header's toggle writes.
+    // This page carries no control of its own for it (the toggle lives where
+    // the requirement puts it, in the header's row of toggle groups); it only
+    // reads whatever the reader last chose there. `useViewPreference`'s
+    // per-tab sessionStorage read happens at mount, which is exactly when a
+    // route change lands here, so a choice made on the detail page is already
+    // in effect the moment this page opens.
+    const [showReqCountsPref] = useViewPreference('darwin-pipeline-req-counts', 'off');
+    const showReqCounts = showReqCountsPref === 'on';
     // req #3220 — multi-select via the shared ChipFilter, not the old nullable
     // single value. Nothing outside this page reads the filter, so a Zustand
     // store would still be ceremony without a second consumer — but the value
@@ -154,6 +164,12 @@ export default function PipelinesPage() {
 
     const summaries = useMemo(
         () => pipelineSummaries({ pipelines, steps, stepRequirements, requirements }),
+        [pipelines, steps, stepRequirements, requirements]);
+    // req #3225 — one more pass over the same shared reads (design rule 5:
+    // never a per-pipeline fetch), computed unconditionally so toggling the
+    // preference never triggers a fresh read — only a fresh render.
+    const reqCounts = useMemo(
+        () => pipelineRequirementCounts({ pipelines, steps, stepRequirements, requirements }),
         [pipelines, steps, stepRequirements, requirements]);
 
     const filtered = useMemo(
@@ -229,6 +245,8 @@ export default function PipelinesPage() {
                     <PipelinesTableView
                         pipelines={filtered}
                         summaries={summaries}
+                        reqCounts={reqCounts}
+                        showReqCounts={showReqCounts}
                         machines={machines}
                         claims={orchestrationClaims}
                         timezone={timezone}
@@ -239,6 +257,8 @@ export default function PipelinesPage() {
                     <PipelineCardsView
                         pipelines={filtered}
                         summaries={summaries}
+                        reqCounts={reqCounts}
+                        showReqCounts={showReqCounts}
                         machines={machines}
                         claims={orchestrationClaims}
                         onOpen={open}

--- a/src/SwarmView/pipelines/PipelinesTableView.jsx
+++ b/src/SwarmView/pipelines/PipelinesTableView.jsx
@@ -43,14 +43,24 @@ function PipelinesNoRowsOverlay({ hiddenStatusCounts = [] }) {
     );
 }
 
-export default function PipelinesTableView({ pipelines, summaries, machines, claims = [],
-    timezone, onOpen, hiddenStatusCounts = [] }) {
+export default function PipelinesTableView({ pipelines, summaries, reqCounts,
+    showReqCounts = false, machines, claims = [], timezone, onOpen,
+    hiddenStatusCounts = [] }) {
     const rows = useMemo(() => pipelines.map((p) => {
         const s = summaries.get(p.id) || EMPTY_SUMMARY;
         // req #3224 — the WHOLE-PLAN reservation only. An epic-scoped one is the
         // epics page's answer; showing it here would say a plan is orchestrated
         // when a slice of it is, which is a different and weaker claim.
         const holder = holderView(claimForPipeline(claims, p.id), machines);
+        // req #3225 — behind the shared toggle. `pipelineRequirementCounts`
+        // sets an entry for EVERY pipeline, even {met:0,total:0}. Contrast
+        // the per-epic buckets, which `requirementCounts` (pipelineModel.js)
+        // builds lazily and leaves absent for an epic with no counted
+        // requirement — pipelinePlanLayout.js's `epicBandLabelText` degrades
+        // that miss to the plain name. So a plan legitimately shows "0/0"
+        // rather than the name alone: at the plan level, "no counted
+        // requirements" IS an answer, not a missing one.
+        const counts = showReqCounts ? reqCounts?.get(p.id) : null;
         return {
             ...p,
             machine_label: machineTitle(p.machine_fk, machines),
@@ -61,8 +71,9 @@ export default function PipelinesTableView({ pipelines, summaries, machines, cla
             done_count: s.done,
             running_count: s.running,
             pending_count: s.pending,
+            req_counts_label: counts ? `${counts.met}/${counts.total}` : '',
         };
-    }), [pipelines, summaries, machines, claims]);
+    }), [pipelines, summaries, reqCounts, showReqCounts, machines, claims]);
 
     const columns = useMemo(() => [
         { field: 'id', headerName: 'ID', width: 80, type: 'number' },
@@ -71,6 +82,43 @@ export default function PipelinesTableView({ pipelines, summaries, machines, cla
             headerName: 'Pipeline',
             flex: 1,
             minWidth: 280,
+            // req #3225 — the count suffix behind the shared toggle, added to
+            // the column definition ONLY while the toggle is on. Toggle off
+            // must render byte-identical to before this requirement — no
+            // `renderCell` at all, so the DataGrid's native text-overflow
+            // ellipsis on a long title is untouched. `display: 'flex'` is the
+            // column-level flag DataGrid itself uses for a renderCell's
+            // content (`GridCell.js`'s own `column.display === 'flex'`
+            // check) — a bare wrapping Box with no such flag defeated the
+            // ellipsis outright (code review finding).
+            //
+            // THE ELLIPSIS ITSELF has to be re-applied by hand even with that
+            // flag set: `display:flex` on the cell only says the CELL is a
+            // flex row, it says nothing about which CHILD may shrink and
+            // truncate — a plain DataGrid cell gets its ellipsis CSS on the
+            // cell itself, which this renderCell's content bypasses (second
+            // review pass, same finding). So the title gets its OWN
+            // ellipsis-capable span (`minWidth: 0` is load-bearing: without
+            // it a flex child refuses to shrink below its content width and
+            // the ellipsis rule never engages) and the count suffix is a
+            // separate, non-shrinking span that always stays whole.
+            ...(showReqCounts ? {
+                display: 'flex',
+                renderCell: (params) => (
+                    <Box sx={{ display: 'flex', alignItems: 'center', height: '100%',
+                                minWidth: 0, width: '100%' }}>
+                        <Box component="span" sx={{ overflow: 'hidden',
+                            textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
+                            {params.value}
+                        </Box>
+                        {params.row.req_counts_label && (
+                            <Box component="span" sx={{ flexShrink: 0, pl: 0.5 }}>
+                                {params.row.req_counts_label}
+                            </Box>
+                        )}
+                    </Box>
+                ),
+            } : {}),
         },
         {
             field: 'pipeline_status',
@@ -123,7 +171,7 @@ export default function PipelinesTableView({ pipelines, summaries, machines, cla
             width: 190,
             valueFormatter: (value) => (value ? formatDateTime(value, timezone) : '—'),
         },
-    ], [timezone]);
+    ], [timezone, showReqCounts]);
 
     // The testid goes on a WRAPPING Box, not on <DataGrid> — MUI does not
     // forward unknown props to the grid root, so a `data-testid` handed to the

--- a/src/SwarmView/pipelines/__tests__/pipelineConformance.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineConformance.test.js
@@ -36,6 +36,7 @@ import { describe, it, expect } from 'vitest';
 
 import {
     buildPlanRows, displayOrder, verifyOrder, eligibility, launchBatches,
+    requirementCounts,
 } from '../pipelineModel';
 import { SUBSTRATE_REBUILD_MODEL } from './substrateRebuildFixture';
 
@@ -181,6 +182,17 @@ function observe(wireModel, now) {
         }
     }
 
+    // req #3225 — rename onto the wire (snake_case) shape `pipeline_derive.py`
+    // speaks natively; nothing here derives anything `requirementCounts`
+    // did not already compute.
+    const counts = requirementCounts(model);
+    const observedCounts = {
+        overall: counts.overall,
+        by_epic: counts.byEpic.map((c) => ({
+            epic_id: c.epicId, met: c.met, total: c.total,
+        })),
+    };
+
     return {
         display_order: outRows.map((r) => r.id),
         rows: observedRows,
@@ -190,6 +202,7 @@ function observe(wireModel, now) {
         cycle_step_ids: [...ordered.cycleStepIds],
         duplicate_step_ids: [...ordered.duplicateStepIds],
         unresolved_req_ids: unresolved,
+        requirement_counts: observedCounts,
     };
 }
 
@@ -336,6 +349,21 @@ describe('pipeline conformance — the anchors', () => {
         expect(observed.batches).toHaveLength(1);
         expect(observed.batches[0].step_ids).toEqual([2, 3]);
         expect(c.expect.batches, 'the server keeps them apart').toEqual([]);
+    });
+
+    it('requirement_counts excludes tracking and keeps terminal statuses in '
+        + 'the denominator (req #3225)', () => {
+        // The two decisions the requirement asked to be stated, not guessed:
+        // a TRACKING requirement moves neither side of the ratio (even a
+        // `met` one), and wontfix/deferred count toward the denominator but
+        // never the numerator.
+        const c = byName('requirement-counts-tracking-and-terminal-statuses');
+        const observed = observe(c.model, c.now).requirement_counts;
+        expect(observed.overall).toEqual({ met: 2, total: 5 });
+        expect(observed.by_epic).toEqual([
+            { epic_id: 21, met: 2, total: 3 },
+            { epic_id: 22, met: 0, total: 2 },
+        ]);
     });
 
     it('reads a stringified zero as WORK, not as a tracking container', () => {

--- a/src/SwarmView/pipelines/__tests__/pipelineModel.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineModel.test.js
@@ -10,7 +10,7 @@ import {
     deriveStepState, buildPlanRows, displayOrder, verifyOrder,
     eligibility, launchBatches, condensationProposals,
     dominantLabels, machineLabels, fmtCost, aggregateStepCost,
-    aggregateRowCost, sumReqCost,
+    aggregateRowCost, sumReqCost, requirementCounts, isTrackingRequirement,
 } from '../pipelineModel';
 import { PLAN_JSON_ROWS, SUBSTRATE_REBUILD_MODEL } from './substrateRebuildFixture';
 
@@ -1126,6 +1126,130 @@ describe('cost aggregation (req #3117 server-side rollup)', () => {
         expect(row7.reqIds).toEqual([]);
         const cost = aggregateRowCost(row7, INDEX);
         expect(fmtCost(cost.wallSecs, cost.tokens)).toBe('—');
+    });
+});
+
+describe('requirementCounts — met/total, per epic and for the whole plan (req #3225)', () => {
+    const model = (requirements, features = [], epics = []) => ({ requirements, features, epics });
+
+    it('counts met over total, excluding nothing but tracking containers', () => {
+        const m = model([
+            { id: 1, requirement_status: 'met', feature_fk: 101 },
+            { id: 2, requirement_status: 'development', feature_fk: 101 },
+            { id: 3, requirement_status: 'approved', feature_fk: 101 },
+        ], [{ id: 101, title: 'F', epic_fk: 1 }], [{ id: 1, title: 'E' }]);
+        expect(requirementCounts(m)).toEqual({
+            overall: { met: 1, total: 3 },
+            byEpic: [{ epicId: 1, met: 1, total: 3 }],
+        });
+    });
+
+    it('excludes a TRACKING requirement from both the numerator and the denominator', () => {
+        // req #3123's container exemption, applied to the ratio: a container
+        // carries no acceptance criteria of its own, so counting it either way
+        // would make a self-tracking plan read as permanently short of — or
+        // trivially at — 100%.
+        const m = model([
+            { id: 1, requirement_status: 'met', feature_fk: 101 },
+            // met AND tracking — if tracking exclusion ran second, or not at
+            // all, this would inflate the numerator too.
+            { id: 2, requirement_status: 'met', tracking: 1, feature_fk: 101 },
+        ], [{ id: 101, title: 'F', epic_fk: 1 }], [{ id: 1, title: 'E' }]);
+        expect(requirementCounts(m)).toEqual({
+            overall: { met: 1, total: 1 },
+            byEpic: [{ epicId: 1, met: 1, total: 1 }],
+        });
+    });
+
+    it('a stringified tracking zero is WORK, matching isTrackingRequirement elsewhere', () => {
+        const m = model([
+            { id: 1, requirement_status: 'met', tracking: '0', feature_fk: 101 },
+        ], [{ id: 101, title: 'F', epic_fk: 1 }], [{ id: 1, title: 'E' }]);
+        expect(requirementCounts(m).overall).toEqual({ met: 1, total: 1 });
+    });
+
+    it('wontfix and deferred count toward the denominator, never the numerator', () => {
+        // req #3225's own recommendation: the ratio answers "how much of this
+        // is FINISHED", not "how much has stopped moving" — a plan can sit
+        // permanently short of its total on these two statuses, by design.
+        const m = model([
+            { id: 1, requirement_status: 'met', feature_fk: 101 },
+            { id: 2, requirement_status: 'wontfix', feature_fk: 101 },
+            { id: 3, requirement_status: 'deferred', feature_fk: 101 },
+        ], [{ id: 101, title: 'F', epic_fk: 1 }], [{ id: 1, title: 'E' }]);
+        expect(requirementCounts(m)).toEqual({
+            overall: { met: 1, total: 3 },
+            byEpic: [{ epicId: 1, met: 1, total: 3 }],
+        });
+    });
+
+    it('groups by the REQUIREMENT\'S OWN feature->epic chain, not a step\'s dominant epic', () => {
+        // Two epics, one requirement apiece — no steps are involved at all,
+        // which is the point: the count is a property of the requirement,
+        // independent of which step (if any) links it.
+        const m = model([
+            { id: 1, requirement_status: 'met', feature_fk: 101 },
+            { id: 2, requirement_status: 'development', feature_fk: 102 },
+        ], [
+            { id: 101, title: 'F1', epic_fk: 11 },
+            { id: 102, title: 'F2', epic_fk: 12 },
+        ], [{ id: 11, title: 'E1' }, { id: 12, title: 'E2' }]);
+        expect(requirementCounts(m)).toEqual({
+            overall: { met: 1, total: 2 },
+            byEpic: [
+                { epicId: 11, met: 1, total: 1 },
+                { epicId: 12, met: 0, total: 1 },
+            ],
+        });
+    });
+
+    it('a requirement with no resolvable feature/epic counts toward overall only', () => {
+        const m = model([
+            { id: 1, requirement_status: 'met', feature_fk: null },
+            { id: 2, requirement_status: 'met', feature_fk: 999 }, // unknown feature
+        ], [{ id: 101, title: 'F', epic_fk: 1 }], [{ id: 1, title: 'E' }]);
+        expect(requirementCounts(m)).toEqual({ overall: { met: 2, total: 2 }, byEpic: [] });
+    });
+
+    it('byEpic sorts by epic id ascending, independent of requirement or feature order', () => {
+        const m = model([
+            { id: 1, requirement_status: 'met', feature_fk: 202 },
+            { id: 2, requirement_status: 'met', feature_fk: 201 },
+        ], [
+            { id: 202, title: 'F2', epic_fk: 22 },
+            { id: 201, title: 'F1', epic_fk: 21 },
+        ], [{ id: 21, title: 'E1' }, { id: 22, title: 'E2' }]);
+        expect(requirementCounts(m).byEpic.map((b) => b.epicId)).toEqual([21, 22]);
+    });
+
+    it('tolerates an absent requirements/features list rather than throwing', () => {
+        expect(requirementCounts({})).toEqual({ overall: { met: 0, total: 0 }, byEpic: [] });
+        expect(requirementCounts({ requirements: [null, undefined] }))
+            .toEqual({ overall: { met: 0, total: 0 }, byEpic: [] });
+    });
+
+    it('on the Substrate Rebuild fixture: excludes exactly the one tracking '
+        + 'requirement (#3083) and matches an independent reduce', () => {
+        const reqs = SUBSTRATE_REBUILD_MODEL.requirements;
+        const trackingIds = reqs.filter(isTrackingRequirement).map((r) => r.id);
+        expect(trackingIds).toEqual([3083]);
+        const observed = requirementCounts(SUBSTRATE_REBUILD_MODEL);
+        const nonTracking = reqs.filter((r) => !trackingIds.includes(r.id));
+        expect(observed.overall.total).toBe(nonTracking.length);
+        expect(observed.overall.met).toBe(
+            nonTracking.filter((r) => r.requirement_status === 'met').length);
+        // #3083 is `development` and would have moved the numerator toward
+        // zero-relative-to-itself either way, but it must not appear in ANY
+        // epic bucket at all — this is the one requirement excluded outright.
+        const featuresById = new Map(SUBSTRATE_REBUILD_MODEL.features.map((f) => [f.id, f]));
+        const trackingEpicId = featuresById.get(
+            reqs.find((r) => r.id === 3083).feature_fk)?.epic_fk;
+        const trackingBucket = observed.byEpic.find((b) => b.epicId === trackingEpicId);
+        const expectedBucketTotal = nonTracking.filter((r) => {
+            const f = r.feature_fk != null ? featuresById.get(r.feature_fk) : null;
+            return f && f.epic_fk === trackingEpicId;
+        }).length;
+        expect(trackingBucket.total).toBe(expectedBucketTotal);
     });
 });
 

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -708,6 +708,53 @@ describe('launch-batch box geometry', () => {
         });
     }
 
+    // ── req #3225 — epic label counts on TOP of long titles + batch letters ──
+    // `crossPlan`'s two epics (47/48 chars) are already close to the worst
+    // realistic case; double-digit counts push them further. THE ACCEPTANCE
+    // CRITERION ITSELF: the zero-overlap invariant must still hold once labels
+    // grow by a count suffix — wider labels COVERED BY the invariant, never
+    // drawn around it.
+    it('appends "met/total" to the band whose epic the map names', () => {
+        const [firstBand] = crossPlan.rows
+            .map((r) => r.epicId).filter((id) => id != null);
+        const epicCounts = new Map([[firstBand, { met: 3, total: 7 }]]);
+        const layout = computePlanLayout(crossPlan.rows, crossPlan.batches,
+            { reqLayout: 'vertical', stepLabel: 'title', epicCounts });
+        const band = layout.bands.find((b) => b.epicId === firstBand);
+        expect(band.epicLabel).toBe(`${band.epic} 3/7`);
+        // THE SAME STRING measures the zero-overlap label rect — not a second,
+        // unchecked rectangle drawn beside the name.
+        const label = layout.labels.find((l) => l.kind === 'epic' && l.epicId === firstBand);
+        expect(label.text).toBe(band.epicLabel);
+        expect(label.w).toBeCloseTo(band.epicLabel.length * EPIC_CHIP_CHAR_W, 6);
+    });
+
+    it('accepts a plain object as well as a Map, matching the reqTitles convention', () => {
+        const [firstBand] = crossPlan.rows
+            .map((r) => r.epicId).filter((id) => id != null);
+        const layout = computePlanLayout(crossPlan.rows, crossPlan.batches, {
+            epicCounts: { [firstBand]: { met: 2, total: 4 } },
+        });
+        const band = layout.bands.find((b) => b.epicId === firstBand);
+        expect(band.epicLabel).toBe(`${band.epic} 2/4`);
+    });
+
+    const WIDE_COUNTS = new Map([[11, { met: 99, total: 100 }], [12, { met: 0, total: 100 }]]);
+    for (const opts of COMBOS) {
+        const name = `${opts.reqLayout} reqs × ${opts.stepLabel} labels, counts on`;
+        it(`zero label overlap with long epic titles AND count suffixes (${name})`, () => {
+            const withCounts = computePlanLayout(crossPlan.rows, crossPlan.batches,
+                { ...opts, epicCounts: WIDE_COUNTS });
+            assertNoLabelOverlap(withCounts, name);
+            const beads = [...withCounts.nodes.values()].map(beadRect);
+            for (const label of withCounts.labels) {
+                for (const bead of beads) {
+                    expect(rectsOverlap(label, bead)).toBe(false);
+                }
+            }
+        });
+    }
+
     // Verification-round regression: two batches at the same depth in ONE band.
     // The first packing pass let a batch's mates spread around the other
     // batch's lanes, so its box enclosed all of them. The contiguous-run
@@ -1111,6 +1158,104 @@ describe('floating epic chips (req #3168)', () => {
         expect(placeEpicChips({ bands: layout.bands, transform: { x: 0, y: 0, k: 1 },
             viewport: { w: 0, h: 0 }, worldWidth: layout.width })).toEqual([]);
         expect(placeEpicChips()).toEqual([]);
+    });
+});
+
+describe('epic band label counts, behind a toggle (req #3225)', () => {
+    const VIEWPORT = { w: 1500, h: 900 };
+
+    it('omitting epicCounts leaves every band label exactly as it reads today', () => {
+        const withCounts = computePlanLayout(plan.rows, plan.batches,
+            { reqLayout: 'vertical', stepLabel: 'title' });
+        for (const band of withCounts.bands) {
+            expect(band.epicLabel).toBe(band.epic);
+        }
+        const epicLabels = withCounts.labels.filter((l) => l.kind === 'epic');
+        for (const label of epicLabels) {
+            const band = withCounts.bands.find((b) => b.epicId === label.epicId);
+            expect(label.text).toBe(band.epic);
+            expect(label.w).toBeCloseTo(band.epic.length * EPIC_CHIP_CHAR_W, 6);
+        }
+    });
+
+    it('leaves a band untouched when the map carries no entry for its epic', () => {
+        const layout = computePlanLayout(plan.rows, plan.batches,
+            { epicCounts: new Map([[999999, { met: 1, total: 1 }]]) });
+        for (const band of layout.bands) {
+            expect(band.epicLabel).toBe(band.epic);
+        }
+    });
+
+    it('never suffixes the "No epic" band, even with a non-empty counts map', () => {
+        // A bead with no epic has no requirement set to count against — a
+        // stray "0/0" would claim an answer that does not exist.
+        const reads = {
+            steps: [{ id: 1, pipeline_fk: 1, title: 'req-less', run: 'auto',
+                notes: null, completed_at: '2026-07-01T00:00:00' }],
+            stepRequirements: [], stepDeps: [], requirements: [],
+            features: [], epics: [], machines: MACHINES,
+        };
+        const p = orderedPlan(buildPipelineModel({
+            pipeline: { id: 1, title: 'x', pipeline_status: 'active' }, ...reads,
+        }), { now: NOW });
+        expect(p.rows[0].epicId).toBeNull();
+        const layout = computePlanLayout(p.rows, p.batches,
+            { epicCounts: new Map([[1, { met: 1, total: 1 }]]) });
+        const noEpicBand = layout.bands.find((b) => b.epicId == null);
+        expect(noEpicBand.epicLabel).toBe(noEpicBand.epic);
+    });
+
+    it('placeEpicChips draws the epicLabel text and measures its width, not the bare name', () => {
+        const baseLayout = computePlanLayout(plan.rows, plan.batches,
+            { reqLayout: 'vertical', stepLabel: 'title' });
+        const epicCounts = new Map(baseLayout.bands
+            .filter((b) => b.epicId != null)
+            .map((b) => [b.epicId, { met: 9, total: 99 }]));
+        const withCounts = computePlanLayout(plan.rows, plan.batches,
+            { reqLayout: 'vertical', stepLabel: 'title', epicCounts });
+        const chips = placeEpicChips({
+            bands: withCounts.bands, transform: { x: 0, y: 0, k: K_READABLE },
+            viewport: VIEWPORT, worldWidth: withCounts.width,
+        });
+        expect(chips.length).toBeGreaterThan(0);
+        for (const chip of chips) {
+            const band = withCounts.bands.find((b) => b.key === chip.key
+                || (b.key == null && chip.key === 'none'));
+            expect(chip.text).toBe(band.epicLabel);
+            if (band.epicId != null) expect(chip.text).toMatch(/ 9\/99$/);
+        }
+    });
+
+    // placeEpicChips is also called directly, in tests and potentially by other
+    // callers, against hand-built band objects that predate this field — the
+    // fallback to `band.epic` must hold so those callers see no behaviour change.
+    it('placeEpicChips falls back to band.epic when a hand-built band omits epicLabel', () => {
+        const [chip] = placeEpicChips({
+            bands: [{ key: 1, epicId: 1, epic: 'X'.repeat(20), color: '#fff',
+                y: 8, height: 400, headerH: 46 }],
+            transform: { x: 0, y: 0, k: 1 }, viewport: VIEWPORT, worldWidth: 3000,
+        });
+        expect(chip.text).toBe('X'.repeat(20));
+        expect(chip.w).toBeCloseTo(20 * EPIC_CHIP_CHAR_W + 18, 6);
+    });
+
+    it('the toggle is a pure display transform: the ONLY thing that changes '
+        + 'with epicCounts is band.epicLabel and the label/chip rects built from it', () => {
+        const without = computePlanLayout(plan.rows, plan.batches,
+            { reqLayout: 'vertical', stepLabel: 'title' });
+        const withCounts = computePlanLayout(plan.rows, plan.batches, {
+            reqLayout: 'vertical', stepLabel: 'title',
+            epicCounts: new Map(without.bands
+                .filter((b) => b.epicId != null)
+                .map((b) => [b.epicId, { met: 1, total: 2 }])),
+        });
+        // Geometry — bead positions, column widths, world size — is untouched.
+        expect(withCounts.width).toBe(without.width);
+        expect(withCounts.colW).toEqual(without.colW);
+        expect([...withCounts.nodes.values()].map((n) => [n.x, n.y]))
+            .toEqual([...without.nodes.values()].map((n) => [n.x, n.y]));
+        expect(withCounts.bands.map((b) => ({ ...b, epicLabel: undefined })))
+            .toEqual(without.bands.map((b) => ({ ...b, epicLabel: undefined })));
     });
 });
 

--- a/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
@@ -13,6 +13,7 @@ import {
     planRenderRows,
     pipelineSummary,
     pipelineSummaries,
+    pipelineRequirementCounts,
     hiddenPipelineStatusCounts,
     pipelinesEmptyMessage,
     machineTitle,
@@ -25,7 +26,7 @@ import {
     formatTimeGates,
     PLAN_REQUIREMENT_FIELDS,
 } from '../pipelineViewModel';
-import { STEP_DONE, STEP_RUNNING, STEP_PENDING } from '../pipelineModel';
+import { STEP_DONE, STEP_RUNNING, STEP_PENDING, requirementCounts } from '../pipelineModel';
 import {
     STEPS,
     STEP_REQUIREMENTS,
@@ -184,6 +185,14 @@ describe('orderedPlan — engine run + self-check', () => {
     it('finds no launch batch in the Substrate Rebuild plan', () => {
         expect(plan.batches).toEqual([]);
         expect(plan.batchLetterByStepId.size).toBe(0);
+    });
+
+    it('carries requirementCounts straight from the engine (req #3225)', () => {
+        // No second derivation here — `orderedPlan` must hand back exactly
+        // what `requirementCounts(model)` computes, so the plan header and
+        // the plan visualizer print the same number from the same call.
+        expect(plan.requirementCounts).toEqual(requirementCounts(model()));
+        expect(plan.requirementCounts.overall.total).toBeGreaterThan(0);
     });
 });
 
@@ -370,6 +379,32 @@ describe('pipelineSummary / pipelineSummaries', () => {
 
     it('handles no pipelines at all', () => {
         expect(pipelineSummaries().size).toBe(0);
+    });
+});
+
+describe('pipelineRequirementCounts — the LIST page\'s per-plan met/total (req #3225)', () => {
+    it('matches the whole-plan overall bucket requirementCounts(model) computes', () => {
+        const map = pipelineRequirementCounts({
+            pipelines: [PIPELINE, OTHER_PIPELINE],
+            steps: READS.steps,
+            stepRequirements: READS.stepRequirements,
+            requirements: READS.requirements,
+        });
+        expect(map.get(1)).toEqual(requirementCounts(model()).overall);
+    });
+
+    it('gives a pipeline with no linked requirements an explicit zero, not a missing key', () => {
+        const map = pipelineRequirementCounts({
+            pipelines: [PIPELINE, OTHER_PIPELINE],
+            steps: READS.steps,
+            stepRequirements: READS.stepRequirements,
+            requirements: READS.requirements,
+        });
+        expect(map.get(2)).toEqual({ met: 0, total: 0 });
+    });
+
+    it('handles no pipelines at all', () => {
+        expect(pipelineRequirementCounts().size).toBe(0);
     });
 });
 

--- a/src/SwarmView/pipelines/pipelineModel.js
+++ b/src/SwarmView/pipelines/pipelineModel.js
@@ -1250,3 +1250,58 @@ export function aggregateStepCost(step, model, index) {
 export function aggregateRowCost(row, index) {
     return sumReqCost(row && row.reqIds, index);
 }
+
+// ── Requirement counts (req #3225) ──────────────────────────────────────────
+//
+// Met/total requirement counts, per epic and for the whole plan — DERIVED from
+// `model.requirements` alone, the same rows `buildPlanRows` already reads. Zero
+// extra cost: no new gateway read, no per-step fan-out, no stored counter.
+//
+// TRACKING REQUIREMENTS ARE EXCLUDED from both the numerator and the
+// denominator (req #3123's container exemption, matching the exclusion
+// `deriveStepState` applies to a step's gating set). A container carries no
+// acceptance criteria of its own; counting it either way would make a plan
+// that TRACKS ITSELF read as permanently short of — or trivially at — 100%.
+//
+// `wontfix`/`deferred` stay IN THE DENOMINATOR and OUT OF THE NUMERATOR
+// (req #3225's own recommendation): the ratio answers "how much of this is
+// FINISHED", not "how much has stopped moving" — a plan can sit permanently
+// short of its total, and that is the intended reading, not a stall.
+//
+// GROUPED BY THE REQUIREMENT'S OWN feature_fk -> epic chain, deliberately not
+// the step's dominant epic (rule 10's tie-break answers a different question —
+// which ONE epic a multi-requirement step bands under for display — while a
+// met/total count is a property of the requirement itself, independent of
+// which step happens to link it, or whether any step links it at all).
+//
+// `byEpic` is an ARRAY, not a Map, for the same reason `epicLabels` is: a Map
+// is not JSON-stable across the two engines (Python dict keys stringify, a JS
+// Map does not survive JSON at all), and the conformance corpus compares this
+// output for exact equality. Sorted by epic id ascending for a deterministic
+// order — nothing here depends on discovery order the way band colour does.
+//
+// @param {PipelineModel} model
+// @returns {{overall: {met: number, total: number},
+//            byEpic: {epicId: number, met: number, total: number}[]}}
+export function requirementCounts(model) {
+    const featuresById = indexById(model.features);
+    const overall = { met: 0, total: 0 };
+    const byEpic = new Map();
+    for (const req of (model && model.requirements) || []) {
+        if (!req || isTrackingRequirement(req)) continue;
+        const met = req.requirement_status === 'met';
+        overall.total += 1;
+        if (met) overall.met += 1;
+        const feature = req.feature_fk != null ? featuresById.get(req.feature_fk) : null;
+        const epicId = feature && feature.epic_fk != null ? feature.epic_fk : null;
+        if (epicId == null) continue;
+        const bucket = byEpic.get(epicId) || { epicId, met: 0, total: 0 };
+        bucket.total += 1;
+        if (met) bucket.met += 1;
+        byEpic.set(epicId, bucket);
+    }
+    return {
+        overall,
+        byEpic: [...byEpic.values()].sort((a, b) => a.epicId - b.epicId),
+    };
+}

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -1032,6 +1032,35 @@ export function reqLabelText(reqId, { reqLabel = 'id', reqTitles = null,
 
 const reqStr = (row) => (row.reqIds || []).join(' ');
 
+// ── Epic band label text (req #3225) ─────────────────────────────────────
+//
+// THE COUNT SUFFIX IS AN ARGUMENT, NOT A ROW FIELD — the same reasoning as
+// `reqTitles` above: `epicCounts` is display data, and the engine's PlanRows
+// stay untouched by it. Unlike `reqTitles` though, this is measured into the
+// band's own label rectangle rather than a per-requirement mark, because the
+// zero-overlap contract is asserted over `layout.labels` and a count drawn
+// beside the name in a second rectangle would not be covered by it — exactly
+// the failure the requirement calls out by name.
+//
+// Absent for the "No epic" band (epicId null): a bead with no epic has no
+// requirement set to count against, and a stray "0/0" would claim an answer
+// that does not exist. Absent equally when `epicCounts` carries no entry for
+// a real epic — a truncated or stale counts map degrades to the plain name
+// rather than a wrong number.
+//
+// @param {?number} epicId
+// @param {string} epicName
+// @param {?(Map|Object)} epicCounts  epicId -> {met, total}, or null/undefined
+//                                    to leave every band's plain name alone
+// @returns {string}
+function epicBandLabelText(epicId, epicName, epicCounts) {
+    if (!epicCounts || epicId == null) return epicName;
+    const counts = typeof epicCounts.get === 'function'
+        ? epicCounts.get(epicId)
+        : (Object.hasOwn(epicCounts, epicId) ? epicCounts[epicId] : null);
+    return counts ? `${epicName} ${counts.met}/${counts.total}` : epicName;
+}
+
 /**
  * Compute the full Plan-mode layout.
  *
@@ -1047,11 +1076,14 @@ const reqStr = (row) => (row.reqIds || []).join(' ');
  * @param {?Object} [opts.timeAxis]  planTimeAxis() output (req #3201). Omitted,
  *                             the axis degenerates to pure dependency depth and
  *                             bands stack by epic id — see computeTimeColumns.
+ * @param {?(Map|Object)} [opts.epicCounts]  req #3225 — epicId -> {met, total}.
+ *                             Null/omitted (the toggle-off state) leaves every
+ *                             band's label exactly as it reads today.
  * @returns {Object} layout — see the shape assembled at the bottom
  */
 export function computePlanLayout(rows, batches, {
     reqLayout = 'horizontal', stepLabel = 'id', stepWidth = DEFAULT_STEP_WIDTH,
-    reqLabel = 'id', reqTitles = null, timeAxis = null,
+    reqLabel = 'id', reqTitles = null, timeAxis = null, epicCounts = null,
 } = {}) {
     const safeRows = Array.isArray(rows) ? rows : [];
     const safeBatches = Array.isArray(batches) ? batches : [];
@@ -1207,7 +1239,14 @@ export function computePlanLayout(rows, batches, {
     for (const r of safeRows) {
         const key = r.epicId != null ? r.epicId : null;
         if (!bandByKey.has(key)) {
-            bandByKey.set(key, { key, epicId: key, epic: r.epic || 'No epic', steps: [] });
+            const epic = r.epic || 'No epic';
+            bandByKey.set(key, {
+                key, epicId: key, epic,
+                // req #3225 — the SAME string measures the zero-overlap label
+                // rect and the floating chip; see the helper's own comment.
+                epicLabel: epicBandLabelText(key, epic, epicCounts),
+                steps: [],
+            });
             bandKeys.push(key);
         }
         bandByKey.get(key).steps.push(r);
@@ -1871,9 +1910,14 @@ export function computePlanLayout(rows, batches, {
         });
     }
     for (const band of bands) {
+        // req #3225 — `epicLabel` already carries the count suffix when the
+        // toggle is on (identical to `band.epic` when it is off), so this
+        // rectangle — the one the zero-overlap contract asserts over — grows
+        // to cover it rather than a second, unchecked box drawn beside it.
+        const bandText = band.epicLabel || band.epic;
         labels.push({
-            kind: 'epic', epicId: band.epicId, text: band.epic,
-            x: 12, y: band.y + 6, w: band.epic.length * CHW_EPIC, h: 16,
+            kind: 'epic', epicId: band.epicId, text: bandText,
+            x: 12, y: band.y + 6, w: bandText.length * CHW_EPIC, h: 16,
         });
     }
     // Batch letters live in the reserved header strip of a segment's band —
@@ -2070,7 +2114,12 @@ export function placeEpicChips({
         // measured at the size it is actually drawn — otherwise the shrink would
         // silently re-introduce the over-measurement the width metric fixed.
         const scale = h / labelH;
-        const w = band.epic.length * charW * scale + EPIC_CHIP_PAD_W * scale;
+        // req #3225 — `epicLabel` carries the count suffix when the toggle is
+        // on; hand-built band fixtures that predate the field fall back to
+        // the plain name, so this stays the identity transform for callers
+        // that never set it.
+        const bandText = band.epicLabel || band.epic;
+        const w = bandText.length * charW * scale + EPIC_CHIP_PAD_W * scale;
         const minY = top + 2;
         const maxY = Math.max(minY, laneBottom - h - 2);
         const y = Math.min(Math.max(2, minY), maxY);
@@ -2108,7 +2157,7 @@ export function placeEpicChips({
         out.push({
             key: band.key == null ? 'none' : band.key,
             epicId: band.epicId,
-            text: band.epic,
+            text: bandText,
             color: band.color,
             // The band itself, so a click can fit it (req #3204). Carried rather
             // than re-looked-up by key: `band.key` is null for the "No epic"

--- a/src/SwarmView/pipelines/pipelineViewModel.js
+++ b/src/SwarmView/pipelines/pipelineViewModel.js
@@ -22,6 +22,7 @@ import {
     launchBatches,
     condensationProposals,
     eligibility,
+    requirementCounts,
     STEP_DONE,
     STEP_RUNNING,
     STEP_PENDING,
@@ -280,6 +281,9 @@ export function orderedPlan(model, { now, costIndex = null } = {}) {
         cycleStepIds,
         duplicateStepIds,
         unresolvedReqIds,
+        // req #3225 — pure CPU over `model.requirements`/`model.features`,
+        // both already in hand. No extra read, same as cost/timeAxis above.
+        requirementCounts: requirementCounts(model || {}),
     };
 }
 
@@ -393,6 +397,34 @@ export function pipelineSummaries({ pipelines, steps, stepRequirements, requirem
             machines: [],
         });
         out.set(p.id, pipelineSummary(buildPlanRows(model)));
+    }
+    return out;
+}
+
+/**
+ * Per-pipeline requirement met/total counts for the LIST page (req #3225),
+ * mirroring `pipelineSummaries` — one pass over the same shared reads, never a
+ * per-pipeline fetch (design rule 5). Only the plan-wide `overall` bucket is
+ * needed here: the list page names a PLAN, never an epic.
+ *
+ * @param {Object} args  same lists as buildPipelineModel, plus `pipelines`
+ * @returns {Map<number, {met: number, total: number}>}
+ */
+export function pipelineRequirementCounts({ pipelines, steps, stepRequirements,
+    requirements } = {}) {
+    const out = new Map();
+    for (const p of asArray(pipelines)) {
+        const model = buildPipelineModel({
+            pipeline: p,
+            steps,
+            stepRequirements,
+            stepDeps: [],
+            requirements,
+            features: [],
+            epics: [],
+            machines: [],
+        });
+        out.set(p.id, requirementCounts(model).overall);
     }
     return out;
 }


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-02T00:51:41Z
- chore: init swarm session feature/3225-met-total-counts-beside-plan-1

## Files changed
```
 src/SwarmView/pipelines/PipelineCardsView.jsx      |  14 +-
 src/SwarmView/pipelines/PipelineDetail.jsx         |  40 +++++-
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx |  20 ++-
 src/SwarmView/pipelines/PipelinesPage.jsx          |  20 +++
 src/SwarmView/pipelines/PipelinesTableView.jsx     |  56 +++++++-
 .../__tests__/pipelineConformance.test.js          |  28 ++++
 .../pipelines/__tests__/pipelineModel.test.js      | 126 +++++++++++++++++-
 .../pipelines/__tests__/pipelinePlanLayout.test.js | 145 +++++++++++++++++++++
 .../pipelines/__tests__/pipelineViewModel.test.js  |  37 +++++-
 src/SwarmView/pipelines/pipelineModel.js           |  55 ++++++++
 src/SwarmView/pipelines/pipelinePlanLayout.js      |  61 ++++++++-
 src/SwarmView/pipelines/pipelineViewModel.js       |  32 +++++
 12 files changed, 617 insertions(+), 17 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related PRs: BillWilliams79/DarwinAI-Config#756