### PR TITLE
Plan visualizer: the next-up halo is invisible at L1 because it scales with the zoom

### DIFF
--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -114,6 +114,7 @@ import {
     CHW_EPIC, ZOOM_MIN_RATIO, ZOOM_MAX_RATIO,
     K_READABLE, DEFAULT_STEP_WIDTH, EPIC_CHIP_BG_ALPHA,
     NEXT_HALO_RADIUS, NEXT_HALO_STROKE, NEXT_HALO_OPACITY, NEXT_HALO_DASH,
+    nextHaloMagnify, BEAD_LANE_OFFSET,
     buildMachineColorView, reqIdStyle, reqIdKeyEntries, normalizeColorKey,
     DEFAULT_COLOR_KEY, PLAN_KEY_MAX_W, pinnedLevelOf, DEFAULT_PLAN_LEVEL_PREF,
     EPIC_PAUSE_BUBBLE_D, pauseBubbleColor, stickyRulerY, rulerScreenBottom,
@@ -162,14 +163,19 @@ const FOCUS_MS = 420;
 // channel colours TYPE instead (LegendWord, below) — a dot there would
 // misrepresent it as another bead, which is why this swatch only ever draws
 // the STEP channel's marks now.
-function LegendDot({ fill, ring, label, animated }) {
+// `dashed` (req #3271): the canvas's next-step halo is DASHED, and that is not
+// decoration — only 0.25px separates it from the bead's own eligible ring, so
+// form rather than distance is the whole of what makes it read as a second mark
+// (see NEXT_HALO_DASH). A key that advertised it as a solid ring described a
+// mark the canvas does not draw, in the one channel where form carries meaning.
+function LegendDot({ fill, ring, label, animated, dashed }) {
     return (
         <Stack direction="row" spacing={0.5} alignItems="center">
             <Box sx={{
                 width: 10, height: 10, flexShrink: 0,
                 borderRadius: '50%',
                 bgcolor: fill || 'transparent',
-                border: ring ? `2px solid ${ring}` : 'none',
+                border: ring ? `2px ${dashed ? 'dashed' : 'solid'} ${ring}` : 'none',
                 // The key SHOWS the motion it describes rather than only
                 // naming it — the two animated marks are the two questions
                 // this page exists to answer, and a static swatch beside the
@@ -1308,7 +1314,11 @@ export default function PipelinePlanVisualizer({
         for (let l = 0; l < band.sub; l++) {
             // band.laneY, not l × pitch — lanes have individual heights since
             // req #3119 and a constant-pitch wire would drift off its beads.
-            const wy = band.y + band.headerH + band.laneY[l] + 10;
+            // BEAD_LANE_OFFSET, not a literal 10: this is the same offset the
+            // layout places the beads at, and the wire's whole job is to run
+            // through them (req #3271 hoist — two copies that "only have to
+            // agree" is what the naming exists to prevent).
+            const wy = band.y + band.headerH + band.laneY[l] + BEAD_LANE_OFFSET;
             worldNodes.push(
                 <Line key={`wire-${band.key}-${l}`}
                       points={[36, wy, layout.width - 14, wy]}
@@ -1418,6 +1428,21 @@ export default function PipelinePlanVisualizer({
                   onMouseLeave={(e) => { cursorPointer(e, false); hideCard(); }} />);
     });
 
+    // The next-step halo's magnification for THIS frame (req #3271). Computed
+    // once per render rather than per row: it depends only on the scale being
+    // drawn at and on whether this level draws labels, and `dash` is an array
+    // prop — a fresh one per bead would hand react-konva a changed reference for
+    // every halo on every frame of a zoom.
+    //
+    // NOT a `useMemo`, and it cannot become one: the `!rows.length` early return
+    // above sits between this and the last hook, so a hook here would be
+    // conditional. At m === 1 the shared constant is returned by reference and
+    // nothing is allocated at all; above it the array is rebuilt per render,
+    // which costs one `setAttr` on a layer the halo animation is already
+    // redrawing every frame.
+    const haloM = nextHaloMagnify(t.k, drawsKind('step'));
+    const haloDash = haloM === 1 ? NEXT_HALO_DASH : NEXT_HALO_DASH.map((d) => d * haloM);
+
     rows.forEach((row) => {
         const n = layout.nodes.get(row.id);
         if (!n) return;
@@ -1433,12 +1458,21 @@ export default function PipelinePlanVisualizer({
         // when the engine says this step's launch is SUPPRESSED (a paused
         // scope): the ring beneath it stays green (still eligible), so the
         // two together read as "eligible, but held", not "about to run".
+        //
+        // req #3271 — EMITTING it at 'out' was never the same as it reading
+        // there. This Group is scaled by `t.k` and Konva scales stroke and dash
+        // with it, so on the live plan Overview drew a 0.8px stroke with 1.2px
+        // dashes: present in the scene graph, absent on the screen. `haloM`
+        // magnifies the whole mark — radius, stroke and dash by ONE factor, so
+        // its shape is invariant — into the room the labels vacate at that
+        // level. It is exactly 1 wherever the labels ARE drawn, so 'mid' and
+        // 'in' are untouched. See `nextHaloMagnify`.
         if (style.next) {
             worldNodes.push(
                 <Circle key={`next-${row.id}`} name="next-halo" x={n.x} y={n.y}
-                        radius={NEXT_HALO_RADIUS} stroke={style.haloColor}
-                        strokeWidth={NEXT_HALO_STROKE} opacity={NEXT_HALO_OPACITY}
-                        dash={NEXT_HALO_DASH} listening={false} />);
+                        radius={NEXT_HALO_RADIUS * haloM} stroke={style.haloColor}
+                        strokeWidth={NEXT_HALO_STROKE * haloM} opacity={NEXT_HALO_OPACITY}
+                        dash={haloDash} listening={false} />);
         }
         worldNodes.push(
             <Group key={`bead-${row.id}`} name={style.pulse ? 'pulse-bead' : undefined}>
@@ -2119,7 +2153,7 @@ export default function PipelinePlanVisualizer({
                                     mark answers the question in the plan's own
                                     words: these are the steps that run next. */}
                                 <LegendDot ring={P.eligibleRing} label="next up"
-                                           animated="pipeKeyBreathe" />
+                                           dashed animated="pipeKeyBreathe" />
                             </KeyGroup>
 
                             {/* THE REQUIREMENT channel — all three scales in ONE

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -17,7 +17,9 @@ import {
     computePlanLayout, beadStyle, stepLabelText, BEAD_RADIUS, BEAD_HIT_RADIUS,
     PLAN_VIZ_PALETTE, placeEpicChips, EPIC_CHIP_OPEN_LINK_W,
     STEP_WIDTH_FACTORS, isStepWidth, K_READABLE, PLAN_VIZ_FONT, READABLE_MIN_PX,
-    NEXT_HALO_RADIUS, NEXT_HALO_STROKE, EPIC_CHIP_CHAR_W,
+    NEXT_HALO_RADIUS, NEXT_HALO_STROKE, NEXT_HALO_DASH, EPIC_CHIP_CHAR_W,
+    NEXT_HALO_SCREEN_RADIUS, NEXT_HALO_MAX_OUTER, NEXT_HALO_MAX_MAGNIFY,
+    NEXT_HALO_CLEARANCES, nextHaloMagnify, BEAD_RING_W_EMPHASIS, BEAD_OUTER_RADIUS,
     EPIC_CHIP_FONT, EPIC_CHIP_H, EPIC_CHIP_MIN_H, EPIC_CHIP_MIN_CHARS,
     EPIC_CHIP_PAD_W,
     REQ_STATUS_COLORS, REQ_STATUS_ORDER, REQ_STATUS_UNKNOWN_COLOR, reqStatusColor,
@@ -1167,7 +1169,13 @@ describe('batch letters and box lane spans (req #3256)', () => {
         }
         // Guards the sweep against silently generating nothing to look at.
         expect(boxes).toBeGreaterThan(1000);
-    });
+        // The 5s default was never right for this one — "well under a second"
+        // above was measured on an idle machine, and 300 seeded plans × the
+        // full property set runs 1.1–3.9s in practice, so it timed out
+        // intermittently under any parallel load (observed on an unmodified
+        // tree, before req #3271 added to this file). A budget matched to the
+        // work it actually does, rather than a flake nobody owns.
+    }, 30000);
 });
 
 describe('bead vocabulary (POC roles)', () => {
@@ -2181,6 +2189,349 @@ describe('next-step highlight (req #3168)', () => {
     it('suppressed with no `next` (not eligible) is inert — nothing draws the halo', () => {
         const style = beadStyle(rowById.get(1), false, true);
         expect(style.next).toBe(false);
+    });
+});
+
+// ── The halo has to SURVIVE Overview (req #3271) ────────────────────────────
+// Everything above pins the halo's WORLD geometry. None of it could see the
+// bug: the mark is drawn inside a group scaled by `k`, and Konva scales stroke
+// width and dash pitch along with the radius, so at the live plan's Overview
+// (measured: kDefault 0.8, therefore k < 0.4 by the level ladder's own
+// definition of 'out') a 2px stroke with 3px dashes rendered at 0.8px and 1.2px
+// — emitted, and invisible. These cases pin the SCREEN-side behaviour, which is
+// the half no world-unit assertion can reach.
+describe('the next-step halo survives Overview (req #3271)', () => {
+    // A k sweep spanning everything the zoom behavior can reach: the scale
+    // extent is [kFloor, kDefault × 8] and kDefault is at least K_READABLE.
+    const K_SWEEP = [0.05, 0.1, 0.15, 0.2, 0.3, 0.35, 0.4, 0.5, 0.7,
+        0.9, 1, 1.2, 1.9, 2.5, 4, 6.4, 10];
+    const outerAt = (m) => (NEXT_HALO_RADIUS + NEXT_HALO_STROKE / 2) * m;
+    const innerAt = (m) => (NEXT_HALO_RADIUS - NEXT_HALO_STROKE / 2) * m;
+
+    // The halo's ceiling is measured against the bead's own ring, so that width
+    // has to be the one `beadStyle` HANDS THE CANVAS, not a second copy of it.
+    // (Asserting `BEAD_OUTER_RADIUS === BEAD_RADIUS + BEAD_RING_W_EMPHASIS / 2`
+    // as well would restate the line that defines it; the literal 2.5 is already
+    // pinned independently above.)
+    it('reads the bead ring width from the style the canvas is given', () => {
+        const eligibleRow = plan.rows.find((r) => r.id === 17);
+        expect(beadStyle(eligibleRow, true).ringWidth).toBe(BEAD_RING_W_EMPHASIS);
+    });
+
+    // THE 'in'/'mid' GUARANTEE, and the reason the label-clearance case above
+    // stays the binding one: wherever a step or requirement label is drawn, the
+    // halo is byte-identical to what it was before this existed.
+    it('is exactly 1 at every k where the labels are drawn', () => {
+        for (const k of K_SWEEP) {
+            expect(nextHaloMagnify(k, true), `k=${k}`).toBe(1);
+        }
+    });
+
+    // Zooming IN never changes the mark either. Only the zoomed-OUT half of the
+    // range, where the mark had shrunk below its target, is touched at all.
+    it('is exactly 1 once the mark already meets its target on screen', () => {
+        for (const k of K_SWEEP.filter((v) => v >= 1)) {
+            expect(nextHaloMagnify(k, false), `k=${k}`).toBe(1);
+        }
+    });
+
+    // THE REGRESSION PIN THE REQUIREMENT ASKED FOR. If this ever reverts to
+    // world units, every one of these products collapses to `constant × k` and
+    // the case fails at the first k in the sweep.
+    it('holds the halo SCREEN-constant across a k sweep, until the cap bites', () => {
+        for (const k of K_SWEEP) {
+            const m = nextHaloMagnify(k, false);
+            if (m >= NEXT_HALO_MAX_MAGNIFY || m === 1) continue;
+            // The RADIUS product is an algebraic identity of the definition of
+            // `m` and can never fail — it is here to name the target, not to
+            // guard it. The STROKE and DASH products are the load-bearing
+            // assertions: they hold only while the screen radius the halo aims
+            // at is its own world radius, so retuning NEXT_HALO_SCREEN_RADIUS
+            // in isolation breaks them.
+            expect(NEXT_HALO_RADIUS * m * k, `radius px at k=${k}`)
+                .toBeCloseTo(NEXT_HALO_SCREEN_RADIUS, 10);
+            expect(NEXT_HALO_STROKE * m * k, `stroke px at k=${k}`)
+                .toBeCloseTo(NEXT_HALO_STROKE, 10);
+            for (const [i, d] of NEXT_HALO_DASH.entries()) {
+                expect(d * m * k, `dash[${i}] px at k=${k}`).toBeCloseTo(d, 10);
+            }
+        }
+        // The sweep must actually EXERCISE the screen-constant branch, or the
+        // loop above passes by skipping everything (review-proofing).
+        const exercised = K_SWEEP.filter((k) => {
+            const m = nextHaloMagnify(k, false);
+            return m > 1 && m < NEXT_HALO_MAX_MAGNIFY;
+        });
+        expect(exercised.length).toBeGreaterThan(0);
+    });
+
+    // ONE factor for the whole mark, so the shape is invariant: the halo can
+    // only move OUTWARD from a bead that does not grow with it, which is what
+    // keeps the two rings two marks. A fix that counter-scaled the stroke alone
+    // would close this gap instead of opening it.
+    //
+    // IN SCREEN PIXELS, because that is the only place the defect lived. The
+    // world-unit version of this case (`11.5m ≥ 11.25` for every `m ≥ 1`)
+    // cannot fail and says nothing — a review finding on the first draft of
+    // this very block.
+    it('never merges with the bead ring — the gap only opens, on SCREEN', () => {
+        // Below k = 0.5 the world gap of 0.25 is itself sub-pixel, so the
+        // magnification is the ONLY thing that separates the two rings there.
+        // Bounded below by the live plan's own reachable zoom floor
+        // (`min(kFit, kDefault) × ZOOM_MIN_RATIO` = 0.0829 on a 1200px panel) —
+        // the sweep runs further out than the camera can actually go.
+        const LIVE_ZOOM_FLOOR = (1200 / 3620.2) * ZOOM_MIN_RATIO;   // 0.0829
+        // The floor is IN the swept set, not merely its lower bound — a bound
+        // that filters everything below 0.1 does not test the floor it names.
+        // 0.9 rather than 1, because the floor measures 0.97px and rounding that
+        // up to a rule the code does not meet is how a green suite starts lying.
+        const swept = [LIVE_ZOOM_FLOOR,
+            ...K_SWEEP.filter((v) => v < 0.5 && v > LIVE_ZOOM_FLOOR)];
+        for (const k of swept) {
+            const gapPx = (innerAt(nextHaloMagnify(k, false)) - BEAD_OUTER_RADIUS) * k;
+            const unfixedPx = (innerAt(1) - BEAD_OUTER_RADIUS) * k;
+            expect(unfixedPx, `world-constant gap px at k=${k}`).toBeLessThan(0.2);
+            expect(gapPx, `gap px at k=${k}`).toBeGreaterThan(0.9);
+            // The magnification is pinned at its ceiling across this whole band,
+            // so the ratio is one number restated per k — it pins the ceiling
+            // being REACHED, and the per-k pixel assertions carry the rest.
+            //
+            // A LOWER BOUND, not the exact 47. Pinning the number made this case
+            // a second and stricter opinion about how far the ceiling may move
+            // than `takes its ceiling` holds: a retune to 1.9 turns 47 into 42.4
+            // and reddens this for no reason a reader could see, and a ceiling
+            // above 2.5 puts k = 0.4 into the screen-constant branch and breaks
+            // it from the other side (review finding). 30 holds for any
+            // magnification at or above 1.65, and still says the thing worth
+            // saying — the two rings are tens of times further apart than the
+            // mark this requirement replaced.
+            expect(gapPx / unfixedPx, `gap ratio at k=${k}`).toBeGreaterThan(30);
+        }
+        // At the scale the plan OPENS in, the gap is comfortably supra-pixel —
+        // that is the claim this case exists to make, distinct from the floor.
+        const kOpen = 1440 / 3620.2;
+        expect((innerAt(nextHaloMagnify(kOpen, false)) - BEAD_OUTER_RADIUS) * kOpen,
+            'gap px at the opening view').toBeGreaterThan(4);
+        // And the world gap never closes at any k, magnified or not.
+        let prevGap = null;
+        for (const k of [...K_SWEEP].sort((a, b) => b - a)) {
+            const gap = innerAt(nextHaloMagnify(k, false)) - BEAD_OUTER_RADIUS;
+            expect(gap, `k=${k}`).toBeGreaterThan(0);
+            if (prevGap !== null) expect(gap, `k=${k}`).toBeGreaterThanOrEqual(prevGap);
+            prevGap = gap;
+        }
+    });
+
+    // WHAT STOPS IT GROWING, measured against the furniture ITSELF rather than
+    // against the constants the ceiling is derived from. Review found the first
+    // two ceilings by doing exactly this by hand: "never reaches another bead"
+    // cleared beads and crossed the epic chip's strip and its own launch-unit
+    // box on all four sides, through the whole of Overview.
+    it('crosses no world furniture, at any k the zoom can reach', () => {
+        const worstOuter = outerAt(NEXT_HALO_MAX_MAGNIFY);
+        // The substrate fixture in all four label/layout combinations, PLUS the
+        // timed fuzz corpus — which is the only source here that draws launch
+        // -unit boxes in quantity (the substrate plan draws none).
+        const layouts = [
+            ...COMBOS.map((opts) => ({
+                label: `${opts.reqLayout}/${opts.stepLabel}`,
+                layout: computePlanLayout(plan.rows, plan.batches, opts),
+            })),
+            // BOTH requirement layouts. `horizontal` is the default, and its
+            // box bottom is BATCH_BOX_DROP_H = 30 — three world px of slack.
+            // `vertical` is BATCH_BOX_DROP_V = 28, which is the clearance the
+            // ceiling is actually SET BY, leaving exactly the designed 1px. A
+            // sweep that ran only the default asserted 934 times against the
+            // looser constant and never touched the binding one (review finding).
+            ...[...timedFuzzCorpus()].flatMap(({ seed, reads }) => {
+                const p = orderedPlan(buildPipelineModel(reads), { now: FUZZ_NOW });
+                return ['horizontal', 'vertical'].map((reqLayout) => ({
+                    label: `fuzz seed ${seed} ${reqLayout}`,
+                    layout: computePlanLayout(p.rows, p.batches,
+                        { reqLayout, timeAxis: p.timeAxis }),
+                }));
+            }),
+        ];
+        // Violations are COLLECTED and asserted once, not `expect`ed per pair:
+        // this sweeps ~10^5 comparisons and vitest's per-expect overhead is what
+        // pushed the case past its timeout.
+        const bad = [];
+        const seen = { boxes: 0, bands: 0, laneZero: 0, letters: 0, letterPairs: 0 };
+        // Per requirement layout, because `vertical` is the one carrying the
+        // BINDING clearance (BATCH_BOX_DROP_V = 28, 1px of margin) and a total
+        // cannot tell a both-layout sweep from a horizontal-only one: the
+        // horizontal-only version drew 467 boxes, comfortably over any total
+        // threshold that a both-layout count of 934 would also clear.
+        const boxesByLayout = { horizontal: 0, vertical: 0 };
+        let minLetterD2 = Infinity;
+        let minLetterAt = 'none';
+        for (const { label: where, layout } of layouts) {
+            seen.boxes += layout.batchBoxes.length;
+            seen.bands += layout.bands.length;
+            for (const key of Object.keys(boxesByLayout)) {
+                if (where.includes(key)) boxesByLayout[key] += layout.batchBoxes.length;
+            }
+            // Its own launch-unit box, on all four sides.
+            for (const box of layout.batchBoxes) {
+                for (const id of box.stepIds) {
+                    const n = layout.nodes.get(id);
+                    const at = `${where} step ${id}`;
+                    if (n.y - worstOuter <= box.y) bad.push(`${at}: box top`);
+                    if (n.y + worstOuter >= box.y + box.height) bad.push(`${at}: box bottom`);
+                    if (n.x - worstOuter <= box.x) bad.push(`${at}: box left`);
+                    if (n.x + worstOuter >= box.x + box.width) bad.push(`${at}: box right`);
+                }
+            }
+            // The epic chip's strip, which is the room above a LANE-0 bead.
+            // Tested UNCONDITIONALLY for every lane-0 bead: the first version
+            // skipped on the PASSING condition, so its `expect` could only ever
+            // throw and 136 rows sailed past without one comparison running.
+            for (const band of layout.bands) {
+                const chipBottom = band.y + (band.epicLaneH ?? band.headerH);
+                for (const stepId of band.stepIds) {
+                    const n = layout.nodes.get(stepId);
+                    if (!n || n.lane !== 0) continue;
+                    seen.laneZero += 1;
+                    if (n.y - worstOuter <= chipBottom) {
+                        bad.push(`${where} step ${stepId}: epic chip strip`);
+                    }
+                }
+            }
+            // The launch-unit LETTER — text, and the one thing a per-bead
+            // clearance cannot bound, because the letter a halo crosses belongs
+            // to a NEIGHBOURING column's box. Measured at 4 crossings in 467
+            // letters before `beadRectsOf` was widened to the halo's reach.
+            //
+            // Stated as a measured MINIMUM DISTANCE rather than as "no pair
+            // intersects". After the fix no pair comes close, so an
+            // intersection counter reads zero for two different reasons — fixed,
+            // or never compared — and cannot tell them apart. A minimum shrinks
+            // visibly when the geometry moves. Squared distances: this is the
+            // hot loop of the case.
+            const beads = [...layout.nodes.values()];
+            for (const l of layout.labels.filter((x) => x.kind === 'batch')) {
+                seen.letters += 1;
+                for (const n of beads) {
+                    seen.letterPairs += 1;
+                    const dx = Math.max(l.x - n.x, 0, n.x - (l.x + l.w));
+                    const dy = Math.max(l.y - n.y, 0, n.y - (l.y + l.h));
+                    const d2 = dx * dx + dy * dy;
+                    if (d2 < minLetterD2) {
+                        minLetterD2 = d2;
+                        minLetterAt = `${where}: letter ${l.letter} × bead ${n.id}`;
+                    }
+                }
+            }
+        }
+        expect(bad.slice(0, 12)).toEqual([]);
+        // No bead's halo reaches ANY launch-unit letter. MEASURED at its
+        // tightest: 30.82 world px, seed 127 / letter A / bead 4 — the same
+        // letter-and-bead the review found at 19.34, i.e. inside the 23..27
+        // annulus — against a reach of 27, so 3.8px of margin. The MINIMUM is
+        // the whole assertion: a letter far outside the ring and a letter
+        // wholly inside it are both safe, and only the first is reachable here.
+        expect(Math.sqrt(minLetterD2), `nearest letter: ${minLetterAt}`)
+            .toBeGreaterThan(worstOuter);
+        // Non-vacuity, per FURNITURE KIND — a total says nothing about whether
+        // each kind was actually compared against.
+        // Thresholds sit just under the MEASURED counts, not orders of
+        // magnitude below them: a guard at 20 against an actual 1624 catches
+        // total collapse and nothing else.
+        expect(boxesByLayout.horizontal, 'boxes swept, horizontal reqs')
+            .toBeGreaterThan(400);
+        expect(boxesByLayout.vertical, 'boxes swept, vertical reqs — the BINDING clearance')
+            .toBeGreaterThan(400);
+        expect(seen.boxes, 'launch-unit boxes swept').toBeGreaterThan(900);
+        expect(seen.bands, 'epic bands swept').toBeGreaterThan(1500);
+        expect(seen.laneZero, 'lane-0 beads compared to a chip strip')
+            .toBeGreaterThan(6000);
+        expect(seen.letters, 'launch-unit letters swept').toBeGreaterThan(900);
+        expect(seen.letterPairs, 'letter × bead pairs measured').toBeGreaterThan(15000);
+    }, 20000);
+
+    // Kept separate because it is O(beads²): the substrate fixture in all four
+    // combinations is enough to pin it, and the corpus above already covers the
+    // furniture that varies with the plan's SHAPE.
+    it('never reaches another bead, or another bead\'s hit circle', () => {
+        const worstOuter = outerAt(NEXT_HALO_MAX_MAGNIFY);
+        let pairs = 0;
+        for (const opts of COMBOS) {
+            const pts = [...computePlanLayout(plan.rows, plan.batches, opts)
+                .nodes.values()];
+            for (let i = 0; i < pts.length; i += 1) {
+                for (let j = i + 1; j < pts.length; j += 1) {
+                    pairs += 1;
+                    const d = Math.hypot(pts[i].x - pts[j].x, pts[i].y - pts[j].y);
+                    expect(d, `${opts.reqLayout}/${opts.stepLabel}: bead pair`)
+                        .toBeGreaterThan(worstOuter + BEAD_HIT_RADIUS);
+                }
+            }
+        }
+        expect(pairs, 'bead pairs swept').toBeGreaterThan(100);
+    });
+
+    // THE CEILING IS THE SMALLEST OF THE CLEARANCES, and every one of them is
+    // derived. A retuned constant anywhere in the module moves this number
+    // rather than silently invalidating it.
+    // THE TWO ASSERTIONS HERE THAT CAN ACTUALLY FAIL, and they are the pair
+    // that would have caught both wrong ceilings: a DELETED clearance (the list
+    // shrinking back toward the one-constraint answers), and a new TIGHT
+    // clearance silently strangling the fix — 2.37 was the first ceiling tried
+    // and it is below this floor. Re-deriving `MAX_OUTER` from
+    // `min(clearances) - 1` here would only restate the three lines above it in
+    // the source, so it is deliberately not asserted.
+    it('takes its ceiling from the tightest clearance, derived not typed', () => {
+        expect(Object.keys(NEXT_HALO_CLEARANCES).length).toBeGreaterThanOrEqual(7);
+        expect(NEXT_HALO_MAX_MAGNIFY).toBeGreaterThan(1.8);
+    });
+
+    it('is monotone — zooming out never shrinks the mark', () => {
+        const ms = K_SWEEP.map((k) => nextHaloMagnify(k, false));
+        for (let i = 1; i < ms.length; i += 1) {
+            expect(ms[i], `k=${K_SWEEP[i]}`).toBeLessThanOrEqual(ms[i - 1]);
+        }
+    });
+
+    it('falls back to 1 on a scale that is not a usable number', () => {
+        for (const k of [0, -1, NaN, Infinity, -Infinity, undefined, null]) {
+            expect(nextHaloMagnify(k, false), `k=${k}`).toBe(1);
+        }
+    });
+
+    // THE MEASUREMENT THIS REQUIREMENT WAS FILED ON, as an assertion. Live
+    // pipeline 2 renders 136 rows into a 3620px world, so kFit is 0.33–0.40 on
+    // a 1200–1440px panel and kDefault is K_READABLE (0.8) — which puts the
+    // plan's OPENING view at 'out', with k at or below the 0.4 ceiling the
+    // level ladder gives that level. Before this fix the halo drew a 0.80px
+    // stroke there; a sub-pixel dashed outline whose inner edge sat 0.1px from
+    // the bead's own ring.
+    it('turns the measured Overview scales into a mark that can be seen', () => {
+        // The three scales that matter on the live plan: fit-to-width on a
+        // 1200px and a 1440px panel (both level 'out' — the plan OPENS there),
+        // and the ceiling of 'out' itself.
+        const LIVE_WORLD_W = 3620.2;
+        const kOutCeiling = K_READABLE * 0.5;            // 0.4, 'out' by definition
+        const cases = [1200 / LIVE_WORLD_W, 1440 / LIVE_WORLD_W, kOutCeiling];
+        for (const k of cases) {
+            expect(nextHaloMagnify(k, true), `labels drawn at k=${k}`).toBe(1);
+            // What it used to be, at that same k: a sub-pixel dashed outline
+            // whose inner edge sat a tenth of a pixel from the bead's own ring.
+            expect(NEXT_HALO_STROKE * k, `old stroke px at k=${k}`).toBeLessThan(0.81);
+            expect((innerAt(1) - BEAD_OUTER_RADIUS) * k, `old gap px at k=${k}`)
+                .toBeLessThan(0.11);
+            // What it is now — a dashed ring, clear of the bead.
+            const m = nextHaloMagnify(k, false);
+            expect(NEXT_HALO_STROKE * m * k, `stroke px at k=${k}`).toBeGreaterThan(1.3);
+            expect(NEXT_HALO_RADIUS * m * k, `radius px at k=${k}`).toBeGreaterThan(8);
+            expect(NEXT_HALO_DASH[0] * m * k, `dash px at k=${k}`).toBeGreaterThan(1.9);
+            expect((innerAt(m) - BEAD_OUTER_RADIUS) * k, `gap px at k=${k}`)
+                .toBeGreaterThan(3.5);
+            // ...and enough circumference for the dashes to READ as dashes,
+            // which is the whole reason the mark is dashed at all.
+            const cycles = (2 * Math.PI * NEXT_HALO_RADIUS * m * k)
+                / (NEXT_HALO_DASH[0] + NEXT_HALO_DASH[1]);
+            expect(cycles, `dash cycles at k=${k}`).toBeGreaterThan(6);
+        }
     });
 });
 

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -530,6 +530,12 @@ const BAND_HEADER = 83;
 // How far lane 0's step label reaches back up into the header: 31px above the
 // bead, less the 10px the bead sits below the header.
 const STEP_LABEL_RISE = 21;
+// Where a bead sits inside its lane, measured from the lane's top. Named
+// because the NEXT-STEP HALO's ceiling is derived from it (req #3271): the room
+// above a LANE-0 bead is the epic chip's strip, and the distance to it is
+// `STEP_LABEL_RISE + BEAD_LANE_OFFSET` — headerH cancels, so the bound holds for
+// batch-hosting and staggered bands identically.
+export const BEAD_LANE_OFFSET = 10;
 const BATCH_HEADER_EXTRA = 16;  // extra header for bands hosting batch members:
                                 // reserves the letter strip + keeps box tops
                                 // below the epic label (review finding)
@@ -546,8 +552,27 @@ const BATCH_LETTER_GAP = 3;
 // over it something else sits between the two and the line is what keeps them
 // one thing.
 const BATCH_LETTER_LEADER_MIN = 20;
+// The launch-unit box's own geometry, relative to the beads it encloses: how
+// far it insets from its column, its width floor, and how far above/below a
+// bead centre its edges sit. Named because the NEXT-STEP HALO's ceiling is the
+// SMALLEST of these clearances (req #3271) — a halo that grew past one would
+// leave the box that says "one /swarm-start launches these", at exactly the
+// zoom level a launch unit is read at.
+const BATCH_BOX_INSET = 8;
+const BATCH_BOX_MIN_W = 56;
+const BATCH_BOX_RISE = 40;      // above the bead centre
+const BATCH_BOX_DROP_V = 28;    // below it, 'vertical' reqs — the TIGHTEST edge
+const BATCH_BOX_DROP_H = 30;    // below it, 'horizontal' reqs
 const BAND_GAP = 8;
 const LANE_BASE_H = 62;         // POC 56 + type-scale headroom, before the title slot
+// The content floor a column may never shrink below, per requirement layout.
+// Named rather than inlined at the `colW` sizing because the NEXT-STEP HALO's
+// magnification ceiling is derived from the smaller of the two (req #3271): the
+// halo may grow at Overview, and the tightest bead-to-bead pitch it must stop
+// short of is this number. Two copies that "only have to agree" is exactly the
+// desync this module has already taken review findings on.
+const COL_MIN_W_HORIZONTAL = 64;
+const COL_MIN_W_VERTICAL = 70;
 const TITLE_SLOT = 14;          // deviation 2 — reserved per-lane title line
 // One requirement mark per line at font 13.75. EXPORTED since the swim-lane
 // directive: it is the exact vertical cost a lane pays when titles stagger, and
@@ -582,6 +607,11 @@ export const LABEL_MAX_CHARS = 35;
 // column. Only the SAME-PARITY columns (d±2) share a line, and the budget below
 // keeps two of those from meeting.
 const STAGGER_GAP = 18;
+// The shortest a lane can ever be: `lanePitch()` adds a per-lane requirement
+// stack on top of this and never subtracts. Named because two separate proofs
+// read it — the batch-letter sweep's band-scoping argument, and the next-step
+// halo's band-rectangle clearance (req #3271).
+const MIN_LANE_PITCH = LANE_BASE_H + TITLE_SLOT + STAGGER_GAP;
 // Fraction of a neighbouring column a staggered label may reach into, PER SIDE.
 // Labels are centred on their column, so the budget must bound the reach into
 // the NARROWER neighbour and then apply symmetrically — bounding the sum of both
@@ -606,6 +636,17 @@ export const PLAN_VIZ_FONT = {
 };
 
 export const BEAD_RADIUS = BEAD_R;
+
+// The bead's own ring, in the two weights `beadStyle` picks between. EXPORTED
+// and named rather than left as literals because the next-step halo's ceiling
+// is measured against the EMPHASIS weight (req #3271): what bounds the halo's
+// growth at Overview is the distance to the neighbouring bead's outer edge, and
+// that edge is `BEAD_RADIUS + BEAD_RING_W_EMPHASIS / 2`. A literal there and a
+// literal here would only agree by accident.
+export const BEAD_RING_W_EMPHASIS = 2.5;   // manual, or eligible-now
+export const BEAD_RING_W_BASE = 1.5;
+// The outer edge of the widest bead ring drawn — 11.25.
+export const BEAD_OUTER_RADIUS = BEAD_R + BEAD_RING_W_EMPHASIS / 2;
 
 // The bead's invisible HIT circle, slightly larger than the bead so a small
 // target stays easy to point at. It lives here rather than as a literal in the
@@ -639,6 +680,10 @@ export const BEAD_HIT_RADIUS = BEAD_R + 5;
 // S/M/L all by 10% higher except L by 20%" — so S is no longer the identity and
 // the compact plan is deliberately a little airier than the pre-#3168 one.
 export const STEP_WIDTH_FACTORS = { compact: 1.1, medium: 1.1836, wide: 1.428 };
+// The narrowest world the user can ask for. Read by the next-step halo's
+// ceiling (req #3271), which measures against the TIGHTEST column any setting
+// can produce, never against the unmultiplied content floor.
+export const MIN_STEP_WIDTH_FACTOR = Math.min(...Object.values(STEP_WIDTH_FACTORS));
 export const DEFAULT_STEP_WIDTH = 'compact';
 // `Object.hasOwn`, not a truthiness test on the lookup (review finding). The
 // value arrives from localStorage, so `"toString"` and `"constructor"` are both
@@ -1237,9 +1282,10 @@ export function computePlanLayout(rows, batches, {
             : Math.max(0, ...steps.map((r) => stepLabelText(r, stepLabel).length * CHW_LABEL + 16));
         let w;
         if (reqLayout === 'horizontal') {
-            w = Math.max(64, labelW, ...steps.map((r) => reqStr(r).length * CHW_REQ + 30));
+            w = Math.max(COL_MIN_W_HORIZONTAL, labelW,
+                ...steps.map((r) => reqStr(r).length * CHW_REQ + 30));
         } else {
-            w = Math.max(70, labelW,
+            w = Math.max(COL_MIN_W_VERTICAL, labelW,
                 ...steps.map((r) => Math.min(reqStr(r).length, 6) * CHW_REQ + 40));
         }
         // The user's width choice (req #3168) applies HERE, after the content
@@ -1882,7 +1928,8 @@ export function computePlanLayout(rows, batches, {
             nodes.set(r.id, {
                 id: r.id,
                 x: colX[d],
-                y: band.y + band.headerH + band.laneY[laneById.get(r.id)] + 10,
+                y: band.y + band.headerH + band.laneY[laneById.get(r.id)]
+                    + BEAD_LANE_OFFSET,
                 depth: d,
                 lane: laneById.get(r.id),
                 bandIndex,
@@ -2000,15 +2047,17 @@ export function computePlanLayout(rows, batches, {
         for (const cell of cells) {
             const ms = byCell.get(cell);
             const [bandIndex, depth] = cell.split('|').map(Number);
-            const w = Math.max((colW[depth] || 110) - 8, 56);
-            const yTop = Math.min(...ms.map((n) => n.y)) - 40;
+            const w = Math.max((colW[depth] || 110) - BATCH_BOX_INSET,
+                BATCH_BOX_MIN_W);
+            const yTop = Math.min(...ms.map((n) => n.y)) - BATCH_BOX_RISE;
             const yBot = Math.max(...ms.map((n) => {
                 const row = byId.get(n.id);
                 const nReqs = (row.reqIds || []).length;
                 // The box must enclose the marks it is drawn around, and in
                 // titles mode an odd column's stack starts a line lower.
                 return n.y + reqStaggerOf(n.depth) + (reqLayout === 'vertical'
-                    ? 28 + Math.max(0, nReqs - 1) * REQ_LINE_H : 30);
+                    ? BATCH_BOX_DROP_V + Math.max(0, nReqs - 1) * REQ_LINE_H
+                    : BATCH_BOX_DROP_H);
             }));
             batchBoxes.push({
                 letter: b.letter, stepIds: ms.map((n) => n.id),
@@ -2286,22 +2335,39 @@ export function computePlanLayout(rows, batches, {
     // where mates share only their remaining gate, and an unlabelled dashed box
     // beside a labelled one reads as a second, anonymous batch. Repeating
     // "batch A" is the honest rendering: both boxes ARE batch A.
-    // Beads as rects covering their hit circle, PER BAND — the sweep below is
-    // band-scoped and the memo is what makes that cheap. Scoping is sound
-    // because a letter cannot leave its own band (its ceiling is inside it) and
-    // the nearest foreign bead is ~103px away: the previous band's deepest bead
-    // sits at least `lanePitch − 10` above its band bottom, and `lanePitch` is
-    // at least LANE_BASE_H + TITLE_SLOT + STAGGER_GAP = 94, comfortably more
-    // than BEAD_HIT_RADIUS + 10. That inequality is the dependency; if a lane
-    // could ever be shorter than a bead, this filter would have to go.
+    // Beads as rects covering EVERYTHING A BEAD OWNS, PER BAND — the sweep
+    // below is band-scoped and the memo is what makes that cheap. Scoping is
+    // sound because a letter cannot leave its own band (its ceiling is inside
+    // it) and the nearest foreign bead is ~103px away: the previous band's
+    // deepest bead sits at least `lanePitch − BEAD_LANE_OFFSET` above its band
+    // bottom, and `lanePitch` is at least MIN_LANE_PITCH = 94, comfortably more
+    // than the bead's own reach plus BEAD_LANE_OFFSET. That inequality is the
+    // dependency; if a lane could ever be shorter than a bead, this filter
+    // would have to go. THE NUMBER TO BEAT IS 37, NOT 25 — req #3271 widened
+    // the rects from the hit circle (15) to the halo's reach (27), so the
+    // margin here narrowed from 69 to 57 while the conclusion held.
     const bandBeadRects = new Map();
     const beadRectsOf = (bandIndex) => {
         if (!bandBeadRects.has(bandIndex)) {
+            // THE HIT CIRCLE IS NO LONGER THE OUTERMOST THING A BEAD OWNS
+            // (req #3271). The next-step halo magnifies at Overview and reaches
+            // NEXT_HALO_MAX_OUTER — further than BEAD_HIT_RADIUS — so a search
+            // that cleared only the hit circle left the letter inside the ring:
+            // measured over the fuzz corpus, 4 letters in 467 sliced by a
+            // NEIGHBOURING column's halo. A per-bead entry in
+            // NEXT_HALO_CLEARANCES cannot bound that, because the letter belongs
+            // to a different column's box — the clearance model that has to
+            // widen is this one. `max()` rather than the halo constant alone, so
+            // the hit circle still governs if it ever grows past the halo.
+            //
+            // Read at CALL time, not at module init: `computePlanLayout` runs
+            // long after this module is evaluated, so the forward reference to a
+            // constant declared below is not a TDZ hazard.
+            const reach = Math.max(BEAD_HIT_RADIUS, NEXT_HALO_MAX_OUTER);
             bandBeadRects.set(bandIndex, [...nodes.values()]
                 .filter((n) => n.bandIndex === bandIndex)
                 .map((n) => ({
-                    x: n.x - BEAD_HIT_RADIUS, y: n.y - BEAD_HIT_RADIUS,
-                    w: 2 * BEAD_HIT_RADIUS, h: 2 * BEAD_HIT_RADIUS,
+                    x: n.x - reach, y: n.y - reach, w: 2 * reach, h: 2 * reach,
                 })));
         }
         return bandBeadRects.get(bandIndex);
@@ -2343,8 +2409,9 @@ export function computePlanLayout(rows, batches, {
         // lands the letter's top edge exactly on the bead's CENTRE — measured in
         // review on every congested column, breaking the no-label-on-bead and
         // hit-circle invariants at once and putting the letter's own hover rect
-        // over a step's. Beads join the sweep as rects covering the hit circle,
-        // so the search displaces off them exactly as it does off a label.
+        // over a step's. Beads join the sweep as rects covering the bead's full
+        // reach (`BEAD_MARK_RADIUS` — the halo, not just the hit circle, since
+        // req #3271), so the search displaces off them exactly as off a label.
         const beadRects = beadRectsOf(box.bandIndex);
         const hits = (r, xx, yy) => r.x < xx + w && xx < r.x + r.w
             && r.y < yy + BATCH_LETTER_H && yy < r.y + r.h;
@@ -2375,7 +2442,11 @@ export function computePlanLayout(rows, batches, {
             // `band.y + 78`, identically in both stagger modes (the `+18` in
             // `headerH` cancels the `−18` lift). Measured at review over 1592
             // batch-hosting bands: zero rects in that window, the nearest
-            // topping at `band.y + 55` against the 40 required. Kept anyway,
+            // topping at `band.y + 55` against the 40 required — measured when
+            // the bead rects were the hit circle. RE-MEASURED at req #3271's
+            // wider rects over the fuzz corpus: still zero fallbacks and an
+            // unchanged max climb of 85, with the first fallback appearing only
+            // at a rect radius of 60 against the 27 shipped. Kept anyway,
             // because a `best` of null would otherwise be a crash and because
             // the strip is the one place whose freedom is a construction rather
             // than a measurement.
@@ -2791,7 +2862,8 @@ export function beadStyle(row, eligible, suppressed = false) {
     return {
         fill,
         ring: eligible ? P.eligibleRing : baseRing,
-        ringWidth: row.run === 'manual' || eligible ? 2.5 : 1.5,
+        ringWidth: row.run === 'manual' || eligible
+            ? BEAD_RING_W_EMPHASIS : BEAD_RING_W_BASE,
         pulse: running,
         check: done,
         // Req #3168 — "highlight for next steps". The ring alone carried this,
@@ -2800,6 +2872,8 @@ export function beadStyle(row, eligible, suppressed = false) {
         // answer was the hardest mark on it to find. `next` drives an animated
         // OUTER halo the renderer draws at every zoom level, including Overview,
         // where "what runs next" is asked most and a 1px ring reads as nothing.
+        // Drawing it there was never enough on its own — see
+        // `nextHaloMagnify` for what it took to make it READ there (req #3271).
         next: !!eligible,
         haloColor: suppressed ? PAUSE_PAUSED_COLOR : P.eligibleRing,
     };
@@ -2825,6 +2899,147 @@ export const NEXT_HALO_RADIUS = BEAD_R + 2.5;
 export const NEXT_HALO_STROKE = 2;
 export const NEXT_HALO_OPACITY = 0.85;
 export const NEXT_HALO_DASH = [3, 3];
+
+// ── The halo has to survive Overview (req #3271) ────────────────────────────
+// Every world node draws inside `<Group scaleX={k} scaleY={k}>`, and Konva's
+// `strokeScaleEnabled` defaults to TRUE — so radius, stroke width AND dash
+// pitch above are all multiplied by k. MEASURED on the live plan (pipeline 2,
+// 136 rows, world width 3620): `kDefault = max(kFit, K_READABLE)` is 0.8 at
+// every realistic panel width, so the 'out' level is by definition k < 0.4, and
+// the plan OPENS there on a 1440px panel (kFit = 0.398). At k = 0.4 this mark
+// renders as a 0.8px stroke with 1.2px dashes at 85% opacity, and its inner
+// edge sits 0.1px from the bead's own eligible ring — a sub-pixel dashed
+// outline touching a solid one. It is not that the halo is not drawn at
+// Overview; it is that at Overview it is not a ring.
+//
+// THE MARK MUST MOVE OUTWARD, and there is no alternative. Thickening it in
+// place is arithmetically impossible: the text bound below caps the outer edge
+// at 13.75 and the bead's ring caps the inner edge at 11.5, so the world stroke
+// can be at most 2 — exactly what it already is. Making the stroke
+// screen-constant while pinning the radius merges the two rings for all k < 0.8.
+// The only room is the room the LABELS vacate, which is why this is gated on
+// the label predicate and not on k alone.
+//
+// ONE MAGNIFICATION FOR THE WHOLE MARK, never per-property. Radius, stroke and
+// dash all scale by the same `m`, so the halo is always the same SHAPE — the
+// dash-to-circumference ratio is fixed, and because only the halo grows while
+// the bead does not, the gap between the two rings can only OPEN. A fix that
+// counter-scaled the stroke alone would close it.
+//
+// `m` targets a fixed on-screen radius, so between the ceiling and k = 1 the
+// apparent thickness is a flat NEXT_HALO_STROKE px and the dash pitch a flat
+// NEXT_HALO_DASH px — the k = 1 appearance, held constant as you zoom out
+// instead of thinning to nothing. ON A LARGE PLAN THE CEILING BINDS FIRST and
+// that band is never reached: the live plan's 'out' is the whole reachable
+// range below k = 0.4, which asks for 2.5× at its top and 12.1× at the zoom
+// floor, against a ceiling of 2.0. Measured at the view the plan OPENS in
+// (1440px panel, kFit 0.398,
+// the view the plan OPENS in): radius 9.94px, stroke 1.59px, dash 2.39px, ten
+// dash cycles, and 4.67px of clear space to the bead — against 4.97 / 0.80 /
+// 1.19 / 0.10 before. The mark is unambiguous at the scale the question is
+// asked at, which is what was actually broken.
+export const NEXT_HALO_SCREEN_RADIUS = 12.5;
+// The halo's outer edge at m = 1: 13.5 against the 14 the text bound allows.
+const NEXT_HALO_OUTER = NEXT_HALO_RADIUS + NEXT_HALO_STROKE / 2;
+// HOW FAR IT MAY GROW: the SMALLEST clearance to any piece of world furniture
+// the halo would otherwise cross. Enumerated, because picking one and reasoning
+// about it is how this got written twice and reviewed wrong twice:
+//
+//  - HALF A COLUMN PITCH was the first ceiling (2.37×). Wrong in the other
+//    direction: the live plan's Overview asks for 2.51 at kFit = 0.398, so the
+//    screen-constant branch would never once have executed on the very plan
+//    this was filed against.
+//  - "NEVER REACHES ANOTHER BEAD" was the second (3.76×). It cleared beads and
+//    crossed everything else — the epic chip's strip at every k below 0.371
+//    (which INCLUDES the opening view on a 1200px panel), and its own launch
+//    -unit box on all four sides through essentially the whole 'out' band. Both
+//    found in review, measured, not hypothetical.
+//
+// So the ceiling is `min()` over the real list, and each entry is DERIVED from
+// the constant that actually places that furniture. A new mark near a bead adds
+// an entry here; it does not get to be discovered on screen.
+//
+// TWO DELIBERATE EXCLUSIONS, named so the rule above is not read too literally:
+//
+//  - DEPENDENCY ARCS radiate FROM the bead — `x1 = a.x + BEAD_R + 1`, so every
+//    arc starts 11 world px from the centre, on the bead's own row. They passed
+//    through the halo at m = 1 too. Entering them here would force the ceiling
+//    below the UNMAGNIFIED radius, i.e. it would forbid the mark that already
+//    exists. An arc is not furniture the halo runs into; it is the bead's own
+//    connection, and crossing it reads as attachment rather than collision.
+//  - LANE WIRES run straight THROUGH bead centres by construction, for the same
+//    reason.
+//
+// AND ONE PIECE OF FURNITURE IS NOT BOUNDABLE HERE AT ALL: the launch-unit
+// LETTER. The letter a halo crosses belongs to a NEIGHBOURING column's box, so
+// no per-bead clearance reaches it. It is handled where the stale model was —
+// `beadRectsOf` sizes its rects on `max(BEAD_HIT_RADIUS, NEXT_HALO_MAX_OUTER)`.
+// Named here because this list advertises itself as the index.
+//
+// The test for this lives in the halo's own describe block and measures against
+// the layout's OUTPUT — batch boxes, chip strips, letters, bead pairs — not
+// against the constants below, because measuring against the constants is
+// exactly what let two wrong ceilings through review.
+export const NEXT_HALO_CLEARANCES = {
+    // The launch-unit box, whose four edges are the tightest things a bead has
+    // near it. `DROP_V` (28) is the binding one across the whole module.
+    batchBoxBelow: BATCH_BOX_DROP_V,
+    batchBoxAbove: BATCH_BOX_RISE,
+    batchBoxSide: (COL_MIN_W_HORIZONTAL * MIN_STEP_WIDTH_FACTOR
+        - BATCH_BOX_INSET) / 2,
+    // The epic chip's strip, above a LANE-0 bead. `headerH` cancels out of the
+    // derivation, so one number covers batch-hosting and staggered bands too.
+    // It describes the chip's RESTING position: `placeEpicChips` pins a chip
+    // down into the band body while its band is partly scrolled off, and in that
+    // state the chip overlaps beads and halos alike. Pre-existing sticky
+    // behaviour, not something a world clearance can promise about.
+    epicChipStrip: STEP_LABEL_RISE + BEAD_LANE_OFFSET,
+    // The time axis's vertical slot rules, drawn at column LEFT EDGES — so half
+    // the tightest column, not the whole pitch. Non-binding today (35.2 against
+    // the batch box's 28) and listed because it would bind before the
+    // neighbouring bead if this list ever loosened.
+    slotRule: COL_MIN_W_HORIZONTAL * MIN_STEP_WIDTH_FACTOR / 2,
+    // The BAND rectangle, which is the last piece of world geometry a bead can
+    // reach. A lane-0 bead is `headerH + BEAD_LANE_OFFSET` >= 93 below the band
+    // top; the deepest lane's bead is `lanePitch - BEAD_LANE_OFFSET` >= 84 above
+    // the bottom. Non-binding by a wide margin, listed because a list that
+    // silently omits the outermost boundary is not the index it claims to be.
+    bandRect: MIN_LANE_PITCH - BEAD_LANE_OFFSET,
+    // The nearest other bead's own outer ring. The column pitch is the tightest
+    // bead-to-bead distance (the lane pitch is at least
+    // `LANE_BASE_H + TITLE_SLOT + STAGGER_GAP` = 94) and `widthFactor` only ever
+    // widens, so its floor is the horizontal column floor times the smallest
+    // width factor the user can choose.
+    neighbourBead: COL_MIN_W_HORIZONTAL * MIN_STEP_WIDTH_FACTOR
+        - BEAD_OUTER_RADIUS,
+};
+// One world pixel of margin, so "clears it" is not "touches it".
+export const NEXT_HALO_MAX_OUTER =
+    Math.min(...Object.values(NEXT_HALO_CLEARANCES)) - 1;
+export const NEXT_HALO_MAX_MAGNIFY = NEXT_HALO_MAX_OUTER / NEXT_HALO_OUTER;
+
+/**
+ * The magnification applied to the next-step halo's radius, stroke width and
+ * dash pattern (req #3271). ALWAYS 1 where the step and requirement labels are
+ * drawn: their boxes start 14px from the bead centre in both directions, and
+ * that bound is what fixes NEXT_HALO_RADIUS in the first place. It is also 1
+ * once the mark is already at or above its target size on screen, so zooming IN
+ * never changes it — at 'in' and 'mid' the halo is byte-identical to what it
+ * was before this function existed.
+ *
+ * @param {number} k             the world→screen scale actually being drawn at
+ * @param {boolean} labelsDrawn  does this level draw step/requirement labels?
+ *                               (the visualizer's own `drawsKind('step')` — the
+ *                               halo takes exactly the room the labels vacate)
+ * @returns {number} a factor in [1, NEXT_HALO_MAX_MAGNIFY]
+ */
+export function nextHaloMagnify(k, labelsDrawn) {
+    if (labelsDrawn) return 1;
+    if (!Number.isFinite(k) || k <= 0) return 1;
+    const want = NEXT_HALO_SCREEN_RADIUS / (NEXT_HALO_RADIUS * k);
+    if (!(want > 1)) return 1;
+    return Math.min(want, NEXT_HALO_MAX_MAGNIFY);
+}
 
 // ── Epic focus geometry (req #3204) ─────────────────────────────────────────
 // Clicking an epic's name fits that epic's steps to the viewport. This is pure


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3271-plan-visualizer-the-next-up-halo-is-1
- wip(Darwin): 2026-08-02T12:39:15Z
- chore: init swarm session feature/3271-plan-visualizer-the-next-up-halo-is-1

## Files changed
```
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx |  48 ++-
 .../pipelines/__tests__/pipelinePlanLayout.test.js | 355 ++++++++++++++++++++-
 src/SwarmView/pipelines/pipelinePlanLayout.js      | 255 +++++++++++++--
 3 files changed, 629 insertions(+), 29 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)