### PR TITLE
Date Header stuck to viewport header

### DIFF
--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -116,7 +116,7 @@ import {
     NEXT_HALO_RADIUS, NEXT_HALO_STROKE, NEXT_HALO_OPACITY, NEXT_HALO_DASH,
     buildMachineColorView, reqIdStyle, reqIdKeyEntries, normalizeColorKey,
     DEFAULT_COLOR_KEY, PLAN_KEY_MAX_W, pinnedLevelOf, DEFAULT_PLAN_LEVEL_PREF,
-    EPIC_PAUSE_BUBBLE_D, pauseBubbleColor,
+    EPIC_PAUSE_BUBBLE_D, pauseBubbleColor, stickyRulerY,
 } from './pipelinePlanLayout';
 import '../../CalendarFC/swarmVisualizer.css';
 
@@ -1026,6 +1026,16 @@ export default function PipelinePlanVisualizer({
 
     // ── World-space nodes ───────────────────────────────────────────────────
     const worldNodes = [];
+    // ── Sticky ruler-strip nodes (req #3254) ────────────────────────────────
+    // The baseline, the tick marks and the slot date/future/undated labels —
+    // everything that reads as "the header" — draw in a SEPARATE Konva Group
+    // (below) whose y is `stickyRulerY(t)` rather than `t.y`, so the strip
+    // pins to the top of the viewport instead of scrolling off with the
+    // timeline beneath it. The full-height separators and the future-region
+    // tint stay in `worldNodes`: they are background guides spanning the
+    // whole plan's vertical extent, not the header itself, and belong to the
+    // content they mark rather than to viewport chrome.
+    const stickyRulerNodes = [];
 
     layout.bands.forEach((band) => {
         worldNodes.push(
@@ -1046,27 +1056,41 @@ export default function PipelinePlanVisualizer({
         }
     });
 
-    // ── The time ruler (req #3207) ──────────────────────────────────────────
+    // ── The time ruler (req #3207, sticky since req #3254) ──────────────────
     // Drawn AFTER the band washes and BEFORE the arcs and beads: the rules and
     // the future tint are background furniture that must sit over the band fill
     // (a 6% wash would otherwise swallow them) and under everything a reader
     // actually reads. The label TEXT is not here — it rides `layout.labels` as
     // `kind: 'slot'` so the zero-overlap contract covers it, and is drawn in the
-    // label loop below with every other piece of text on the surface.
+    // label loop below with every other piece of text on the surface — into
+    // `stickyRulerNodes`, same as the baseline and ticks here, not `worldNodes`.
     {
         const R = layout.ruler || { h: 0, slots: [], futureX: null };
         // The FUTURE REGION, first, so the rules draw on top of its edge. A rule
         // alone says where the boundary is; it does not say which side of it has
-        // not happened yet.
+        // not happened yet. WORLD space — it tints the whole plan's height, not
+        // just the header strip.
         if (R.futureX != null && R.futureX < layout.width) {
             worldNodes.push(
                 <Rect key="ruler-future" x={R.futureX} y={0}
                       width={layout.width - R.futureX} height={layout.height}
                       fill={P.wire} opacity={0.07} listening={false} />);
         }
+        // The strip's OWN opaque backing (req #3254, code-review finding): once
+        // pinned, the strip floats over whatever band content scrolled up to
+        // meet it, and neither the ticks nor the date text otherwise carry any
+        // fill — so without this a date could render as text bleeding through
+        // a step title rather than legibly over it. Same colour and the same
+        // "chrome gets its own opaque plate" move as the shared top time-axis
+        // in `KonvaSwarmCanvas.jsx` (`background: C.axisBg`), the truer sibling
+        // of this strip than the per-row day headers (which float with no
+        // backing because they are never more than one line of text wide).
+        stickyRulerNodes.push(
+            <Rect key="ruler-sticky-bg" x={0} y={0} width={layout.width} height={R.h}
+                  fill={P.panel} listening={false} />);
         // The strip's baseline — what makes the ticks read as one ruler rather
-        // than as a row of unrelated marks.
-        worldNodes.push(
+        // than as a row of unrelated marks. STICKY: part of the header itself.
+        stickyRulerNodes.push(
             <Line key="ruler-baseline"
                   points={[0, R.h - 2, layout.width, R.h - 2]}
                   stroke={P.line} strokeWidth={1} opacity={0.7}
@@ -1077,7 +1101,8 @@ export default function PipelinePlanVisualizer({
             // three days apart — and the dashes are how the ruler says so
             // without spending a second label on it. `gapDays` is null on the
             // first dated slot and on the undated/future ones, where there is no
-            // predecessor to have skipped anything.
+            // predecessor to have skipped anything. WORLD space — the boundary
+            // runs the whole plan's height, same reasoning as the future tint.
             const gapped = s.gapDays != null && s.gapDays > 1;
             // The first slot's rule would land in the left gutter, where it
             // marks nothing: there is no earlier slot for it to divide from.
@@ -1092,8 +1117,8 @@ export default function PipelinePlanVisualizer({
             // The tick itself, in the strip, at every slot — including the ones
             // whose LABEL was thinned away. The tick is 1px of geometry and can
             // never collide, so a degraded ruler still shows every boundary it
-            // has; only the dates thin out.
-            worldNodes.push(
+            // has; only the dates thin out. STICKY: part of the header strip.
+            stickyRulerNodes.push(
                 <Line key={`ruler-tick-${s.key}`}
                       points={[s.x, R.h - 9, s.x, R.h - 2]}
                       stroke={P.dim} strokeWidth={1} opacity={0.8}
@@ -1301,7 +1326,21 @@ export default function PipelinePlanVisualizer({
             // would make a plan with no timestamps read as a plan that is
             // entirely in the future, which is the opposite claim.
             const accented = label.slotKind === 'future';
-            worldNodes.push(
+            // STICKY (req #3254): part of the header strip, not the world —
+            // see `stickyRulerNodes`'s own comment above. `label.x`/`label.y`
+            // are unchanged (the vitest zero-overlap sweep, which runs at a
+            // fixed transform with no pan, still covers this rect exactly as
+            // it did before), but the sweep's guarantee is a LAYOUT-time one:
+            // it does NOT extend across a live pan, because this is now the
+            // one label kind whose SCREEN position is `stickyRulerY(t)` where
+            // every other label's is `t.y`. Once the strip pins (`t.y < 0`),
+            // a step or requirement label scrolled up near the viewport top
+            // can land under it on screen — the same trade-off the sticky
+            // epic chips already accept (their own comment: "a sticky chip
+            // landed on a live bead" was a known, documented cost, not a
+            // defect to chase to zero). `collectWorldObstacles` excludes this
+            // kind for the identical reason it already excludes `'epic'`.
+            stickyRulerNodes.push(
                 <Text key={`lbl-${i}`} x={label.x} y={label.y} text={label.text}
                       fontSize={F.slot} fontFamily={MONO}
                       fill={accented ? P.accent : P.dim}
@@ -1391,6 +1430,14 @@ export default function PipelinePlanVisualizer({
                  // proof that thinning ran.
                  data-ruler={`${layout.ruler.slots.length},${
                      layout.ruler.slots.filter((s) => s.showLabel).length}`}
+                 // The sticky ruler's actual rendered Y (req #3254) — same
+                 // device and same reason as `data-transform`: whether the
+                 // strip is genuinely pinned to the viewport top rather than
+                 // scrolling off with the world is otherwise only observable
+                 // as pixels. `stickyRulerY(t)` is exactly what the sticky
+                 // Group below is drawn at, so this can never drift from what
+                 // the canvas actually did.
+                 data-ruler-y={stickyRulerY(t).toFixed(2)}
                  data-level={level}
                  data-drawn={drawnKinds}
                  // Full-page canvas (req #3119), the KonvaSwarmCanvas figure
@@ -1417,6 +1464,18 @@ export default function PipelinePlanVisualizer({
                         <Layer ref={layerRef}>
                             <Group x={t.x} y={t.y} scaleX={t.k} scaleY={t.k}>
                                 {worldNodes}
+                            </Group>
+                            {/* The sticky ruler strip (req #3254) — SAME x/scale
+                                as the world Group above (so ticks and labels
+                                still pan/zoom horizontally with the columns
+                                beneath them), but `y` is pinned via
+                                `stickyRulerY(t)` instead of `t.y`, decoupling it
+                                from vertical pan. Drawn AFTER the world Group so
+                                it floats on top of scrolled-under content, the
+                                same z-order a sticky header always wants. */}
+                            <Group x={t.x} y={stickyRulerY(t)} scaleX={t.k}
+                                   scaleY={t.k} listening={false}>
+                                {stickyRulerNodes}
                             </Group>
                         </Layer>
                     </Stage>

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -29,6 +29,7 @@ import {
     REQ_LINE_H,
     FOCUS_MAX_RATIO, FOCUS_MIN_RATIO, FOCUS_PAD, STEP_DONE, ZOOM_MAX_RATIO, ZOOM_MIN_RATIO, bandFitRect, epicFocusTransform,
     RULER_H, computeRuler, slotTickText, factoryDefaultScale,
+    stickyRulerY, rulerScreenBottom,
     EPIC_PALETTE,
     PAUSE_ACTIVE_COLOR, PAUSE_PAUSED_COLOR, pauseBubbleColor, EPIC_PAUSE_BUBBLE_W,
 } from '../pipelinePlanLayout';
@@ -1222,6 +1223,22 @@ describe('collectWorldObstacles (req #3210)', () => {
         const epicLabels = layout.labels.filter((l) => l.kind === 'epic');
         expect(epicLabels.length).toBeGreaterThan(0);
         for (const l of epicLabels) {
+            expect(out.some((o) => o.x === l.x && o.y === l.y && o.w === l.w && o.h === l.h))
+                .toBe(false);
+        }
+    });
+
+    it('excludes ruler slot labels (req #3254) — sticky since #3254, not world-projectable', () => {
+        // The strip pins to `stickyRulerY(t)`, a DIFFERENT transform than every
+        // other label here, so a world-space rect for it would be silently
+        // wrong the moment the strip pins — `placeEpicChips` would project it
+        // with the ordinary `t.y + y·k` formula and clear a box the label does
+        // not actually occupy on screen. Same treatment as `kind: 'epic'` above,
+        // and for the identical reason.
+        const out = collectWorldObstacles(layout, { drawsKind: () => true });
+        const slotLabels = layout.labels.filter((l) => l.kind === 'slot');
+        expect(slotLabels.length).toBeGreaterThan(0);
+        for (const l of slotLabels) {
             expect(out.some((o) => o.x === l.x && o.y === l.y && o.w === l.w && o.h === l.h))
                 .toBe(false);
         }
@@ -3471,6 +3488,53 @@ describe('time ruler (req #3207)', () => {
 
     it('renders a tick with no # — the production directive covers generated text', () => {
         for (const l of rulerLabels(timedLayout)) expect(l.text).not.toContain('#');
+    });
+});
+
+// ── The sticky ruler pin (req #3254) ────────────────────────────────────────
+// The ruler used to be plain world content — attached to the top of the
+// timeline, so panning down scrolled it away with the rest of the plan.
+// `stickyRulerY`/`rulerScreenBottom` are the pure pin primitives the canvas
+// now anchors the ruler's Group to instead of `t.y` directly — same shape as
+// `computeDayHeaders`' `Math.max(axisH, screenY)`, simplified to the one-strip
+// case (nothing pushes it, nothing for it to drop behind).
+describe('sticky ruler pin (req #3254)', () => {
+    it('draws at the natural position while the world has not scrolled past the top', () => {
+        expect(stickyRulerY({ x: 0, y: 0, k: 1 })).toBe(0);
+        expect(stickyRulerY({ x: 0, y: 40, k: 1 })).toBe(40);
+        expect(stickyRulerY({ x: 0, y: 200, k: 2.5 })).toBe(200);
+    });
+
+    it('clamps flush to the viewport top once the natural position scrolls past it', () => {
+        expect(stickyRulerY({ x: 0, y: -1, k: 1 })).toBe(0);
+        expect(stickyRulerY({ x: 0, y: -600, k: 1 })).toBe(0);
+        expect(stickyRulerY({ x: 0, y: -3000, k: 3 })).toBe(0);
+    });
+
+    it('degrades safely on a missing or malformed transform', () => {
+        expect(stickyRulerY(null)).toBe(0);
+        expect(stickyRulerY(undefined)).toBe(0);
+        expect(stickyRulerY({})).toBe(0);
+    });
+
+    it("rulerScreenBottom is the pinned Y plus the strip's own scaled height", () => {
+        // Scrolled past — pinned to 0, so the bottom edge is exactly RULER_H
+        // scaled by k, the number req #3257 clamps epic names below.
+        expect(rulerScreenBottom({ x: 0, y: -400, k: 1 })).toBe(RULER_H);
+        expect(rulerScreenBottom({ x: 0, y: -400, k: 2 })).toBe(RULER_H * 2);
+        // Not yet scrolled past — natural position adds to the strip height.
+        expect(rulerScreenBottom({ x: 0, y: 50, k: 1 })).toBe(50 + RULER_H);
+    });
+
+    it('accepts a custom ruler height, defaulting to RULER_H', () => {
+        expect(rulerScreenBottom({ x: 0, y: -400, k: 1 }, 20)).toBe(20);
+        expect(rulerScreenBottom({ x: 0, y: 0, k: 1 })).toBe(RULER_H);
+    });
+
+    it('degrades safely on a missing or zero/negative k', () => {
+        expect(rulerScreenBottom(null)).toBe(RULER_H);
+        expect(rulerScreenBottom({ x: 0, y: 0, k: 0 })).toBe(RULER_H);
+        expect(rulerScreenBottom({ x: 0, y: 0, k: -1 })).toBe(RULER_H);
     });
 });
 

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -842,11 +842,16 @@ export function computeTimeColumns(rows, byId, depsOf, timeAxis) {
 // Three marks, because each answers a different question and none of them is a
 // restatement of another (the ONE FACT, ONE CHANNEL rule above):
 //
-//   · the STRIP says WHICH day a column is. It is world text at the top of the
-//     plan, so it scrolls off when you pan down — which is exactly why it is
-//     not the only mark.
+//   · the STRIP says WHICH day a column is. Sticky to the viewport top since
+//     req #3254 (`stickyRulerY`, below) — it used to be world text that
+//     scrolled off when you panned down, which was the ORIGINAL reason it
+//     could not be the only mark. Now pinned, it still is not the only mark:
+//     a reader scrolled deep into one band has no strip-adjacent reference
+//     for a column that is off past the right or left edge, which the
+//     separators and future tint answer without moving.
 //   · the SEPARATORS say WHERE a day begins. Full-height rules at slot origins,
-//     readable at any vertical pan.
+//     readable at any vertical pan (deliberately NOT sticky — they mark
+//     content, not chrome, so they stay world-space and scroll with it).
 //   · the FUTURE TINT says where the not-yet-begun region starts. That boundary
 //     is the single thing a plan is most often opened to find, and a rule alone
 //     does not say which SIDE of it is the future.
@@ -995,6 +1000,37 @@ export function computeRuler(slots, colX, colW, totalW) {
         slots: out,
         futureX: fut ? fut.x : null,
     };
+}
+
+// ── The sticky ruler pin (req #3254) ────────────────────────────────────────
+// The ruler used to be plain world content — baseline, ticks and slot labels
+// all sat at world y ∈ [0, RULER_H], "attached to the top item in the stack"
+// (the requirement's own words) — so panning down scrolled it away with the
+// rest of the plan and left nothing on screen naming which column is which
+// day. `stickyRulerY` is the SAME pin primitive `computeDayHeaders`
+// (`dayHeaderLayout.js`) and the sticky prev/next epic chips above
+// (`placeEpicChips`) both use — draw at the natural screen position until it
+// scrolls past the viewport edge, then clamp flush to it — simplified to the
+// one-strip case: there is exactly one ruler, so nothing pushes it and it
+// never drops behind (it is a standing fact about the whole plan, not a
+// per-row banner that can be superseded). Only the Y anchor decouples from
+// vertical pan; X is untouched, so slot ticks and labels still pan and zoom
+// with the columns beneath them.
+export function stickyRulerY(t) {
+    const ty = (t && typeof t.y === 'number') ? t.y : 0;
+    return Math.max(0, ty);
+}
+
+// The pinned strip's bottom edge in SCREEN space — req #3254's contract with
+// req #3257 (the concurrent epic-name work): "the date header owns the
+// topmost strip and the epic names stop just below it" needs ONE readable
+// number, not a guessed pixel offset. Scales with zoom because the strip's
+// own ticks and text do (deviation 2 — zoom is a pure transform on this
+// surface), so a caller reading the SAME transform gets the exact edge the
+// ruler is drawn at, pinned or not.
+export function rulerScreenBottom(t, rulerH = RULER_H) {
+    const k = (t && typeof t.k === 'number' && t.k > 0) ? t.k : 1;
+    return stickyRulerY(t) + rulerH * k;
 }
 
 const truncate = (s, n) => {
@@ -2177,6 +2213,24 @@ export const EPIC_CHIP_BG_ALPHA = 0.6;
  * see the `kind === 'epic'` no-op in the component's own world-node loop), so
  * including them would avoid a mark that is not actually there.
  *
+ * `kind: 'slot'` labels (the time ruler, req #3207) are excluded for the SAME
+ * reason, since req #3254: the ruler now draws in a Group anchored at
+ * `stickyRulerY(t)`, not `t.y` (it pins to the viewport top instead of
+ * scrolling with the world) — a DIFFERENT transform than every other label
+ * this function assumes. Reporting `{x: l.x, y: l.y, ...}` here is a world
+ * coordinate `placeEpicChips` then projects with the ORDINARY `t.y + y·k`
+ * formula, which only agrees with where a slot label actually draws while
+ * `t.y >= 0`; the moment the strip pins (`t.y < 0`) the reported rect drifts
+ * from the real one by the exact pin distance, silently clearing a box a
+ * sticky epic chip can then land on. There is no world-space rect this
+ * function could report that `placeEpicChips`' transform would project
+ * correctly at every `t.y` — the sticky strip is screen-anchored, full stop
+ * — so, like the epic label, it is left out rather than reported wrong.
+ * (Which means a sticky/natural epic chip can currently land on a ruler
+ * label — the concurrent req #3257 is what clamps epic names below the
+ * strip via `rulerScreenBottom`; this function only has to stop lying about
+ * where the label is, not solve that placement itself.)
+ *
  * @param {Object} layout `computePlanLayout`'s own return value
  * @param {Object} [args]
  * @param {(kind: string) => boolean} [args.drawsKind]
@@ -2190,7 +2244,7 @@ export function collectWorldObstacles(layout, { drawsKind = () => true, eligible
         out.push({ x: n.x - r, y: n.y - r, w: 2 * r, h: 2 * r });
     }
     for (const l of layout?.labels || []) {
-        if (l.kind === 'epic' || !drawsKind(l.kind)) continue;
+        if (l.kind === 'epic' || l.kind === 'slot' || !drawsKind(l.kind)) continue;
         out.push({ x: l.x, y: l.y, w: l.w, h: l.h });
     }
     for (const a of layout?.arcs || []) {

--- a/tests/tests/pipelines.spec.ts
+++ b/tests/tests/pipelines.spec.ts
@@ -713,6 +713,50 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             }
         });
 
+    test('PIPE-10c: the time ruler pins to the viewport top through a vertical pan (req #3254)',
+        async ({ page }) => {
+            // Req #3254: the ruler used to be plain world content — attached to
+            // the top of the timeline — so a vertical pan scrolled it away with
+            // the rest of the plan. `data-ruler-y` publishes what the sticky
+            // Group is ACTUALLY drawn at (`stickyRulerY(t)`, the same device as
+            // `data-transform` beside it), so this is checked without a pixel
+            // diff — the same reasoning PIPE-10b uses for the ruler's other
+            // half (the degradation count).
+            const canvas = await openPlanVisualizer(page, fixture.batchPipelineId);
+            const container = page.getByTestId('pipeline-plan-visualizer');
+
+            const readTy = async () =>
+                Number((await container.getAttribute('data-transform'))!.split(',')[1]);
+
+            // At the DEFAULT view the world hasn't scrolled past the top yet,
+            // so the strip draws at its natural (unpinned) position — 0, same
+            // as `t.y` at the identity transform.
+            const tyBefore = await readTy();
+            expect(tyBefore).toBeCloseTo(0, 3);
+            await expect(container).toHaveAttribute('data-ruler-y', '0.00');
+
+            // A LARGE, PURELY VERTICAL drag — the batch plan has more than one
+            // band, so there is real room to scroll down into it.
+            const box = (await canvas.boundingBox())!;
+            await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+            await page.mouse.down();
+            await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 - 400,
+                { steps: 12 });
+            await page.mouse.up();
+
+            const tyAfter = await readTy();
+            // The pan must be REAL, not swallowed by the zoom behavior's
+            // filter or clamped away by `bound()` — otherwise the assertion
+            // below (that the strip stayed pinned) would be vacuous.
+            expect(tyBefore - tyAfter, 'the drag must move the world vertically')
+                .toBeGreaterThan(50);
+
+            // The whole point: once the world has scrolled past the top, the
+            // strip clamps flush to the viewport edge — 0 again — rather than
+            // following `t.y` off-screen the way it did before this fix.
+            await expect(container).toHaveAttribute('data-ruler-y', '0.00');
+        });
+
     test('PIPE-11: bead, requirement and epic click targets navigate', async ({ page }) => {
         // The BATCH plan, on purpose. Canvas hit targets are world-space and the
         // stage is fit to width, so the screen-space tolerance is


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3254-date-header-stuck-to-viewport-1
- wip(Darwin): 2026-08-02T09:35:35Z
- chore: init swarm session feature/3254-date-header-stuck-to-viewport-1

## Files changed
```
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx | 79 +++++++++++++++++++---
 .../pipelines/__tests__/pipelinePlanLayout.test.js | 64 ++++++++++++++++++
 src/SwarmView/pipelines/pipelinePlanLayout.js      | 64 ++++++++++++++++--
 tests/tests/pipelines.spec.ts                      | 44 ++++++++++++
 4 files changed, 236 insertions(+), 15 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)