### PR TITLE
Frontend status writes skip the timestamp derivation MCP performs

### DIFF
--- a/src/SwarmView/CategoryCard.jsx
+++ b/src/SwarmView/CategoryCard.jsx
@@ -13,6 +13,7 @@ import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { useSwarmTabStore } from '../stores/useSwarmTabStore';
 import { useShowClosedStore } from '../stores/useShowClosedStore';
 import { RequirementActionsContext } from '../hooks/useRequirementActions';
+import { requirementStatusTimestampFields, requirementStatusTimestampState } from '../utils/requirementStatusTimestamps';
 
 import AuthContext from '../Context/AuthContext'
 import AppContext from '../Context/AppContext';
@@ -524,40 +525,56 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
 
     const STATUS_CYCLE = ['authoring', 'approved', 'swarm_ready'];
     const statusClick = (requirementIndex, requirementId) => {
-        const current = requirementsArray[requirementIndex].requirement_status;
+        const currentRow = requirementsArray[requirementIndex];
+        const current = currentRow.requirement_status;
         const idx = STATUS_CYCLE.indexOf(current);
         if (idx === -1) return; // not a cycleable status (development/met/deferred)
         const next = STATUS_CYCLE[(idx + 1) % STATUS_CYCLE.length];
+        // req #3244 — every requirement_status write re-derives all three status
+        // timestamps, matching darwin-mcp's update_requirement, so this UI path
+        // never leaves a stale started_at/completed_at/deferred_at behind. One `now`
+        // shared between the PUT body and the local-state form so they can't drift.
+        const now = new Date().toISOString();
+        const timestampState = requirementStatusTimestampState(next, now);
+        const timestampFields = requirementStatusTimestampFields(next, now);
+        const previousTimestamps = {
+            started_at: currentRow.started_at,
+            completed_at: currentRow.completed_at,
+            deferred_at: currentRow.deferred_at,
+        };
 
         if (requirementId !== '') {
             // Optimistic write-through across every requirement cache (req #2381).
             // Snapshot BEFORE any local-state mutation: requirementsArray and the cache
             // share object references (useEffect seeds from serverRequirements via shallow
             // copy), so in-place mutation would poison the snapshot.
-            const revert = writeThroughRequirementCaches(requirementId, { requirement_status: next });
+            const revert = writeThroughRequirementCaches(requirementId, { requirement_status: next, ...timestampState });
 
             let uri = `${darwinUri}/requirements`;
-            call_rest_api(uri, 'PUT', [{'id': requirementId, 'requirement_status': next}], idToken)
+            call_rest_api(uri, 'PUT', [{'id': requirementId, 'requirement_status': next, ...timestampFields}], idToken)
                 .then(result => {
                     if (result.httpStatus.httpStatus !== 200 && result.httpStatus.httpStatus !== 204) {
                         revert();
                         setRequirementsArray(prev => prev.map(r =>
-                            r.id === requirementId ? { ...r, requirement_status: current } : r));
+                            r.id === requirementId ? { ...r, requirement_status: current, ...previousTimestamps } : r));
                         showError(result, "Unable to change requirement status");
                     }
                 }).catch(error => {
                     revert();
                     setRequirementsArray(prev => prev.map(r =>
-                        r.id === requirementId ? { ...r, requirement_status: current } : r));
+                        r.id === requirementId ? { ...r, requirement_status: current, ...previousTimestamps } : r));
                     showError(error, "Unable to change requirement status");
                 });
         } else if (savingRef.current) {
+            // pendingMutationsRef feeds a raw PUT body (see saveRequirement below), so it
+            // needs the 'NULL' sentinel form, not the null-bearing local-state form.
             pendingMutationsRef.current.requirement_status = next;
+            Object.assign(pendingMutationsRef.current, timestampFields);
         }
         // Immutable update — new object at the target index rather than in-place mutation
         // on a cache-shared object reference (see snapshot comment above).
         setRequirementsArray(prev => prev.map((r, i) =>
-            i === requirementIndex ? { ...r, requirement_status: next } : r));
+            i === requirementIndex ? { ...r, requirement_status: next, ...timestampState } : r));
     }
 
     // Autonomy is mandatory (req #2745) — no null/empty state. Cycling a legacy
