### PR TITLE
Remove the pipelined-exclusion notice from the SwarmStartCard

### DIFF
--- a/src/TaskPlanView/SwarmStartCard.jsx
+++ b/src/TaskPlanView/SwarmStartCard.jsx
@@ -189,30 +189,21 @@ const SwarmStartCard = () => {
     //
     // req #3180 — a launch chip's count applies the SAME rule as its list, from
     // the same Set, so the header can never disagree with the rows beneath it.
-    // `hidden` tallies what the exclusion removed per status, so a chip that
-    // drops to zero can SAY why (see the card body) instead of reading as
-    // "there is no work" while the requirements table plainly shows some.
     //
-    // LOAD-BEARING: `hidden[s]` is the count dropped from that chip's LIST only
-    // because both sources are the same population — `useAllRequirements` here
-    // and `useRequirementsByStatus` above both read /requirements with NO
-    // category predicate and NO closed-category guard. RequirementsTableView
-    // does filter through `categoryMap`, and copying that here would look like
-    // an improvement while desynchronizing the count from the list AND
-    // overcounting the note, in one edit. See `tallyRequirementStatuses`.
-    const { statusCountMap, hiddenCountMap } = React.useMemo(() => {
-        const { counts, hidden } = tallyRequirementStatuses(
+    // LOAD-BEARING: the two queries feeding count and list read the SAME
+    // population — `useAllRequirements` here and `useRequirementsByStatus` above
+    // both read /requirements with NO category predicate and NO closed-category
+    // guard. RequirementsTableView does filter through `categoryMap`, and
+    // copying that here would look like an improvement while desynchronizing the
+    // count from the list. See `tallyRequirementStatuses`.
+    const { statusCountMap } = React.useMemo(() => {
+        const { counts } = tallyRequirementStatuses(
             allRequirementsForCounts, SWARM_START_STATUSES, pipelinedIds);
         if (Array.isArray(serverMetRequirements)) {
             counts.met = serverMetRequirements.length;
         }
-        return { statusCountMap: counts, hiddenCountMap: hidden };
+        return { statusCountMap: counts };
     }, [allRequirementsForCounts, serverMetRequirements, pipelinedIds]);
-
-    // How many rows the exclusion removed from the chip currently on screen.
-    // Surfaced in the card body — a hidden row the user is never told about is
-    // the defect this requirement is about.
-    const hiddenCount = chipOffersLaunch ? (hiddenCountMap[effectiveStatus] ?? 0) : 0;
 
     // Template rows (id === '') always sort last so they stay anchored at the
     // bottom of the card on every re-sort.
@@ -542,31 +533,6 @@ const SwarmStartCard = () => {
                         {requirementsArray.filter(r => r.id !== '').length === 0 && (
                             <Typography variant="body2" sx={{ color: 'text.disabled', p: 1 }}>
                                 No {requirementStatusLabel(effectiveStatus).toLowerCase()} requirements
-                            </Typography>
-                        )}
-                        {/* req #3180 — a chip that hides work must SAY SO. On the
-                            live plan every swarm-ready requirement is plan-carried,
-                            so without this the card reads "No swarm ready
-                            requirements" while the requirements table plainly shows
-                            fifteen — the same "shrinking pool with no explanation
-                            reads as a bug" failure /swarm-start's STOP message
-                            exists to prevent. Rendered whether or not the list is
-                            empty, because a partly-filtered chip is just as
-                            misleading as an empty one.
-
-                            The wording must READ CORRECTLY AT ZERO. "N more …"
-                            was the first attempt and it presupposes rows above it,
-                            which is exactly wrong in the guaranteed opening state:
-                            the default chip is Swarm-Ready, and today that chip is
-                            15 of 15 hidden. */}
-                        {hiddenCount > 0 && (
-                            <Typography variant="body2"
-                                        sx={{ color: 'text.secondary', px: 1, pb: 1, fontStyle: 'italic' }}
-                                        data-testid="swarm-start-pipelined-note">
-                                {hiddenCount} {requirementStatusLabel(effectiveStatus).toLowerCase()}{' '}
-                                requirement{hiddenCount === 1 ? ' is' : 's are'} carried by a pipeline
-                                step — launched from the plan, not from here. See Pipelines, or launch
-                                one directly by id.
                             </Typography>
                         )}
                         {requirementsArray.map((requirement, requirementIndex) => (

--- a/src/TaskPlanView/__tests__/swarmStartCardUtils.test.js
+++ b/src/TaskPlanView/__tests__/swarmStartCardUtils.test.js
@@ -107,40 +107,26 @@ describe('tallyRequirementStatuses', () => {
         req(6, { requirement_status: 'met' }),
     ];
 
-    it('counts every chip and hides nothing when no requirement is pipelined', () => {
-        const { counts, hidden } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set());
+    it('counts every chip when no requirement is pipelined', () => {
+        const { counts } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set());
         expect(counts).toEqual({
             authoring: 2, approved: 1, swarm_ready: 1, development: 1, met: 1,
         });
-        expect(Object.values(hidden).every(n => n === 0)).toBe(true);
     });
 
-    it('moves a pipelined launch-chip requirement from counts into hidden', () => {
-        const { counts, hidden } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([2, 4]));
+    it('drops a pipelined launch-chip requirement from counts', () => {
+        const { counts } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([2, 3, 4]));
         expect(counts.authoring).toBe(1);
-        expect(hidden.authoring).toBe(1);
+        expect(counts.approved).toBe(0);
         expect(counts.swarm_ready).toBe(0);
-        expect(hidden.swarm_ready).toBe(1);
     });
 
     it('leaves development and met counted even when pipelined', () => {
         // THE decision. If this test starts failing because someone made the
         // exclusion uniform, the Development chip has just gone blank.
-        const { counts, hidden } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([5, 6]));
+        const { counts } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([5, 6]));
         expect(counts.development).toBe(1);
         expect(counts.met).toBe(1);
-        expect(hidden.development).toBe(0);
-        expect(hidden.met).toBe(0);
-    });
-
-    it('keeps count + hidden summing to the population, so the note is exact', () => {
-        // `hidden[s]` is the number of rows dropped from that chip's LIST, which
-        // is only true while count and list read the same population.
-        const { counts, hidden } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([1, 2, 3, 4]));
-        for (const s of ALL_CHIPS) {
-            const total = rows.filter(r => r.requirement_status === s).length;
-            expect(counts[s] + hidden[s]).toBe(total);
-        }
     });
 
     it('never counts the template row', () => {
@@ -152,10 +138,9 @@ describe('tallyRequirementStatuses', () => {
     });
 
     it('matches a numeric Set against string row ids', () => {
-        const { counts, hidden } = tallyRequirementStatuses(
+        const { counts } = tallyRequirementStatuses(
             [{ id: '4', requirement_status: 'swarm_ready' }], ALL_CHIPS, new Set([4]));
         expect(counts.swarm_ready).toBe(0);
-        expect(hidden.swarm_ready).toBe(1);
     });
 
     it('ignores statuses outside the chip vocabulary', () => {
@@ -165,14 +150,13 @@ describe('tallyRequirementStatuses', () => {
         expect(Object.keys(counts)).toEqual(ALL_CHIPS);
     });
 
-    it('returns zeroed maps for a missing read, hiding nothing', () => {
+    it('returns a zeroed map for a missing read', () => {
         // The in-flight state. Showing MORE than we eventually will is the
         // deliberate direction — never hide eligible work behind a pending fetch.
-        const { counts, hidden } = tallyRequirementStatuses(undefined, ALL_CHIPS, new Set([1]));
+        const { counts } = tallyRequirementStatuses(undefined, ALL_CHIPS, new Set([1]));
         expect(counts).toEqual({
             authoring: 0, approved: 0, swarm_ready: 0, development: 0, met: 0,
         });
-        expect(hidden.authoring).toBe(0);
     });
 
     it('tolerates a missing pipelined Set', () => {

--- a/src/TaskPlanView/swarmStartCardUtils.js
+++ b/src/TaskPlanView/swarmStartCardUtils.js
@@ -25,7 +25,7 @@ export const sortSwarmReadyItems = (items) => {
 export const PIPELINE_FILTERED_STATUSES = ['authoring', 'approved', 'swarm_ready'];
 
 /**
- * Per-status counts for the chip badges, plus what the pipeline exclusion removed.
+ * Per-status counts for the chip badges, applying the pipeline exclusion.
  *
  * Pure so the "which chips filter" decision is pinned by tests rather than only
  * by a rendered card.
@@ -33,21 +33,20 @@ export const PIPELINE_FILTERED_STATUSES = ['authoring', 'approved', 'swarm_ready
  * INVARIANT THIS DEPENDS ON: the card counts from `useAllRequirements` while it
  * lists from `useRequirementsByStatus`, and applies NO closed-category filter to
  * EITHER — unlike RequirementsTableView, which filters its rows through
- * `categoryMap`. That is what makes `hidden[status]` exactly the number of rows
- * dropped from that chip's list. Adding a closed-category guard to one source and
- * not the other would desynchronize the count from the list AND overcount the
- * note, in the same edit. Today the pipelined-in-closed-category population is 0.
+ * `categoryMap`. That is what keeps the count in sync with the list it's paired
+ * with. Adding a closed-category guard to one source and not the other would
+ * desynchronize the count from the list. Today the pipelined-in-closed-category
+ * population is 0.
  *
  * @param {Array<{id: number, requirement_status: string}>} requirements
  * @param {string[]} statuses      the chip vocabulary; every key is initialized to 0
  * @param {Set<number>} pipelinedIds  from `pipelinedRequirementIds`
- * @returns {{counts: Object, hidden: Object}}
+ * @returns {{counts: Object}}
  */
 export const tallyRequirementStatuses = (requirements, statuses, pipelinedIds) => {
     const counts = {};
-    const hidden = {};
-    statuses.forEach(s => { counts[s] = 0; hidden[s] = 0; });
-    if (!Array.isArray(requirements)) return { counts, hidden };
+    statuses.forEach(s => { counts[s] = 0; });
+    if (!Array.isArray(requirements)) return { counts };
 
     for (const r of requirements) {
         // The template row (id === '') is not a requirement and must never be
@@ -57,12 +56,11 @@ export const tallyRequirementStatuses = (requirements, statuses, pipelinedIds) =
         if (counts[status] === undefined) continue;
         if (PIPELINE_FILTERED_STATUSES.includes(status)
                 && pipelinedIds && pipelinedIds.has(Number(r.id))) {
-            hidden[status] += 1;
             continue;
         }
         counts[status] += 1;
     }
-    return { counts, hidden };
+    return { counts };
 };
 
 // Map coordination_type to a display label for tooltips / aria.


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-02T08:18:05Z
- chore: init swarm session feature/3248-remove-the-pipelined-exclusion-1

## Files changed
```
 src/TaskPlanView/SwarmStartCard.jsx                | 52 ++++------------------
 .../__tests__/swarmStartCardUtils.test.js          | 34 ++++----------
 src/TaskPlanView/swarmStartCardUtils.js            | 20 ++++-----
 3 files changed, 27 insertions(+), 79 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)