### PR TITLE
Deferred requirements should count as done in met/total displays

### DIFF
--- a/src/SwarmView/pipelines/__tests__/pipelineConformance.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineConformance.test.js
@@ -367,18 +367,19 @@ describe('pipeline conformance — the anchors', () => {
         expect(c.expect.batches, 'the server keeps them apart').toEqual([]);
     });
 
-    it('requirement_counts excludes tracking and keeps terminal statuses in '
-        + 'the denominator (req #3225)', () => {
+    it('requirement_counts excludes tracking and counts terminal statuses in '
+        + 'the numerator (req #3269, correcting req #3225)', () => {
         // The two decisions the requirement asked to be stated, not guessed:
         // a TRACKING requirement moves neither side of the ratio (even a
-        // `met` one), and wontfix/deferred count toward the denominator but
-        // never the numerator.
+        // `met` one), and wontfix/deferred count toward BOTH the denominator
+        // AND the numerator, exactly like `met` — they are already
+        // `TERMINAL_REQUIREMENT_STATUSES`.
         const c = byName('requirement-counts-tracking-and-terminal-statuses');
         const observed = observe(c.model, c.now).requirement_counts;
-        expect(observed.overall).toEqual({ met: 2, total: 5 });
+        expect(observed.overall).toEqual({ met: 4, total: 5 });
         expect(observed.by_epic).toEqual([
-            { epic_id: 21, met: 2, total: 3 },
-            { epic_id: 22, met: 0, total: 2 },
+            { epic_id: 21, met: 3, total: 3 },
+            { epic_id: 22, met: 1, total: 2 },
         ]);
     });
 

--- a/src/SwarmView/pipelines/__tests__/pipelineModel.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineModel.test.js
@@ -1130,7 +1130,7 @@ describe('cost aggregation (req #3117 server-side rollup)', () => {
     });
 });
 