@@ -638,7 +655,11 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
 
                     const pending = pendingMutationsRef.current;
                     if (Object.keys(pending).length > 0) {
-                        Object.assign(newRequirementsArray[requirementIndex], pending);
+                        // pending is a raw PUT body — its 'NULL' sentinels must not leak into
+                        // displayed local state, where a cleared column is a real `null`.
+                        const displayPending = Object.fromEntries(
+                            Object.entries(pending).map(([k, v]) => [k, v === 'NULL' ? null : v]));
+                        Object.assign(newRequirementsArray[requirementIndex], displayPending);
                         call_rest_api(uri, 'PUT', [{'id': result.data[0].id, ...pending}], idToken)
                             .then(putResult => {
                                 if (putResult.httpStatus.httpStatus !== 200 && putResult.httpStatus.httpStatus !== 204) {

--- a/src/SwarmView/__tests__/CategoryCard.statusTimestamps.test.jsx
+++ b/src/SwarmView/__tests__/CategoryCard.statusTimestamps.test.jsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+//
+// Req #3244 — CategoryCard.jsx's status-toggle PUT must send all three
+// timestamp columns (started_at/completed_at/deferred_at), matching darwin-mcp's
+// update_requirement derivation, not just requirement_status alone. See the
+// sibling SwarmStartCard test for the "two writers agree" half of this.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DndProvider } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
+
+let reqData;
+const EMPTY_SESSIONS = [];
+vi.mock('../../hooks/useDataQueries', () => ({
+    useRequirements: () => ({ data: reqData }),
+    useSessions: () => ({ data: EMPTY_SESSIONS }),
+}));
+
+const putBodies = [];
+vi.mock('../../RestApi/RestApi', () => ({
+    default: vi.fn((uri, method, body) => {
+        if (method === 'PUT') putBodies.push(body);
+        return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+    }),
+}));
+
+import CategoryCard from '../CategoryCard';
+import AuthContext from '../../Context/AuthContext';
+import AppContext from '../../Context/AppContext';
+
+const CATEGORY = { id: 5, category_name: 'Test Cat', project_fk: 1, sort_mode: 'process', color: null };
+const noop = () => {};
+
+function Harness() {
+    return (
+        <CategoryCard
+            category={CATEGORY}
+            categoryIndex={0}
+            projectId={1}
+            categoryChange={noop}
+            categoryKeyDown={noop}
+            categoryOnBlur={noop}
+            clickCardClosed={noop}
+            clickCardDelete={noop}
+            moveCard={noop}
+            persistCategoryOrder={noop}
+            removeCategory={noop}
+            isTemplate={false}
+            showClosed={false}
+        />
+    );
+}
+
+let roots = [];
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
+                            <Harness />
+                        </DndProvider>
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    return { container };
+}
+
+async function flush() {
+    await act(async () => {
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+        await new Promise((r) => setTimeout(r, 0));
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+    });
+}
+
+describe('CategoryCard status writes carry all three timestamp columns (req #3244)', () => {
+    beforeEach(() => {
+        putBodies.length = 0;
+        roots = [];
+        reqData = [{ id: 20, title: 'agree with me', requirement_status: 'approved', category_fk: 5, sort_order: 0 }];
+    });
+    afterEach(() => {
+        act(() => { roots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+    });
+
+    it('sends all three NULL-sentinel timestamp columns alongside requirement_status', async () => {
+        const { container } = mount();
+        await flush();
+
+        const toggle = container.querySelector('[data-testid="status-toggle-20"]');
+        expect(toggle).not.toBeNull();
+
+        await act(async () => { toggle.click(); });
+        await flush();
+
+        expect(putBodies).toHaveLength(1);
+        const [[body]] = putBodies;
+        expect(body).toEqual({
+            id: 20,
+            requirement_status: 'swarm_ready',
+            started_at: 'NULL',
+            completed_at: 'NULL',
+            deferred_at: 'NULL',
+        });
+    });
+});

--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -8,6 +8,7 @@ import { useEpicPipelineLocation } from './useEpicPipelineLocation';
 import { epicLinkTo } from '../pipelines/pipelineEpicLink';
 import { siblingActiveSort } from './requirementSort';
 import { formatDateTime, formatDate } from '../../utils/dateFormat';
+import { requirementStatusTimestampFields, requirementStatusTimestampState } from '../../utils/requirementStatusTimestamps';
 import AuthContext from '../../Context/AuthContext';
 import AppContext from '../../Context/AppContext';
 import { DataGrid } from '@mui/x-data-grid';
@@ -406,22 +407,17 @@ const RequirementDetail = () => {
     const executeStatusChange = (newStatus) => {
         const now = new Date().toISOString();
 
-        // wontfix is a terminal state like met — both set completed_at (req #2783)
-        const setsCompleted = newStatus === 'met' || newStatus === 'wontfix';
-
+        // req #3244 — shared with CategoryCard/SwarmStartCard so all three frontend
+        // writers of requirement_status derive the same timestamps darwin-mcp does.
         const updates = {
             requirement_status: newStatus,
-            started_at: newStatus === 'development' ? now : 'NULL',
-            completed_at: setsCompleted ? now : 'NULL',
-            deferred_at: newStatus === 'deferred' ? now : 'NULL',
+            ...requirementStatusTimestampFields(newStatus, now),
         };
 
         setRequirement(prev => ({
             ...prev,
             requirement_status: newStatus,
-            started_at: newStatus === 'development' ? now : null,
-            completed_at: setsCompleted ? now : null,
-            deferred_at: newStatus === 'deferred' ? now : null,
+            ...requirementStatusTimestampState(newStatus, now),
         }));
 
         let uri = `${darwinUri}/requirements`;

--- a/src/SwarmView/detail/__tests__/RequirementDetail.statusTimestamps.test.jsx
+++ b/src/SwarmView/detail/__tests__/RequirementDetail.statusTimestamps.test.jsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+//
+// Req #3244 — a requirement_status transition made from the Darwin UI must leave
+// the same timestamps a transition made through MCP leaves
+// (darwin-mcp/services/requirements.py::update_requirement). This exercises the
+// REAL RequirementDetail component and asserts the PUT body it sends.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-router-dom', () => ({
+    useParams: () => ({ id: '42' }),
+    useNavigate: () => () => {},
+    useLocation: () => ({ state: {} }),
+}));
+
+vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        useMachines: () => ({ data: [] }),
+        useAllCategories: () => ({ data: [{ id: 1, category_name: 'Swarm' }] }),
+    };
+});
+
+let requirementRow;
+const putBodies = [];
+vi.mock('../../../RestApi/RestApi', () => ({
+    default: vi.fn((uri, method, body) => {
+        if (method === 'PUT') {
+            putBodies.push(body);
+            return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+        }
+        if (method === 'GET' && uri.includes('/requirements?id=')) {
+            return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [requirementRow] });
+        }
+        return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+    }),
+}));
+
+import RequirementDetail from '../RequirementDetail';
+import AuthContext from '../../../Context/AuthContext';
+import AppContext from '../../../Context/AppContext';
+
+let mountedRoots = [];
+
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0, refetchOnWindowFocus: false } },
+    });
+    const root = createRoot(container);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <RequirementDetail />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    mountedRoots.push(root);
+    return { container };
+}
+
+async function flush() {
+    await act(async () => {
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+        await new Promise((r) => setTimeout(r, 0));
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+    });
+}
+
+const statusChip = (container, value) => container.querySelector(`[data-testid="state-${value}"]`);
+
+function baseRequirement(overrides = {}) {
+    return {
+        id: 42,
+        title: 'stamp me',
+        description: '',
+        category_fk: 1,
+        requirement_status: 'swarm_ready',
+        coordination_type: 'implemented',
+        ai_model: 'opus',
+        effort: 'xhigh',
+        machine_fk: null,
+        started_at: null, completed_at: null, deferred_at: null,
+        create_ts: null, update_ts: null,
+        ...overrides,
+    };
+}
+
+describe('RequirementDetail status timestamp derivation (req #3244)', () => {
+    beforeEach(() => {
+        putBodies.length = 0;
+        requirementRow = baseRequirement();
+        mountedRoots = [];
+    });
+    afterEach(() => {
+        act(() => { mountedRoots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+    });
+
+    it('stamps completed_at (and clears the others) when moved to met through the UI', async () => {
+        const { container } = mount();
+        await flush();
+
+        await act(async () => { statusChip(container, 'met').click(); });
+        await flush();
+
+        expect(putBodies).toHaveLength(1);
+        const [[body]] = putBodies;
+        expect(body.id).toBe(42);
+        expect(body.requirement_status).toBe('met');
+        expect(body.started_at).toBe('NULL');
+        expect(body.deferred_at).toBe('NULL');
+        expect(typeof body.completed_at).toBe('string');
+        expect(Number.isNaN(new Date(body.completed_at).getTime())).toBe(false);
+    });
+
+    it('stamps started_at (and clears the others) when moved to development', async () => {
+        const { container } = mount();
+        await flush();
+
+        await act(async () => { statusChip(container, 'development').click(); });
+        await flush();
+
+        const [[body]] = putBodies;
+        expect(body.requirement_status).toBe('development');
+        expect(typeof body.started_at).toBe('string');
+        expect(body.completed_at).toBe('NULL');
+        expect(body.deferred_at).toBe('NULL');
+    });
+
+    it('stamps deferred_at (and clears the others) when moved to deferred', async () => {
+        const { container } = mount();
+        await flush();
+
+        await act(async () => { statusChip(container, 'deferred').click(); });
+        await flush();
+
+        const [[body]] = putBodies;
+        expect(body.requirement_status).toBe('deferred');
+        expect(body.started_at).toBe('NULL');
+        expect(body.completed_at).toBe('NULL');
+        expect(typeof body.deferred_at).toBe('string');
+    });
+
+    it('clears all three when moved back to authoring', async () => {
+        const { container } = mount();
+        await flush();
+
+        await act(async () => { statusChip(container, 'authoring').click(); });
+        await flush();
+
+        const [[body]] = putBodies;
+        expect(body.requirement_status).toBe('authoring');
+        expect(body.started_at).toBe('NULL');
+        expect(body.completed_at).toBe('NULL');
+        expect(body.deferred_at).toBe('NULL');
+    });
+});

--- a/src/TaskPlanView/SwarmStartCard.jsx
+++ b/src/TaskPlanView/SwarmStartCard.jsx
@@ -24,6 +24,7 @@ import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { RequirementActionsContext } from '../hooks/useRequirementActions';
 import { useSwarmStartCardStore } from '../stores/useSwarmStartCardStore';
 import { requirementStatusChipProps, requirementStatusLabel } from '../SwarmView/statusChipStyles';
+import { requirementStatusTimestampFields, requirementStatusTimestampState } from '../utils/requirementStatusTimestamps';
 
 // Chip statuses shown on this card. Mirrors the requirements page filter chips minus
 // 'deferred' and 'wontfix' — both terminal/historical states outside this card's
@@ -126,8 +127,11 @@ const SwarmStartCard = () => {
     }, []);
 
     // Active-status query — disabled when Met is selected (the done query below
-    // is the row source in that case).
+    // is the row source in that case). started_at/completed_at/deferred_at are
+    // added to the default projection (req #3244) so statusClick's revert-on-failure
+    // path has the row's real prior timestamps to restore, not undefined.
     const { data: serverRequirements } = useRequirementsByStatus(profile?.userName, effectiveStatus, {
+        fields: 'id,title,requirement_status,coordination_type,ai_model,effort,machine_fk,category_fk,started_at,completed_at,deferred_at',
         enabled: !isMet,
     });
 
@@ -327,21 +331,34 @@ const SwarmStartCard = () => {
     // Status click — items cycle off the selected status leave the card.
     const STATUS_CYCLE = ['authoring', 'approved', 'swarm_ready'];
     const statusClick = (requirementIndex, requirementId) => {
-        const current = requirementsArray[requirementIndex].requirement_status;
+        const currentRow = requirementsArray[requirementIndex];
+        const current = currentRow.requirement_status;
         const idx = STATUS_CYCLE.indexOf(current);
         if (idx === -1) return;
         const next = STATUS_CYCLE[(idx + 1) % STATUS_CYCLE.length];
+        // req #3244 — every requirement_status write re-derives all three status
+        // timestamps, matching darwin-mcp's update_requirement, so this UI path
+        // never leaves a stale started_at/completed_at/deferred_at behind. One `now`
+        // shared between the PUT body and the local-state form so they can't drift.
+        const now = new Date().toISOString();
+        const timestampState = requirementStatusTimestampState(next, now);
+        const timestampFields = requirementStatusTimestampFields(next, now);
+        const previousTimestamps = {
+            started_at: currentRow.started_at,
+            completed_at: currentRow.completed_at,
+            deferred_at: currentRow.deferred_at,
+        };
 
         // Capture cache snapshots BEFORE touching local state (shared refs, see helper comment).
-        const revert = writeThroughRequirementCaches(requirementId, { requirement_status: next });
+        const revert = writeThroughRequirementCaches(requirementId, { requirement_status: next, ...timestampState });
 
         call_rest_api(`${darwinUri}/requirements`, 'PUT',
-            [{ id: requirementId, requirement_status: next }], idToken)
+            [{ id: requirementId, requirement_status: next, ...timestampFields }], idToken)
             .then(result => {
                 if (result.httpStatus.httpStatus !== 200 && result.httpStatus.httpStatus !== 204) {
                     revert();
                     setRequirementsArray(prev => prev ? prev.map(r =>
-                        r.id === requirementId ? { ...r, requirement_status: current } : r) : prev);
+                        r.id === requirementId ? { ...r, requirement_status: current, ...previousTimestamps } : r) : prev);
                     showError(result, 'Unable to change requirement status');
                 } else {
                     // Item no longer matches the card's aggregate status — remove it.
@@ -353,14 +370,14 @@ const SwarmStartCard = () => {
             }).catch(error => {
                 revert();
                 setRequirementsArray(prev => prev ? prev.map(r =>
-                    r.id === requirementId ? { ...r, requirement_status: current } : r) : prev);
+                    r.id === requirementId ? { ...r, requirement_status: current, ...previousTimestamps } : r) : prev);
                 showError(error, 'Unable to change requirement status');
             });
 
         // Immutable local update — new object at the target index rather than in-place
         // mutation on a cache-shared object reference.
         setRequirementsArray(prev => prev ? prev.map((r, i) =>
-            i === requirementIndex ? { ...r, requirement_status: next } : r) : prev);
+            i === requirementIndex ? { ...r, requirement_status: next, ...timestampState } : r) : prev);
     };
 
     // Coordination click — mirrors CategoryCard

