### PR TITLE
Visualizer maintains last viewport

### DIFF
--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -98,12 +98,35 @@ const RequirementDetail = () => {
     const fromPipelineId = location.state?.from === 'pipeline'
         ? Number(location.state?.pipelineId) : null;
     const hasPipelineOrigin = Number.isFinite(fromPipelineId) && fromPipelineId > 0;
+    // Req #3252: WHICH PANEL of that plan. The route names the plan; the panel
+    // comes from a stored preference, and a reader who reached the visualizer
+    // through a `?mode=plan` link never persisted `plan` — that override is
+    // transient by design. So "Back to Plan" landed such a reader in the TABLE,
+    // where the pan and zoom this requirement restores are not even on screen.
+    //
+    // NOT VALIDATED AGAINST THE MODE LIST HERE, on purpose. `pipelineDetailModes`
+    // imports both panels, so importing it would pull react-konva and the whole
+    // plan visualizer into this page's bundle to check one string. The receiving
+    // page already validates `?mode=` against that list and falls back to the
+    // stored preference on anything it does not recognise — one validation, at
+    // the end that owns the vocabulary. All this needs is that the value cannot
+    // corrupt the URL it is interpolated into, and it comes from in-app router
+    // state rather than the address bar.
+    const rawBackMode = location.state?.mode;
+    const fromPipelineMode = typeof rawBackMode === 'string'
+        && /^[a-z]{1,16}$/.test(rawBackMode) ? rawBackMode : null;
     // "new" mode (req #2414): the user came from the aggregator template row.
     // No DB record exists yet — the requirement is POSTed only when the user
     // picks a category. Until then this page edits a purely local draft.
     const isNew = id === 'new';
     const handleBack = () => {
-        if (hasPipelineOrigin) return navigate(`/swarm/pipeline/${fromPipelineId}`);
+        if (hasPipelineOrigin) {
+            // `?mode=` is a TRANSIENT override on the receiving page, never a
+            // write to the reader's stored preference — so returning them to the
+            // panel they left cannot change what any other plan opens in.
+            return navigate(`/swarm/pipeline/${fromPipelineId}`
+                + (fromPipelineMode ? `?mode=${fromPipelineMode}` : ''));
+        }
         return navigate(fromCalendar ? '/calview' : '/swarm');
     };
     const backLabel = hasPipelineOrigin ? 'Back to Plan'

--- a/src/SwarmView/pipelines/PipelinePlanTable.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanTable.jsx
@@ -264,8 +264,14 @@ function RequirementLinks({ row, pipelineId }) {
                         component={RouterLink}
                         to={`/swarm/requirement/${id}`}
                         // Provenance, so the detail page's Back returns to THIS plan
-                        // rather than the Roadmap (req #3119).
-                        state={pipelineId ? { from: 'pipeline', pipelineId } : undefined}
+                        // rather than the Roadmap (req #3119) — and to THIS PANEL of
+                        // it (req #3252). The route names the plan; which panel it
+                        // opens is a stored preference, and a reader who reached the
+                        // table through a bead click or a `?step=` link never
+                        // persisted `table` (both are transient overrides by design),
+                        // so Back sent them to whichever panel their preference held.
+                        state={pipelineId
+                            ? { from: 'pipeline', pipelineId, mode: 'table' } : undefined}
                         underline="hover"
                         sx={{
                             fontFamily: 'monospace',

--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -109,7 +109,7 @@ import { effortLabel } from '../effortChipStyles';
 import { OrderViolationsAlert } from './PipelinePlanTable';
 import {
     computePlanLayout, beadStyle, placeEpicChips, collectWorldObstacles,
-    epicFocusTransform, factoryDefaultScale,
+    epicFocusTransform, factoryDefaultScale, clampPlanTransform,
     PLAN_VIZ_PALETTE as P, PLAN_VIZ_FONT as F, BEAD_RADIUS, BEAD_HIT_RADIUS,
     CHW_EPIC, ZOOM_MIN_RATIO, ZOOM_MAX_RATIO,
     K_READABLE, DEFAULT_STEP_WIDTH, EPIC_CHIP_BG_ALPHA,
@@ -118,6 +118,8 @@ import {
     DEFAULT_COLOR_KEY, PLAN_KEY_MAX_W, pinnedLevelOf, DEFAULT_PLAN_LEVEL_PREF,
     EPIC_PAUSE_BUBBLE_D, pauseBubbleColor,
 } from './pipelinePlanLayout';
+import { useSavedViewport } from '../../hooks/useSavedViewport';
+import { viewportStorageKey, writeViewport } from '../../utils/viewportMemory';
 import '../../CalendarFC/swarmVisualizer.css';
 
 const MONO = '"SF Mono", "JetBrains Mono", Menlo, monospace';
@@ -395,6 +397,68 @@ export default function PipelinePlanVisualizer({
     const [transform, setTransform] = useState(null);
     const [card, setCard] = useState(null);   // {x, y, kind: 'step'|'batch', ...}
 
+    // ── The camera survives leaving the page (req #3252) ────────────────────
+    // `transform` above is component state, and EVERY way of leaving this panel
+    // unmounts the component: a requirement label, an epic chip's ↗, the
+    // breadcrumb, a bead click (which switches the page to Table mode — a return
+    // with no navigation at all), browser Back, a reload. The comment on the
+    // requirement label below used to end "only pan/zoom re-fits"; this is that
+    // sentence being retired.
+    //
+    // There is deliberately NO LIST OF RETURN PATHS anywhere in this file. The
+    // camera is written down whenever it moves and read back when the canvas
+    // lands, so a link added tomorrow is covered without being enumerated today
+    // — the user's ask was "all occasions, not just the three I mentioned".
+    //
+    // KEYED ON THE PLAN: two plans open in one tab keep their own camera, and
+    // `pipeline?.id` being absent disables persistence rather than letting an
+    // unidentified canvas read another one's position.
+    const viewportKey = pipeline?.id != null
+        ? viewportStorageKey('pipeline-plan', pipeline.id) : null;
+    // SIGNATURE is the world the camera was taken over, DERIVED from the layout
+    // rather than enumerated from the inputs that produce it. `computePlanLayout`
+    // takes eight options and reads the whole plan; listing the ones that move
+    // geometry is a list that goes stale the first time a ninth is added, while
+    // the layout's own dimensions cannot. A wider column, a step added by a
+    // background refetch, a band gained — all move these three numbers, and a
+    // restore whose signature disagrees is refused (see useSavedViewport).
+    //
+    // `colorKey` is deliberately absent: it repaints fills and moves nothing, so
+    // it must NOT invalidate a camera.
+    const viewportFingerprint = `${Math.round(layout.width)}x${Math.round(layout.height)}`
+        + `:${rows.length}:${layout.bands.length}`;
+    const viewport = useSavedViewport(viewportKey, viewportFingerprint);
+    // The live camera, mirrored out of the d3-zoom 'zoom' handler so the commit
+    // on unmount has something to write. A ref, not state: this is read only by
+    // effects and costs one assignment per pointermove.
+    const liveTransformRef = useRef(null);
+    // Raised for the duration of a `?epic=` deep-link focus so that ONE camera
+    // move does not persist (req #3252). Everything else does — a drag, a wheel,
+    // Reset, a band-header click, the landing view — because those are the reader
+    // moving the camera. A deep link is an EXTERNAL condition, and this page's
+    // standing doctrine for `?mode=`/`?step=`/`?epic=` is that a link asks to see
+    // one thing ONCE and must never rewrite what the reader chose (PipelineDetail's
+    // transient-override comment). A saved viewport IS what the reader chose here,
+    // so the link is shown and the stored camera is left alone; the reader's very
+    // next gesture saves normally.
+    //
+    // Suppress the ONE exception rather than tagging the several rules: the
+    // default is persist, so a flag that leaked would save an epic-focus camera
+    // (harmless) and can never lose one.
+    const suppressSaveRef = useRef(false);
+    // Has the reader CHOSEN where to look this mount? Guards the `?epic=`
+    // re-focus below — see it for why (req #3252 review).
+    //
+    // Three things set it, and they are exactly the three that also persist:
+    // a d3 gesture (drag or wheel), the header's Reset, and a band-header or
+    // sticky-chip focus click. The last two are the ones a `sourceEvent` test
+    // alone MISSES — both reach the camera through `zoom.transform`, which
+    // carries no source event, so watching gestures only would let a window
+    // resize yank a reader who had explicitly clicked Reset (or another band)
+    // straight back onto the linked epic. `persist` is the same predicate in
+    // both places for the same reason: it means "the reader asked for this".
+    const userMovedCameraRef = useRef(false);
+
     useLayoutEffect(() => {
         if (!containerEl) return undefined;
         const ro = new ResizeObserver((entries) => {
@@ -536,13 +600,20 @@ export default function PipelinePlanVisualizer({
         // panel. Without it the bound would force a re-centre on the very first
         // transform, moving the world frame that the E2E click maths reads as
         // `screen = world × k + t`.
+        //
+        // THE ARITHMETIC MOVED to `clampPlanTransform` in pipelinePlanLayout.js
+        // (req #3252) and this reads it. It was a closure here while the zoom
+        // behavior was the only thing that could produce a transform; a viewport
+        // RESTORED from storage is a second producer, it arrives through
+        // `zoom.transform` (which constrains nothing — see the `scaleExtent`
+        // comment below), and two copies of a bound that "only have to agree" is
+        // the desync class this file has already taken two review findings on.
+        // Passing `t.k` for both scale bounds clamps the translation only, which
+        // is all `constrain` wants: d3 has applied `scaleExtent` before calling it.
         const bound = (t) => {
-            const loX = Math.min(0, size.w / 2 - t.k * layout.width);
-            const loY = Math.min(0, size.h / 2 - t.k * layout.height);
-            const x = Math.min(Math.max(t.x, loX), Math.max(0, size.w / 2));
-            const y = Math.min(Math.max(t.y, loY), Math.max(0, size.h / 2));
-            return (x === t.x && y === t.y) ? t : t.translate((x - t.x) / t.k,
-                (y - t.y) / t.k);
+            const c = clampPlanTransform(t, size, layout, t.k, t.k);
+            return (c.x === t.x && c.y === t.y) ? t : t.translate((c.x - t.x) / t.k,
+                (c.y - t.y) / t.k);
         };
         const zb = d3zoom()
             // The SAME pair the epic-focus clamp reads (req #3204). They have to
@@ -578,6 +649,16 @@ export default function PipelinePlanVisualizer({
             .on('zoom', (ev) => {
                 const tr = ev.transform;
                 setTransform({ x: tr.x, y: tr.y, k: tr.k });
+                // req #3252 — one ref assignment per pointermove, no render and
+                // no write. The write happens once, on 'end' below.
+                liveTransformRef.current = { x: tr.x, y: tr.y, k: tr.k };
+                if (!suppressSaveRef.current) viewport.record(liveTransformRef.current);
+                // `sourceEvent` is non-null only for a USER gesture — a drag or
+                // a wheel — and null for every programmatic transform. Once the
+                // reader has moved the camera themselves, the `?epic=` deep link
+                // has been answered and must never move it again (req #3252
+                // review). See that effect for what this stops.
+                if (ev.sourceEvent) userMovedCameraRef.current = true;
                 // The world slides under a stationary datacard, which would
                 // then caption whatever bead ends up beneath it — dismiss.
                 setCard(null);
@@ -589,6 +670,13 @@ export default function PipelinePlanVisualizer({
                 if (c) c.style.cursor = 'grabbing';
             })
             .on('end', () => {
+                // req #3252 — BEFORE the cursor guard, deliberately. d3 emits
+                // 'end' exactly once per gesture: a drag, a wheel's settle
+                // timeout, a transition, or a programmatic `zoom.transform`. Only
+                // the first of those sets `draggingRef`, so committing after the
+                // guard below would persist drags and silently drop every wheel
+                // zoom, every Reset and every band-header fit.
+                viewport.commit();
                 if (!draggingRef.current) return;
                 draggingRef.current = false;
                 const c = stageRef.current?.container();
@@ -608,7 +696,8 @@ export default function PipelinePlanVisualizer({
             // page to Table mode, which unmounts this component.
             sel.interrupt();
         };
-    }, [containerEl, size.w, size.h, kFit, kDefault, kZoomFloor, layout.width, layout.height]);
+    }, [containerEl, size.w, size.h, kFit, kDefault, kZoomFloor, layout.width, layout.height,
+        viewport]);
 
     // ── Reset = FACTORY DEFAULT (req #3216 D1) ──────────────────────────────
     // Deliberately NOT `kDefault` above — see `factoryDefaultScale`'s own
@@ -648,12 +737,126 @@ export default function PipelinePlanVisualizer({
         const k = recenterModeRef.current === 'factory' ? kFactoryDefault : kDefault;
         select(el).call(zb.transform, zoomIdentity.scale(k));
     }, [containerEl, size.w, kDefault, kFactoryDefault]);
+    // ── THE LANDING VIEW (req #3252) ────────────────────────────────────────
+    // What this canvas shows when it arrives at a given world. Two answers, in
+    // order: the camera the reader left on this plan under THIS geometry, or —
+    // failing that, and it is the first visit or the geometry moved — the base
+    // view `resetView` computes, byte-identical to what this effect did before.
+    //
+    // THE RESTORE SUBSTITUTES FOR resetView, IT DOES NOT RACE IT. Same code
+    // path, same `zb.transform`, one of them runs. `resetView` itself is left
+    // alone and still means "the base view", which is what keeps the header's
+    // Reset honest: if the read lived inside `resetView`, a Reset click would
+    // read back the pan it was asked to discard and do nothing.
+    //
+    // ── WHEN IT LANDS: on a RESCALE, never on a mere resize or growth ───────
+    // `landKey` is the plan plus the world's WIDTH, because width is what
+    // rescales the columns: it drives `kFit` → `kDefault`, and after it moves a
+    // remembered pan points at unrelated content. That is exactly the set the
+    // effect this replaced re-fitted on (through `resetView`'s own identity),
+    // so a layout toggle re-lands as it always did.
+    //
+    // Three things must NOT re-land, and each was a measured defect:
+    //   · A RESIZE. That is the difference between "maintains last viewport" and
+    //     the contract this requirement retires — and the panel is sized TWICE
+    //     at mount (the `calc(100vh - 260px)` fallback, then `measureAvailH`),
+    //     so keying on size discarded a camera set milliseconds earlier.
+    //   · A WORLD THAT GREW BUT WAS NOT RESCALED — a background refetch adding a
+    //     step to an existing column moves `layout.height` and `rows.length`
+    //     while every column stays put. Keying the landing on the full
+    //     fingerprint snapped the reader home mid-read for a plan they could
+    //     still perfectly well see (review finding).
+    //   · THE PLAN ID ALONE. `landKey` carries `viewportKey`, so an in-place
+    //     switch between two plans of coincidentally identical width still
+    //     lands — `PipelineDetail` renders this component with no `key` and
+    //     survives a `pipelineId` change without remounting (review finding).
+    //
+    // The readiness guard does NOT consume the mark: with no container, no
+    // behaviour or no measured width there is nothing to apply a transform to,
+    // and marking that as "landed" would strand the canvas at the identity
+    // transform forever. `focusEpic`'s own retry contract, for the same reason.
+    const landKey = `${viewportKey}|${Math.round(layout.width)}`;
+    const landedKeyRef = useRef(null);
+    const committedFingerprintRef = useRef(null);
     useEffect(() => {
-        resetView();
-    }, [resetView, size.h, reqLayout, stepLabel, stepWidth, reqLabel]);
+        const el = containerEl;
+        const zb = zoomRef.current;
+        if (!el || zb == null || size.w === 0) return;
+        const kMax = kDefault * ZOOM_MAX_RATIO;
+        // CLAMPED BEFORE IT IS APPLIED, k first and then the translation — the
+        // pan bound is computed FROM k, so clamping position first would
+        // immediately re-invalidate it. `zoom.transform` runs neither
+        // `constrain` nor `scaleExtent` (it applies what it is given verbatim).
+        const apply = (t) => {
+            const c = clampPlanTransform(t, size, layout, kZoomFloor, kMax);
+            // THROUGH THE BEHAVIOUR, never `setTransform`. Writing state alone
+            // leaves d3's own `__zoom` stale and the next wheel or drag snaps
+            // back — the integration bug this file warns about twice.
+            select(el).call(zb.transform,
+                zoomIdentity.translate(c.x, c.y).scale(c.k));
+        };
+
+        if (landedKeyRef.current !== landKey) {
+            landedKeyRef.current = landKey;
+            committedFingerprintRef.current = viewportFingerprint;
+            const saved = viewport.read();
+            // Clamp rather than refuse: a clamped camera is still near where the
+            // reader was, which is the whole ask. Refusing is reserved for one
+            // that cannot be trusted at all — a fingerprint mismatch or a
+            // non-finite number — and `viewport.read()` has already done that.
+            if (saved) apply(saved);
+            else resetView();
+            return;
+        }
+
+        // ── Already landed on this world. Two housekeeping jobs, and NEITHER
+        // may move the camera the reader chose.
+        const live = liveTransformRef.current;
+        if (!live) return;
+
+        // (a) THE EXTENT MOVES WITH THE PANEL. Both ends are proportional to
+        // `size.w` (`kFit` → `kDefault` → `kZoomFloor` and `kDefault * MAX`), so
+        // narrowing the window can leave a perfectly good camera above the
+        // ceiling. Nothing else re-clamps it — `constrain` only ever fixes
+        // translation and `scaleExtent` is consulted only by a wheel — so it
+        // would sit there looking correct until the reader's first scroll
+        // snapped it (review finding). Re-clamp ONLY when it is actually out of
+        // range, so a resize is otherwise a no-op on the camera.
+        const c = clampPlanTransform(live, size, layout, kZoomFloor, kMax);
+        if (c.k !== live.k || c.x !== live.x || c.y !== live.y) {
+            apply(live);
+            return;
+        }
+
+        // (b) THE WORLD GREW UNDER A CAMERA THAT IS STILL CORRECT. Re-stamp the
+        // stored record with the new fingerprint, or the reader's position would
+        // be refused on their next return for a change they never made and could
+        // not see. Costs one write per geometry change, never per render.
+        //
+        // WRITTEN DIRECTLY, not through `record`/`commit` (review finding). The
+        // hook stamps from a ref it assigns during RENDER, while this branch
+        // DECIDES from the effect closure's `viewportFingerprint` — and React
+        // only guarantees render-N's passive effects run before render N+1's
+        // COMMIT, not before its render. An N/N+1 interleave could therefore
+        // stamp the record with one fingerprint while the guard had approved
+        // another, and mark it committed under the third. Both halves read the
+        // same two closure values here, so the pair cannot disagree.
+        if (committedFingerprintRef.current !== viewportFingerprint) {
+            committedFingerprintRef.current = viewportFingerprint;
+            writeViewport(viewportKey, viewportFingerprint, live);
+        }
+    // `reqLayout`/`stepLabel`/`stepWidth`/`reqLabel` are deliberately NOT on this
+    // list any more. They were here as a hand-maintained enumeration of "things
+    // that rescale the world", and `landKey` is that same fact DERIVED — it
+    // cannot go stale when a ninth layout option is added, and a list can.
+    }, [resetView, containerEl, size, layout, kZoomFloor, kDefault,
+        landKey, viewportFingerprint, viewport]);
 
     const factoryReset = useCallback(() => {
         recenterModeRef.current = 'factory';
+        // An explicit, in-the-moment instruction about where to look — so it
+        // ends any `?epic=` re-fit, exactly as a drag does (req #3252 review).
+        userMovedCameraRef.current = true;
         resetView();
     }, [resetView]);
     // `resetViewNonce` only ever increments (the header's click handler), so
@@ -888,7 +1091,11 @@ export default function PipelinePlanVisualizer({
     // mount-time effect below needs that signal: without it, a transient
     // zero-size container would be recorded as "already focused" and the deep
     // link would silently never apply once the canvas actually became ready.
-    const focusEpic = useCallback((band) => {
+    // `persist` is false for the ONE caller that is not the reader moving the
+    // camera: the `?epic=` deep link (req #3252 — see that effect below). A
+    // band-header or sticky-chip click is a user pick, indistinguishable in
+    // intent from a drag, and saves like one.
+    const focusEpic = useCallback((band, { persist = true } = {}) => {
         const el = containerEl;
         const zb = zoomRef.current;
         if (!el || !zb) return false;
@@ -898,14 +1105,40 @@ export default function PipelinePlanVisualizer({
         // as it does on a pan.
         setCard(null);
         focusingRef.current = true;
+        // ASSIGNED, not raised (req #3252 review). A `persist: true` focus that
+        // begins while a deep link's suppression is still up must LOWER it —
+        // otherwise the band fit the reader explicitly clicked for is swallowed
+        // by the previous transition's flag and never saved. Only this
+        // transition's own intent decides, and it decides every time.
+        suppressSaveRef.current = !persist;
+        // A band-header click is the reader choosing where to look; the
+        // `?epic=` deep link is not. See `userMovedCameraRef`'s own comment.
+        if (persist) userMovedCameraRef.current = true;
         const seq = (focusSeqRef.current += 1);
         select(el).transition().duration(FOCUS_MS)
-            // 'end' fires on completion, 'interrupt' when a user gesture, a
-            // second focus or the unmount cleanup pre-empts this one — both mean
-            // the world has stopped being a moving target. Only the LATEST
-            // transition may lower the flag.
-            .on('end.focus interrupt.focus', () => {
-                if (focusSeqRef.current === seq) focusingRef.current = false;
+            // 'end' fires on completion; a pre-emption fires one of two
+            // different events and BOTH must be listened for. d3-transition
+            // dispatches 'interrupt' only for a transition that has already
+            // STARTED, and 'cancel' for one still scheduled — see
+            // d3-transition/src/interrupt.js, `state > STARTING && state < ENDING`.
+            // A transition created inside an effect sits at CREATED/SCHEDULED
+            // until the next animation frame, so anything that pre-empts it
+            // inside that window — a mousedown, a wheel, the unmount cleanup's
+            // `sel.interrupt()`, or `resetView`'s own `zoom.transform` (which
+            // interrupts first) — dispatched 'cancel' and NOTHING lowered these
+            // flags. `focusingRef` stuck true kills every world click; a stuck
+            // `suppressSaveRef` silently stops persisting for the whole visit.
+            // Both were reachable by pressing the mouse within one frame of a
+            // `?epic=` landing, and unbounded in a backgrounded tab where no
+            // frame ever comes. (The `focusingRef` half predates req #3252.)
+            //
+            // Only the LATEST transition may lower them: d3 pre-empts the older
+            // one on the next tick, i.e. AFTER its successor has already set the
+            // flags, so an unstamped handler would clear its successor's.
+            .on('end.focus interrupt.focus cancel.focus', () => {
+                if (focusSeqRef.current !== seq) return;
+                focusingRef.current = false;
+                suppressSaveRef.current = false;
             })
             .call(zb.transform, zoomIdentity.translate(tr.x, tr.y).scale(tr.k));
         return true;
@@ -927,28 +1160,53 @@ export default function PipelinePlanVisualizer({
     // dependencies rather than marking a no-op "applied".
     //
     // `epicFocusAppliedRef` KEYS ON THE MEASURED SIZE TOO, not just the
-    // (pipeline, epic) pair (code review finding) — the panel is sized TWICE
-    // at mount (the `calc(100vh - 260px)` fallback in the JSX below, then
-    // again once `measureAvailH` resolves), and that second resize re-runs
-    // the `resetView` effect above (its deps include `size.h`), whose
-    // cleanup INTERRUPTS an in-flight focus transition and snaps the camera
-    // back to the default view — after which this effect, unkeyed on size,
-    // would see its own stale "applied" mark and never retry. Folding the
-    // measured size into the key means that second resize (and any later
-    // real one) invalidates the earlier mark and reapplies the focus, landing
-    // AFTER `resetView` in the same commit because both effects react to the
-    // same size change and this one is declared later in hook order. A
-    // genuine later browser resize reapplying the focus for the same reason
-    // matches `resetView`'s own existing contract, which already discards
-    // whatever view the reader was on whenever the container resizes.
+    // (pipeline, epic) pair (req #3235 code review finding) — the panel is
+    // sized TWICE at mount (the `calc(100vh - 260px)` fallback in the JSX
+    // below, then again once `measureAvailH` resolves), and the focus applied
+    // against the first of those is a fit for a panel the reader never sees.
+    // Folding the measured size into the key re-fits it once the panel has
+    // settled.
+    //
+    // ── BUT NOT AFTER THE READER HAS TAKEN THE WHEEL (req #3252 review) ─────
+    // That key used to be justified by REPAIR: the second resize re-ran the
+    // `resetView` effect, whose cleanup interrupted the focus and snapped the
+    // camera home, so re-applying put back what the resize had broken. Req
+    // #3252 replaced that effect with one keyed on the world's own geometry, so
+    // A RESIZE NO LONGER RESETS ANYTHING — and the re-focus stopped being a
+    // repair and became the only thing moving the camera, away from wherever
+    // the reader had put it. `availH` is re-measured on EVERY render, so a
+    // header-height change alone (the description dialog, an order-violations
+    // alert appearing on a refetch) was enough to yank a reader who had panned
+    // somewhere else back onto the linked band — while storage still held their
+    // pan, so the screen and the memory silently disagreed.
+    //
+    // `userMovedCameraRef` is the boundary: the deep link may re-fit itself as
+    // the panel settles, and stops existing the moment the reader drags or
+    // wheels. One flag, set from the only place that can know the difference —
+    // d3's `sourceEvent`.
+    //
+    // ── AND IT DOES NOT OVERWRITE THE SAVED CAMERA (req #3252) ──────────────
+    // A `?epic=` link WINS over a restored viewport — it is the more specific
+    // request, and letting a stale camera silently swallow it produces exactly
+    // the dead-link outcome req #3235 exists to rule out. But it must not
+    // PERSIST, because this page's standing doctrine for `?mode=`/`?step=`/
+    // `?epic=` is that a link asks to see one thing ONCE and must never rewrite
+    // what the reader chose as their own default — and a saved viewport IS what
+    // the reader chose here. So the band is shown and the stored camera is left
+    // untouched; the reader's very next gesture saves normally.
+    //
+    // Concretely: pan to the bottom of a plan, follow an `?epic=` link into it,
+    // then Back to the plain plan URL — you are returned to your pan, not to the
+    // epic the link happened to name.
     const epicFocusAppliedRef = useRef(null);
     useEffect(() => {
         if (focusEpicId == null) return;
+        if (userMovedCameraRef.current) return;
         const key = `${pipeline?.id}:${focusEpicId}:${size.w}x${size.h}`;
         if (epicFocusAppliedRef.current === key) return;
         const band = layout.bands.find((b) => b.epicId === focusEpicId);
         if (!band) return;
-        if (focusEpic(band)) epicFocusAppliedRef.current = key;
+        if (focusEpic(band, { persist: false })) epicFocusAppliedRef.current = key;
     }, [focusEpicId, pipeline?.id, size, layout, focusEpic]);
 
     // Req #3235 code review — the resolved pipeline can legitimately hold no
@@ -1260,13 +1518,23 @@ export default function PipelinePlanVisualizer({
                       onMouseEnter={(e) => { cursorPointer(e, true); showReqCard(label.reqId, e); }}
                       onMouseLeave={(e) => { cursorPointer(e, false); hideCard(); }}
                       // Carry the plan's identity so the requirement page's Back
-                      // returns HERE and not to the Roadmap (req #3119). The
-                      // mode/layout/label toggles restore themselves — they are
-                      // useViewPreference — so landing back on this route is
-                      // enough to resume the view; only pan/zoom re-fits.
+                      // returns HERE and not to the Roadmap (req #3119).
+                      //
+                      // `mode: 'plan'` (req #3252) is the other half of "HERE".
+                      // The route alone names the PLAN, not the panel: which
+                      // panel it opens is a stored preference, and a reader who
+                      // reached the visualizer through a `?mode=plan` link never
+                      // persisted `plan` — that override is transient by design.
+                      // So Back landed them in the TABLE, where the camera this
+                      // requirement restores is not even on screen. Naming the
+                      // mode makes Back return to the panel they left.
+                      //
+                      // The pan and zoom now come back too, which is what retires
+                      // the old closing clause of this comment ("only pan/zoom
+                      // re-fits") — see the saved-viewport block near the top.
                       onActivate={() => navigate(`/swarm/requirement/${label.reqId}`,
                           pipeline?.id
-                              ? { state: { from: 'pipeline', pipelineId: pipeline.id } }
+                              ? { state: { from: 'pipeline', pipelineId: pipeline.id, mode: 'plan' } }
                               : undefined)} />);
         } else if (label.kind === 'title') {
             worldNodes.push(

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanClamp.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanClamp.test.js
@@ -1,0 +1,112 @@
+// Req #3252 — `clampPlanTransform`, the legal region of a plan-canvas camera.
+//
+// A SEPARATE FILE from pipelinePlanLayout.test.js on purpose: this function has
+// two callers with two different jobs, and the cases that matter are about the
+// DIFFERENCE between them —
+//   · the zoom behaviour's `.constrain()`, which passes `t.k` for both scale
+//     bounds because d3 has already applied `scaleExtent` before calling it, so
+//     only the translation is in question;
+//   · the restore path (req #3252), which passes the REAL extent, because
+//     `zoom.transform` applies what it is given verbatim and runs neither
+//     `constrain` nor `scaleExtent`.
+//
+// The bound itself is req #3168's "scroll pane" rule: the world may overshoot
+// the panel by at most HALF A PANEL on each side, measured on screen at every
+// scale, so a pan can never carry the whole plan out of view.
+
+import { describe, it, expect } from 'vitest';
+
+import { clampPlanTransform } from '../pipelinePlanLayout';
+
+const SIZE = { w: 1000, h: 600 };
+const LAYOUT = { width: 4000, height: 2000 };
+// Translation-only, the shape `.constrain()` uses.
+const pan = (t, size = SIZE, layout = LAYOUT) =>
+    clampPlanTransform(t, size, layout, t.k, t.k);
+
+describe('clampPlanTransform', () => {
+    describe('scale', () => {
+        it('clamps k into [kMin, kMax]', () => {
+            expect(clampPlanTransform({ x: 0, y: 0, k: 0.01 }, SIZE, LAYOUT, 0.2, 4).k).toBe(0.2);
+            expect(clampPlanTransform({ x: 0, y: 0, k: 99 }, SIZE, LAYOUT, 0.2, 4).k).toBe(4);
+            expect(clampPlanTransform({ x: 0, y: 0, k: 1.5 }, SIZE, LAYOUT, 0.2, 4).k).toBe(1.5);
+        });
+
+        // THE ORDER IS LOAD-BEARING. The pan bound is computed FROM k, so
+        // clamping the translation first would immediately re-invalidate it. A
+        // camera saved at k=8 on a wide window, restored with a ceiling of 1,
+        // must be bounded against k=1's world extent, not k=8's.
+        it('bounds the translation against the CLAMPED k, not the requested one', () => {
+            const at8 = pan({ x: -30000, y: 0, k: 8 });
+            const clamped = clampPlanTransform({ x: -30000, y: 0, k: 8 }, SIZE, LAYOUT, 0.2, 1);
+            expect(clamped.k).toBe(1);
+            // k=1 → world 4000 wide → loX = 500 - 4000 = -3500.
+            expect(clamped.x).toBe(-3500);
+            // k=8 would have allowed far more overshoot; the two must differ, or
+            // the clamp order is not being respected.
+            expect(at8.x).toBeLessThan(clamped.x);
+        });
+    });
+
+    describe('the half-a-panel bound', () => {
+        it('leaves a transform already inside the bound untouched', () => {
+            const t = { x: -1200, y: -400, k: 1 };
+            expect(pan(t)).toEqual(t);
+        });
+
+        it('clamps an overshoot past the top-left to half a panel', () => {
+            // hiX = w/2 = 500, hiY = h/2 = 300.
+            expect(pan({ x: 99999, y: 99999, k: 1 })).toEqual({ x: 500, y: 300, k: 1 });
+        });
+
+        it('clamps an overshoot past the bottom-right to half a panel', () => {
+            // loX = 500 - 1*4000 = -3500; loY = 300 - 1*2000 = -1700.
+            expect(pan({ x: -99999, y: -99999, k: 1 })).toEqual({ x: -3500, y: -1700, k: 1 });
+        });
+
+        // The whole reason req #3168 used a custom `constrain` rather than
+        // `translateExtent`: a world-space extent grants overshoot in WORLD
+        // units, so the slack grows on screen as you zoom in and the bound
+        // quietly stops binding at exactly the zoom where the plan is easiest to
+        // lose. Half a panel is half a panel at every k.
+        it('grants the same SCREEN overshoot at every scale', () => {
+            for (const k of [0.25, 1, 4, 8]) {
+                expect(pan({ x: 99999, y: 99999, k }).x).toBe(SIZE.w / 2);
+                expect(pan({ x: -99999, y: 0, k }).x).toBe(SIZE.w / 2 - k * LAYOUT.width);
+            }
+        });
+    });
+
+    describe('a world smaller than the panel', () => {
+        // `Math.min(0, …)` is what keeps the DEFAULT view — world origin at the
+        // panel's top-left — legal on a plan smaller than the panel. Without it
+        // the bound would force a re-centre on the very first transform, moving
+        // the world frame the E2E click maths reads as `screen = world*k + t`.
+        const small = { width: 200, height: 100 };
+        it('keeps the origin legal', () => {
+            expect(pan({ x: 0, y: 0, k: 1 }, SIZE, small)).toEqual({ x: 0, y: 0, k: 1 });
+        });
+
+        it('does not allow panning it off past the origin', () => {
+            expect(pan({ x: -50, y: -50, k: 1 }, SIZE, small)).toEqual({ x: 0, y: 0, k: 1 });
+        });
+    });
+
+    describe('degenerate inputs', () => {
+        // Reachable at mount: the ResizeObserver has not measured yet, and the
+        // restore effect's own readiness guard is what keeps this from being
+        // applied — but the function must not produce NaN if it is called.
+        it('survives a zero-size panel', () => {
+            const t = clampPlanTransform({ x: 10, y: 10, k: 1 }, { w: 0, h: 0 }, LAYOUT, 1, 1);
+            expect(Number.isFinite(t.x)).toBe(true);
+            expect(Number.isFinite(t.y)).toBe(true);
+            expect(t).toEqual({ x: 0, y: 0, k: 1 });
+        });
+
+        it.each([[undefined], [null], [{}]])('survives a missing size/layout (%s)', (bad) => {
+            const t = clampPlanTransform({ x: 10, y: 10, k: 1 }, bad, bad, 1, 1);
+            expect(Number.isFinite(t.x)).toBe(true);
+            expect(Number.isFinite(t.y)).toBe(true);
+        });
+    });
+});

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -2718,4 +2718,50 @@ export function factoryDefaultScale(layout, size, kFit, kFloor) {
     return Math.max(Math.min(kFit, kVertFit), kFloor);
 }
 
+// ── The legal region of a transform (req #3168's bound, extracted req #3252) ──
+// The "scroll pane" rule: the world may overshoot the panel by at most HALF A
+// PANEL on each side, measured on screen at every scale, so a pan can never
+// carry the whole plan out of view. It lived as a closure inside
+// PipelinePlanVisualizer's zoom behaviour, which was correct while the zoom
+// behaviour was the only thing that could produce a transform.
+//
+// Req #3252 gave it a second producer: a viewport RESTORED from storage. That
+// one arrives through `zoom.transform`, which applies what it is given verbatim
+// and calls neither `constrain` nor `scaleExtent` (the `epicFocusTransform`
+// comment above, verified against d3-zoom 3.0.0) — so a camera saved when the
+// panel was tall, restored into a short one, would sit outside the bound until
+// the reader's first gesture snapped it. Two copies of this arithmetic that
+// "only have to agree" is the desync `factoryDefaultScale`'s own comment already
+// argues against, so there is one copy and both callers read it.
+//
+// `Math.min(0, …)` / `Math.max(0, …)` is what keeps the DEFAULT view — world
+// origin at the panel's top-left — legal on a plan smaller than the panel.
+// Without it the bound would force a re-centre on the very first transform.
+/**
+ * `t` clamped into the pan bound, and its scale into `[kMin, kMax]`.
+ *
+ * Pass `t.k` for both bounds to clamp the translation only, which is what the
+ * zoom behaviour's own `constrain` wants — d3 has already applied `scaleExtent`
+ * by the time it calls that.
+ *
+ * @param {{x:number,y:number,k:number}} t
+ * @param {{w:number,h:number}} size the viewport, in screen px
+ * @param {{width:number,height:number}} layout the world dimensions
+ * @param {number} kMin
+ * @param {number} kMax
+ * @returns {{x:number,y:number,k:number}}
+ */
+export function clampPlanTransform(t, size, layout, kMin, kMax) {
+    const k = Math.min(Math.max(t.k, kMin), kMax);
+    const w = size?.w || 0;
+    const h = size?.h || 0;
+    const loX = Math.min(0, w / 2 - k * (layout?.width || 0));
+    const loY = Math.min(0, h / 2 - k * (layout?.height || 0));
+    return {
+        x: Math.min(Math.max(t.x, loX), Math.max(0, w / 2)),
+        y: Math.min(Math.max(t.y, loY), Math.max(0, h / 2)),
+        k,
+    };
+}
+
 export { STEP_DONE, STEP_RUNNING, STEP_PENDING };

--- a/src/hooks/__tests__/useSavedViewport.test.jsx
+++ b/src/hooks/__tests__/useSavedViewport.test.jsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+//
+// Req #3252 — the LIFECYCLE half of the canvas-camera memory.
+//
+// `viewportMemory.test.js` pins the storage contract. This pins the three things
+// only the hook can get wrong, each of which is silent when it does:
+//   · a `record()` with no `commit()` writes NOTHING (the drag that never ends)
+//   · unmount commits anyway (the navigation that lands mid-gesture — the main
+//     path this feature exists for, not an edge case)
+//   · a commit that straddles a geometry change stamps the camera with the
+//     geometry it was TAKEN in, not the one that happens to be current
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import { useSavedViewport } from '../useSavedViewport';
+import { readViewport, viewportStorageKey } from '../../utils/viewportMemory';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const KEY = viewportStorageKey('test-canvas', 1);
+const FP = '100x100';
+const CAM = { x: 5, y: 6, k: 2 };
+
+/** Mount a probe that hands the hook's API back through a mutable box. */
+function mount(api, props = { key: KEY, fingerprint: FP }) {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    function Probe({ storageKey, fingerprint }) {
+        api.current = useSavedViewport(storageKey, fingerprint);
+        return null;
+    }
+    const render = (p) => act(() => {
+        root.render(<Probe storageKey={p.key} fingerprint={p.fingerprint} />);
+    });
+    render(props);
+    return {
+        rerender: render,
+        unmount: () => act(() => root.unmount()),
+    };
+}
+
+describe('useSavedViewport', () => {
+    beforeEach(() => { sessionStorage.clear(); });
+    afterEach(() => { sessionStorage.clear(); });
+
+    it('record alone writes nothing; commit writes', () => {
+        const api = {};
+        const h = mount(api);
+        act(() => api.current.record(CAM));
+        expect(readViewport(KEY, FP)).toBeNull();
+        act(() => api.current.commit());
+        expect(readViewport(KEY, FP)).toEqual(CAM);
+        h.unmount();
+    });
+
+    it('commit with nothing pending is a no-op, not an empty write', () => {
+        const api = {};
+        const h = mount(api);
+        act(() => api.current.commit());
+        expect(sessionStorage.getItem(KEY)).toBeNull();
+        h.unmount();
+    });
+
+    it('only the LAST record of a burst is written — one write per gesture', () => {
+        const api = {};
+        const h = mount(api);
+        act(() => {
+            api.current.record({ x: 1, y: 1, k: 1 });
+            api.current.record({ x: 2, y: 2, k: 1 });
+            api.current.record(CAM);
+            api.current.commit();
+        });
+        expect(readViewport(KEY, FP)).toEqual(CAM);
+        h.unmount();
+    });
+
+    it('a second commit does not re-write the same camera', () => {
+        const api = {};
+        const h = mount(api);
+        act(() => { api.current.record(CAM); api.current.commit(); });
+        sessionStorage.removeItem(KEY);
+        act(() => api.current.commit());
+        expect(sessionStorage.getItem(KEY)).toBeNull();
+        h.unmount();
+    });
+
+    // THE MAIN PATH, not an edge case: the reader's last act is a pan and their
+    // very next act is a click, so d3 never emits the 'end' that would commit.
+    it('unmount commits a pending record', () => {
+        const api = {};
+        const h = mount(api);
+        act(() => api.current.record(CAM));
+        expect(readViewport(KEY, FP)).toBeNull();
+        h.unmount();
+        expect(readViewport(KEY, FP)).toEqual(CAM);
+    });
+
+    it('pagehide commits a pending record — reload and tab close never unmount', () => {
+        const api = {};
+        const h = mount(api);
+        act(() => api.current.record(CAM));
+        act(() => { window.dispatchEvent(new Event('pagehide')); });
+        expect(readViewport(KEY, FP)).toEqual(CAM);
+        h.unmount();
+    });
+
+    it('stops listening to pagehide after unmount', () => {
+        const api = {};
+        const h = mount(api);
+        const stale = api.current;
+        h.unmount();
+        sessionStorage.clear();
+        act(() => stale.record(CAM));
+        window.dispatchEvent(new Event('pagehide'));
+        expect(readViewport(KEY, FP)).toBeNull();
+    });
+
+    // A transform belongs to the world it was produced in. A commit that lands
+    // after a layout toggle — or after an in-place switch from one plan to the
+    // next, which the plan page survives without remounting — must not stamp the
+    // outgoing camera with the incoming geometry. That is the ONE bad record the
+    // fingerprint check cannot catch, because it looks perfectly valid.
+    it('commits under the fingerprint the camera was recorded in', () => {
+        const api = {};
+        const h = mount(api);
+        act(() => api.current.record(CAM));
+        h.rerender({ key: KEY, fingerprint: 'GEOMETRY-MOVED' });
+        act(() => api.current.commit());
+        expect(readViewport(KEY, 'GEOMETRY-MOVED')).toBeNull();
+        expect(readViewport(KEY, FP)).toEqual(CAM);
+        h.unmount();
+    });
+
+    it('commits under the key the camera was recorded in', () => {
+        const api = {};
+        const other = viewportStorageKey('test-canvas', 2);
+        const h = mount(api);
+        act(() => api.current.record(CAM));
+        h.rerender({ key: other, fingerprint: FP });
+        act(() => api.current.commit());
+        expect(readViewport(other, FP)).toBeNull();
+        expect(readViewport(KEY, FP)).toEqual(CAM);
+        h.unmount();
+    });
+
+    it('read follows the CURRENT key and fingerprint', () => {
+        const api = {};
+        const h = mount(api);
+        act(() => { api.current.record(CAM); api.current.commit(); });
+        expect(api.current.read()).toEqual(CAM);
+        h.rerender({ key: KEY, fingerprint: 'GEOMETRY-MOVED' });
+        expect(api.current.read()).toBeNull();
+        h.unmount();
+    });
+
+    // A canvas with no identity must not read or write another canvas's camera.
+    it('a null key disables persistence in both directions', () => {
+        const api = {};
+        const h = mount(api, { key: null, fingerprint: FP });
+        act(() => { api.current.record(CAM); api.current.commit(); });
+        expect(sessionStorage.length).toBe(0);
+        expect(api.current.read()).toBeNull();
+        h.unmount();
+        expect(sessionStorage.length).toBe(0);
+    });
+
+    it('clear forgets both the stored camera and a pending one', () => {
+        const api = {};
+        const h = mount(api);
+        act(() => { api.current.record(CAM); api.current.commit(); });
+        act(() => { api.current.record({ x: 9, y: 9, k: 9 }); api.current.clear(); });
+        expect(api.current.read()).toBeNull();
+        h.unmount();
+        // The cleared pending record must not be resurrected by the unmount commit.
+        expect(readViewport(KEY, FP)).toBeNull();
+    });
+
+    // The caller attaches `record`/`commit` inside its d3-zoom effect, so these
+    // land in that effect's dependency list. A new identity per render would
+    // tear the zoom behaviour down and rebuild it on every pointermove of a drag.
+    it('returns a stable API across re-renders, including prop changes', () => {
+        const api = {};
+        const h = mount(api);
+        const first = api.current;
+        h.rerender({ key: KEY, fingerprint: FP });
+        expect(api.current).toBe(first);
+        h.rerender({ key: viewportStorageKey('test-canvas', 2), fingerprint: 'other' });
+        expect(api.current).toBe(first);
+        h.unmount();
+    });
+});

--- a/src/hooks/useSavedViewport.js
+++ b/src/hooks/useSavedViewport.js
@@ -1,0 +1,109 @@
+// useSavedViewport.js — the LIFECYCLE half of the canvas-camera memory (req #3252).
+//
+// `utils/viewportMemory.js` is the whole mechanism: read, write, clear, and the
+// doctrine for why a camera is stored per-tab and fingerprinted. It is a pure
+// module with no React in it, deliberately. This file is the small amount of
+// component lifecycle that a canvas would otherwise hand-roll, and it exists
+// because that is the half that is silently wrong when hand-rolled.
+//
+// ── WHY record/commit AND NOT A DEBOUNCE ───────────────────────────────────
+// d3-zoom fires `'zoom'` per pointermove — ~60 a second during a drag — and
+// `'end'` exactly ONCE per gesture: at the close of a drag, after the wheel's own
+// settle timeout, and at the end of a transition or a programmatic
+// `zoom.transform`. The gesture boundary a write wants already exists and is
+// emitted for free. So `record()` on every move costs one ref assignment and no
+// storage write, and `commit()` on `'end'` writes once.
+//
+// A trailing debounce was the obvious alternative and it is worse on exactly the
+// path that matters: the reader's last act is a pan and their very next act is a
+// click, so a 200ms timer is routinely outrun by the unmount — dropping precisely
+// the camera this feature exists to remember. A timer would still need the
+// unmount flush below, and then it is a timer nobody needs on top of it.
+//
+// ── THE UNMOUNT COMMIT IS LOAD-BEARING, NOT A TIDY-UP ──────────────────────
+// A navigation can land between `'zoom'` and `'end'` — d3 emits no `'end'` for a
+// gesture whose container is torn out from under it — and that is the single most
+// likely moment for this feature to be exercised at all. `pagehide` covers the
+// returns where nothing unmounts: a reload, a tab close, and a Back served from
+// the bfcache.
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import { clearViewport, readViewport, writeViewport } from '../utils/viewportMemory';
+
+/**
+ * Save-and-restore for one canvas's camera.
+ *
+ * @param {?string} key          storage key from `viewportStorageKey()`; null
+ *                               disables persistence entirely, which is what an
+ *                               unresolved record id must do — a canvas with no
+ *                               identity must never read or write another
+ *                               canvas's camera
+ * @param {string}  fingerprint  a string that CHANGES whenever the world geometry
+ *                               changes, so a stale camera is discarded rather
+ *                               than restored onto a layout it does not describe
+ * @returns {{record: function({x:number,y:number,k:number}): void,
+ *            commit: function(): void,
+ *            read: function(): ?{x:number,y:number,k:number},
+ *            clear: function(): void}}
+ */
+export function useSavedViewport(key, fingerprint) {
+    // Read through a ref rather than closing over the arguments, so every
+    // returned callback is identity-stable for the life of the component. That
+    // matters concretely: the caller attaches `record`/`commit` inside its
+    // d3-zoom effect, so these land in that effect's dependency list, and a new
+    // identity per render would tear the zoom behaviour down and rebuild it on
+    // every pointermove of a drag.
+    //
+    // Written during render on purpose — it mirrors props, and doing it in an
+    // effect would leave `record` stamping the PREVIOUS fingerprint for one
+    // commit, which is exactly the commit a geometry change lands in.
+    const argsRef = useRef({ key, fingerprint });
+    argsRef.current = { key, fingerprint };
+
+    const pendingRef = useRef(null);
+
+    // THE KEY AND FINGERPRINT ARE TAKEN WHEN THE CAMERA MOVED, not when the write
+    // lands. A transform belongs to the world it was produced in, so a commit
+    // that straddles a layout toggle — or an in-place switch from one plan to the
+    // next, which this page survives without remounting — must not stamp the
+    // outgoing camera with the incoming geometry. That is the one bad record the
+    // fingerprint check cannot catch, because it looks perfectly valid.
+    const record = useCallback((cam) => {
+        const { key: k, fingerprint: fp } = argsRef.current;
+        if (!k || !cam) return;
+        pendingRef.current = { key: k, fp, x: cam.x, y: cam.y, k: cam.k };
+    }, []);
+
+    const commit = useCallback(() => {
+        const p = pendingRef.current;
+        if (!p) return;
+        pendingRef.current = null;
+        writeViewport(p.key, p.fp, p);
+    }, []);
+
+    const read = useCallback(() => {
+        const { key: k, fingerprint: fp } = argsRef.current;
+        return readViewport(k, fp);
+    }, []);
+
+    const clear = useCallback(() => {
+        pendingRef.current = null;
+        clearViewport(argsRef.current.key);
+    }, []);
+
+    useEffect(() => {
+        window.addEventListener('pagehide', commit);
+        return () => {
+            window.removeEventListener('pagehide', commit);
+            commit();
+        };
+    }, [commit]);
+
+    // Memoized, not a fresh literal per render — see the stability contract on
+    // `argsRef` above; the object itself lands in the caller's effect deps too.
+    return useMemo(() => ({ record, commit, read, clear }),
+        [record, commit, read, clear]);
+}
+
+export default useSavedViewport;

--- a/src/utils/__tests__/viewportMemory.test.js
+++ b/src/utils/__tests__/viewportMemory.test.js
@@ -1,0 +1,205 @@
+// Req #3252 — the canvas-camera memory contract.
+//
+// The module is pure and React-free precisely so this file needs no DOM. It
+// needs a `sessionStorage`, which jsdom would provide but which is cheaper and
+// more controllable as a stub — the point of several cases below is storage
+// BEHAVING BADLY (throwing, holding garbage), and a real one cannot be made to.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+    VIEWPORT_SCHEMA_VERSION,
+    clearViewport,
+    readViewport,
+    viewportStorageKey,
+    writeViewport,
+} from '../viewportMemory';
+
+const KEY = viewportStorageKey('pipeline-plan', 2);
+const FP = '1200x800:64:9';
+const CAM = { x: -340.5, y: -120.25, k: 1.75 };
+
+/** A minimal in-memory sessionStorage; `fail` makes every method throw. */
+function installStorage({ fail = false } = {}) {
+    const map = new Map();
+    const boom = () => { throw new DOMException('quota', 'QuotaExceededError'); };
+    const stub = {
+        getItem: fail ? boom : (k) => (map.has(k) ? map.get(k) : null),
+        setItem: fail ? boom : (k, v) => { map.set(k, String(v)); },
+        removeItem: fail ? boom : (k) => { map.delete(k); },
+    };
+    vi.stubGlobal('sessionStorage', stub);
+    return map;
+}
+
+describe('viewportMemory', () => {
+    let store;
+    beforeEach(() => { store = installStorage(); });
+    afterEach(() => { vi.unstubAllGlobals(); });
+
+    describe('viewportStorageKey', () => {
+        // The key namespace is deliberately NOT `darwin-<feature>-view`: that
+        // belongs to view preferences, and the whole doctrine here is that a
+        // camera is not one. A collision would let a preference read as a camera.
+        it('namespaces by surface and record id', () => {
+            expect(viewportStorageKey('pipeline-plan', 2)).toBe('darwin-viewport-pipeline-plan-2');
+            expect(viewportStorageKey('pipeline-plan', 3))
+                .not.toBe(viewportStorageKey('pipeline-plan', 2));
+        });
+    });
+
+    describe('round trip', () => {
+        it('returns exactly what was written, for the same fingerprint', () => {
+            writeViewport(KEY, FP, CAM);
+            expect(readViewport(KEY, FP)).toEqual(CAM);
+        });
+
+        it('keeps two records independent', () => {
+            const other = viewportStorageKey('pipeline-plan', 3);
+            writeViewport(KEY, FP, CAM);
+            writeViewport(other, FP, { x: 10, y: 20, k: 0.5 });
+            expect(readViewport(KEY, FP)).toEqual(CAM);
+            expect(readViewport(other, FP)).toEqual({ x: 10, y: 20, k: 0.5 });
+        });
+
+        it('a later write replaces the earlier one', () => {
+            writeViewport(KEY, FP, CAM);
+            writeViewport(KEY, FP, { x: 1, y: 2, k: 3 });
+            expect(readViewport(KEY, FP)).toEqual({ x: 1, y: 2, k: 3 });
+        });
+
+        it('reads back a camera at the origin — 0,0 is a real position', () => {
+            writeViewport(KEY, FP, { x: 0, y: 0, k: 1 });
+            expect(readViewport(KEY, FP)).toEqual({ x: 0, y: 0, k: 1 });
+        });
+    });
+
+    describe('the fingerprint gate', () => {
+        // THE LOAD-BEARING RULE. A camera restored onto rescaled geometry does
+        // not fail loudly — it lands somewhere unrelated, which reads as a defect
+        // in the drawing rather than in the restore. Refuse, never approximate.
+        it('refuses a camera taken under different geometry', () => {
+            writeViewport(KEY, FP, CAM);
+            expect(readViewport(KEY, '1400x800:64:9')).toBeNull();
+            expect(readViewport(KEY, '1200x800:65:9')).toBeNull();
+            expect(readViewport(KEY, '1200x800:64:10')).toBeNull();
+        });
+
+        it('does not delete the refused record — the geometry may come back', () => {
+            writeViewport(KEY, FP, CAM);
+            expect(readViewport(KEY, 'other')).toBeNull();
+            expect(readViewport(KEY, FP)).toEqual(CAM);
+        });
+
+        it('an undefined fingerprint does not match a stored one', () => {
+            writeViewport(KEY, FP, CAM);
+            expect(readViewport(KEY, undefined)).toBeNull();
+        });
+    });
+
+    describe('validation — never trust what came out of storage', () => {
+        const put = (value) => store.set(KEY, typeof value === 'string' ? value : JSON.stringify(value));
+        const rec = (over) => ({ v: VIEWPORT_SCHEMA_VERSION, fp: FP, ...CAM, ...over });
+
+        it('refuses unparseable JSON', () => {
+            put('{not json');
+            expect(readViewport(KEY, FP)).toBeNull();
+        });
+
+        // `typeof null === 'object'`, and `"7"` parses to a number — both would
+        // sail past a bare truthiness check straight into a property read.
+        it.each([['null', 'null'], ['a bare number', '7'], ['a string', '"hi"'], ['an array', '[]']])(
+            'refuses %s', (_label, raw) => {
+                put(raw);
+                expect(readViewport(KEY, FP)).toBeNull();
+            });
+
+        // A NaN does not throw when it reaches the canvas — it multiplies into
+        // every coordinate and renders nothing, with no error to see. That is
+        // why this is validated here rather than trusted downstream.
+        it.each(['x', 'y', 'k'])('refuses a non-finite %s', (field) => {
+            put(rec({ [field]: null }));
+            expect(readViewport(KEY, FP)).toBeNull();
+            // NaN and Infinity do not survive JSON.stringify — they arrive as
+            // null — so the string forms are what a hand-edited record looks like.
+            put(rec({ [field]: 'NaN' }));
+            expect(readViewport(KEY, FP)).toBeNull();
+        });
+
+        it('refuses a missing field', () => {
+            const r = rec();
+            delete r.y;
+            put(r);
+            expect(readViewport(KEY, FP)).toBeNull();
+        });
+
+        // A zero or negative scale is not a small view, it is a collapsed or
+        // mirrored world. No zoom behaviour can produce one.
+        it.each([0, -1])('refuses a scale of %s', (k) => {
+            put(rec({ k }));
+            expect(readViewport(KEY, FP)).toBeNull();
+        });
+
+        it('refuses a record from a different schema version', () => {
+            put(rec({ v: VIEWPORT_SCHEMA_VERSION + 1 }));
+            expect(readViewport(KEY, FP)).toBeNull();
+            put(rec({ v: undefined }));
+            expect(readViewport(KEY, FP)).toBeNull();
+        });
+
+        it('refuses to write a camera it would refuse to read', () => {
+            writeViewport(KEY, FP, { x: NaN, y: 0, k: 1 });
+            writeViewport(KEY, FP, { x: 0, y: Infinity, k: 1 });
+            expect(store.has(KEY)).toBe(false);
+        });
+    });
+
+    describe('no key means no persistence', () => {
+        // A canvas whose record id has not resolved must not read or write
+        // another canvas's camera. Null is how the caller says so.
+        it.each([null, undefined, ''])('reads null and writes nothing for %s', (key) => {
+            writeViewport(key, FP, CAM);
+            expect(store.size).toBe(0);
+            expect(readViewport(key, FP)).toBeNull();
+            expect(() => clearViewport(key)).not.toThrow();
+        });
+    });
+
+    describe('clearViewport', () => {
+        it('forgets the camera', () => {
+            writeViewport(KEY, FP, CAM);
+            clearViewport(KEY);
+            expect(readViewport(KEY, FP)).toBeNull();
+        });
+
+        it('leaves other records alone', () => {
+            const other = viewportStorageKey('pipeline-plan', 3);
+            writeViewport(KEY, FP, CAM);
+            writeViewport(other, FP, CAM);
+            clearViewport(KEY);
+            expect(readViewport(other, FP)).toEqual(CAM);
+        });
+    });
+
+    describe('storage unavailable (Safari private mode, quota)', () => {
+        // This is a convenience, not a feature that can fail loudly. Every path
+        // has to degrade to "there is no saved camera", which is a state the
+        // caller already handles — it is the first-ever visit.
+        beforeEach(() => { installStorage({ fail: true }); });
+
+        it('never throws, and reads as absent', () => {
+            expect(() => writeViewport(KEY, FP, CAM)).not.toThrow();
+            expect(() => clearViewport(KEY)).not.toThrow();
+            expect(readViewport(KEY, FP)).toBeNull();
+        });
+    });
+
+    describe('storage missing entirely', () => {
+        it('never throws when there is no sessionStorage at all', () => {
+            vi.stubGlobal('sessionStorage', undefined);
+            expect(readViewport(KEY, FP)).toBeNull();
+            expect(() => writeViewport(KEY, FP, CAM)).not.toThrow();
+            expect(() => clearViewport(KEY)).not.toThrow();
+        });
+    });
+});

--- a/src/utils/viewportMemory.js
+++ b/src/utils/viewportMemory.js
@@ -1,0 +1,185 @@
+// viewportMemory.js — "the canvas I come back to is the canvas I left" (req #3252).
+//
+// THE DEFECT THIS EXISTS FOR. A pan/zoom canvas holds its camera in component
+// state. Every way of leaving the page unmounts that component, so the camera is
+// gone before the browser has finished navigating — and coming back re-lands on
+// the default view. The user reported it as three cases (a requirement link, a
+// step link, "link to anything") and then named the general form: *all occasions,
+// not just the three I mentioned*.
+//
+// THE POINT IS THAT THERE IS NO LIST OF OCCASIONS. Every return — a link out and
+// Back, a bead click that switches to the Table and a switch back, a mode toggle,
+// a breadcrumb round-trip, a reload — arrives at one place: the canvas mounts.
+// Write the camera down when it moves, read it back when the canvas lands, and
+// the enumeration disappears. A per-call-site patch would have to be exhaustive
+// today AND stay exhaustive as links are added. Two of the plan visualizer's own
+// return paths involve NO NAVIGATION AT ALL (a bead click and the Table|Plan
+// toggle both unmount the canvas inside one route), so there is no navigation to
+// hang a patch on even if the list were complete.
+//
+// ── A PLAIN MODULE, NOT A HOOK AND NOT A STORE ─────────────────────────────
+// It holds no state and has no lifecycle, so it is a module — and it must stay
+// one. `useViewPreference` is a hook because it OWNS THE VALUE REACT RENDERS. A
+// camera must never be React state owned by a second party: the d3-zoom BEHAVIOR
+// owns the camera, and a second copy desyncs on the first wheel event
+// (PipelinePlanVisualizer's own "the classic integration bug" note). This is a
+// SIDE CHANNEL, and a side channel with no state is a function.
+//
+// It is not a Zustand store either: a store is cross-tab by default (wrong, see
+// below) and re-renders every subscriber on a value that changes at pointermove
+// frequency during a drag.
+//
+// No JSX and no React, so vitest exercises it without a DOM — the same rule
+// `pipelineStepLink.js` and `normalizeView.js` are written to.
+//
+// ── PER TAB, NEVER CROSS-TAB (sessionStorage only, no localStorage seed) ────
+// A VIEWPORT IS NOT A VIEW PREFERENCE, and conflating them breaks three ways.
+// A preference answers "how do I like to look at this KIND of page" — durable,
+// meaningful with no context, so `useViewPreference` seeds a new tab from
+// localStorage. A viewport answers "where was I in THIS artifact, a moment ago".
+// A second tab was never there, and handing it a camera from a different task is
+// the browser's own scroll restoration getting it wrong — which is why no
+// browser does that either.
+//
+// THERE IS A MEASURED DARWIN PRECEDENT. `stores/useSwarmVisualizerStore.js`
+// persisted the swarm canvas's `currentDate` to localStorage as the reader
+// panned, and the next page load rehydrated a camera from days earlier — the
+// "late-May affinity", req #2799. `partialize` now strips it and `migrate`
+// deletes it from old blobs. A plan camera in localStorage is that bug with two
+// axes instead of one. sessionStorage gets the #2799 protection for free, from
+// the storage boundary itself rather than from an exclusion list, while still
+// surviving the things that matter: a reload and every in-tab navigation.
+//
+// Same call req #3220 made for the pipelines status filter, and the same shape
+// as the three shipped scroll-restore precedents (`visualizer_scrollY`,
+// `maps_scrollY`, `calview_scrollY`) — the closest existing thing in the
+// codebase to what was asked for.
+//
+// ── A CAMERA IS ONLY VALID FOR THE GEOMETRY IT WAS TAKEN IN ────────────────
+// `{x, y, k}` is a camera over a WORLD, and the world is a layout. Change the
+// layout — a wider column, a step added by a background refetch, a band gained —
+// and the same numbers point at different content. A stale camera DOES NOT FAIL
+// LOUDLY: it lands somewhere unrelated, which reads as a defect in the drawing
+// rather than in the restore. So every record carries a FINGERPRINT of the
+// geometry it was taken under, and a mismatch means NO RESTORE — never an
+// approximate one. The caller computes the fingerprint, because only the caller
+// knows what its own world is made of.
+//
+// ── WHAT THIS DOES NOT DO ──────────────────────────────────────────────────
+// It does not clamp. A stored camera is validated for SHAPE (three finite
+// numbers, a positive scale) and for the geometry it belongs to, and that is
+// all. The legal range of a transform is the caller's zoom behaviour's business —
+// scale extent and pan bound — and lives in the caller's own pure layout module;
+// a copy here would be the desync class that file has already taken two review
+// findings on. Read, then clamp with your own rule. This matters more than it
+// sounds: `zoom.transform` applies what it is given VERBATIM and runs neither
+// `constrain` nor `scaleExtent`, so an unclamped restore sits out of range
+// looking correct until the reader's first wheel event snaps it.
+//
+// ── ADOPTION ───────────────────────────────────────────────────────────────
+// One caller today: `SwarmView/pipelines/PipelinePlanVisualizer.jsx`, through
+// `hooks/useSavedViewport.js` (the lifecycle half — see that file). Darwin has
+// exactly three React-owned pan/zoom cameras and they are one idiom, so the
+// other two are the candidate adopters, and NEITHER should adopt blindly:
+//
+//   · `BuildVisualizer/KonvaBuildCanvas.jsx` can adopt as-is — fingerprint
+//     `projectId` + rounded world dimensions, and its `lastFramedProjectRef`
+//     becomes "restore, else frame".
+//   · `SwarmView/KonvaSwarmCanvas.jsx` MUST NOT restore across page loads: that
+//     is precisely what req #2799 removed. If it adopts, it adopts for the
+//     in-tab return path only, with `selectedDate|rangeEnd` in the fingerprint,
+//     and it must be reconciled with the `recenterDecision`/`userPannedRef`
+//     machinery it already carries, which a restore would otherwise fight.
+
+export const VIEWPORT_STORAGE_PREFIX = 'darwin-viewport-';
+
+// Bumped only if the record's SHAPE changes. On a mismatch a record is dropped
+// rather than migrated: a one-time reset to the default view costs a reader one
+// gesture, and a migration branch for a convenience feature lives forever.
+export const VIEWPORT_SCHEMA_VERSION = 1;
+
+/**
+ * The storage key for one camera.
+ *
+ * Deliberately NOT the `darwin-<feature>-view` shape: that namespace belongs to
+ * view PREFERENCES, and the whole point of this module is that a camera is not
+ * one.
+ *
+ * @param {string} surface e.g. `pipeline-plan`
+ * @param {string|number} recordId the artifact the camera is over
+ */
+export const viewportStorageKey = (surface, recordId) =>
+    `${VIEWPORT_STORAGE_PREFIX}${surface}-${recordId}`;
+
+/**
+ * The camera stored under `key`, or null.
+ *
+ * VALIDATED, NEVER TRUSTED. The value is JSON out of web storage, so it can be
+ * anything an older version of this app wrote, anything a different feature
+ * wrote under a colliding key, or anything a reader typed into devtools. It is
+ * handed to a d3-zoom transform and multiplied into every coordinate on the
+ * canvas: a NaN in any of the three fields DOES NOT THROW — it renders an empty
+ * canvas with no error to see, the worst possible failure for a view whose only
+ * job is to be looked at. This is the discipline `pipelinePlanLayout.js` already
+ * applies to every storage-sourced value it hands to Konva, for the same reason.
+ *
+ * @param {?string} key
+ * @param {string}  fingerprint the geometry the caller is rendering NOW
+ * @returns {?{x: number, y: number, k: number}}
+ */
+export function readViewport(key, fingerprint) {
+    if (!key) return null;
+    try {
+        const raw = sessionStorage.getItem(key);
+        if (raw == null) return null;
+        const rec = JSON.parse(raw);
+        // `typeof null === 'object'`, and a stored `"7"` parses to a number —
+        // both sail past a bare truthiness check straight into `rec.fp`.
+        if (!rec || typeof rec !== 'object' || Array.isArray(rec)) return null;
+        if (rec.v !== VIEWPORT_SCHEMA_VERSION) return null;
+        if (rec.fp !== fingerprint) return null;
+        const { x, y, k } = rec;
+        if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(k)) return null;
+        // A zero or negative scale is not a small view, it is a collapsed or
+        // mirrored world. No zoom behaviour can produce one; only corruption can.
+        if (!(k > 0)) return null;
+        return { x, y, k };
+    } catch {
+        // Storage unavailable (Safari private mode) or unparseable JSON. There
+        // is no saved camera — a state the caller already handles, because it is
+        // the first-ever visit.
+        return null;
+    }
+}
+
+/**
+ * Store `cam` under `key`, stamped with the geometry it was taken in.
+ *
+ * @param {?string} key
+ * @param {string}  fingerprint
+ * @param {{x: number, y: number, k: number}} cam
+ */
+export function writeViewport(key, fingerprint, cam) {
+    if (!key || !cam) return;
+    if (!Number.isFinite(cam.x) || !Number.isFinite(cam.y) || !Number.isFinite(cam.k)) return;
+    try {
+        sessionStorage.setItem(key, JSON.stringify({
+            v: VIEWPORT_SCHEMA_VERSION, fp: fingerprint, x: cam.x, y: cam.y, k: cam.k,
+        }));
+    } catch {
+        // Safari private mode / quota exceeded. The camera still works; it just
+        // will not be there next time. Never worth breaking the canvas over, and
+        // never worth surfacing — this is a convenience, not a feature that can
+        // fail loudly.
+    }
+}
+
+/** Forget the camera under `key`. */
+export function clearViewport(key) {
+    if (!key) return;
+    try {
+        sessionStorage.removeItem(key);
+    } catch {
+        // See writeViewport.
+    }
+}

--- a/tests/tests/pipelines.spec.ts
+++ b/tests/tests/pipelines.spec.ts
@@ -185,6 +185,24 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             // 'none'). Pinned to the default so PIPE-15's gesture starts from a
             // known position and no other test inherits a previous one.
             set('darwin-pipeline-viz-color-key', 'state');
+            // Req #3252 — THE CAMERA IS NOW PART OF THE PINNED STATE. The
+            // visualizer remembers its pan and zoom per tab, so a `goto` no
+            // longer implies the default view: PIPE-14 pans, wheel-zooms and
+            // focuses a band before re-opening the plan, and would then look for
+            // an epic chip that its own earlier gesture had carried off screen.
+            // Every `goto` in this suite starts from the readable default, which
+            // is what these tests have always assumed.
+            //
+            // Cleared by PREFIX rather than by key, because the key carries a
+            // pipeline id and the fixture's ids are allocated at seed time.
+            //
+            // This runs on every NAVIGATION, i.e. on every new document — so a
+            // test that needs the camera to SURVIVE (PIPE-21) must travel by
+            // in-app routing, which creates no new document and therefore does
+            // not re-run this. That is also the journey the user actually makes.
+            for (const k of Object.keys(sessionStorage)) {
+                if (k.startsWith('darwin-viewport-')) sessionStorage.removeItem(k);
+            }
         }, [mode, viz.reqLayout, viz.stepLabel] as const);
     }
 
@@ -1956,5 +1974,144 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             // makes the chip two controls rather than one ambiguous one.
             await expect(page.getByTestId(`pipeline-viz-epic-open-${epicBand.epicId}`))
                 .toHaveAttribute('title', `Open “${epicText}” in the features view`);
+        });
+
+    // ── PIPE-21: the visualizer maintains the last viewport (req #3252) ─────
+    //
+    // The user's report: "there are multiple occasions when I am returning back
+    // to the visualizer ... it will not recall my view port. so have the ability
+    // to return to just that view port for all occasion not just the three i
+    // mentioned."
+    //
+    // TRAVELS BY IN-APP ROUTING ONLY, never `page.goto`. Two reasons and both
+    // matter: that is the journey the user actually makes, and `pinPreferences`
+    // clears the saved camera on every new document (see its comment), so a
+    // `goto` here would be testing the pin rather than the feature.
+    test('PIPE-21: the camera survives leaving the visualizer and coming back',
+        async ({ page }) => {
+            const canvas = await openPlanVisualizer(page, fixture.batchPipelineId);
+            const container = page.getByTestId('pipeline-plan-visualizer');
+            const read = async () =>
+                (await container.getAttribute('data-transform'))!.split(',').map(Number);
+
+            const opened = await read();
+
+            // Pan somewhere distinctive. `data-transform` is the component's own
+            // published camera, so the assertion never has to infer one.
+            const box = (await canvas.boundingBox())!;
+            const cx = box.x + box.width / 2;
+            const cy = box.y + box.height / 2;
+            await page.mouse.move(cx, cy);
+            await page.mouse.down();
+            await page.mouse.move(cx - 140, cy - 70, { steps: 12 });
+            await page.mouse.up();
+            // Polled on the DISTANCE, not on `not.toHaveAttribute(opened)`:
+            // `read()` maps through Number, so the published "0.00,-12.50,0.8000"
+            // round-trips to "0,-12.5,0.8" — a string the component's own
+            // toFixed(2)/toFixed(4) can never emit, making that comparison
+            // vacuously true and the wait no wait at all (review finding).
+            await expect.poll(async () => {
+                const [x, y] = await read();
+                return Math.hypot(x - opened[0], y - opened[1]);
+            }, { timeout: 10000 }).toBeGreaterThan(50);
+            const panned = await read();
+
+            /** Every camera number back where it was left. */
+            const expectRestored = async (what: string) => {
+                await expect(container).toBeVisible({ timeout: 15000 });
+                await expect.poll(async () => (await read())[2], { timeout: 10000 })
+                    .toBeCloseTo(panned[2], 3);
+                const [x, y] = await read();
+                expect(x, `${what}: x`).toBeCloseTo(panned[0], 0);
+                expect(y, `${what}: y`).toBeCloseTo(panned[1], 0);
+            };
+
+            // ── Occasion 1: the mode toggle. A return with NO navigation at
+            // all — the visualizer unmounts inside one route, which is why no
+            // per-call-site patch could ever have covered it.
+            await page.getByTestId('pipeline-mode-table').click();
+            await expect(page.getByTestId('pipeline-plan-table')).toBeVisible();
+            await page.getByTestId('pipeline-mode-plan').click();
+            await expectRestored('mode toggle');
+
+            // ── Occasion 2: out to a requirement and back through the page's
+            // own "Back to Plan" control. This is the case the user named first,
+            // and it needs BOTH halves: the camera, and landing on the Plan
+            // panel at all (req #3252 carries `mode` in the router state — the
+            // stored preference here is `plan`, but a reader who arrived by
+            // `?mode=plan` link would previously have been returned to the Table
+            // and never seen the restored camera).
+            const layout = computePlanLayout(batchPlan.rows, batchPlan.batches,
+                { ...PLAN_VIEW_OPTIONS, timeAxis: batchPlan.timeAxis || null });
+            // The label to click is chosen by WHERE IT NOW IS, not by being
+            // first in the list. The camera has been panned by (-140, -70), and
+            // the first `kind === 'req'` label sits near the world's left edge —
+            // so the naive choice can land outside the canvas entirely and the
+            // click hits nothing (review finding). Pick one comfortably inside
+            // the panned viewport.
+            // The predicate must clear the CHROME, not just the panel edges: a
+            // click that lands on the floating key or an epic chip is swallowed
+            // by the visualizer's own CHROME_SELECTOR guard and resolves against
+            // no bead at all, so the navigation simply never happens and the
+            // wait below times out with nothing to explain it. The key is up to
+            // PLAN_KEY_MAX_W (470px) wide in the TOP-RIGHT corner and is open by
+            // default; the epic chips clamp to the top of the viewport.
+            const [tx, ty, k] = panned;
+            const M = 24;             // panel edges
+            const KEY_W = 470 + M;    // PLAN_KEY_MAX_W, top-right
+            const CHIP_H = 100;       // the clamped epic-chip strip along the top
+            const reqLabel = (layout.labels as Array<
+                { kind: string; x: number; y: number; reqId: number }>).find((l) => {
+                    if (l.kind !== 'req') return false;
+                    const sx = tx + (l.x + 3) * k;
+                    const sy = ty + (l.y + 3) * k;
+                    if (sx <= M || sx >= box.width - M) return false;
+                    if (sy <= CHIP_H || sy >= box.height - M) return false;
+                    // Anything in the top-right rectangle belongs to the key.
+                    return !(sx > box.width - KEY_W && sy < 260);
+                })!;
+            expect(reqLabel,
+                'a requirement label is on screen at the panned camera').toBeTruthy();
+            await page.mouse.click(box.x + tx + (reqLabel.x + 3) * k,
+                box.y + ty + (reqLabel.y + 3) * k);
+            await expect(page).toHaveURL(
+                new RegExp(`/swarm/requirement/${reqLabel.reqId}$`), { timeout: 15000 });
+
+            await page.getByTestId('btn-back-to-swarm').click();
+            await expect(page).toHaveURL(/\/swarm\/pipeline\/\d+(\?mode=plan)?$/,
+                { timeout: 15000 });
+            await expectRestored('back from a requirement');
+
+            // ── Occasion 3: browser Back, from the epic chip's ↗ navigation.
+            // A different exit and a different way home, restoring the same way.
+            const epicBand = layout.bands.find(
+                (b: { epicId: number | null }) => b.epicId != null) as { epicId: number };
+            expect(epicBand, 'the plan renders epic bands').toBeTruthy();
+            await page.getByTestId(`pipeline-viz-epic-open-${epicBand.epicId}`).click();
+            await expect(page).toHaveURL(
+                new RegExp(`/swarm/features\\?epic=${epicBand.epicId}$`), { timeout: 15000 });
+            await page.goBack();
+            await expectRestored('browser Back');
+
+            // ── And Reset still resets, and STICKS. The camera memory must not
+            // turn the header's Reset into a control that is undone by the next
+            // navigation — it is an explicit, in-the-moment instruction, so it
+            // overwrites what was remembered.
+            await page.getByTestId('pipeline-viz-reset').click();
+            await expect.poll(async () => (await read())[0], { timeout: 10000 })
+                .not.toBeCloseTo(panned[0], 0);
+            const afterReset = await read();
+            await page.getByTestId('pipeline-mode-table').click();
+            await expect(page.getByTestId('pipeline-plan-table')).toBeVisible();
+            await page.getByTestId('pipeline-mode-plan').click();
+            await expect(container).toBeVisible({ timeout: 15000 });
+            await expect.poll(async () => (await read())[0], { timeout: 10000 })
+                .toBeCloseTo(afterReset[0], 0);
+            const [rx, ry, rk] = await read();
+            expect(ry, 'Reset survives the round trip: y').toBeCloseTo(afterReset[1], 0);
+            expect(rk, 'Reset survives the round trip: k').toBeCloseTo(afterReset[2], 3);
+            expect(Math.hypot(rx - panned[0], ry - panned[1]),
+                'and it is the reset view, not the pan that preceded it')
+                .toBeGreaterThan(1);
         });
 });


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3252-visualizer-maintains-last-viewport-1
- wip(Darwin): 2026-08-02T10:00:26Z
- chore: init swarm session feature/3252-visualizer-maintains-last-viewport-1

## Files changed
```
 src/SwarmView/detail/RequirementDetail.jsx         |  25 +-
 src/SwarmView/pipelines/PipelinePlanTable.jsx      |  10 +-
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx | 342 ++++++++++++++++++---
 .../pipelines/__tests__/pipelinePlanClamp.test.js  | 112 +++++++
 src/SwarmView/pipelines/pipelinePlanLayout.js      |  46 +++
 src/hooks/__tests__/useSavedViewport.test.jsx      | 195 ++++++++++++
 src/hooks/useSavedViewport.js                      | 109 +++++++
 src/utils/__tests__/viewportMemory.test.js         | 205 ++++++++++++
 src/utils/viewportMemory.js                        | 185 +++++++++++
 tests/tests/pipelines.spec.ts                      | 157 ++++++++++
 10 files changed, 1346 insertions(+), 40 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)