-describe('requirementCounts — met/total, per epic and for the whole plan (req #3225)', () => {
+describe('requirementCounts — met/total, per epic and for the whole plan (req #3225, req #3269)', () => {
     const model = (requirements, features = [], epics = []) => ({ requirements, features, epics });
 
     it('counts met over total, excluding nothing but tracking containers', () => {
@@ -1169,18 +1169,34 @@ describe('requirementCounts — met/total, per epic and for the whole plan (req 
         expect(requirementCounts(m).overall).toEqual({ met: 1, total: 1 });
     });
 
-    it('wontfix and deferred count toward the denominator, never the numerator', () => {
-        // req #3225's own recommendation: the ratio answers "how much of this
-        // is FINISHED", not "how much has stopped moving" — a plan can sit
-        // permanently short of its total on these two statuses, by design.
+    it('wontfix and deferred count toward the numerator, exactly like met '
+        + '(req #3269, correcting req #3225)', () => {
+        // Both sit in TERMINAL_REQUIREMENT_STATUSES — the same set that
+        // already makes a step derive `done` — so an epic whose only
+        // non-met requirement is deferred/wontfix must read N/N, not one
+        // short.
         const m = model([
             { id: 1, requirement_status: 'met', feature_fk: 101 },
             { id: 2, requirement_status: 'wontfix', feature_fk: 101 },
             { id: 3, requirement_status: 'deferred', feature_fk: 101 },
         ], [{ id: 101, title: 'F', epic_fk: 1 }], [{ id: 1, title: 'E' }]);
         expect(requirementCounts(m)).toEqual({
-            overall: { met: 1, total: 3 },
-            byEpic: [{ epicId: 1, met: 1, total: 3 }],
+            overall: { met: 3, total: 3 },
+            byEpic: [{ epicId: 1, met: 3, total: 3 }],
+        });
+    });
+
+    it('authoring/approved/swarm_ready/development stay outstanding', () => {
+        const m = model([
+            { id: 1, requirement_status: 'met', feature_fk: 101 },
+            { id: 2, requirement_status: 'authoring', feature_fk: 101 },
+            { id: 3, requirement_status: 'approved', feature_fk: 101 },
+            { id: 4, requirement_status: 'swarm_ready', feature_fk: 101 },
+            { id: 5, requirement_status: 'development', feature_fk: 101 },
+        ], [{ id: 101, title: 'F', epic_fk: 1 }], [{ id: 1, title: 'E' }]);
+        expect(requirementCounts(m)).toEqual({
+            overall: { met: 1, total: 5 },
+            byEpic: [{ epicId: 1, met: 1, total: 5 }],
         });
     });
 
@@ -1237,8 +1253,12 @@ describe('requirementCounts — met/total, per epic and for the whole plan (req 
         const observed = requirementCounts(SUBSTRATE_REBUILD_MODEL);
         const nonTracking = reqs.filter((r) => !trackingIds.includes(r.id));
         expect(observed.overall.total).toBe(nonTracking.length);
+        // Literal set, not the imported constant — this must stay an INDEPENDENT
+        // reduce, so a regression that silently grows or shrinks
+        // TERMINAL_REQUIREMENT_STATUSES still fails this assertion.
         expect(observed.overall.met).toBe(
-            nonTracking.filter((r) => r.requirement_status === 'met').length);
+            nonTracking.filter((r) => ['met', 'deferred', 'wontfix']
+                .includes(r.requirement_status)).length);
         // #3083 is `development` and would have moved the numerator toward
         // zero-relative-to-itself either way, but it must not appear in ANY
         // epic bucket at all — this is the one requirement excluded outright.

--- a/src/SwarmView/pipelines/pipelineModel.js
+++ b/src/SwarmView/pipelines/pipelineModel.js
@@ -1268,10 +1268,14 @@ export function aggregateRowCost(row, index) {
 // acceptance criteria of its own; counting it either way would make a plan
 // that TRACKS ITSELF read as permanently short of — or trivially at — 100%.
 //
-// `wontfix`/`deferred` stay IN THE DENOMINATOR and OUT OF THE NUMERATOR
-// (req #3225's own recommendation): the ratio answers "how much of this is
-// FINISHED", not "how much has stopped moving" — a plan can sit permanently
-// short of its total, and that is the intended reading, not a stall.
+// THE NUMERATOR IS `TERMINAL_REQUIREMENT_STATUSES`, not a bare `=== 'met'`
+// compare (req #3269). `wontfix`/`deferred` count toward it exactly like
+// `met` does — the same set that already makes a step derive `done` (design
+// rule 1), so a step whose requirements are all deferred is already Complete
+// and its epic's count must agree rather than reading one short. req #3225's
+// original "deferred/wontfix count toward the denominator only" reading made
+// the label disagree with the state machine drawn beside it; this is the
+// correction, not a new notion of doneness.
 //
 // GROUPED BY THE REQUIREMENT'S OWN feature_fk -> epic chain, deliberately not
 // the step's dominant epic (rule 10's tie-break answers a different question —
@@ -1294,7 +1298,7 @@ export function requirementCounts(model) {
     const byEpic = new Map();
     for (const req of (model && model.requirements) || []) {
         if (!req || isTrackingRequirement(req)) continue;
-        const met = req.requirement_status === 'met';
+        const met = TERMINAL_REQUIREMENT_STATUSES.includes(req.requirement_status);
         overall.total += 1;
         if (met) overall.met += 1;
         const feature = req.feature_fk != null ? featuresById.get(req.feature_fk) : null;


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-02T11:08:57Z
- chore: init swarm session feature/3269-deferred-requirements-should-count-1

## Files changed
```
 .../__tests__/pipelineConformance.test.js          | 15 ++++-----
 .../pipelines/__tests__/pipelineModel.test.js      | 36 +++++++++++++++++-----
 src/SwarmView/pipelines/pipelineModel.js           | 14 ++++++---
 3 files changed, 45 insertions(+), 20 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)