--- a/src/TaskPlanView/__tests__/SwarmStartCard.statusTimestamps.test.jsx
+++ b/src/TaskPlanView/__tests__/SwarmStartCard.statusTimestamps.test.jsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+//
+// Req #3244 — CategoryCard.jsx and SwarmStartCard.jsx are the two frontend
+// writers named in the requirement's "FOUND BY" section: both PUT
+// requirement_status alone, skipping the timestamp derivation darwin-mcp's
+// update_requirement performs on the same transition. This asserts the two
+// writers now AGREE — same status in, same PUT body shape out — by driving
+// the real components rather than re-deriving the expectation independently.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DndProvider } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
+
+let reqData;
+const EMPTY = [];
+vi.mock('../../hooks/useDataQueries', () => ({
+    useRequirementsByStatus: () => ({ data: reqData }),
+    useRequirementsDone: () => ({ data: EMPTY }),
+    useSessions: () => ({ data: EMPTY }),
+    useCategoryColors: () => ({ data: EMPTY }),
+    useAllRequirements: () => ({ data: reqData }),
+    usePipelinedRequirementIds: () => new Set(),
+}));
+
+const putBodies = [];
+vi.mock('../../RestApi/RestApi', () => ({
+    default: vi.fn((uri, method, body) => {
+        if (method === 'PUT') putBodies.push(body);
+        return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+    }),
+}));
+
+import SwarmStartCard from '../SwarmStartCard';
+import AuthContext from '../../Context/AuthContext';
+import AppContext from '../../Context/AppContext';
+import { useSwarmStartCardStore } from '../../stores/useSwarmStartCardStore';
+
+let roots = [];
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
+                            <SwarmStartCard />
+                        </DndProvider>
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    return { container };
+}
+
+async function flush() {
+    await act(async () => {
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+        await new Promise((r) => setTimeout(r, 0));
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+    });
+}
+
+describe('SwarmStartCard status writes agree with CategoryCard (req #3244)', () => {
+    beforeEach(() => {
+        putBodies.length = 0;
+        roots = [];
+        reqData = [{ id: 20, title: 'agree with me', requirement_status: 'approved', category_fk: 5 }];
+        useSwarmStartCardStore.setState({ selectedStatus: 'approved' });
+    });
+    afterEach(() => {
+        act(() => { roots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+    });
+
+    it('sends all three NULL-sentinel timestamp columns alongside requirement_status', async () => {
+        const { container } = mount();
+        await flush();
+
+        const toggle = container.querySelector('[data-testid="status-toggle-20"]');
+        expect(toggle).not.toBeNull();
+
+        await act(async () => { toggle.click(); });
+        await flush();
+
+        expect(putBodies).toHaveLength(1);
+        const [[body]] = putBodies;
+        expect(body).toEqual({
+            id: 20,
+            requirement_status: 'swarm_ready',
+            started_at: 'NULL',
+            completed_at: 'NULL',
+            deferred_at: 'NULL',
+        });
+    });
+});

--- a/src/utils/__tests__/requirementStatusTimestamps.test.js
+++ b/src/utils/__tests__/requirementStatusTimestamps.test.js
@@ -1,0 +1,53 @@
+// req #3244 — the frontend's requirement_status timestamp derivation must match
+// darwin-mcp/services/requirements.py::update_requirement exactly:
+//   development -> started_at, met/wontfix -> completed_at, deferred -> deferred_at,
+//   every other status -> all three cleared.
+import { describe, it, expect } from 'vitest';
+import { requirementStatusTimestampFields, requirementStatusTimestampState } from '../requirementStatusTimestamps';
+
+const NOW = '2026-08-02T12:00:00.000Z';
+
+describe('requirementStatusTimestampFields (PUT body form)', () => {
+    it('stamps started_at and clears the other two for development', () => {
+        expect(requirementStatusTimestampFields('development', NOW)).toEqual({
+            started_at: NOW, completed_at: 'NULL', deferred_at: 'NULL',
+        });
+    });
+
+    it('stamps completed_at and clears the other two for met', () => {
+        expect(requirementStatusTimestampFields('met', NOW)).toEqual({
+            started_at: 'NULL', completed_at: NOW, deferred_at: 'NULL',
+        });
+    });
+
+    it('stamps completed_at for wontfix — terminal like met (req #2783)', () => {
+        expect(requirementStatusTimestampFields('wontfix', NOW)).toEqual({
+            started_at: 'NULL', completed_at: NOW, deferred_at: 'NULL',
+        });
+    });
+
+    it('stamps deferred_at and clears the other two for deferred', () => {
+        expect(requirementStatusTimestampFields('deferred', NOW)).toEqual({
+            started_at: 'NULL', completed_at: 'NULL', deferred_at: NOW,
+        });
+    });
+
+    for (const status of ['authoring', 'approved', 'swarm_ready']) {
+        it(`clears all three for '${status}'`, () => {
+            expect(requirementStatusTimestampFields(status, NOW)).toEqual({
+                started_at: 'NULL', completed_at: 'NULL', deferred_at: 'NULL',
+            });
+        });
+    }
+});
+
+describe('requirementStatusTimestampState (local-state form)', () => {
+    it('uses real null instead of the NULL sentinel', () => {
+        expect(requirementStatusTimestampState('met', NOW)).toEqual({
+            started_at: null, completed_at: NOW, deferred_at: null,
+        });
+        expect(requirementStatusTimestampState('authoring', NOW)).toEqual({
+            started_at: null, completed_at: null, deferred_at: null,
+        });
+    });
+});

--- a/src/utils/__tests__/requirementStatusWriters.sourceGuard.test.js
+++ b/src/utils/__tests__/requirementStatusWriters.sourceGuard.test.js
@@ -1,0 +1,34 @@
+// req #3244 — belt-and-suspenders guard against the failure mode a plain PUT-body
+// assertion can't catch: swapping `requirementStatusTimestampState` (real `null`,
+// for local/cache state) for `requirementStatusTimestampFields` (the 'NULL'
+// sentinel, PUT-body-only) at an optimistic-update call site would write the
+// literal string 'NULL' into every requirement cache, but the component tests
+// only inspect the network PUT body and would stay green. Nothing in the
+// rendered DOM surfaces started_at/completed_at/deferred_at to assert against
+// directly (see RequirementRow.jsx), so this checks the call shape in source
+// instead of leaving the swap undetectable.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (relPath) => readFileSync(join(here, relPath), 'utf8');
+
+describe('requirement_status writers use the right timestamp helper at each call site', () => {
+    for (const [label, relPath] of [
+        ['CategoryCard.jsx', '../../SwarmView/CategoryCard.jsx'],
+        ['SwarmStartCard.jsx', '../../TaskPlanView/SwarmStartCard.jsx'],
+    ]) {
+        it(`${label}: optimistic cache/local writes use requirementStatusTimestampState`, () => {
+            const src = read(relPath);
+            expect(src).toMatch(/writeThroughRequirementCaches\(requirementId, \{ requirement_status: next, \.\.\.timestampState \}\)/);
+            expect(src).toMatch(/i === requirementIndex \? \{ \.\.\.r, requirement_status: next, \.\.\.timestampState \} : r/);
+        });
+
+        it(`${label}: the PUT body uses requirementStatusTimestampFields`, () => {
+            const src = read(relPath);
+            expect(src).toMatch(/'?requirement_status'?: next, \.\.\.timestampFields/);
+        });
+    }
+});

--- a/src/utils/requirementStatusTimestamps.js
+++ b/src/utils/requirementStatusTimestamps.js
@@ -1,0 +1,39 @@
+// Derives the three requirement status timestamps (started_at, completed_at,
+// deferred_at) for a requirement_status transition — the identical rule
+// darwin-mcp/services/requirements.py applies server-side (req #3244). Every
+// frontend writer of requirement_status must send all three columns on every
+// write, so a status change made from the UI leaves the same timestamps a
+// change made through MCP leaves. One place to get this right; a third writer
+// inherits it by calling in rather than having to remember the rule.
+
+const STATUS_TIMESTAMP_COLUMN = {
+    development: 'started_at',
+    met: 'completed_at',
+    wontfix: 'completed_at',   // terminal, like met (req #2783)
+    deferred: 'deferred_at',
+};
+
+const TIMESTAMP_COLUMNS = ['started_at', 'completed_at', 'deferred_at'];
+
+// PUT body form — the stamped column gets `now` (ISO string), the other two get
+// the literal string 'NULL', Lambda-Rest's REST PUT NULL sentinel that clears a
+// column (see RequirementDetail.jsx's machine_fk handling for the same convention).
+export function requirementStatusTimestampFields(status, now = new Date().toISOString()) {
+    const stamped = STATUS_TIMESTAMP_COLUMN[status];
+    const fields = {};
+    for (const column of TIMESTAMP_COLUMNS) {
+        fields[column] = column === stamped ? now : 'NULL';
+    }
+    return fields;
+}
+
+// Local-state / cache form — same derivation, but a real `null` instead of the
+// 'NULL' sentinel, for optimistic React state and TanStack cache updates.
+export function requirementStatusTimestampState(status, now = new Date().toISOString()) {
+    const stamped = STATUS_TIMESTAMP_COLUMN[status];
+    const fields = {};
+    for (const column of TIMESTAMP_COLUMNS) {
+        fields[column] = column === stamped ? now : null;
+    }
+    return fields;
+}


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-02T08:50:03Z
- chore: init swarm session feature/3244-frontend-status-writes-skip-the-1

## Files changed
```
 src/SwarmView/CategoryCard.jsx                     |  35 ++++-
 .../CategoryCard.statusTimestamps.test.jsx         | 124 +++++++++++++++
 src/SwarmView/detail/RequirementDetail.jsx         |  14 +-
 .../RequirementDetail.statusTimestamps.test.jsx    | 170 +++++++++++++++++++++
 src/TaskPlanView/SwarmStartCard.jsx                |  31 +++-
 .../SwarmStartCard.statusTimestamps.test.jsx       | 109 +++++++++++++
 .../__tests__/requirementStatusTimestamps.test.js  |  53 +++++++
 .../requirementStatusWriters.sourceGuard.test.js   |  34 +++++
 src/utils/requirementStatusTimestamps.js           |  39 +++++
 9 files changed, 586 insertions(+), 23 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)