### PR TITLE
Epic names stick during zoom

### DIFF
--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -109,7 +109,8 @@ import { aiModelLabel } from '../modelChipStyles';
 import { effortLabel } from '../effortChipStyles';
 import { OrderViolationsAlert } from './PipelinePlanTable';
 import {
-    computePlanLayout, beadStyle, placeEpicChips, epicFocusTransform, factoryDefaultScale,
+    computePlanLayout, beadStyle, placeEpicChips, collectWorldObstacles,
+    epicFocusTransform, factoryDefaultScale,
     PLAN_VIZ_PALETTE as P, PLAN_VIZ_FONT as F, BEAD_RADIUS, BEAD_HIT_RADIUS,
     CHW_EPIC, ZOOM_MIN_RATIO, ZOOM_MAX_RATIO,
     K_READABLE, DEFAULT_STEP_WIDTH, EPIC_CHIP_BG_ALPHA,
@@ -818,6 +819,21 @@ export default function PipelinePlanVisualizer({
     }, [level]);
     const drawnKinds = ['step', 'req', 'title'].filter(drawsKind).join(',');
 
+    // Every world-space rect currently DRAWN — beads (widened to the
+    // eligible-step halo where one draws), batch-box outlines, whichever
+    // labels the semantic LEVEL actually shows, and every dependency arc's
+    // bbox — for the sticky epic chips (req #3210) to steer clear of.
+    // `collectWorldObstacles` is PURE (`pipelinePlanLayout.js`) precisely so
+    // this assembly — otherwise only provable by rendering the component — is
+    // a testable property of plain data; `drawsKind`/`level` is passed in
+    // because it is this component's own gate; the pure module has no notion
+    // of semantic level on its own (review finding — the first cut passed
+    // `layout.labels` unfiltered, which dropped stickies to avoid marks that
+    // were not actually on screen).
+    const worldObstacles = useMemo(
+        () => collectWorldObstacles(layout, { drawsKind, eligibleStepIds }),
+        [layout, drawsKind, eligibleStepIds]);
+
     // Report the level actually being rendered so the toolbar's selector can
     // softly mark it while on Auto — BuildVisualizerPage's `onEffectiveLevel`
     // handshake. In an EFFECT, not during render: this calls a setState on the
@@ -989,6 +1005,11 @@ export default function PipelinePlanVisualizer({
         keepOut: legendSize
             ? { x: size.w - 10 - legendSize.w, y: 8, w: legendSize.w, h: legendSize.h }
             : null,
+        // Sticky prev/next chips (req #3210) pin to the viewport edge rather
+        // than to their own band, so — unlike the natural chips, which are
+        // confined to their own band's content-free epic lane — they need an
+        // explicit collision source: `worldObstacles`, above.
+        worldObstacles,
     });
 
     const chipBg = rgba(P.panel, EPIC_CHIP_BG_ALPHA);
@@ -1401,11 +1422,24 @@ export default function PipelinePlanVisualizer({
                     Re-enabling pointer events does not cost the drag-pan: the
                     chip is a DESCENDANT of the container d3-zoom is bound to, so
                     a mousedown on the chip still bubbles and still starts a pan.
-                    Only the click is the chip's. */}
+                    Only the click is the chip's.
+
+                    SOME entries are STICKY (req #3210, `e.sticky === 'top' |
+                    'bottom'`): the epic immediately above/below the visible
+                    range, pinned to the viewport edge inside the blank margin
+                    `epicFocusTransform` already reserves, so a reader who has
+                    focused one epic can still see — and one click away from —
+                    its neighbours in the stack. `e.band` already resolves to
+                    that neighbour, so `focusEpic(e.band)` chains exactly like
+                    a normal chip click; nothing about the click wiring differs. */}
                 <Box sx={{ position: 'absolute', inset: 0, pointerEvents: 'none',
                             overflow: 'hidden' }}
                      data-testid="pipeline-viz-epic-layer">
-                    {floatingEpics.map((e) => (
+                    {floatingEpics.map((e) => {
+                        const stickyTitle = e.sticky === 'top'
+                            ? `Jump to the epic above — ${e.text}`
+                            : `Jump to the epic below — ${e.text}`;
+                        return (
                         <Box
                             key={e.key}
                             onClick={() => focusEpic(e.band)}
@@ -1429,8 +1463,13 @@ export default function PipelinePlanVisualizer({
                             // worse than either. The chip's two controls each
                             // name themselves: the body zooms, the ↗ below
                             // opens the features view, and both say so.
-                            title="Zoom pipeline epic"
-                            aria-label={`Zoom pipeline epic ${e.text}`}
+                            // A STICKY chip names the DIRECTION it climbs
+                            // instead (req #3210) — "Zoom pipeline epic" is
+                            // true of it too, but "the epic above/below" is
+                            // the fact the reader actually needs to decide
+                            // whether to click.
+                            title={e.sticky ? stickyTitle : 'Zoom pipeline epic'}
+                            aria-label={e.sticky ? stickyTitle : `Zoom pipeline epic ${e.text}`}
                             data-testid={`pipeline-viz-epic-${e.key}`}
                             sx={{
                                 position: 'absolute', left: e.x, top: e.y,
@@ -1453,7 +1492,13 @@ export default function PipelinePlanVisualizer({
                                 // crosses.
                                 background: chipBg,
                                 px: 0.9, py: 0, borderRadius: '5px',
-                                border: `1px solid ${e.color}55`,
+                                // A sticky chip's border rides at full colour
+                                // rather than the ambient 33% (req #3210): it is
+                                // the one thing on screen naming an epic with no
+                                // content of its own in view, so it reads as a
+                                // standing control rather than a label that
+                                // happens to still be there.
+                                border: `1px solid ${e.color}${e.sticky ? '' : '55'}`,
                                 whiteSpace: 'nowrap', userSelect: 'none',
                                 pointerEvents: 'auto',
                                 cursor: 'pointer',
@@ -1474,6 +1519,15 @@ export default function PipelinePlanVisualizer({
                                 },
                             }}
                         >
+                            {/* No directional glyph here on purpose (req #3210
+                                review finding): the chip's measured width comes
+                                straight from `placeEpicChips`, which — unlike
+                                the ↗ control below — sizes the chip to exactly
+                                `e.text`, so any further in-flow content would
+                                render past what the collision math measured.
+                                The pinned position (viewport edge, not a band)
+                                plus the solid border and the "Jump to…" title
+                                below are the sticky affordance instead. */}
                             <Box component="span" className="pipeline-viz-epic-name">
                                 {e.text}
                             </Box>
@@ -1514,7 +1568,8 @@ export default function PipelinePlanVisualizer({
                                 </Box>
                             )}
                         </Box>
-                    ))}
+                        );
+                    })}
                 </Box>
 
                 {/* ── THE KEY (req #3168, user directives 2026-08-01) ────────

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -14,10 +14,10 @@ import { buildPipelineModel, orderedPlan } from '../pipelineViewModel';
 import { semanticLevel } from '../../konvaSwarmModel';
 import {
     computePlanLayout, beadStyle, stepLabelText, BEAD_RADIUS, BEAD_HIT_RADIUS,
-    PLAN_VIZ_PALETTE, placeEpicChips,
+    PLAN_VIZ_PALETTE, placeEpicChips, collectWorldObstacles, EPIC_CHIP_OPEN_LINK_W,
     STEP_WIDTH_FACTORS, isStepWidth, K_READABLE, PLAN_VIZ_FONT, READABLE_MIN_PX,
     NEXT_HALO_RADIUS, NEXT_HALO_STROKE, EPIC_CHIP_CHAR_W,
-    EPIC_CHIP_FONT, EPIC_CHIP_H,
+    EPIC_CHIP_FONT, EPIC_CHIP_H, EPIC_CHIP_MIN_H,
     REQ_STATUS_COLORS, REQ_STATUS_ORDER, REQ_STATUS_UNKNOWN_COLOR, reqStatusColor,
     MACHINE_MAC_COLOR, MACHINE_WINDOWS_COLOR, MACHINE_ANY_COLOR,
     MACHINE_FALLBACK_PALETTE, machineEcosystem, buildMachineColorView,
@@ -49,6 +49,15 @@ const beadRect = (n) => ({
     x: n.x - BEAD_RADIUS, y: n.y - BEAD_RADIUS,
     w: 2 * BEAD_RADIUS, h: 2 * BEAD_RADIUS,
 });
+
+// `placeEpicChips`'s `worldObstacles` (req #3210) is assembled by
+// `collectWorldObstacles` — deliberately the CALLER's job, since the layout
+// module has no notion of the component's semantic-level draw gate on its
+// own. Defaulting `drawsKind` here to "draw everything" is the conservative
+// (superset) case a level-aware caller only ever narrows from, so a chip this
+// function refuses to place would also be refused in production at SOME
+// level, never the reverse.
+const worldObstaclesOf = (layout) => collectWorldObstacles(layout);
 
 // The reservation invariant, checked from layout OUTPUT: a straight (same-lane)
 // arc may cross only beads that are part of its own chain — a transitive
@@ -962,9 +971,14 @@ describe('floating epic chips (req #3168)', () => {
     const layout = computePlanLayout(plan.rows, plan.batches,
         { reqLayout: 'vertical', stepLabel: 'title' });
     const VIEWPORT = { w: 1500, h: 900 };
+    // `worldObstacles` mirrors what PipelinePlanVisualizer.jsx actually
+    // assembles (req #3210) — the sticky chips this function can now also
+    // return need it to stay clear of drawn content, so a suite that omits it
+    // would be asserting against a configuration production never uses.
     const chipsAt = (transform, keepOut = null) => placeEpicChips({
         bands: layout.bands, transform, viewport: VIEWPORT,
         worldWidth: layout.width, keepOut,
+        worldObstacles: worldObstaclesOf(layout),
     });
 
     it('draws one chip per band at the default view', () => {
@@ -1158,6 +1172,376 @@ describe('floating epic chips (req #3168)', () => {
         expect(placeEpicChips({ bands: layout.bands, transform: { x: 0, y: 0, k: 1 },
             viewport: { w: 0, h: 0 }, worldWidth: layout.width })).toEqual([]);
         expect(placeEpicChips()).toEqual([]);
+    });
+});
+
+// ── `collectWorldObstacles` (req #3210) ─────────────────────────────────────
+// The sticky chips' collision source is assembled by a PURE function
+// precisely so the caller-side semantic-level gate — otherwise only provable
+// by rendering PipelinePlanVisualizer.jsx — is a testable property of plain
+// data (review finding: an earlier version of this assembly lived only in
+// the component and had no coverage at all).
+describe('collectWorldObstacles (req #3210)', () => {
+    const layout = computePlanLayout(plan.rows, plan.batches,
+        { reqLayout: 'vertical', stepLabel: 'title' });
+
+    it('includes one rect per bead, at the bead radius, when nothing is eligible', () => {
+        const out = collectWorldObstacles(layout);
+        const beads = [...layout.nodes.values()].map(beadRect);
+        expect(out.length).toBeGreaterThanOrEqual(beads.length);
+        for (const b of beads) {
+            expect(out.some((o) => o.x === b.x && o.y === b.y && o.w === b.w && o.h === b.h))
+                .toBe(true);
+        }
+    });
+
+    it('widens an ELIGIBLE step\'s footprint to the halo radius, not the bead radius', () => {
+        const [firstRow] = plan.rows;
+        const eligibleStepIds = new Set([firstRow.id]);
+        const node = layout.nodes.get(firstRow.id);
+        const withHalo = collectWorldObstacles(layout, { eligibleStepIds });
+        const withoutHalo = collectWorldObstacles(layout);
+        const haloRect = withHalo.find((o) => o.x < node.x && o.x + o.w > node.x
+            && Math.abs((o.x + o.w / 2) - node.x) < 0.01 && Math.abs((o.y + o.h / 2) - node.y) < 0.01);
+        const bareRect = withoutHalo.find((o) => Math.abs((o.x + o.w / 2) - node.x) < 0.01
+            && Math.abs((o.y + o.h / 2) - node.y) < 0.01);
+        expect(haloRect.w).toBeGreaterThan(bareRect.w);
+        expect(haloRect.w).toBeCloseTo(2 * (NEXT_HALO_RADIUS + NEXT_HALO_STROKE / 2), 6);
+        expect(bareRect.w).toBeCloseTo(2 * BEAD_RADIUS, 6);
+    });
+
+    it('excludes epic labels — never drawn in the world — regardless of drawsKind', () => {
+        const out = collectWorldObstacles(layout, { drawsKind: () => true });
+        const epicLabels = layout.labels.filter((l) => l.kind === 'epic');
+        expect(epicLabels.length).toBeGreaterThan(0);
+        for (const l of epicLabels) {
+            expect(out.some((o) => o.x === l.x && o.y === l.y && o.w === l.w && o.h === l.h))
+                .toBe(false);
+        }
+    });
+
+    it('honours the caller\'s drawsKind gate — a suppressed kind contributes no rect', () => {
+        const stepLabels = layout.labels.filter((l) => l.kind === 'step');
+        expect(stepLabels.length).toBeGreaterThan(0);
+        const withStep = collectWorldObstacles(layout, { drawsKind: () => true });
+        const withoutStep = collectWorldObstacles(layout, { drawsKind: (k) => k !== 'step' });
+        for (const l of stepLabels) {
+            expect(withStep.some((o) => o.x === l.x && o.y === l.y)).toBe(true);
+            expect(withoutStep.some((o) => o.x === l.x && o.y === l.y)).toBe(false);
+        }
+        // Nothing else moved — the gate is scoped to the ONE kind it names.
+        expect(withoutStep.length).toBe(withStep.length - stepLabels.length);
+    });
+
+    // The Substrate Rebuild fixture draws ZERO batch boxes (its nearest pair
+    // differs in run mode — see 'launch-batch box geometry' above), so a
+    // genuine one is built locally, minimally, rather than reused across
+    // `describe` blocks (each is its own closure).
+    it('normalizes batch-box width/height into the shared w/h rect shape', () => {
+        const batchReads = {
+            steps: [
+                { id: 1, pipeline_fk: 1, title: 'gate', run: 'auto', notes: null,
+                    completed_at: '2026-07-01T00:00:00' },
+                { id: 2, pipeline_fk: 1, title: 'batch mate A', run: 'auto', notes: null,
+                    completed_at: null },
+                { id: 3, pipeline_fk: 1, title: 'batch mate B', run: 'auto', notes: null,
+                    completed_at: null },
+            ],
+            stepRequirements: [
+                { step_fk: 2, requirement_fk: 900 },
+                { step_fk: 3, requirement_fk: 901 },
+            ],
+            stepDeps: [
+                { id: 1, step_fk: 2, dep_step_fk: 1, time_at: null },
+                { id: 2, step_fk: 3, dep_step_fk: 1, time_at: null },
+            ],
+            requirements: [
+                { id: 900, requirement_status: 'approved', machine_fk: 2, feature_fk: 101 },
+                { id: 901, requirement_status: 'approved', machine_fk: 2, feature_fk: 101 },
+            ],
+            features: [{ id: 101, title: 'Wave One', epic_fk: 11 }],
+            epics: [{ id: 11, title: 'Batch Epic' }],
+            machines: MACHINES,
+        };
+        const batchPlan = orderedPlan(buildPipelineModel({
+            pipeline: { id: 1, title: 'x', pipeline_status: 'active', machine_fk: 2 },
+            ...batchReads,
+        }), { now: NOW });
+        expect(batchPlan.batches).toHaveLength(1);
+        const batchLayout = computePlanLayout(batchPlan.rows, batchPlan.batches);
+        expect(batchLayout.batchBoxes.length).toBeGreaterThan(0);
+        const out = collectWorldObstacles(batchLayout);
+        for (const b of batchLayout.batchBoxes) {
+            expect(out.some((o) => o.x === b.x && o.y === b.y
+                && o.w === b.width && o.h === b.height)).toBe(true);
+        }
+    });
+
+    it('includes every arc bbox', () => {
+        const out = collectWorldObstacles(layout);
+        for (const a of layout.arcs) {
+            expect(out.some((o) => o.x === a.bbox.x && o.y === a.bbox.y
+                && o.w === a.bbox.w && o.h === a.bbox.h)).toBe(true);
+        }
+    });
+
+    it('is inert on a null/undefined layout rather than throwing', () => {
+        expect(collectWorldObstacles(null)).toEqual([]);
+        expect(collectWorldObstacles(undefined)).toEqual([]);
+        expect(collectWorldObstacles({})).toEqual([]);
+    });
+});
+
+// ── Sticky prev/next epic chips (req #3210) ────────────────────────────────
+// "The epics above and below the displayed epic ... stick" — when the epic
+// immediately before/after the visible band range is scrolled entirely off
+// screen (the common case once a reader has focused one epic, req #3204),
+// its name pins to the corresponding viewport edge instead of vanishing, and
+// stays clickable to focus that band in turn.
+describe('sticky prev/next epic chips (req #3210)', () => {
+    const layout = computePlanLayout(plan.rows, plan.batches,
+        { reqLayout: 'vertical', stepLabel: 'title' });
+    const VIEWPORT = { w: 1500, h: 900 };
+    // `worldObstacles` defaults to the layout's own (via `worldObstaclesOf`) —
+    // matching what PipelinePlanVisualizer.jsx actually assembles — so this
+    // suite exercises the collision sources the sticky chips are checked
+    // against in production, not an easier configuration that omits them.
+    const chipsAt = (transform, keepOut = null, overrides = {}) => placeEpicChips({
+        bands: layout.bands, transform, viewport: VIEWPORT,
+        worldWidth: layout.width, keepOut,
+        worldObstacles: worldObstaclesOf(layout),
+        ...overrides,
+    });
+    // The same kFit/kDefault the component computes (PipelinePlanVisualizer.jsx).
+    const kFit = VIEWPORT.w / layout.width;
+    const kDefault = Math.max(kFit, K_READABLE);
+
+    // The fixture needs at least 3 bands for "above" and "below" to both be
+    // exercisable in the same suite.
+    it('the fixture carries enough bands to exercise both directions', () => {
+        expect(layout.bands.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('draws no sticky chip when every band already fits on screen', () => {
+        // Fit-to-both-axes at the origin — the same "contain" idiom
+        // `factoryDefaultScale` uses — puts the whole plan in view, so there is
+        // no off-screen neighbour for either edge to represent.
+        const k = Math.min(VIEWPORT.w / layout.width, VIEWPORT.h / layout.height);
+        const chips = chipsAt({ x: 0, y: 0, k });
+        expect(chips.some((c) => c.sticky)).toBe(false);
+    });
+
+    // THE REVIEW FINDING, closed: `epicFocusTransform` — the ACTUAL production
+    // trigger (req #3204's "click an epic name to zoom to it") — is what this
+    // feature has to fire under, not a hand-picked transform. `FOCUS_PAD`
+    // (screen px) dwarfing `BAND_GAP` (world px) at every k the focus clamp can
+    // reach means a neighbour's own trailing content sliver always still
+    // technically intersects the viewport, so a first cut of this feature
+    // (gated on rect intersection) never engaged here — measured in review: 0
+    // sticky chips across every band on this fixture at its real focus
+    // transform. Swept over EVERY band so a fix that works on one but not
+    // another (a real risk given `FOCUS_PAD`/`BAND_GAP`'s ratio is roughly
+    // constant but band heights are not) cannot hide.
+    it('fires under the REAL epic-focus transform, for every band in the stack', () => {
+        for (let i = 0; i < layout.bands.length; i++) {
+            const band = layout.bands[i];
+            const t = epicFocusTransform(layout, band, VIEWPORT, kDefault);
+            expect(t, `band ${i} ("${band.epic}") did not produce a focus transform`)
+                .toBeTruthy();
+            const chips = chipsAt(t);
+            // The focused band's own name is on screen — the feature's whole
+            // premise is that this alone is not enough.
+            expect(chips.some((c) => !c.sticky && c.band === band),
+                `band ${i} ("${band.epic}") drew no natural chip for itself`)
+                .toBe(true);
+            // "At least three names on screen" means the NEIGHBOUR'S IDENTITY
+            // is visible, not specifically that it arrives via a sticky chip —
+            // natural chips are anchored to a band's OWN top (the epic lane),
+            // so a band peeking in from BELOW (the next one down, focusing
+            // head-first into view) routinely earns its own natural chip
+            // without any help; a band peeking in from ABOVE (the tail of the
+            // one before, focusing in feet-first) never can, which is
+            // precisely the case the sticky exists for. Assert the fact that
+            // matters — the neighbour is named somehow — for both directions,
+            // and additionally require STICKY specifically on the top edge,
+            // since that direction has no other path to a name at all.
+            const namedBy = (target) => chips.find((c) => c.band === target);
+            if (i > 0) {
+                const prev = layout.bands[i - 1];
+                const shown = namedBy(prev);
+                expect(shown, `band ${i} ("${band.epic}") — "${prev.epic}" is not `
+                    + 'named on screen at all').toBeTruthy();
+                expect(shown.sticky, `band ${i} ("${band.epic}") — "${prev.epic}" `
+                    + 'is shown but not as a sticky-top').toBe('top');
+            } else {
+                expect(chips.some((c) => c.sticky === 'top')).toBe(false);
+            }
+            if (i < layout.bands.length - 1) {
+                const next = layout.bands[i + 1];
+                expect(namedBy(next), `band ${i} ("${band.epic}") — "${next.epic}" `
+                    + 'is not named on screen at all').toBeTruthy();
+            } else {
+                expect(chips.some((c) => c.sticky === 'bottom')).toBe(false);
+            }
+        }
+    });
+
+    it('pins the epic above to the top edge once it scrolls fully off, '
+        + 'clickable back to that same band', () => {
+        const target = layout.bands[1];
+        const k = 5;
+        const topOfNext = 30;   // band[1]'s screen top — inside its own budget
+        const t = { x: 0, y: -(target.y * k) + topOfNext, k };
+        const chips = chipsAt(t);
+        const sticky = chips.find((c) => c.sticky === 'top');
+        expect(sticky).toBeTruthy();
+        expect(sticky.band).toBe(layout.bands[0]);
+        expect(sticky.text).toBe(layout.bands[0].epicLabel || layout.bands[0].epic);
+        expect(sticky.epicId).toBe(layout.bands[0].epicId);
+        // Confined to the blank strip above band[1]'s own screen top — the
+        // "swim lane" — never past it.
+        expect(sticky.y).toBeGreaterThanOrEqual(0);
+        expect(sticky.y + sticky.h).toBeLessThanOrEqual(topOfNext + 0.01);
+        // Scaled honestly, same invariant the natural chips assert.
+        expect(sticky.fontSize / sticky.h).toBeCloseTo(EPIC_CHIP_FONT / EPIC_CHIP_H, 6);
+        // band[1] itself is still on screen with room for its OWN chip too —
+        // both the current epic and the one above it are visible at once.
+        expect(chips.some((c) => !c.sticky && c.band === layout.bands[1])).toBe(true);
+    });
+
+    it('never draws a sticky chip for a side with no neighbouring band', () => {
+        // band[0] is the FIRST band in the stack: however much blank margin sits
+        // above it, there is nothing above to name — same for the LAST band and
+        // the bottom edge.
+        const first = layout.bands[0];
+        const chipsTop = chipsAt({ x: 0, y: -(first.y * 1) + 200, k: 1 });
+        expect(chipsTop.some((c) => c.sticky === 'top')).toBe(false);
+
+        const lastIdx = layout.bands.length - 1;
+        const last = layout.bands[lastIdx];
+        const chipsBottom = chipsAt({
+            x: 0, y: (VIEWPORT.h - 200) - (last.y + last.height) * 1, k: 1,
+        });
+        expect(chipsBottom.some((c) => c.sticky === 'bottom')).toBe(false);
+    });
+
+    it('draws nothing on that edge when the gap is honestly too small '
+        + `(below ${EPIC_CHIP_MIN_H}px)`, () => {
+        const target = layout.bands[1];
+        const k = 5;
+        // Only 6px of budget above band[1] — under EPIC_CHIP_MIN_H once the 4px
+        // margin is subtracted, so this is the same "nowhere honest left"
+        // refusal the natural chips make rather than a chip too small to read.
+        const t = { x: 0, y: -(target.y * k) + 6, k };
+        const chips = chipsAt(t);
+        expect(chips.some((c) => c.sticky === 'top')).toBe(false);
+    });
+
+    it('never collides with the legend keep-out even when a sticky chip '
+        + 'would otherwise land under it', () => {
+        const target = layout.bands[1];
+        const k = 5;
+        const topOfNext = 30;
+        // Panned so the natural (left-aligned) x for every chip sits under a
+        // top-right legend — the exact shape the non-sticky version of this
+        // collision is measured against elsewhere in this file.
+        const t = { x: 900, y: -(target.y * k) + topOfNext, k };
+        const keepOut = { x: VIEWPORT.w - 10 - 420, y: 8, w: 420, h: 30 };
+        for (const chip of chipsAt(t, keepOut)) {
+            expect(rectsOverlap(chip, keepOut),
+                `chip "${chip.text}" (sticky=${chip.sticky || 'no'}) under the legend`)
+                .toBe(false);
+        }
+    });
+
+    // THE OTHER REVIEW FINDING: a sticky chip is not confined to its own
+    // band's reserved epic lane the way a natural chip is (it's anchored to
+    // the viewport edge instead), so it needs an explicit collision source for
+    // the one thing genuinely drawn in that margin — a dependency arc crossing
+    // in from an off-screen band. Built directly rather than found on the
+    // fixture: a synthetic arc whose bbox sits exactly where the sticky-top
+    // slot would otherwise place its chip.
+    it('steps aside from a dependency arc crossing into its margin, rather '
+        + 'than drawing over it', () => {
+        const target = layout.bands[1];
+        const k = 5;
+        const topOfNext = 30;
+        const t = { x: 0, y: -(target.y * k) + topOfNext, k };
+        // Where the natural (unobstructed) sticky-top would land, in WORLD
+        // units — back-computed from the chip's own placement formula so the
+        // synthetic obstacle genuinely overlaps it rather than merely being
+        // nearby. Stands in for an arc's `bbox` (a rect either way, once past
+        // `computePlanLayout`'s own Bézier-hull computation — see that
+        // function's comment) — what matters here is that `worldObstacles`
+        // carries it, exactly as PipelinePlanVisualizer.jsx's own assembly
+        // folds `layout.arcs`' bboxes in.
+        const bareChip = chipsAt(t).find((c) => c.sticky === 'top');
+        expect(bareChip).toBeTruthy();
+        const blockingRect = {
+            x: (bareChip.x - t.x) / k, y: (bareChip.y - t.y) / k,
+            w: bareChip.w / k, h: bareChip.h / k,
+        };
+        const chips = chipsAt(t, null,
+            { worldObstacles: [...worldObstaclesOf(layout), blockingRect] });
+        const arcScreen = {
+            x: t.x + blockingRect.x * k, y: t.y + blockingRect.y * k,
+            w: blockingRect.w * k, h: blockingRect.h * k,
+        };
+        for (const chip of chips) {
+            expect(rectsOverlap(chip, arcScreen),
+                `chip "${chip.text}" (sticky=${chip.sticky || 'no'}) over the blocking arc`)
+                .toBe(false);
+        }
+    });
+
+    it('never overlaps another chip, sticky or not, on the fixture at any '
+        + 'zoom or pan', () => {
+        for (const k of [0.5, 1, 2, 5, 8]) {
+            for (const y of [0, -60, -400, -1200]) {
+                for (const x of [0, -300, 400]) {
+                    const chips = chipsAt({ x, y, k });
+                    for (let i = 0; i < chips.length; i++) {
+                        for (let j = i + 1; j < chips.length; j++) {
+                            expect(rectsOverlap(chips[i], chips[j]),
+                                `${chips[i].text} (sticky=${chips[i].sticky || 'no'}) vs `
+                                + `${chips[j].text} (sticky=${chips[j].sticky || 'no'}) `
+                                + `at k=${k} x=${x} y=${y}`)
+                                .toBe(false);
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    it('never lets a sticky chip touch a step, requirement or title label, '
+        + 'sweeping the same k/pan range as the natural chips', () => {
+        const content = layout.labels.filter((l) => l.stepId != null);
+        for (const k of [0.2, 0.3, 0.39, 0.5, 0.8, 1, 1.5, 2.5, 5]) {
+            for (const y of [0, -120, -600, -1400]) {
+                const chips = chipsAt({ x: 0, y, k }).filter((c) => c.sticky);
+                for (const chip of chips) {
+                    for (const l of content) {
+                        const screen = {
+                            x: 0 + l.x * k, y: y + l.y * k, w: l.w * k, h: l.h * k,
+                        };
+                        expect(rectsOverlap(chip, screen),
+                            `sticky "${chip.text}" (${chip.sticky}) collides with `
+                            + `${l.kind} label of step ${l.stepId} at k=${k} y=${y}`)
+                            .toBe(false);
+                    }
+                }
+            }
+        }
+    });
+
+    it('is inert with one band or fewer — nothing to be adjacent to', () => {
+        const [chip] = placeEpicChips({
+            bands: [{ key: 1, epicId: 1, epic: 'Solo', color: '#fff',
+                y: 8, height: 400, headerH: 46 }],
+            transform: { x: 0, y: 0, k: 1 }, viewport: VIEWPORT, worldWidth: 3000,
+        });
+        expect(chip.sticky).toBeUndefined();
     });
 });
 

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -1618,26 +1618,50 @@ export function computePlanLayout(rows, batches, {
             const x2 = b.x - BEAD_R - 1;
             const y2 = b.y;
             if (y1 === y2) {
-                arcs.push({ fromId: dId, toId: r.id, straight: true, route: 'straight', x1, y1, x2, y2 });
+                // A 1px-tall AABB — see `bbox` below — so a degenerate straight
+                // arc still has SOME height for the sticky-chip avoidance check
+                // (req #3210) to test against, rather than a zero-height rect
+                // that can only ever collide by exact-Y coincidence.
+                arcs.push({
+                    fromId: dId, toId: r.id, straight: true, route: 'straight', x1, y1, x2, y2,
+                    bbox: { x: Math.min(x1, x2), y: y1 - 1, w: Math.abs(x2 - x1), h: 2 },
+                });
                 continue;
             }
             const sameBand = a.bandIndex === b.bandIndex;
             const late = sameBand
                 && corridorClear(a.bandIndex, a.lane, a.depth, b.depth, dId, r.id);
             let path;
+            // `pts` is every X/Y pair the SVG path string below is built from —
+            // start, both cubic controls, and end. A cubic Bézier always lies
+            // within the convex hull of its control points (never bulges past
+            // them), so min/max over this exact set is a CONSERVATIVE but
+            // never-too-small bounding box (req #3210's `bbox`, below) — no
+            // curve sampling required, and it can only over- rather than
+            // under-estimate what the arc occupies on screen.
+            let pts;
             if (late) {
                 const bend = Math.min((colW[b.depth] || 110) * 0.9, Math.max(40, x2 - x1));
                 const xb = Math.max(x1, x2 - bend);
                 path = `M${x1},${y1} L${xb},${y1} C${xb + bend * 0.45},${y1} `
                     + `${xb + bend * 0.55},${y2} ${x2},${y2}`;
+                pts = [[x1, y1], [xb, y1], [xb + bend * 0.45, y1], [xb + bend * 0.55, y2], [x2, y2]];
             } else {
                 const bend = Math.min((colW[a.depth] || 110) * 0.9, Math.max(40, x2 - x1));
                 path = `M${x1},${y1} C${x1 + bend * 0.45},${y1} ${x1 + bend * 0.55},${y2} `
                     + `${x1 + bend},${y2} L${Math.max(x2, x1 + bend)},${y2}`;
+                pts = [[x1, y1], [x1 + bend * 0.45, y1], [x1 + bend * 0.55, y2],
+                    [x1 + bend, y2], [Math.max(x2, x1 + bend), y2]];
             }
+            const xs = pts.map((p) => p[0]);
+            const ys = pts.map((p) => p[1]);
+            const bbox = {
+                x: Math.min(...xs), y: Math.min(...ys),
+                w: Math.max(...xs) - Math.min(...xs), h: Math.max(...ys) - Math.min(...ys),
+            };
             arcs.push({
                 fromId: dId, toId: r.id, straight: false,
-                route: late ? 'late' : 'early', x1, y1, x2, y2, path,
+                route: late ? 'late' : 'early', x1, y1, x2, y2, path, bbox,
             });
         }
     }
@@ -2052,6 +2076,18 @@ export const EPIC_CHIP_H = 24;      // the HTML chip's own height, in SCREEN px
 export const EPIC_CHIP_CHAR_W = CHW_EPIC;
 export const EPIC_CHIP_PAD_W = 18;  // px + border, both sides
 export const EPIC_CHIP_FONT = PLAN_VIZ_FONT.epic;
+// The "open in features view" ↗ control's own footprint (req #3204) — a
+// FLAT, unscaled screen-px reservation, not part of `EPIC_CHIP_PAD_W`
+// (review finding, req #3210): the control is a fixed `fontSize: 12` glyph
+// plus its own padding and the chip's `gap`, none of which shrinks when the
+// chip does, unlike the name text `EPIC_CHIP_PAD_W` already accounts for. A
+// natural chip has never needed this reserved — it is checked only against
+// the legend and other chips, both comfortably clear at the sizes this
+// surface reaches in practice — but a STICKY chip (`placeEpicChips`, below)
+// is checked against beads, arcs and labels it can end up flush against, so
+// leaving the control unmeasured there is the exact under-measurement bug
+// this module's own header comment warns about, just for a different mark.
+export const EPIC_CHIP_OPEN_LINK_W = 24;
 // The floor a scaled chip stops at. Below this the name is not readable anyway,
 // and the layout would rather draw a small legible-ish chip inside its own lane
 // than a full-size one over the first row of steps.
@@ -2062,9 +2098,60 @@ export const EPIC_CHIP_MIN_H = 11;
 // wins over whatever it crosses.
 export const EPIC_CHIP_BG_ALPHA = 0.6;
 
+/**
+ * Every world-space rect currently DRAWN on this surface — bead footprints
+ * (widened to the eligible-step halo where the engine says a step is
+ * launchable now), batch-box outlines, every dependency arc's `bbox`, and
+ * whichever labels the caller's OWN `drawsKind` says the current semantic
+ * level actually draws (req #3210's `placeEpicChips` sticky chips are the
+ * consumer — see that function's own comment for why this assembly cannot
+ * live inside it).
+ *
+ * PURE and exported rather than inlined in the component, so the level gate
+ * — otherwise only provable by rendering `PipelinePlanVisualizer.jsx` — is a
+ * testable property of plain data instead. `drawsKind` defaults to "draw
+ * everything", the conservative superset a caller with no notion of semantic
+ * level (a test, a hand-built probe) should get rather than a silent
+ * under-count; `eligibleStepIds` defaults to none, since a caller that omits
+ * it has no eligibility concept to widen the footprint for.
+ *
+ * `kind: 'epic'` labels are excluded outright, unconditionally: they are
+ * NEVER drawn in the world at all (an HTML overlay draws the name instead —
+ * see the `kind === 'epic'` no-op in the component's own world-node loop), so
+ * including them would avoid a mark that is not actually there.
+ *
+ * @param {Object} layout `computePlanLayout`'s own return value
+ * @param {Object} [args]
+ * @param {(kind: string) => boolean} [args.drawsKind]
+ * @param {?Set<number>} [args.eligibleStepIds]
+ * @returns {{x:number,y:number,w:number,h:number}[]}
+ */
+export function collectWorldObstacles(layout, { drawsKind = () => true, eligibleStepIds = null } = {}) {
+    const out = [];
+    for (const n of (layout?.nodes || new Map()).values()) {
+        const r = eligibleStepIds?.has(n.id) ? NEXT_HALO_RADIUS + NEXT_HALO_STROKE / 2 : BEAD_R;
+        out.push({ x: n.x - r, y: n.y - r, w: 2 * r, h: 2 * r });
+    }
+    for (const l of layout?.labels || []) {
+        if (l.kind === 'epic' || !drawsKind(l.kind)) continue;
+        out.push({ x: l.x, y: l.y, w: l.w, h: l.h });
+    }
+    for (const a of layout?.arcs || []) {
+        if (a.bbox) out.push(a.bbox);
+    }
+    // Batch boxes carry `width`/`height`, not `w`/`h` (`computePlanLayout`'s
+    // own field names for them) — normalized here to the one obstacle shape
+    // this function promises.
+    for (const b of layout?.batchBoxes || []) {
+        out.push({ x: b.x, y: b.y, w: b.width, h: b.height });
+    }
+    return out;
+}
+
 export function placeEpicChips({
     bands = [], transform, viewport, worldWidth,
     labelH = EPIC_CHIP_H, charW = EPIC_CHIP_CHAR_W, keepOut = null,
+    worldObstacles = [],
 } = {}) {
     const t = transform || { x: 0, y: 0, k: 1 };
     const vw = viewport?.w || 0;
@@ -2078,8 +2165,14 @@ export function placeEpicChips({
     const hits = (a, b) => a.x < b.x + b.w && b.x < a.x + a.w
         && a.y < b.y + b.h && b.y < a.y + a.h;
     const out = [];
+    // Which bands actually got their OWN chip drawn (req #3210) — the sticky
+    // pass below reads this rather than re-deriving "visible" from scratch; see
+    // that section's own comment for why a geometric visibility test isn't the
+    // same question.
+    const placedAt = new Array(bands.length).fill(false);
 
-    for (const band of bands) {
+    for (let bi = 0; bi < bands.length; bi++) {
+        const band = bands[bi];
         const top = t.y + band.y * t.k;
         const bottom = t.y + (band.y + band.height) * t.k;
         // The EPIC LANE's bottom, not the header's: a lane-0 step label reaches
@@ -2153,6 +2246,7 @@ export function placeEpicChips({
         }
         if (!placed) continue;   // nowhere honest left — see the header comment
 
+        placedAt[bi] = true;
         obstacles.push(placed);
         out.push({
             key: band.key == null ? 'none' : band.key,
@@ -2170,6 +2264,146 @@ export function placeEpicChips({
             fontSize: EPIC_CHIP_FONT * scale,
         });
     }
+
+    // ── Sticky prev/next epic names (req #3210) ─────────────────────────────
+    // A focused epic (req #3204's `epicFocusTransform`, FOCUS_PAD margin on
+    // every side) fills the viewport with its own chip — the epics immediately
+    // above and below it in the stack can end up with no name on screen at
+    // all, and the reader loses any reference to — or one-click path to — a
+    // neighbour. "Always at least three epic names" is the focused band's own
+    // chip plus these two.
+    //
+    // `bands` is already ordered top-to-bottom in world-Y (req #3201's
+    // DERIVED-START sort — see the module header), so "the epic above/below"
+    // is simply the previous/next array entry relative to whichever bands
+    // currently carry their OWN chip — `placedAt`, from the loop above.
+    //
+    // PLACED, NOT MERELY ON SCREEN — the first of two review findings this
+    // block fixes. `FOCUS_PAD` is 44 SCREEN px while the gap between bands
+    // (`BAND_GAP`) is 8 WORLD px, so at every k `epicFocusTransform` can
+    // actually reach, the neighbour band's own trailing content sliver
+    // projects to fewer screen px than the margin — its RECTANGLE still
+    // technically intersects the viewport even though its NAME (confined to
+    // its own epic lane, up near ITS top) is nowhere close to on screen. A
+    // geometric "does the rect intersect" test therefore counted that
+    // neighbour as already visible and never engaged. Whether its chip was
+    // actually PLACED is the test that agrees with what the reader can see.
+    //
+    // BUT "nothing renders above the first CHIPPED band" is FALSE, and that is
+    // the second finding: `placedAt[i]` can be false for a band whose CONTENT
+    // is still genuinely on screen — the same tail-sliver case above, one step
+    // short of fully scrolling off, or simply too little epic-lane room left
+    // for its own chip while its beads and labels are still visible. Skipping
+    // straight to the next-chipped band's boundary would let the sticky box
+    // land on top of that real, drawn content (measured in review — a sticky
+    // chip overlapping a live step label, and separately a live bead). So the
+    // "swim lane" this reuses is not assumed empty; it is KEPT empty exactly
+    // like every other chip on this surface — routed through the same
+    // `obstacles`/`candidates` horizontal-displacement pass, now widened to
+    // also carry `worldObstacles`.
+    //
+    // `worldObstacles` is the CALLER's job to assemble, deliberately: this
+    // module has no notion of `drawsKind`/semantic LEVEL (`PipelinePlanVisualizer.jsx`'s
+    // own gate on which labels are actually drawn at the current zoom), so it
+    // cannot tell a currently-hidden label from a currently-drawn one — and
+    // the epic label rects `layout.labels` itself carries are NEVER drawn in
+    // the world at all (an HTML overlay draws the name instead; see the
+    // `kind === 'epic'` no-op in the component's world-node loop). Handing
+    // this module the FULL unfiltered `layout.labels`/`layout.nodes`/`layout.arcs`
+    // would make it avoid marks that are not actually on screen (dropping a
+    // sticky that had genuine room) while still missing marks it has no
+    // vocabulary for (bead footprints are not labels or arcs at all — a
+    // second review finding: a sticky chip landed on a live bead in the first
+    // cut of this fix). The caller already computes exactly what is currently
+    // drawn for its own rendering, so it is the one source that cannot drift
+    // from what the reader actually sees.
+    if (bands.length > 1) {
+        let firstVisible = -1;
+        let lastVisible = -1;
+        for (let i = 0; i < placedAt.length; i++) {
+            if (!placedAt[i]) continue;
+            if (firstVisible === -1) firstVisible = i;
+            lastVisible = i;
+        }
+        const left = t.x + 2 * t.k;
+        const right = t.x + (worldWidth - 2) * t.k;
+        if (firstVisible !== -1 && right >= 0 && left <= vw) {
+            const minX = Math.max(0, left) + 6;
+            const maxXCap = Math.min(right, vw) - 6;
+
+            // Places one sticky chip, or draws nothing if there is no honest
+            // room — the same refusal the natural loop makes when a candidate
+            // can't be found, rather than shrinking past legibility or
+            // overlapping something.
+            const placeSticky = (targetBand, room, atTop) => {
+                if (room < EPIC_CHIP_MIN_H) return;
+                const h = Math.min(labelH, room);
+                const scale = h / labelH;
+                const bandText = targetBand.epicLabel || targetBand.epic;
+                // The ↗ control renders whenever `epicId != null` (mirrors
+                // the component's own condition) — its flat footprint has to
+                // be in `w` before anything is checked against beads/arcs/
+                // labels, or the collision math clears a box the reader
+                // cannot actually see the edge of.
+                const w = bandText.length * charW * scale + EPIC_CHIP_PAD_W * scale
+                    + (targetBand.epicId != null ? EPIC_CHIP_OPEN_LINK_W : 0);
+                const maxX = maxXCap - w;
+                if (maxX < minX) return;
+                const y = atTop ? 2 : (vh - h - 2);
+                const rectObstacles = [...obstacles];
+                // Only marks whose screen box actually reaches this chip's own
+                // row are relevant — filtered here, not carried as a permanent
+                // obstacle, because the top and bottom sticky slots occupy
+                // disjoint rows and a mark relevant to one is almost never
+                // relevant to the other.
+                for (const r of worldObstacles) {
+                    const box = {
+                        x: t.x + r.x * t.k, y: t.y + r.y * t.k,
+                        w: r.w * t.k, h: r.h * t.k,
+                    };
+                    if (box.y < y + h && y < box.y + box.h) rectObstacles.push(box);
+                }
+                const x0 = minX;
+                const candidates = [x0];
+                for (const o of rectObstacles) {
+                    candidates.push(o.x + o.w + CHIP_PAD, o.x - CHIP_PAD - w);
+                }
+                let placed = null;
+                for (const cx of candidates.sort((a, b) =>
+                    Math.abs(a - x0) - Math.abs(b - x0))) {
+                    if (cx < minX || cx > maxX) continue;
+                    const rect = { x: cx, y, w, h };
+                    if (rectObstacles.some((o) => hits(rect, o))) continue;
+                    placed = rect;
+                    break;
+                }
+                if (!placed) return;   // nowhere honest left
+                obstacles.push(placed);
+                out.push({
+                    key: `${targetBand.key == null ? 'none' : targetBand.key}`
+                        + `-stick-${atTop ? 'top' : 'bottom'}`,
+                    epicId: targetBand.epicId,
+                    text: bandText,
+                    color: targetBand.color,
+                    band: targetBand,
+                    sticky: atTop ? 'top' : 'bottom',
+                    x: placed.x, y: placed.y, w, h,
+                    fontSize: EPIC_CHIP_FONT * scale,
+                });
+            };
+
+            if (firstVisible > 0) {
+                const topOfFirst = t.y + bands[firstVisible].y * t.k;
+                placeSticky(bands[firstVisible - 1], topOfFirst - 4, true);
+            }
+            if (lastVisible < bands.length - 1) {
+                const bottomOfLast = t.y
+                    + (bands[lastVisible].y + bands[lastVisible].height) * t.k;
+                placeSticky(bands[lastVisible + 1], vh - bottomOfLast - 4, false);
+            }
+        }
+    }
+
     return out;
 }
 


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-02T02:21:27Z
- chore: init swarm session feature/3210-epic-names-stick-during-zoom-1

## Files changed
```
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx |  69 +++-
 .../pipelines/__tests__/pipelinePlanLayout.test.js | 388 ++++++++++++++++++++-
 src/SwarmView/pipelines/pipelinePlanLayout.js      | 242 ++++++++++++-
 3 files changed, 686 insertions(+), 13 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)