### PR TITLE
Documents registry page — polish pass (mutability clarity, DB-vs-file distinction, #3051 review follow-ups)

### DIFF
--- a/src/Agents/DocumentAgentChips.jsx
+++ b/src/Agents/DocumentAgentChips.jsx
@@ -67,6 +67,10 @@ const DocumentAgentChips = ({
     onOpenLink,
     busy = false,
     testIdPrefix,
+    // The commit-mode marker for this row (req #3101). Supplied by the page rather
+    // than built here so the card's seven markers all come from one place and
+    // cannot drift into seven slightly different sentences.
+    commitMarker,
 }) => {
     const [paletteOpen, setPaletteOpen] = useState(false);
 
@@ -80,6 +84,8 @@ const DocumentAgentChips = ({
 
     return (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap', rowGap: 0.75 }}>
+            {commitMarker}
+
             {bound.length === 0 && !paletteOpen && (
                 <Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
                     No other agent references this —

--- a/src/Agents/DocumentLinkPopover.jsx
+++ b/src/Agents/DocumentLinkPopover.jsx
@@ -38,10 +38,11 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
 import {
-    parseRoles, serializeRoles, relationshipChipProps,
+    parseRoles, serializeRoles, resolveRoleConflicts, relationshipChipProps,
     relationshipSetError, relationshipSetHint,
     documentNotesError, charLength, DOCUMENT_NOTES_MAX,
 } from './agentRegistryUtils';
+import { CommitModeMarker } from './commitModes';
 
 // `owned` is handled by the card's owner row — see the header note.
 const EDITABLE_ROLES = ['curated', 'autoload', 'referenced'];
@@ -71,7 +72,14 @@ const DocumentLinkPopover = ({
     // after an external refetch shows the stored values, not the last draft.
     useEffect(() => {
         if (!open) return;
-        setRoles(parseRoles(link?.relationship).filter(r => r !== 'owned'));
+        // Seeded through `resolveRoleConflicts` (req #3101): a stored set carrying
+        // a superseded member — `owned,referenced`, which this UI cannot produce
+        // but the MCP daemon can — would otherwise seed a `referenced` chip that
+        // is switched ON, disabled, and holding the Save button behind a
+        // validation error the user has no way to clear. Show what the row
+        // actually means.
+        setRoles(resolveRoleConflicts(parseRoles(link?.relationship))
+            .filter(r => r !== 'owned'));
         setNotes(link?.notes || '');
     }, [open, link?.agent_fk, link?.document_fk, link?.relationship, link?.notes]);
 
@@ -124,15 +132,28 @@ const DocumentLinkPopover = ({
         >
             <Stack spacing={1.5}>
                 <Box>
-                    <Link
-                        component="button"
-                        type="button"
-                        underline="hover"
-                        onClick={() => onOpenAgent(agent.id)}
-                        sx={{ fontWeight: 500 }}
-                    >
-                        {agent.name}
-                    </Link>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                        <Link
+                            component="button"
+                            type="button"
+                            underline="hover"
+                            onClick={() => onOpenAgent(agent.id)}
+                            sx={{ fontWeight: 500 }}
+                        >
+                            {agent.name}
+                        </Link>
+                        {/* req #3101 — this popover is the ONE control on the
+                            registry that stages its changes, and the reason is in
+                            this file's header. The marker is what makes that
+                            legible before the user has clicked Save and found out. */}
+                        <CommitModeMarker
+                            mode="staged"
+                            note={'One Save writes the whole set: an id-less junction means '
+                                + 'every role change is a delete and a re-insert, so ticking '
+                                + 'three roles separately would be three of them.'}
+                            testId={`document-link-commit-${doc?.id}-${agent.id}`}
+                        />
+                    </Box>
                     <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
                         Relationship to {doc?.name}
                     </Typography>
@@ -227,6 +248,28 @@ const DocumentLinkPopover = ({
                         'data-testid': `document-link-notes-${doc?.id}-${agent.id}`,
                     }}
                 />
+
+                {/* THE FIFTH COMMIT MODE, WHICH HAD NO RENDERING AT ALL (req #3101).
+                    `agent_documents.sort_order` is this link's position within that
+                    AGENT's document list. It belongs to AgentDetail, this page
+                    carries it through every write untouched (see `save` below), and
+                    until now the only evidence it existed was a line of code.
+                    Showing it — labelled, and marked read-only — is what makes the
+                    "carried through untouched" contract something a user can see
+                    rather than something they have to take on trust. */}
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <CommitModeMarker
+                        mode="readOnly"
+                        note={`Set on ${agent.name}'s own page, and carried through unchanged `
+                            + 'by every save made here.'}
+                        testId={`document-link-slot-mode-${doc?.id}-${agent.id}`}
+                    />
+                    <Typography variant="caption" color="text.secondary"
+                                data-testid={`document-link-slot-${doc?.id}-${agent.id}`}>
+                        Load-order slot {Number.isFinite(link.sort_order) ? link.sort_order : '—'}
+                        {' · set on the agent page'}
+                    </Typography>
+                </Box>
 
                 <Stack direction="row" spacing={1} justifyContent="flex-end">
                     <Button size="small" onClick={onClose} disabled={busy}

--- a/src/Agents/DocumentTargetChips.jsx
+++ b/src/Agents/DocumentTargetChips.jsx
@@ -1,0 +1,168 @@
+// WHAT IS IN THE DATABASE VERSUS WHAT IS A REAL FILE (req #3101, § 2).
+//
+// An `architecture_documents` row registers a location; it does not contain, own
+// or verify a file. Three facts follow, and none of them was visible on the
+// resting card before this component existed:
+//
+//   1. Deleting the row deletes the REGISTRATION. The file is untouched. (Said
+//      today only inside DocumentDeleteDialog, i.e. only to somebody already
+//      committed to deleting.)
+//   2. Nothing anywhere resolves `location`. Not the browser, which has no
+//      filesystem; not Lambda-Rest, which stores a VARCHAR; not the MCP daemon,
+//      which hands the string to an agent. The first thing that tries is an LLM at
+//      boot, and it fails silently — instruction #83 tells it to read the file, so
+//      a wrong path means it boots without knowledge it was told to have and
+//      reports itself green.
+//   3. `url` and `location` are DIFFERENT KINDS OF THING that the card previously
+//      rendered as two adjacent text boxes. One is a path inside this repo; the
+//      other is an arbitrary external address. Exactly one of them is what the
+//      open-link button actually opens, and which one is a precedence rule
+//      (`documentHref`) nobody could see.
+//
+// WHAT THIS DELIBERATELY DOES NOT DO: check anything. No HEAD request, no
+// existence probe, no "last verified" timestamp — the requirement's own default
+// for this session forbids new AWS resources, and a frontend cannot do it at all.
+// So the affordance states the ABSENCE of verification rather than implying a
+// verification that is not happening. A green tick nobody earned would be worse
+// than the silence it replaced.
+//
+// The `urlRejected` chip is the one genuinely new FACT rather than new framing:
+// `documentHref` silently falls back to the constructed blob URL when a stored
+// `url` fails the scheme guard, so a row with an unusable URL column has always
+// looked exactly like a row with no URL at all.
+
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import LinkOutlinedIcon from '@mui/icons-material/LinkOutlined';
+import LinkOffIcon from '@mui/icons-material/LinkOff';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+
+import { documentTarget } from './agentRegistryUtils';
+
+const REGISTRATION_NOTE =
+    'This row is a REGISTRATION, not the file. Darwin stores a path and a URL and '
+    + 'never the contents, never checks that either one resolves, and never deletes '
+    + 'a file when the row is deleted. A wrong path is discovered only when an agent '
+    + 'fails to read it at boot.';
+
+// `documentUrlError` and `isSafeHref` both let a scheme-less value through on
+// purpose — a relative href is same-origin and inert. Calling that "external"
+// would be the card stating something false, which is the one thing this row
+// exists to stop doing. No live row is in this shape today (all 83 documents
+// carry an https URL or none); the branch is here so the label cannot become a
+// lie the first time one is.
+const isExternalUrl = (url) => /^([a-z][a-z0-9+.-]*:)?\/\//i.test((url || '').trim());
+
+const DocumentTargetChips = ({ document: doc, testIdPrefix }) => {
+    const target = documentTarget(doc);
+    const { hasLocation, hasUrl, urlRejected, opens } = target;
+    const external = isExternalUrl(doc?.url);
+
+    return (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5,
+                   flexWrap: 'wrap', rowGap: 0.5, mb: 1.5 }}
+             data-testid={`${testIdPrefix}-target`}>
+            <Typography variant="caption" color="text.secondary" sx={{ mr: 0.25 }}>
+                Points at
+            </Typography>
+            {/* `role="img"` with the WHOLE note as the label, and no `tabIndex` —
+                the same call as CommitModeMarker, for the same reason: a screen
+                reader gets the sentence without a tab stop, and adding one per card
+                would bury the fields behind non-interactive stops. */}
+            <Tooltip title={REGISTRATION_NOTE}>
+                <Box component="span"
+                     role="img"
+                     sx={{ display: 'inline-flex', color: 'text.disabled',
+                           cursor: 'help', mr: 0.25 }}
+                     aria-label={REGISTRATION_NOTE}
+                     data-testid={`${testIdPrefix}-target-help`}>
+                    <HelpOutlineIcon sx={{ fontSize: '0.95rem' }} />
+                </Box>
+            </Tooltip>
+
+            {hasLocation && (
+                <Tooltip title={`${doc.location} — a repo-relative path registered here. `
+                    + 'Nothing checks that this file exists.'
+                    + (opens === 'path'
+                        ? ' The open-link button resolves to this, as a GitHub blob URL.'
+                        : '')}>
+                    <Chip
+                        size="small"
+                        icon={<DescriptionOutlinedIcon fontSize="small" />}
+                        label="repo path"
+                        // FILLED means "this is the one the link opens". The
+                        // distinction is the whole reason both chips are here: two
+                        // outlined chips would say a row points at two places and
+                        // leave the precedence rule as invisible as it was before.
+                        variant={opens === 'path' ? 'filled' : 'outlined'}
+                        color={opens === 'path' ? 'primary' : 'default'}
+                        data-testid={`${testIdPrefix}-target-path`}
+                        data-opens={opens === 'path' ? '1' : '0'}
+                    />
+                </Tooltip>
+            )}
+
+            {hasUrl && !urlRejected && (
+                <Tooltip title={`${doc.url} — ${external
+                    ? 'an external address'
+                    : 'a same-origin path'} stored verbatim. `
+                    + 'It is never fetched and nothing verifies that it resolves.'
+                    + (opens === 'url' ? ' The open-link button resolves to this.' : '')}>
+                    <Chip
+                        size="small"
+                        icon={<LinkOutlinedIcon fontSize="small" />}
+                        label={external ? 'external URL' : 'stored link'}
+                        variant={opens === 'url' ? 'filled' : 'outlined'}
+                        color={opens === 'url' ? 'primary' : 'default'}
+                        data-testid={`${testIdPrefix}-target-url`}
+                        data-opens={opens === 'url' ? '1' : '0'}
+                    />
+                </Tooltip>
+            )}
+
+            {urlRejected && (
+                <Tooltip title={`The stored URL ("${doc.url}") is not an http or https `
+                    + 'address, so it is never rendered as a link. '
+                    + (hasLocation
+                        ? 'The open-link button falls back to the repo path.'
+                        : 'This row has nothing to open.')}>
+                    <Chip
+                        size="small"
+                        icon={<LinkOffIcon fontSize="small" />}
+                        label="URL unusable"
+                        color="warning"
+                        variant="outlined"
+                        data-testid={`${testIdPrefix}-target-url-rejected`}
+                    />
+                </Tooltip>
+            )}
+
+            {!opens && (
+                <Tooltip title={'This row registers no usable path or URL, so there is '
+                    + 'nothing to open and nothing for an agent to read.'}>
+                    <Chip
+                        size="small"
+                        label="nothing to open"
+                        color="error"
+                        variant="outlined"
+                        data-testid={`${testIdPrefix}-target-none`}
+                    />
+                </Tooltip>
+            )}
+
+            <Tooltip title={'Darwin has never checked that this resolves — there is no '
+                + 'existence check anywhere in the system.'}>
+                <Typography variant="caption" color="text.disabled"
+                            sx={{ cursor: 'help' }}
+                            data-testid={`${testIdPrefix}-target-unverified`}>
+                    · never verified
+                </Typography>
+            </Tooltip>
+        </Box>
+    );
+};
+
+export default DocumentTargetChips;

--- a/src/Agents/DocumentsPage.jsx
+++ b/src/Agents/DocumentsPage.jsx
@@ -128,7 +128,10 @@ import {
 import {
     SORT_MODES, SORT_STORAGE_KEY, readStoredSort, compareDocumentRows,
 } from './documentSort';
+import { useBusyCounts } from '../hooks/useBusyCounts';
+import { CommitModeMarker, CommitModeLegend } from './commitModes';
 import DocumentAgentChips from './DocumentAgentChips';
+import DocumentTargetChips from './DocumentTargetChips';
 import DocumentLinkPopover from './DocumentLinkPopover';
 import DocumentOwnerDialog from './DocumentOwnerDialog';
 import DocumentUnbindDialog from './DocumentUnbindDialog';
@@ -204,9 +207,12 @@ const DocumentsPage = () => {
     const [menuAnchor, setMenuAnchor] = useState(null);
     const [busy, setBusy] = useState(false);
     // Membership writes are pessimistic and scoped to one card, so the spinner is
-    // too. A SET rather than a single id: two cards can legitimately be mid-write,
-    // and a single id would let the first to finish clear the second's spinner.
-    const [membershipBusyIds, setMembershipBusyIds] = useState(() => new Set());
+    // too. A per-row COUNTER rather than a single id or a set of ids: two cards can
+    // legitimately be mid-write (a single id would let the first to finish clear
+    // the second's spinner), and so can two writes against the SAME card — which a
+    // boolean-via-Set got wrong, releasing the flag when the first of the two
+    // finished (req #3101, closing finding 3c). See useBusyCounts.
+    const { mark: markMembershipBusy, isBusy: isMembershipBusy } = useBusyCounts();
     // `${rowId}:${field}` -> error message, for rows holding a blocked value.
     const [fieldErrors, setFieldErrors] = useState({});
     // Which non-owner link is being edited, and where to anchor its popover.
@@ -429,12 +435,6 @@ const DocumentsPage = () => {
     };
 
     // ---------- membership ----------
-
-    const markMembershipBusy = (rowId, on) => setMembershipBusyIds(prev => {
-        const next = new Set(prev);
-        if (on) next.add(rowId); else next.delete(rowId);
-        return next;
-    });
 
     // The freshest junction rows, for work that runs LATER than the render that
     // scheduled it. Read from the CACHE, not from a ref holding the last rendered
@@ -980,6 +980,19 @@ const DocumentsPage = () => {
                         closedCount > 0 && `${closedCount} closed`,
                     ].filter(Boolean).join(' · ')}
                     . At most one owner per document is enforced by the database.
+                    {/* THE REGISTRATION SENTENCE (req #3101, § 2). Stated once, on
+                        the page, rather than only inside the delete and location
+                        dialogs — which is to say, only to somebody already
+                        mid-destruction. Every card carries the per-row half of this
+                        in its "Points at" row. */}
+                    {' '}These rows are <strong>registrations</strong>: Darwin stores a path or a
+                    URL and never the file, never checks that either resolves, and deleting a row
+                    never deletes a file.
+                    {/* THE COMMIT-MODE KEY (req #3101, § 1). Inline spans only —
+                        ViewerHeader wraps this node in a <p>. */}
+                    <Box component="span" sx={{ display: 'block', mt: 0.5 }}>
+                        <CommitModeLegend testIdPrefix="documents" />
+                    </Box>
                 </>}
             />
 
@@ -998,7 +1011,7 @@ const DocumentsPage = () => {
             >
                 {rows.map(row => {
                     const blocked = rowBlocked(row.id);
-                    const membershipBusy = membershipBusyIds.has(row.id);
+                    const membershipBusy = isMembershipBusy(row.id);
                     const href = documentHref(row);
                     const ownerAgent = row.owner ? agentIndex.get(row.owner.agent_fk) : null;
                     const linkedIds = new Set(row.links.map(l => l.agent_fk));
@@ -1064,6 +1077,16 @@ const DocumentsPage = () => {
                                         },
                                     }}
                                     testId={`document-name-input-${row.id}`}
+                                />
+                                {/* The heading is the ONLY control on the card that
+                                    advertises nothing about itself — it renders as
+                                    plain text and carries no label, by design. So it
+                                    is also the one that most needs the marker. */}
+                                <CommitModeMarker
+                                    mode="blur"
+                                    note="The name is prose: nothing in production resolves a document by it."
+                                    testId={`document-commit-name-${row.id}`}
+                                    sx={{ mt: 0.75 }}
                                 />
                                 {href && (
                                     <Tooltip title="Open the document in a new tab">
@@ -1147,6 +1170,12 @@ const DocumentsPage = () => {
                                 is undone by clicking the previous chip. */}
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5,
                                        flexWrap: 'wrap', mb: 1 }}>
+                                <CommitModeMarker
+                                    mode="click"
+                                    note="Clicking the previous type is the undo."
+                                    testId={`document-commit-type-${row.id}`}
+                                    sx={{ mr: 0.25 }}
+                                />
                                 {DOC_TYPES.map(t => {
                                     const on = row.doc_type === t;
                                     return (
@@ -1200,6 +1229,25 @@ const DocumentsPage = () => {
                                             sx={{ mr: 0.5 }}>
                                     Owner
                                 </Typography>
+                                {/* THE OWNER ROW GENUINELY HAS TWO COMMIT MODES and
+                                    the marker says which one is live rather than
+                                    averaging them. Claiming an UNOWNED document is
+                                    one additive write and goes straight through;
+                                    transferring or releasing an owned one is a
+                                    two-write plan with an unowned window, so it
+                                    opens DocumentOwnerDialog. Which of the two a
+                                    click will do depends entirely on whether this
+                                    card currently has an owner. */}
+                                <CommitModeMarker
+                                    mode={row.owner ? 'confirm' : 'click'}
+                                    note={row.owner
+                                        ? 'Transfer and release are two writes with a window in '
+                                          + 'which nothing owns the document, so both are confirmed.'
+                                        : 'Claiming an unowned document is one additive write, '
+                                          + 'so it needs no confirmation.'}
+                                    testId={`document-commit-owner-${row.id}`}
+                                    sx={{ mr: 0.5 }}
+                                />
 
                                 {ownerAgent ? (
                                     <Tooltip title={`${ownerAgent.name} owns this document — click to open its page, ✕ to release`}>
@@ -1288,7 +1336,13 @@ const DocumentsPage = () => {
                                 </Alert>
                             )}
 
-                            <Box sx={{ mb: 1 }}>
+                            {/* The two location/url fields are wrapped in a flex row
+                                with their marker so the marker sits on the field's
+                                own line rather than stealing a row from the card.
+                                `alignItems: flex-start` keeps it pinned to the top
+                                of the box while the helper text grows underneath. */}
+                            <Box sx={{ display: 'flex', alignItems: 'flex-start',
+                                       gap: 0.5, mb: 1 }}>
                                 <GhostTextField
                                     value={row.location || ''}
                                     outlined
@@ -1317,9 +1371,25 @@ const DocumentsPage = () => {
                                     sx={{ '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.8125rem' } }}
                                     testId={`document-location-input-${row.id}`}
                                 />
+                                {/* THE ONE FIELD ON THE PAGE WHOSE COMMIT MODE
+                                    CHANGES ROW BY ROW. A document nothing autoloads
+                                    has no boot to break, so its location commits on
+                                    blur like any other text; one that IS autoloaded
+                                    routes through DocumentLocationDialog. Reading
+                                    `readers`, which the card already computed. */}
+                                <CommitModeMarker
+                                    mode={readers.length ? 'confirm' : 'blur'}
+                                    note={readers.length
+                                        ? `${readers.length} agent${readers.length === 1 ? '' : 's'} `
+                                          + 'read this file at boot, so the change is confirmed first.'
+                                        : 'No agent autoloads this document, so there is no boot to break.'}
+                                    testId={`document-commit-location-${row.id}`}
+                                    sx={{ mt: 1.25 }}
+                                />
                             </Box>
 
-                            <Box sx={{ mb: 1.5 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'flex-start',
+                                       gap: 0.5, mb: 1.5 }}>
                                 <GhostTextField
                                     value={row.url || ''}
                                     outlined
@@ -1335,7 +1405,22 @@ const DocumentsPage = () => {
                                     sx={{ '& .MuiInputBase-input': { fontSize: '0.8125rem' } }}
                                     testId={`document-url-input-${row.id}`}
                                 />
+                                <CommitModeMarker
+                                    mode="blur"
+                                    note="Only http and https values are stored as links."
+                                    testId={`document-commit-url-${row.id}`}
+                                    sx={{ mt: 1.25 }}
+                                />
                             </Box>
+
+                            {/* WHAT THE ROW ACTUALLY POINTS AT (req #3101, § 2).
+                                Directly under the two fields it derives from, so
+                                the reading order is "here is the path, here is the
+                                URL, here is which one is real and which one opens". */}
+                            <DocumentTargetChips
+                                document={row}
+                                testIdPrefix={`document-${row.id}`}
+                            />
 
                             <DocumentAgentChips
                                 links={row.others}
@@ -1349,6 +1434,19 @@ const DocumentsPage = () => {
                                     { docId: row.id, agentId: agent.id, anchorEl })}
                                 busy={membershipBusy}
                                 testIdPrefix={`document-${row.id}`}
+                                commitMarker={(
+                                    // `click` is the mode of the chips themselves —
+                                    // the gesture a user makes here most often, and
+                                    // by a wide margin. The note carries the other
+                                    // two, which belong to controls this row owns
+                                    // but does not visually lead with.
+                                    <CommitModeMarker
+                                        mode="click"
+                                        note={'Removing a link (✕) asks first, and a chip\'s roles '
+                                            + 'and notes are staged behind Save in the popover it opens.'}
+                                        testId={`document-commit-agents-${row.id}`}
+                                    />
+                                )}
                             />
                           </CardContent>
                         </Card>
@@ -1378,6 +1476,19 @@ const DocumentsPage = () => {
                             inputProps={{ maxLength: DOCUMENT_NAME_MAX }}
                             inputRef={templateNameRef}
                             testId="document-name-input-template"
+                        />
+                        {/* The template card's commit model is its own: it is not a
+                            column write but a CREATE, fired on every blur once both
+                            required fields hold a legal value. Marked with the same
+                            vocabulary as everything else so the one control that
+                            behaves differently is not the one control with no
+                            marker. */}
+                        <CommitModeMarker
+                            mode="blur"
+                            note={'This card registers the document as soon as both the name and '
+                                + 'the location hold a legal value — there is no Add button.'}
+                            testId="document-commit-template"
+                            sx={{ mt: 1.5 }}
                         />
                         {creating && <CircularProgress size={14} sx={{ mt: 1.5 }} />}
                     </Box>
@@ -1447,7 +1558,7 @@ const DocumentsPage = () => {
                     : null}
                 onSave={(next) => saveLink(editorRow, next)}
                 onOpenAgent={(agentId) => navigate(`/agents/${agentId}#documents`)}
-                busy={editorRow ? membershipBusyIds.has(editorRow.id) : false}
+                busy={editorRow ? isMembershipBusy(editorRow.id) : false}
             />
 
             <DocumentOwnerDialog

--- a/src/Agents/InstructionsPage.jsx
+++ b/src/Agents/InstructionsPage.jsx
@@ -71,6 +71,7 @@ import {
     useInstructions, useAgents, useAgentInstructions,
     instructionKeys, agentInstructionKeys,
 } from '../hooks/useDataQueries';
+import { useBusyCounts } from '../hooks/useBusyCounts';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { useViewPreference } from '../hooks/useViewPreference';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
@@ -159,11 +160,13 @@ const InstructionsPage = () => {
     const [dialogIntent, setDialogIntent] = useState('delete');
     const [busy, setBusy] = useState(false);
     // Membership writes are pessimistic and scoped to one card, so the spinner and
-    // the disabled controls are scoped to that card too. A SET rather than a single
-    // id: two cards can legitimately be mid-write at once, and a single id would
-    // let the first one to finish clear the second card's spinner while its write
-    // was still in flight.
-    const [membershipBusyIds, setMembershipBusyIds] = useState(() => new Set());
+    // the disabled controls are scoped to that card too. A per-row COUNTER rather
+    // than a single id or a set of ids: two cards can legitimately be mid-write at
+    // once (a single id would let the first one to finish clear the second card's
+    // spinner), and so can two writes against the SAME card — which a
+    // boolean-via-Set got wrong, releasing the flag when the first of the two
+    // finished (req #3101, closing finding 3c). See useBusyCounts.
+    const { mark: markMembershipBusy, isBusy: isMembershipBusy } = useBusyCounts();
     // The row whose CONTENT field is focused, so its hints show only while that
     // field is in use. Deliberately per-field, not per-row: keying it off the row
     // would pop "check this does not contradict…" under the body while the user
@@ -314,12 +317,6 @@ const InstructionsPage = () => {
     };
 
     // ---------- membership ----------
-
-    const markMembershipBusy = (rowId, on) => setMembershipBusyIds(prev => {
-        const next = new Set(prev);
-        if (on) next.add(rowId); else next.delete(rowId);
-        return next;
-    });
 
     // The freshest junction rows, for work that runs LATER than the render that
     // scheduled it — see the queue below.
@@ -660,7 +657,7 @@ const InstructionsPage = () => {
                     agentIndex={agentIndex}
                     openAgents={openAgents}
                     slotOf={slotOf}
-                    membershipBusyIds={membershipBusyIds}
+                    isMembershipBusy={isMembershipBusy}
                     timezone={timezone}
                     sortMode={sortMode}
                     sortDesc={sortDesc}
@@ -705,7 +702,7 @@ const InstructionsPage = () => {
             >
                 {rows.map(row => {
                     const blocked = rowBlocked(row.id);
-                    const membershipBusy = membershipBusyIds.has(row.id);
+                    const membershipBusy = isMembershipBusy(row.id);
                     const boundSet = new Set(row.refs);
 
                     return (

--- a/src/Agents/InstructionsTableView.jsx
+++ b/src/Agents/InstructionsTableView.jsx
@@ -71,7 +71,12 @@ const InstructionsTableView = ({
     agentIndex,
     openAgents,
     slotOf,
-    membershipBusyIds,
+    // (rowId) => boolean. A FUNCTION rather than the Set it used to be (req #3101):
+    // the page now counts in-flight writes per row instead of holding one boolean
+    // per busy row, so "is this row busy?" is a question rather than a membership
+    // test. `useBusyCounts` re-creates the function whenever any count moves, which
+    // is exactly what `gridRows` below needs to re-run on.
+    isMembershipBusy,
     timezone,
     sortMode,
     sortDesc,
@@ -148,8 +153,8 @@ const InstructionsTableView = ({
         blockedMessages: Object.entries(fieldErrors)
             .filter(([key]) => key.startsWith(`${row.id}:`))
             .map(([, message]) => message),
-        membershipBusy: membershipBusyIds.has(row.id),
-    })), [rows, fieldErrors, membershipBusyIds]);
+        membershipBusy: isMembershipBusy(row.id),
+    })), [rows, fieldErrors, isMembershipBusy]);
 
     const columns = useMemo(() => [
         {

--- a/src/Agents/__tests__/DocumentsPage.test.jsx
+++ b/src/Agents/__tests__/DocumentsPage.test.jsx
@@ -973,3 +973,215 @@ describe('DocumentsPage — drill-through', () => {
             .toBe('https://example.test/quiet');
     });
 });
+
+// ===========================================================================
+// req #3101 — the polish pass.
+//
+// Two affordances, both PERSISTENT and both about things the card previously
+// only revealed once you had already acted:
+//
+//   § 1  which of five commit models a control uses (the user learned this by
+//        clicking, and one of the five was not rendered at all)
+//   § 2  that a row is a REGISTRATION, not a file — stated only inside the
+//        delete and location dialogs, i.e. only to somebody mid-destruction
+// ===========================================================================
+
+const commitModeOf = (testId) => byTestId(testId)?.getAttribute('data-commit-mode');
+
+describe('DocumentsPage — the commit-mode language (req #3101 § 1)', () => {
+    it('marks every editable region of a card, not a sample of them', () => {
+        mount();
+        for (const region of ['name', 'type', 'owner', 'location', 'url', 'agents']) {
+            expect(byTestId(`document-commit-${region}-20`)).toBeTruthy();
+        }
+        // ...and the create form, whose commit model is its own (a CREATE fired on
+        // blur once both required columns hold a legal value).
+        expect(commitModeOf('document-commit-template')).toBe('blur');
+    });
+
+    it('says blur for the two ordinary text columns', () => {
+        mount();
+        expect(commitModeOf('document-commit-name-20')).toBe('blur');
+        expect(commitModeOf('document-commit-url-20')).toBe('blur');
+    });
+
+    it('says click for the controls that write on one click', () => {
+        mount();
+        expect(commitModeOf('document-commit-type-20')).toBe('click');
+        expect(commitModeOf('document-commit-agents-20')).toBe('click');
+    });
+
+    it('reads the OWNER row per card, because its mode genuinely differs', () => {
+        // Claiming an unowned document is one additive write and goes straight
+        // through; transferring or releasing an owned one opens a dialog. A single
+        // averaged marker would be wrong on every card.
+        mount();
+        expect(commitModeOf('document-commit-owner-20')).toBe('confirm');   // owned
+        expect(commitModeOf('document-commit-owner-21')).toBe('click');     // unowned
+    });
+
+    it('reads the LOCATION field per card, matching the confirm gate exactly', () => {
+        // doc 20 has an autoload reader, so its location routes through
+        // DocumentLocationDialog; doc 22 has none, so it commits on blur. The
+        // marker must track the gate rather than restate a page-wide rule.
+        mount();
+        expect(commitModeOf('document-commit-location-20')).toBe('confirm');
+        expect(commitModeOf('document-commit-location-22')).toBe('blur');
+    });
+
+    it('follows the gate when the last autoload reader is unlinked', () => {
+        // The marker is derived, not a fixture: removing the only autoload link
+        // must move doc 20 from confirm to blur without anything else changing.
+        mount();
+        expect(commitModeOf('document-commit-location-20')).toBe('confirm');
+
+        junctionData = JUNCTION.filter(l => l.relationship !== 'owned,autoload')
+            .map(l => ({ ...l }));
+        act(() => bump());
+        expect(commitModeOf('document-commit-location-20')).toBe('blur');
+    });
+
+    it('renders the key once on the page, covering all five models', () => {
+        mount();
+        expect(byTestId('documents-commit-legend')).toBeTruthy();
+        for (const mode of ['click', 'blur', 'confirm', 'staged', 'readOnly']) {
+            expect(byTestId(`documents-commit-legend-${mode}`)).toBeTruthy();
+        }
+    });
+
+    it('marks the popover as STAGED and shows the read-only load-order slot', () => {
+        // The fifth model had NO rendering at all before this pass:
+        // `agent_documents.sort_order` belongs to AgentDetail and this page carries
+        // it through every write untouched, which was a contract only the code knew.
+        mount();
+        click(byTestId('document-20-agent-2'));
+        expect(commitModeOf('document-link-commit-20-2')).toBe('staged');
+        expect(commitModeOf('document-link-slot-mode-20-2')).toBe('readOnly');
+        expect(byTestId('document-link-slot-20-2').textContent).toMatch(/Load-order slot 4/);
+    });
+
+    it('is DISPLAY ONLY — a marker never gates or intercepts a write', () => {
+        // The property that makes it safe to put on eight regions at once.
+        mount();
+        return editField('document-url-input-20', 'https://example.test/moved')
+            .then(() => {
+                expect(putBodies()).toEqual([
+                    { id: 20, fields: { url: 'https://example.test/moved' } },
+                ]);
+            });
+    });
+});
+
+describe('DocumentsPage — registration versus file (req #3101 § 2)', () => {
+    it('states on the page itself that a row is a registration, not a file', () => {
+        mount();
+        const text = byTestId('documents-accounting').textContent;
+        expect(text).toMatch(/registrations/);
+        expect(text).toMatch(/never the file/);
+        expect(text).toMatch(/deleting a row never deletes a file/i);
+    });
+
+    it('gives every card a persistent "points at" row', () => {
+        mount();
+        for (const id of [20, 21, 22]) {
+            expect(byTestId(`document-${id}-target`)).toBeTruthy();
+            expect(byTestId(`document-${id}-target-unverified`).textContent)
+                .toMatch(/never verified/);
+        }
+    });
+
+    it('shows a path-only row as a repo path, and says the path is what opens', () => {
+        mount();
+        expect(byTestId('document-20-target-path')).toBeTruthy();
+        expect(byTestId('document-20-target-path').getAttribute('data-opens')).toBe('1');
+        expect(byTestId('document-20-target-url')).toBeNull();
+        expect(byTestId('document-20-target-none')).toBeNull();
+    });
+
+    it('shows BOTH when a row carries both, and marks the URL as the one that opens', () => {
+        // Which of the two the open-link button resolves to is a precedence rule
+        // (`documentHref`) that was previously invisible on the card.
+        mount();
+        expect(byTestId('document-22-target-path').getAttribute('data-opens')).toBe('0');
+        expect(byTestId('document-22-target-url').getAttribute('data-opens')).toBe('1');
+        expect(byTestId('document-22-target-url-rejected')).toBeNull();
+    });
+
+    it('SURFACES a URL the scheme guard rejected — documentHref swallows it silently', () => {
+        // The row keeps a working link (the blob URL), so before this the column
+        // being unusable was indistinguishable from it being empty.
+        documentsData = DOCUMENTS.map(d => (d.id === 22
+            ? { ...d, url: 'javascript:alert(1)' } : { ...d }));
+        mount();
+        expect(byTestId('document-22-target-url-rejected')).toBeTruthy();
+        expect(byTestId('document-22-target-url')).toBeNull();
+        expect(byTestId('document-22-target-path').getAttribute('data-opens')).toBe('1');
+    });
+
+    it('says outright when a row points at NOTHING', () => {
+        documentsData = DOCUMENTS.map(d => (d.id === 21
+            ? { ...d, location: null, url: null } : { ...d }));
+        mount();
+        expect(byTestId('document-21-target-none')).toBeTruthy();
+        expect(byTestId('document-21-target-path')).toBeNull();
+        expect(byTestId('document-21-target-url')).toBeNull();
+        // ...and the open-link button is correspondingly absent rather than dead.
+        expect(byTestId('document-open-link-21')).toBeNull();
+    });
+
+    it('repaints when the location is edited, so it can never state a stale target', () => {
+        documentsData = DOCUMENTS.map(d => (d.id === 21
+            ? { ...d, location: null, url: null } : { ...d }));
+        mount();
+        expect(byTestId('document-21-target-none')).toBeTruthy();
+
+        documentsData = documentsData.map(d => (d.id === 21
+            ? { ...d, location: 'memory/found.md' } : d));
+        act(() => bump());
+        expect(byTestId('document-21-target-none')).toBeNull();
+        expect(byTestId('document-21-target-path').getAttribute('data-opens')).toBe('1');
+    });
+});
+
+describe('DocumentsPage — the affordances do not overstate themselves (req #3101)', () => {
+    it('does not call a scheme-less URL "external" — it is same-origin', () => {
+        // documentUrlError and isSafeHref both let a relative href through on
+        // purpose. Labelling it "external URL" would be the card stating something
+        // false, which is the one thing the "Points at" row exists to stop.
+        documentsData = DOCUMENTS.map(d => (d.id === 22
+            ? { ...d, url: '/docs/quiet.html' } : { ...d }));
+        mount();
+        const chip = byTestId('document-22-target-url');
+        expect(chip.textContent).toMatch(/stored link/);
+        expect(chip.textContent).not.toMatch(/external/);
+        // Still the resolved target — the label changed, not the precedence.
+        expect(chip.getAttribute('data-opens')).toBe('1');
+    });
+
+    it('still says "external URL" for a real off-site address', () => {
+        mount();
+        expect(byTestId('document-22-target-url').textContent).toMatch(/external URL/);
+    });
+
+    it('carries the WHOLE explanation in aria-label, and adds no tab stops', () => {
+        // A tooltip hung off a role-less span is weakly supported by AT, so the
+        // sentence goes in `aria-label` under `role="img"` — where a screen reader
+        // reads it with no interaction at all.
+        //
+        // And deliberately NOT focusable: seven markers per card is ~580
+        // non-interactive tab stops across the live registry, sitting between a
+        // keyboard user and the fields they came to edit. `CommitModeLegend` carries
+        // every mode's name as visible text, so nothing is only-on-hover.
+        mount();
+        for (const id of ['document-commit-name-20', 'document-commit-owner-20',
+                          'document-20-target-help']) {
+            const el = byTestId(id);
+            expect(el.getAttribute('role')).toBe('img');
+            expect(el.hasAttribute('tabindex')).toBe(false);
+            // The full sentence, not the two-word name.
+            expect(el.getAttribute('aria-label').length).toBeGreaterThan(40);
+        }
+        expect(byTestId('document-commit-owner-20').getAttribute('aria-label'))
+            .toMatch(/two writes/);
+    });
+});

--- a/src/Agents/__tests__/documentRegistryUtils.test.js
+++ b/src/Agents/__tests__/documentRegistryUtils.test.js
@@ -18,6 +18,7 @@ import {
     documentUrlError, documentNotesError, docTypeError,
     documentOwnerLink, nextDocumentSortOrder, planOwnerTransfer,
     charLength, restErrorMessage, relationshipLabel, documentHref,
+    resolveRoleConflicts, documentTarget, documentBlobHref,
     DOCUMENT_NAME_MAX, DOCUMENT_LOCATION_MAX, DOCUMENT_URL_MAX, DOCUMENT_NOTES_MAX,
 } from '../agentRegistryUtils';
 
@@ -78,6 +79,59 @@ describe('serializeRoles (req #3051)', () => {
     it('is the exact inverse of parseRoles', () => {
         for (const stored of ['owned', 'referenced', 'owned,autoload', 'curated,referenced']) {
             expect(serializeRoles(parseRoles(stored))).toBe(stored);
+        }
+    });
+
+    // req #3101, finding 3b — the invariant now lives HERE rather than at one
+    // call site. `serializeRoles` is the last thing every junction write crosses
+    // (documentsApi's `linkRow` calls it), so a call site that has not been
+    // written yet cannot reintroduce the combination the way the first version of
+    // `planOwnerTransfer` did.
+    it('drops a role another role in the set already supersedes', () => {
+        expect(serializeRoles(['owned', 'referenced'])).toBe('owned');
+        expect(serializeRoles(['principles', 'autoload', 'referenced']))
+            .toBe('principles,autoload');
+    });
+
+    it('drops the superseded member whichever order it arrives in', () => {
+        expect(serializeRoles(['referenced', 'owned'])).toBe('owned');
+        expect(serializeRoles('referenced,owned')).toBe('owned');
+    });
+
+    it('leaves roles that are merely ORTHOGONAL to ownership alone', () => {
+        // `autoload` and `curated` say nothing about precedence — an owner very
+        // often still reads the file at boot, and dropping that would be a second
+        // change nobody asked for.
+        expect(serializeRoles(['owned', 'autoload', 'curated']))
+            .toBe('owned,curated,autoload');
+    });
+});
+
+describe('resolveRoleConflicts (req #3101)', () => {
+    it('is order-independent', () => {
+        expect(resolveRoleConflicts(['owned', 'referenced']).sort())
+            .toEqual(resolveRoleConflicts(['referenced', 'owned']).sort());
+    });
+
+    it('accepts a stored SET string as well as an array', () => {
+        expect(resolveRoleConflicts('owned,referenced')).toEqual(['owned']);
+    });
+
+    it('leaves a set with no conflict untouched', () => {
+        expect(resolveRoleConflicts(['curated', 'referenced']).sort())
+            .toEqual(['curated', 'referenced']);
+    });
+
+    it('de-duplicates but does NOT drop unknown members — that is serializeRoles\' job', () => {
+        // Two helpers each owning half of one decision is how they drift. Unknown
+        // members are dropped in exactly one place.
+        expect(resolveRoleConflicts(['owned', 'owned', 'nonsense']).sort())
+            .toEqual(['nonsense', 'owned']);
+    });
+
+    it('never empties a set that had any role at all', () => {
+        for (const roles of [['referenced'], ['owned'], ['principles'], ['curated']]) {
+            expect(resolveRoleConflicts(roles).length).toBeGreaterThan(0);
         }
     });
 });
@@ -312,6 +366,85 @@ describe('documentHref refuses a dangerous scheme AT THE RENDER BOUNDARY', () =>
 
     it('constructs the blob URL from location when url is absent', () => {
         expect(documentHref({ location: 'memory/a.md' })).toBe(BLOB);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// documentTarget (req #3101, § 2) — what the row POINTS AT, as opposed to what
+// it contains, which is nothing. This is the derivation behind the card's
+// "Points at" row, and the whole point of it is that a registration is not a
+// file: nothing here checks, fetches or resolves anything.
+// ---------------------------------------------------------------------------
+
+describe('documentTarget distinguishes a path from a URL from nothing', () => {
+    const BLOB = 'https://github.com/BillWilliams79/DarwinAI-Config/blob/main/memory/a.md';
+
+    it('reports a path-only row, and says the path is what opens', () => {
+        const t = documentTarget({ location: 'memory/a.md', url: null });
+        expect(t).toMatchObject({
+            hasLocation: true, hasUrl: false, urlUsable: false, urlRejected: false,
+            opens: 'path', href: BLOB, blobHref: BLOB,
+        });
+    });
+
+    it('reports a url-only row, and says the url is what opens', () => {
+        const t = documentTarget({ location: null, url: 'https://example.test/a' });
+        expect(t).toMatchObject({
+            hasLocation: false, hasUrl: true, urlUsable: true, urlRejected: false,
+            opens: 'url', href: 'https://example.test/a', blobHref: null,
+        });
+    });
+
+    it('reports BOTH when both are present, and url wins — matching documentHref', () => {
+        const doc = { location: 'memory/a.md', url: 'https://example.test/a' };
+        const t = documentTarget(doc);
+        expect(t.hasLocation).toBe(true);
+        expect(t.hasUrl).toBe(true);
+        expect(t.opens).toBe('url');
+        // The two must never disagree: `documentTarget` decides which chip is
+        // drawn as the resolved one and `documentHref` decides where the button
+        // actually goes, so a divergence would mislabel rather than fail.
+        expect(t.href).toBe(documentHref(doc));
+        // The blob URL is still reported, because the path is still registered
+        // and an agent reads THAT, not the url.
+        expect(t.blobHref).toBe(BLOB);
+    });
+
+    it('SURFACES a url the scheme guard rejected, which documentHref swallows', () => {
+        // The one genuinely new fact. `documentHref` falls through to the blob URL
+        // so the row keeps a working link — silently, so a row with an unusable
+        // url column looked identical to a row with no url at all.
+        const doc = { location: 'memory/a.md', url: 'javascript:alert(1)' };
+        const t = documentTarget(doc);
+        expect(t.hasUrl).toBe(true);
+        expect(t.urlUsable).toBe(false);
+        expect(t.urlRejected).toBe(true);
+        expect(t.opens).toBe('path');
+        expect(t.href).toBe(BLOB);
+        expect(t.href).toBe(documentHref(doc));
+    });
+
+    it('reports a row that points at NOTHING rather than pretending it opens', () => {
+        expect(documentTarget({ location: null, url: null })).toMatchObject({
+            hasLocation: false, hasUrl: false, opens: null, href: null, blobHref: null,
+        });
+        expect(documentTarget({ location: null, url: 'javascript:alert(1)' }))
+            .toMatchObject({ urlRejected: true, opens: null, href: null });
+        expect(documentTarget(null)).toMatchObject({ opens: null, href: null });
+    });
+
+    it('treats whitespace-only columns as absent, matching what the fields store', () => {
+        // The card writes NULL rather than '' for a cleared nullable column, but
+        // MCP-written rows have not been past that normalizer.
+        expect(documentTarget({ location: '   ', url: '  ' })).toMatchObject({
+            hasLocation: false, hasUrl: false, opens: null,
+        });
+    });
+
+    it('trims a padded location into the blob URL rather than embedding the padding', () => {
+        expect(documentBlobHref('  memory/a.md  ')).toBe(BLOB);
+        expect(documentBlobHref('')).toBeNull();
+        expect(documentBlobHref(null)).toBeNull();
     });
 });
 

--- a/src/Agents/__tests__/documentsApi.test.js
+++ b/src/Agents/__tests__/documentsApi.test.js
@@ -370,10 +370,14 @@ describe('applyLinkPlan — rollback', () => {
         }]).catch(e => e);
 
         expect(err).toBeInstanceOf(LinkRollbackError);
-        expect(err.message).toMatch(/could not be restored/);
+        expect(err.message).toMatch(/now missing/);
         expect(err.message).toMatch(/Reload the page/);
         expect(err.lost).toHaveLength(1);
         expect(err.lost[0].prev).toBe(prev);
+        // A relink has an incumbent, so nothing here is an ORPHAN — the missing
+        // link is the whole story and the message must not also claim a stray one.
+        expect(err.orphaned).toHaveLength(0);
+        expect(err.message).not.toMatch(/may have been created/);
         expect(err.cause).toBeTruthy();
         // It must still carry httpStatus, or showError throws inside the catch
         // block that is trying to report it.
@@ -411,6 +415,244 @@ describe('applyLinkPlan — rollback', () => {
             .map(c => c.body[0].agent_fk);
         expect(restores).toContain(3);
         expect(restores).toContain(2);
+    });
+
+    // -----------------------------------------------------------------------
+    // req #3101, finding 3a — the CREATE-ONLY ORPHAN.
+    //
+    // A standalone create step (claiming a currently-unowned document, so there is
+    // no incumbent and no `prev` to roll back to) whose INSERT genuinely commits
+    // while its HTTP response is lost, AND whose cleanup DELETE then also fails for
+    // an unrelated reason, leaves a row nobody authorized sitting in the junction.
+    // Before #3101 the rollback tracked only rows the user previously HAD, so this
+    // double fault raised NOTHING beyond the original — by-then-stale — error.
+    // -----------------------------------------------------------------------
+
+    it('reports an ORPHAN when a create-only step cannot be cleaned up', async () => {
+        //   1 POST(5)  the claim — fails (or its response is lost)
+        //   2 DELETE(5) rollback cleanup — ALSO fails, so the row may still be there
+        scriptCalls(() => 'fail');
+
+        const next = link(5, 'owned');
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 5, document_fk: 10, prev: null, next,
+        }]).catch(e => e);
+
+        expect(err).toBeInstanceOf(LinkRollbackError);
+        expect(err.orphaned).toHaveLength(1);
+        expect(err.orphaned[0].agent_fk).toBe(5);
+        expect(err.orphaned[0].next).toBe(next);
+        // Nothing the user HAD went missing, so the message must not say so.
+        expect(err.lost).toHaveLength(0);
+        expect(err.message).toMatch(/may have been created/);
+        expect(err.message).not.toMatch(/now missing/);
+        expect(err.message).toMatch(/Reload the page/);
+        expect(err.cause).toBeTruthy();
+        expect(err.httpStatus).toBeTruthy();
+    });
+
+    it('does NOT report an orphan when the cleanup DELETE succeeds', async () => {
+        // The single-fault case, which is the overwhelmingly common one: the write
+        // failed and its cleanup worked, so the database is exactly where it
+        // started and "your edit was rejected" is the whole truth.
+        scriptCalls((i, method) => (method === 'POST' ? 'fail' : 'ok'));
+
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 5, document_fk: 10, prev: null, next: link(5, 'owned'),
+        }]).catch(e => e);
+
+        expect(err).not.toBeInstanceOf(LinkRollbackError);
+    });
+
+    it('does NOT report an orphan when a 404 tells us the row was never there', async () => {
+        // `unlinkAgentDocument` maps 404 to "already gone", which is the desired
+        // end state rather than a failure. Counting it as an orphan would cry wolf
+        // on the commonest shape of this double fault.
+        scriptCalls((i, method) => (method === 'POST' ? 'fail' : '404'));
+
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 5, document_fk: 10, prev: null, next: link(5, 'owned'),
+        }]).catch(e => e);
+
+        expect(err).not.toBeInstanceOf(LinkRollbackError);
+    });
+
+    it('names BOTH kinds of damage when both happened, missing links first', async () => {
+        // Step 1 is a relink whose restore fails (LOST). Step 2 is a create whose
+        // cleanup fails (ORPHANED). One error has to carry both, or the user
+        // repairs half the damage and stops.
+        //   1 DEL(2)   2 POST(2)     step1 ok
+        //   3 POST(5)                step2 — FAILS
+        //   4 DEL(5)                 rollback step2 cleanup — FAILS -> orphaned
+        //   5 DEL(2)   6 POST(2)     rollback step1 — restore FAILS -> lost
+        scriptCalls((i) => ((i === 3 || i === 4 || i === 6) ? 'fail' : 'ok'));
+
+        const prev = link(2, 'owned,autoload');
+        const err = await applyLinkPlan(URI, TOKEN, [
+            { agent_fk: 2, document_fk: 10, prev, next: { ...prev, relationship: 'autoload' } },
+            { agent_fk: 5, document_fk: 10, prev: null, next: link(5, 'owned') },
+        ]).catch(e => e);
+
+        expect(err).toBeInstanceOf(LinkRollbackError);
+        expect(err.lost).toHaveLength(1);
+        expect(err.orphaned).toHaveLength(1);
+        expect(err.message).toMatch(/now missing/);
+        expect(err.message).toMatch(/may have been created/);
+        // LOST leads: a link an agent was told to read is gone silently, while a
+        // stray one is on the card the user is looking at.
+        expect(err.message.indexOf('now missing'))
+            .toBeLessThan(err.message.indexOf('may have been created'));
+    });
+
+    it('still attempts the RESTORE when the cleanup DELETE threw', async () => {
+        // The two halves of a step's rollback were one try block until #3101, so a
+        // failed cleanup — the half that costs the user nothing — skipped the
+        // restore, which is the half that repairs real damage. They are independent
+        // now, and this pins that: the restore POST must be issued even though the
+        // DELETE before it threw.
+        //   1 DEL(2)  2 POST(2)   step1 — POST FAILS
+        //   3 DEL(2)              rollback cleanup — FAILS
+        //   4 POST(2)             rollback restore — must still happen
+        scriptCalls((i) => ((i === 2 || i === 3) ? 'fail' : 'ok'));
+
+        const prev = link(2, 'owned,autoload', { notes: 'why', sort_order: 6 });
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10, prev, next: { ...prev, relationship: 'autoload' },
+        }]).catch(e => e);
+
+        const c = calls();
+        expect(c).toHaveLength(4);
+        expect(c[3].method).toBe('POST');
+        expect(c[3].body[0]).toMatchObject({
+            agent_fk: 2, relationship: 'owned,autoload', notes: 'why', sort_order: 6,
+        });
+        // The restore SUCCEEDED, so nothing was lost — and a step with a `prev` is
+        // never an orphan, because the restore targets that same composite-PK row.
+        expect(err).not.toBeInstanceOf(LinkRollbackError);
+    });
+
+    it('reports an ORPHAN on a relink whose prev turned out to be already gone', async () => {
+        // THE SHAPE THE FIRST VERSION OF THIS FIX MISSED. Keying the orphan check on
+        // "no `prev`" looks equivalent to "no restore ran" and is not: another writer
+        // removing the link between the plan being built and the write executing
+        // leaves `prev` non-null, the DELETE 404s, and the restore is correctly
+        // SKIPPED (resurrecting a row that did not exist is its own corruption) —
+        // but the INSERT still created a row that was not there a moment earlier.
+        // Reachable from a single popover Save.
+        //   1 DEL(2) -> 404   prev already gone, nothing to restore
+        //   2 POST(2)         our write — FAILS
+        //   3 DEL(2)          rollback cleanup — ALSO fails
+        scriptCalls((i) => (i === 1 ? '404' : 'fail'));
+
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10,
+            prev: link(2, 'referenced'), next: link(2, 'curated'),
+        }]).catch(e => e);
+
+        expect(err).toBeInstanceOf(LinkRollbackError);
+        expect(err.orphaned).toHaveLength(1);
+        expect(err.orphaned[0].agent_fk).toBe(2);
+        expect(err.lost).toHaveLength(0);
+        expect(err.message).toMatch(/may have been created/);
+        expect(err.message).not.toMatch(/now missing/);
+    });
+
+    it('says the link CARRIES THE REJECTED VALUE, not that it is missing, when the cleanup failed too', async () => {
+        // A triple fault, and the most misleading state of the three: the cleanup
+        // DELETE failed so the row is still there holding `next` — the value the
+        // rejected edit asked for — and the restore then collides with it. Telling
+        // the user it is "missing" sends them hunting for a row that is on screen.
+        //   1 DEL(2)  ok       prev removed
+        //   2 POST(2) FAIL     our write
+        //   3 DEL(2)  FAIL     rollback cleanup
+        //   4 POST(2) FAIL     rollback restore
+        scriptCalls((i) => (i === 1 ? 'ok' : 'fail'));
+
+        const prev = link(2, 'owned,autoload');
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10, prev, next: { ...prev, relationship: 'autoload' },
+        }]).catch(e => e);
+
+        expect(err).toBeInstanceOf(LinkRollbackError);
+        expect(err.lost).toHaveLength(1);
+        expect(err.lost[0].cleanupFailed).toBe(true);
+        expect(err.message).toMatch(/still carries the rejected value/);
+        expect(err.message).not.toMatch(/now missing/);
+        // Not an orphan either — a restore WAS attempted for this step.
+        expect(err.orphaned).toHaveLength(0);
+    });
+
+    it('rolls back a step whose LEADING DELETE lost its response', async () => {
+        // The mirror of "the INSERT may have committed", and it was untreated: the
+        // record used to be pushed AFTER the delete, so a DELETE that committed and
+        // then failed to answer left `applied` empty, the rollback never saw the
+        // step, and the link was silently gone with no error naming it.
+        //
+        // The rollback for this shape is ONE POST and nothing else.
+        //   1 DEL(2)  FAIL — may or may not have committed
+        //   2 POST(2) rollback restore
+        scriptCalls((i) => (i === 1 ? 'fail' : 'ok'));
+
+        const prev = link(2, 'owned,autoload', { notes: 'why', sort_order: 6 });
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10, prev, next: { ...prev, relationship: 'autoload' },
+        }]).catch(e => e);
+
+        const c = calls();
+        expect(c.map(x => x.method)).toEqual(['DELETE', 'POST']);
+        expect(c[1].body[0]).toMatchObject({
+            agent_fk: 2, relationship: 'owned,autoload', notes: 'why', sort_order: 6,
+        });
+        // Put back, so the original error is still the headline.
+        expect(err).not.toBeInstanceOf(LinkRollbackError);
+    });
+
+    it('issues NO cleanup DELETE for a step that wrote nothing — it would destroy the row', async () => {
+        // THE REGRESSION THIS PINS, and it is the reason the leading-DELETE repair
+        // is a bare POST. A cleanup DELETE is 404-TOLERANT, which is not the same as
+        // a no-op: against a row that is genuinely still there it SUCCEEDS and
+        // removes it. The commonest failure of all is the database REFUSING the
+        // leading DELETE with the row untouched — so issuing a "just in case"
+        // cleanup on this path makes the rollback destroy the very link it exists to
+        // save, and the loss is then unreportable (`restoreNeeded` is false, so it
+        // is not `lost`; a restore was attempted, so it is not `orphaned`).
+        //
+        // A step whose leading DELETE threw has written nothing. There is nothing of
+        // its own to clean up, and the lone POST is safe in both directions: it
+        // restores a row that really was removed, and collides harmlessly with one
+        // that was not.
+        scriptCalls((i) => (i === 1 ? 'fail' : 'ok'));
+
+        await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10, prev: link(2, 'referenced'), next: null,
+        }]).catch(e => e);
+
+        const c = calls();
+        expect(c.filter(x => x.method === 'DELETE')).toHaveLength(1);   // the failed one only
+        expect(c.map(x => x.method)).toEqual(['DELETE', 'POST']);
+    });
+
+    it('does NOT claim a loss when the leading DELETE never established one', async () => {
+        // REPAIR and REPORT are decided separately, and this is why. A leading
+        // DELETE that threw may or may not have committed, so the repair is
+        // attempted — but if the repair also fails, nothing ever established that a
+        // link went missing. Claiming one here would fire a false alarm on the
+        // COMMON path (the database simply refusing the DELETE, where nothing
+        // changed at all) to cover a rare lost-response.
+        //   1 DEL(2) FAIL   2 POST(2) FAIL
+        scriptCalls(() => 'fail');
+
+        const prev = link(2, 'owned,autoload');
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10, prev, next: { ...prev, relationship: 'autoload' },
+        }]).catch(e => e);
+
+        // The repair WAS attempted — that is the half worth having.
+        expect(calls().map(x => x.method)).toEqual(['DELETE', 'POST']);
+        expect(err).not.toBeInstanceOf(LinkRollbackError);
+        // ...and it is not mistaken for an orphan either: `prev` existed, so any row
+        // sitting in that slot is its, not one this step invented.
+        expect(err.orphaned).toBeUndefined();
     });
 
     it('restores prev when the re-INSERT fails on a SINGLE relink', async () => {

--- a/src/Agents/actions/documentsApi.js
+++ b/src/Agents/actions/documentsApi.js
@@ -186,28 +186,81 @@ export async function unlinkAgentDocument(darwinUri, idToken, agent_fk, document
  *
  * Its own type because the caller must treat it differently from an ordinary
  * failure: an ordinary failure means "nothing changed, try again", while this
- * means "a link you did not ask to remove is now missing". The UI has to say so
- * out loud and force a refetch rather than reporting the original conflict and
- * leaving a stale, wrong screen up.
+ * means "the database is not in either of the two states you asked for". The UI
+ * has to say so out loud and force a refetch rather than reporting the original
+ * conflict and leaving a stale, wrong screen up.
  *
- * This is the one place this module deliberately DIVERGES from the MCP daemon.
- * `darwin-mcp/services/agents.py::link_agent_document` catches a failed restore,
- * logs "the link is now MISSING", and then re-raises the ORIGINAL owner conflict
- * — so the user is told "someone else owns this" while a link has silently
- * vanished. That is a real defect on that path; reproducing it here would just
- * give it a second home.
+ * TWO KINDS OF DAMAGE, AND THEY ARE NOT THE SAME REPORT (req #3101, closing
+ * finding 3a from req #3051's review).
+ *
+ *   `lost`     — steps whose `prev` row was genuinely deleted and could not be
+ *                put back. The user has LESS than they started with: a link they
+ *                did not touch is missing.
+ *   `orphaned` — steps that had NO incumbent (a create-only claim on a
+ *                previously-unowned document) whose INSERT may have committed
+ *                while its response was lost, and whose cleanup DELETE then also
+ *                failed. The user has MORE than they asked for: a link nobody
+ *                authorized may be sitting in the junction.
+ *
+ * Until #3101 only `lost` was tracked, so the second case threw NOTHING — the
+ * user saw the original, by-then-stale error and no mention of the orphan. It is
+ * a double fault and the page's own resync repaints the truth a moment later,
+ * which is exactly why it went unreported: the screen self-corrects while the
+ * MESSAGE stays wrong about what happened.
+ *
+ * This is also the one place this module deliberately DIVERGES from the MCP
+ * daemon. `darwin-mcp/services/agents.py::link_agent_document` catches a failed
+ * restore, logs "the link is now MISSING", and then re-raises the ORIGINAL owner
+ * conflict — so the user is told "someone else owns this" while a link has
+ * silently vanished. That is a real defect on that path; reproducing it here
+ * would just give it a second home.
  */
 export class LinkRollbackError extends Error {
-    constructor(message, { cause, lost } = {}) {
+    constructor(message, { cause, lost, orphaned } = {}) {
         super(message);
         this.name = 'LinkRollbackError';
         this.cause = cause;
         // The links that could not be restored, so the caller can name them.
         this.lost = lost || [];
+        // The links that may have been created and could not be removed.
+        this.orphaned = orphaned || [];
         // Carried through so restErrorMessage / showError still work on it.
         this.httpStatus = cause?.httpStatus;
     }
 }
+
+/**
+ * Compose the headline for a failed rollback.
+ *
+ * LOST OUTRANKS ORPHANED when both happened, because they are different sizes of
+ * problem: a missing link silently changes what an agent loads at boot, while a
+ * stray one is visible on the very card the user is looking at and is removable
+ * with one click. Both are named when both occurred — reporting only the worse
+ * one would leave the user repairing half the damage.
+ */
+const rollbackMessage = (lost, orphaned) => {
+    // A `lost` step splits by whether its CLEANUP succeeded. If it did, the row is
+    // genuinely gone. If it did not, the row is still there — carrying the value
+    // the rejected edit asked for, which is the most misleading state of the three
+    // and the one a message saying "missing" would send the user hunting for.
+    const missing = lost.filter(s => !s.cleanupFailed);
+    const stale = lost.filter(s => s.cleanupFailed);
+
+    const parts = [];
+    if (missing.length) {
+        parts.push(`${missing.length} agent link${missing.length === 1 ? ' is' : 's are'} now missing`);
+    }
+    if (stale.length) {
+        parts.push(`${stale.length} agent link${stale.length === 1 ? '' : 's'} `
+            + `still carr${stale.length === 1 ? 'ies' : 'y'} the rejected value`);
+    }
+    if (orphaned.length) {
+        parts.push(`${orphaned.length} link${orphaned.length === 1 ? '' : 's'} `
+            + 'may have been created and could not be removed');
+    }
+    return `The change was rejected AND the database could not be put back — ${parts.join(', and ')}. `
+        + 'Reload the page to see the real state.';
+};
 
 /**
  * Apply an ordered plan of junction writes, rolling back on failure.
@@ -228,42 +281,99 @@ export class LinkRollbackError extends Error {
  * recoverable are in our control. Nothing here is atomic (each call is a separate
  * Lambda invocation under autocommit), so recoverability is the whole job.
  *
- * On failure every applied step is undone in REVERSE order, restoring exactly
- * what was there. Steps that were never reached are left alone. If the rollback
+ * On failure every applied step is undone in REVERSE order, restoring what was
+ * there — CANONICALISED, not byte-identical: the restore goes back out through
+ * `linkRow`, so `serializeRoles` drops any superseded member the stored value
+ * happened to carry (req #3101). A `prev` of `owned,referenced` comes back as
+ * `owned`. Nothing in the live registry stores such a set, and the normalisation
+ * is the desirable direction, but a rollback is a place where "exactly what was
+ * there" has to be said accurately.
+ *
+ * Steps that were never reached are left alone. If the rollback
  * itself fails, a LinkRollbackError is thrown naming what could not be put back —
  * the original error is attached as `cause`, but it is no longer the headline,
- * because "your edit was rejected" and "a link is now missing" are different
- * things to tell a user and the second one outranks the first.
+ * because "your edit was rejected" and "the database is not in either state you
+ * asked for" are different things to tell a user and the second one outranks the
+ * first. That covers BOTH directions of damage: a `prev` that could not be
+ * restored (`lost`) and a create-only step whose write could not be removed
+ * (`orphaned`) — see LinkRollbackError.
  */
 export async function applyLinkPlan(darwinUri, idToken, steps) {
     if (!steps.length) return null;
 
     const applied = [];   // steps that completed, newest last
 
+    /**
+     * A step's record says WHAT THE ROLLBACK MUST DO, not what happened to it.
+     *
+     * The two are not the same question and conflating them is how this function
+     * has gone wrong twice. `cleanupNeeded` means "a row may exist here that this
+     * step put there"; `restoreNeeded` means "a row that existed before this step
+     * may be gone". Both are set OPTIMISTICALLY — before the await that would tell
+     * us, and true whenever the outcome is UNKNOWN — because every call here is a
+     * separate Lambda invocation under autocommit, so a lost response after a
+     * committed statement is the normal shape of the failure, not an exotic one.
+     *
+     * A CLEANUP DELETE IS NOT A NO-OP, AND OPTIMISM ABOUT IT IS DESTRUCTIVE. It is
+     * 404-TOLERANT, which is a different thing: against a row that is genuinely
+     * there it succeeds and REMOVES it. So `cleanupNeeded` is set only where this
+     * step actually issued a write of its own — never merely because the state is
+     * unknown. Setting it on the leading-DELETE-threw path (a first pass at this
+     * did) turns the most ordinary failure of all, the database REFUSING the
+     * DELETE with the row untouched, into the rollback deleting that row itself.
+     *
+     * The one thing that is NOT optimistic on the restore side either is a 404 on
+     * the leading DELETE. That is a definite answer — the row was already gone —
+     * and resurrecting a row that did not exist is its own corruption, so
+     * `restoreNeeded` stays false.
+     *
+     * `restoreUncertain` is the third state, and it exists so that REPAIRING and
+     * REPORTING can be decided separately. A leading DELETE that THREW may or may
+     * not have committed, and its rollback is exactly ONE POST — safe in both
+     * directions: if the DELETE committed, the POST restores the row; if it did
+     * not, the POST collides on the composite PK and is caught. A failed repair is
+     * NOT reported as a missing link, because nothing ever established that a link
+     * went missing; claiming one on every failed unlink would be a false alarm on
+     * the common path, bought to cover a rare one.
+     */
     const runStep = async (step) => {
-        const deleted = step.prev
-            ? await unlinkAgentDocument(darwinUri, idToken, step.agent_fk, step.document_fk)
-            : false;
-
-        // RECORDED BEFORE THE INSERT IS ATTEMPTED, and that ordering is the whole
-        // point. A relink is DELETE-then-INSERT; if the INSERT fails, the DELETE
-        // has ALREADY committed (autocommit, separate Lambda invocation) and is
-        // precisely what has to be undone. Pushing after the insert — the obvious
-        // way to write this — means the one step that most needs a rollback is the
-        // only step the rollback never sees, and the link is silently gone.
-        //
-        // `deleted` records what ACTUALLY happened rather than what was intended:
-        // a `prev` that turned out to be already absent (404) must never be
-        // resurrected, because recreating a row that did not exist is its own
-        // corruption.
-        const record = { ...step, deleted, attemptedWrite: false };
+        // PUSHED BEFORE ANY CALL IS ATTEMPTED. Recording after an await means the
+        // one step that most needs a rollback is the only step the rollback never
+        // sees. That was true of the INSERT (fixed by req #3051) and it was still
+        // true of the leading DELETE until req #3101: a DELETE that committed and
+        // then lost its response left `applied` empty, so nothing was ever put
+        // back and a link vanished with no report at all.
+        const record = {
+            ...step, cleanupNeeded: false, restoreNeeded: false, restoreUncertain: false,
+        };
         applied.push(record);
+
+        if (step.prev) {
+            try {
+                // A 404 is the desired end state, not a failure — and it is the
+                // one outcome that rules a restore OUT rather than in.
+                record.restoreNeeded = await unlinkAgentDocument(
+                    darwinUri, idToken, step.agent_fk, step.document_fk);
+            } catch (err) {
+                // Outcome unknown, so REPAIR but do not report — see
+                // `restoreUncertain` above.
+                //
+                // Deliberately NOT `cleanupNeeded`. This step has written nothing,
+                // so there is nothing of its own to clean up, and a cleanup DELETE
+                // here would be issued against a row this step may well have failed
+                // to touch — destroying the very link the rollback exists to save.
+                // The lone POST below is the whole repair and it needs no DELETE in
+                // front of it: it either restores the row or collides with it.
+                record.restoreUncertain = true;
+                throw err;
+            }
+        }
 
         if (step.next) {
             // Flagged BEFORE the await for the same reason: the write may commit
             // and the response still fail (a flake after the INSERT landed), and
             // the rollback has to assume it might be there.
-            record.attemptedWrite = true;
+            record.cleanupNeeded = true;
             await linkAgentDocument(darwinUri, idToken, {
                 ...step.next,
                 agent_fk: step.agent_fk,
@@ -274,47 +384,83 @@ export async function applyLinkPlan(darwinUri, idToken, steps) {
 
     const rollback = async () => {
         const lost = [];
+        const orphaned = [];
         for (const step of [...applied].reverse()) {
+            // TWO INDEPENDENT try BLOCKS, not one around both halves.
+            //
+            // They were one until req #3101, and that coupling had its own defect:
+            // a step whose cleanup DELETE threw skipped its own RESTORE entirely,
+            // so a failure on the half that costs the user nothing prevented the
+            // half that repairs real damage from even being attempted. The two
+            // undo different things and fail for different reasons; neither is
+            // allowed to cancel the other.
+            let cleanupFailed = false;
             try {
-                // Remove whatever this step may have written. Unconditionally
-                // attempted whenever a write was STARTED, not only when it was
-                // observed to succeed — `unlinkAgentDocument` tolerates a 404, so
-                // trying costs nothing, while skipping it would leave a committed
-                // row behind whenever a response was lost after the INSERT landed.
-                if (step.attemptedWrite) {
+                // Remove whatever this step may have put here. 404-tolerant, so
+                // issuing it when there is nothing to remove costs one call and
+                // never fails.
+                if (step.cleanupNeeded) {
                     await unlinkAgentDocument(darwinUri, idToken,
                         step.agent_fk, step.document_fk);
                 }
-                // Then put back whatever it genuinely removed.
-                if (step.deleted && step.prev) {
+            } catch {
+                cleanupFailed = true;
+            }
+
+            // REPAIR on either signal; REPORT only on the confirmed one.
+            const restoring = (step.restoreNeeded || step.restoreUncertain) && step.prev;
+            if (restoring) {
+                try {
                     await linkAgentDocument(darwinUri, idToken, {
                         ...step.prev,
                         agent_fk: step.agent_fk,
                         document_fk: step.document_fk,
                     });
+                } catch {
+                    // Keep unwinding the rest — a second failure must not strand
+                    // steps that could still be undone.
+                    //
+                    // `cleanupFailed` rides along because it changes what to TELL
+                    // the user: with a successful cleanup the row is genuinely
+                    // gone, while with a failed one the row is still there holding
+                    // the value the rejected edit asked for. "Missing" and "not
+                    // what you left" are different repairs.
+                    if (step.restoreNeeded) {
+                        lost.push({ ...step, cleanupFailed });
+                        continue;
+                    }
+                    // Uncertain: we never established that anything was removed, so
+                    // there is nothing we can honestly say went missing. The
+                    // original error stays the headline.
                 }
-            } catch {
-                // Keep unwinding the rest — a second failure must not strand steps
-                // that could still be undone. Only a step that had a row to
-                // restore counts as LOST; one that merely failed to have its own
-                // write cleaned up has not cost the user anything they had.
-                if (step.deleted && step.prev) lost.push(step);
             }
+
+            // NO RESTORE WAS ATTEMPTED and the cleanup failed, so a row this step
+            // may have created is still out there, scoped to nobody's intent —
+            // the orphan req #3051's review flagged as unreported.
+            //
+            // The predicate is "no restore ran", NOT "no `prev`". They look
+            // equivalent and are not: a step whose `prev` turned out to be already
+            // absent (404) carries a non-null `prev` and still skips its restore,
+            // and its INSERT created a row that did not exist a moment earlier.
+            // Keying on `prev` alone left exactly that shape silent — reachable
+            // from a single popover Save whenever another writer removed the link
+            // between the plan being built and the write running.
+            //
+            // It cannot double-count: the `lost` branch above `continue`s.
+            if (cleanupFailed && !restoring) orphaned.push(step);
         }
-        return lost;
+        return { lost, orphaned };
     };
 
     try {
         for (const step of steps) await runStep(step);
         return { applied: applied.length };
     } catch (err) {
-        const lost = await rollback();
-        if (lost.length) {
-            throw new LinkRollbackError(
-                'The change was rejected AND the previous links could not be restored — '
-                + `${lost.length} agent link${lost.length === 1 ? ' is' : 's are'} now missing. `
-                + 'Reload the page to see the real state.',
-                { cause: err, lost });
+        const { lost, orphaned } = await rollback();
+        if (lost.length || orphaned.length) {
+            throw new LinkRollbackError(rollbackMessage(lost, orphaned),
+                { cause: err, lost, orphaned });
         }
         throw err;
     }

--- a/src/Agents/agentRegistryUtils.js
+++ b/src/Agents/agentRegistryUtils.js
@@ -33,6 +33,53 @@ export const isAutoload = (rel) => hasRole(rel, 'autoload');
 export const isPrinciples = (rel) => hasRole(rel, 'principles');
 
 /**
+ * SUPERSEDED ROLES, dropped: the precedence rules of instruction #83, as data.
+ *
+ * `referenced` means "may consult on demand". `owned` and `principles` both mean
+ * the agent reads the document as a matter of course, so either of them already
+ * OUTRANKS a reference — a link carrying both ends of that comparison makes the
+ * precedence rule refer to itself, which is why `relationshipSetError` blocks the
+ * combination outright.
+ *
+ * WHY THIS IS A TABLE AND NOT AN `if` AT A CALL SITE (req #3101, closing finding
+ * 3b from req #3051's review). The invariant used to be enforced in exactly one
+ * place — `planOwnerTransfer` filtered `referenced` out before adding `owned` —
+ * and it got there only because the FIRST version of that function shipped the
+ * invalid combination and had to be corrected. One call site is one chance to
+ * forget, and there was nothing stopping the second call site from making the
+ * same mistake the first one already made once.
+ */
+const SUPERSEDES = {
+    owned: ['referenced'],
+    principles: ['referenced'],
+};
+
+/**
+ * Drop every role that another role in the same set already outranks.
+ *
+ * PURE and ORDER-INDEPENDENT: the result depends only on which roles are present,
+ * never on the order they arrive in.
+ *
+ * This function does not drop unknown members — that is `serializeRoles`' job, and
+ * doing it in two places would make neither the authority. **But that is only
+ * observable on the ARRAY form.** A string argument goes through `parseRoles`
+ * first, which keeps only members in `RELATIONSHIP_ORDER`, so `'owned,nonsense'`
+ * arrives here already filtered while `['owned', 'nonsense']` does not. The
+ * asymmetry is inherited from the parse, not decided here, and it does not reach
+ * the database either way.
+ */
+export const resolveRoleConflicts = (roles = []) => {
+    const list = Array.isArray(roles) ? roles : parseRoles(roles);
+    const present = new Set(list.map(r => (r || '').trim()).filter(Boolean));
+    const dropped = new Set();
+    for (const [winner, losers] of Object.entries(SUPERSEDES)) {
+        if (!present.has(winner)) continue;
+        for (const loser of losers) dropped.add(loser);
+    }
+    return [...present].filter(r => !dropped.has(r));
+};
+
+/**
  * The INVERSE of `parseRoles`: roles -> the exact string the database stores.
  *
  * Deliberately named as `parseRoles`' pair and defined next to it, because the
@@ -46,10 +93,20 @@ export const isPrinciples = (rel) => hasRole(rel, 'principles');
  *
  * So: bare comma, no space, unknown members dropped, output in precedence order
  * so two links with the same roles always store byte-identical strings.
+ *
+ * AND SUPERSEDED MEMBERS DROPPED (req #3101). This is the same job as dropping an
+ * unknown member, not a new one: both answer "what does the database actually
+ * store for this set?", and both have to be settled at the ONE boundary every
+ * junction write crosses — `linkRow` in documentsApi.js serializes here, so no
+ * caller can route around it. It does not make `relationshipSetError` redundant
+ * and does not weaken it: the validator still refuses the combination on the raw
+ * set the USER composed, out loud, in the popover. The serializer is the last
+ * line, for sets nobody typed — a transfer plan, an MCP-written row read back,
+ * a future call site that has not been written yet.
  */
 export const serializeRoles = (roles = []) => {
     const list = Array.isArray(roles) ? roles : parseRoles(roles);
-    const present = new Set(list.map(r => (r || '').trim()));
+    const present = new Set(resolveRoleConflicts(list));
     return RELATIONSHIP_ORDER.filter(r => present.has(r)).join(',');
 };
 
@@ -148,10 +205,76 @@ const isSafeHref = (url) => {
     return SAFE_HREF_SCHEME.test(trimmed) || /^https?:$/i.test(scheme[1] + ':');
 };
 
-export const documentHref = (doc) => {
-    if (doc?.url && isSafeHref(doc.url)) return doc.url;
-    if (!doc?.location) return null;
-    return `https://github.com/BillWilliams79/DarwinAI-Config/blob/main/${doc.location}`;
+export const documentBlobHref = (location) => (
+    (location || '').trim()
+        ? `https://github.com/BillWilliams79/DarwinAI-Config/blob/main/${location.trim()}`
+        : null);
+
+/**
+ * DELEGATES to `documentTarget` (req #3101) rather than restating its precedence.
+ *
+ * The two used to be independent implementations of one rule, which is a standing
+ * invitation to drift — and drift here does not fail, it MISLABELS: `documentTarget`
+ * decides which chip the card draws as "the one that opens" while this decides
+ * where the button actually goes. One derivation, one answer.
+ */
+export const documentHref = (doc) => documentTarget(doc).href;
+
+/**
+ * WHAT THIS ROW POINTS AT — the whole answer, in one pure function (req #3101, § 2).
+ *
+ * An `architecture_documents` row is a REGISTRATION, not a file. It records a
+ * repo-relative `location` on disk and/or an external `url`, and Darwin never
+ * touches either: nothing opens the path, nothing fetches the URL, and deleting
+ * the row deletes neither. A typo in `location` is discovered when an agent fails
+ * to read it at boot — which it does silently, because the executor is an LLM.
+ *
+ * Until #3101 that distinction lived only in the DELETE and LOCATION dialogs'
+ * copy: invisible on the resting card, and therefore invisible to everybody who
+ * was not already in the middle of a destructive action. The card now renders it
+ * (DocumentTargetChips) and this is the derivation behind it.
+ *
+ * THIS IS ALSO THE ONE PLACE THE OPEN-LINK PRECEDENCE IS DECIDED. `documentHref`
+ * is `documentTarget(doc).href` — it used to be a second implementation of the same
+ * rule, which is a standing invitation to drift, and drift here would not fail, it
+ * would MISLABEL: this decides which chip the card draws as "the one that opens"
+ * while `documentHref` decides where the button actually goes.
+ *
+ * `urlRejected` is what the card gained beyond a bare href. The precedence
+ * deliberately FALLS THROUGH to the constructed blob URL when a stored `url` fails
+ * the scheme guard, so the row keeps a working link — but that fallback is
+ * completely silent, and a row whose `url` column is unusable looked identical to
+ * a row that never had one. Somebody has to be told, and the card is where they
+ * are looking.
+ *
+ * @returns {{
+ *   hasLocation: boolean, hasUrl: boolean,
+ *   urlUsable: boolean, urlRejected: boolean,
+ *   opens: 'url'|'path'|null, href: string|null, blobHref: string|null,
+ * }}
+ */
+export const documentTarget = (doc) => {
+    const location = (doc?.location || '').trim();
+    const url = (doc?.url || '').trim();
+    const hasLocation = !!location;
+    const hasUrl = !!url;
+    const urlUsable = hasUrl && isSafeHref(url);
+    const blobHref = documentBlobHref(location);
+
+    // THE precedence rule — a stored, usable `url` wins; otherwise the path, as a
+    // constructed blob URL. `documentHref` delegates here rather than restating it,
+    // so the chip labelled "opens" and the button's destination cannot disagree.
+    const opens = urlUsable ? 'url' : (blobHref ? 'path' : null);
+
+    return {
+        hasLocation,
+        hasUrl,
+        urlUsable,
+        urlRejected: hasUrl && !urlUsable,
+        opens,
+        href: opens === 'url' ? url : blobHref,
+        blobHref,
+    };
 };
 
 /**
@@ -720,17 +843,22 @@ export const planOwnerTransfer = ({
     }
 
     if (toAgentId != null) {
-        // `owned` SUPERSEDES `referenced`; it does not stack with it. Instruction
-        // #83 makes an owned document outrank a referenced one, so a link carrying
-        // both makes that precedence rule refer to itself — which is exactly why
-        // `relationshipSetError` blocks the combination. A blind union would
-        // therefore have produced a set this codebase itself rejects: claiming
-        // ownership of a document you currently merely reference (the single
-        // commonest transfer target, since all 32 non-owner links are plain
-        // `referenced`) would build an invalid plan. Drop `referenced` on the way
-        // in. `autoload` and `curated` are orthogonal to ownership and are kept.
+        // `owned` SUPERSEDES `referenced`; it does not stack with it. A blind
+        // union would therefore produce a set this codebase itself rejects:
+        // claiming ownership of a document you currently merely reference (the
+        // single commonest transfer target, since all 32 non-owner links are plain
+        // `referenced`) would build an invalid plan. `autoload` and `curated` are
+        // orthogonal to ownership and are kept.
+        //
+        // THAT RULE IS NO LONGER APPLIED HERE (req #3101). It lives in
+        // `resolveRoleConflicts`, which `serializeRoles` runs on every set on its
+        // way to the wire — so this call site gets it for free and, more to the
+        // point, so does every call site written after this one. This function was
+        // where the invariant was enforced and where the first version of it was
+        // got WRONG; a rule holding in exactly one place is a rule waiting to be
+        // forgotten in the second.
         const merged = serializeRoles([
-            ...parseRoles(toLink?.relationship).filter(r => r !== 'referenced'),
+            ...parseRoles(toLink?.relationship),
             'owned',
         ]);
         steps.push({

--- a/src/Agents/commitModes.jsx
+++ b/src/Agents/commitModes.jsx
@@ -1,0 +1,174 @@
+// A CONSISTENT VISUAL LANGUAGE FOR "WHEN DOES THIS SAVE?" (req #3101, § 1).
+//
+// THE PROBLEM THIS SOLVES. The document card mixes FIVE distinct commit models on
+// one surface, and before this module none of them was distinguishable from any
+// other until you interacted with it:
+//
+//   blur-commit          name, url — click away and it is written
+//   blur-then-confirm    location, but only when an agent autoloads the document
+//   click-commit         doc_type chips, owner claim, agent bind
+//   staged behind Save   the link popover's roles + notes
+//   read-only here       agent_documents.sort_order, owned by AgentDetail
+//
+// Every one of those is individually correct and each has a written reason (see
+// DocumentLinkPopover's header for why the Save button exists, and
+// DocumentLocationDialog's for why one field gets a dialog). The defect was that
+// the reasons are invisible: a user learns which control is which by clicking it.
+//
+// OPTION (a), NOT OPTION (b). The requirement offered a choice between giving the
+// commit types a consistent visual language and REDUCING the number of interaction
+// patterns. This is the first. It is the reversible one — every existing control
+// keeps working exactly as it did, and nothing a user has already learned changes.
+// Collapsing the patterns would change behaviour people already have, and each of
+// the five exists to satisfy a constraint that would still be there afterwards
+// (no PUT on an id-less junction; a DB-unique ownership key; a field an LLM
+// executes). Option (b) stays open and is a design conversation, not a polish pass.
+//
+// THE MARKER IS DISPLAY ONLY. It renders an icon and a tooltip. It never gates,
+// disables, intercepts or defers a write, so a marker that is wrong is a wrong
+// caption and not a broken control — which is the property that makes it safe to
+// put on nine regions at once (seven on a card, two in the link popover).
+
+import Box from '@mui/material/Box';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import ReportProblemOutlinedIcon from '@mui/icons-material/ReportProblemOutlined';
+import TouchAppOutlinedIcon from '@mui/icons-material/TouchAppOutlined';
+import SaveOutlinedIcon from '@mui/icons-material/SaveOutlined';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+
+/**
+ * The five commit models, as data.
+ *
+ * `label` is the two-or-three-word name shown in the legend. `description` is the
+ * full sentence shown in a marker's tooltip — written to say what will HAPPEN, not
+ * to name the mechanism, because "commits on blur" is jargon for the only audience
+ * that does not need the marker.
+ */
+export const COMMIT_MODES = {
+    blur: {
+        id: 'blur',
+        label: 'saves when you click away',
+        description: 'Type and click away — the value is written immediately. '
+            + 'Press Escape to abandon the edit instead.',
+        Icon: EditOutlinedIcon,
+    },
+    confirm: {
+        id: 'confirm',
+        label: 'asks before saving',
+        description: 'Clicking away opens a confirmation naming what the change '
+            + 'affects. Nothing is written until you accept it.',
+        Icon: ReportProblemOutlinedIcon,
+    },
+    click: {
+        id: 'click',
+        label: 'saves on click',
+        description: 'One click writes immediately. There is no Save button and '
+            + 'no confirmation — clicking a different value is the undo.',
+        Icon: TouchAppOutlinedIcon,
+    },
+    staged: {
+        id: 'staged',
+        label: 'staged until you press Save',
+        description: 'Changes here are held and written together when you press '
+            + 'Save. Cancel or clicking away discards them.',
+        Icon: SaveOutlinedIcon,
+    },
+    readOnly: {
+        id: 'readOnly',
+        label: 'read-only here',
+        description: 'Shown for context and edited on a different page. Nothing '
+            + 'here can change it.',
+        Icon: LockOutlinedIcon,
+    },
+};
+
+/** Legend order: increasing ceremony, then the one that is not an edit at all. */
+export const COMMIT_MODE_ORDER = ['click', 'blur', 'confirm', 'staged', 'readOnly'];
+
+/**
+ * One small muted icon saying how the control beside it commits.
+ *
+ * `note` is APPENDED to the mode's own description rather than replacing it, so a
+ * region with a wrinkle (the agent chips, where adding is a click but removing
+ * confirms) can say so without a second copy of the base sentence drifting from
+ * this file.
+ */
+export const CommitModeMarker = ({ mode, note, testId, sx }) => {
+    const spec = COMMIT_MODES[mode];
+    // An unknown mode renders NOTHING rather than a fallback icon. A marker is a
+    // claim about behaviour; a placeholder would be a claim nobody made.
+    if (!spec) return null;
+    const { Icon, label, description } = spec;
+    const title = note ? `${description} ${note}` : description;
+
+    return (
+        <Tooltip title={title}>
+            {/* A span so the tooltip has a real element to hang off even when the
+                icon itself is inside a flex row that would otherwise collapse it.
+                `role="img"` is what makes `aria-label` reliable here — on a
+                role-less generic element it is weakly supported.
+                THE WHOLE SENTENCE GOES IN THE LABEL, not the short name, and there
+                is deliberately NO `tabIndex`. Making each marker focusable would
+                surface the tooltip to keyboard users, but it puts SEVEN
+                non-interactive stops on every card — roughly 580 across the live
+                registry — between a keyboard user and the fields they came to
+                edit. A screen reader reads this label without any of them, and
+                `CommitModeLegend` renders every mode's name as visible text for
+                sighted keyboard users, so nothing is only-on-hover. */}
+            <Box
+                component="span"
+                role="img"
+                aria-label={`Saving: ${label}. ${title}`}
+                sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    color: 'text.disabled',
+                    flexShrink: 0,
+                    cursor: 'help',
+                    ...sx,
+                }}
+                data-testid={testId}
+                data-commit-mode={spec.id}
+            >
+                <Icon sx={{ fontSize: '0.95rem' }} />
+            </Box>
+        </Tooltip>
+    );
+};
+
+/**
+ * The key, rendered once per page.
+ *
+ * INLINE SPANS ONLY, and that is a hard constraint rather than a style: this is
+ * rendered inside ViewerHeader's `accounting` node, which the header wraps in a
+ * `<Typography variant="body2">` — a `<p>`. A `<div>` inside a `<p>` is invalid
+ * HTML that React hydrates around by silently closing the paragraph early, so the
+ * accounting line and the legend would end up in different blocks.
+ */
+export const CommitModeLegend = ({ modes = COMMIT_MODE_ORDER, testIdPrefix }) => (
+    <Box
+        component="span"
+        sx={{ display: 'inline-flex', flexWrap: 'wrap', alignItems: 'center',
+              columnGap: 1.5, rowGap: 0.25, ml: 0.5 }}
+        data-testid={testIdPrefix ? `${testIdPrefix}-commit-legend` : undefined}
+    >
+        {modes.map(id => {
+            const spec = COMMIT_MODES[id];
+            if (!spec) return null;
+            const { Icon, label, description } = spec;
+            return (
+                <Tooltip key={id} title={description}>
+                    <Box component="span"
+                         sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.375,
+                               color: 'text.disabled', cursor: 'help' }}
+                         data-testid={testIdPrefix ? `${testIdPrefix}-commit-legend-${id}` : undefined}>
+                        <Icon sx={{ fontSize: '0.95rem' }} />
+                        <Typography component="span" variant="caption">{label}</Typography>
+                    </Box>
+                </Tooltip>
+            );
+        })}
+    </Box>
+);

--- a/src/hooks/__tests__/useBusyCounts.test.jsx
+++ b/src/hooks/__tests__/useBusyCounts.test.jsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+//
+// Req #3101, finding 3c — the defect this hook exists to fix is invisible in
+// isolation and every one of its four cases is a one-liner, which is exactly why
+// it survived a code review as "cosmetic only" and shipped twice.
+//
+// Both registry pages held `useState(() => new Set())` and add/delete'd a row id
+// around each queued membership write. A Set answers "busy?" with a BOOLEAN, and a
+// boolean cannot be released twice — so TWO writes queued against the SAME row
+// shared one flag and the first to finish cleared it while the second was still in
+// flight. The card stopped spinning and re-enabled its ghost chips mid-write.
+//
+// The old behaviour passes every test that only ever marks one write per row,
+// which is the shape every existing test happens to have.
+
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import { useBusyCounts } from '../useBusyCounts';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+/** Mount a probe that hands the hook's API back through a mutable box. */
+function mount(api) {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    let renders = 0;
+    function Probe() {
+        api.current = useBusyCounts();
+        renders += 1;
+        return null;
+    }
+    act(() => root.render(<Probe />));
+    return {
+        renderCount: () => renders,
+        unmount: () => { act(() => root.unmount()); host.remove(); },
+    };
+}
+
+describe('useBusyCounts', () => {
+    it('starts idle for every row', () => {
+        const api = {};
+        const h = mount(api);
+        expect(api.current.isBusy(1)).toBe(false);
+        expect(api.current.isBusy('anything')).toBe(false);
+        h.unmount();
+    });
+
+    it('marks and releases one write', () => {
+        const api = {};
+        const h = mount(api);
+        act(() => api.current.mark(1, true));
+        expect(api.current.isBusy(1)).toBe(true);
+        act(() => api.current.mark(1, false));
+        expect(api.current.isBusy(1)).toBe(false);
+        h.unmount();
+    });
+
+    it('STAYS BUSY when the first of two writes on the SAME row finishes', () => {
+        // THE DEFECT. With a Set, the release below cleared the only flag and the
+        // card reported itself idle with a write still in flight.
+        const api = {};
+        const h = mount(api);
+        act(() => { api.current.mark(1, true); api.current.mark(1, true); });
+        expect(api.current.isBusy(1)).toBe(true);
+
+        act(() => api.current.mark(1, false));
+        expect(api.current.isBusy(1)).toBe(true);      // second write still running
+
+        act(() => api.current.mark(1, false));
+        expect(api.current.isBusy(1)).toBe(false);
+        h.unmount();
+    });
+
+    it('keeps two rows independent — the reason it was a Set and not one id', () => {
+        const api = {};
+        const h = mount(api);
+        act(() => { api.current.mark(1, true); api.current.mark(2, true); });
+        act(() => api.current.mark(1, false));
+        expect(api.current.isBusy(1)).toBe(false);
+        expect(api.current.isBusy(2)).toBe(true);
+        h.unmount();
+    });
+
+    it('does not go negative on an unbalanced release', () => {
+        // A clamp rather than a stored negative: a deficit would silently suppress
+        // the spinner on every LATER write against that row.
+        const api = {};
+        const h = mount(api);
+        act(() => { api.current.mark(1, false); api.current.mark(1, false); });
+        expect(api.current.isBusy(1)).toBe(false);
+        act(() => api.current.mark(1, true));
+        expect(api.current.isBusy(1)).toBe(true);
+        h.unmount();
+    });
+
+    it('forgets a row once it returns to idle, rather than growing forever', () => {
+        const api = {};
+        const h = mount(api);
+        act(() => api.current.mark(7, true));
+        expect(api.current.counts.has(7)).toBe(true);
+        act(() => api.current.mark(7, false));
+        expect(api.current.counts.has(7)).toBe(false);
+        h.unmount();
+    });
+
+    it('does not re-render when a release finds nothing to release', () => {
+        // The state updater returns the SAME Map, so React bails out. Without it a
+        // no-op release would churn every consumer memoized on `isBusy`.
+        const api = {};
+        const h = mount(api);
+        const before = h.renderCount();
+        act(() => api.current.mark(99, false));
+        expect(h.renderCount()).toBe(before);
+        h.unmount();
+    });
+
+    it('keeps `mark` stable across renders so callers may hold it', () => {
+        const api = {};
+        const h = mount(api);
+        const first = api.current.mark;
+        act(() => api.current.mark(1, true));
+        expect(api.current.mark).toBe(first);
+        h.unmount();
+    });
+
+    it('gives `isBusy` a NEW identity whenever some row moved', () => {
+        // InstructionsTableView memoizes its grid rows on this function, so an
+        // identity that never changed would freeze every row's spinner.
+        const api = {};
+        const h = mount(api);
+        const first = api.current.isBusy;
+        act(() => api.current.mark(1, true));
+        expect(api.current.isBusy).not.toBe(first);
+        h.unmount();
+    });
+});

--- a/src/hooks/useBusyCounts.js
+++ b/src/hooks/useBusyCounts.js
@@ -1,0 +1,65 @@
+// Per-row in-flight WRITE COUNTS for a list of independently-editable rows
+// (req #3101, closing finding 3c from req #3051's review).
+//
+// WHY A COUNTER AND NOT A SET OF IDS.
+//
+// Both registry pages used to hold `useState(() => new Set())` and add/delete a
+// row id around each queued membership write. A Set answers "is this row busy?"
+// with a BOOLEAN, and a boolean cannot be released twice — so two writes queued
+// against the SAME row shared one flag, and the FIRST one to finish deleted it
+// while the second was still in flight. The card stopped spinning, its ghost chips
+// re-enabled, and the user could fire a third write at a card that was still
+// mid-write. The underlying writes stayed correctly serialized behind the page's
+// promise queue, so nothing was ever corrupted — the signal was simply lying about
+// when it was safe to click.
+//
+// A counter is the smallest correct fix: `mark(id, true)` increments, `mark(id,
+// false)` decrements, and a row is busy while its count is above zero. Balanced
+// increment/decrement pairs are already guaranteed by the callers — both pages
+// decrement in a `finally`.
+//
+// Zero counts are DELETED rather than kept at 0. The map is a render dependency;
+// leaving spent entries behind would grow it for the life of the page and produce
+// a new Map identity for every write that returns to idle.
+//
+// Shared by /agents/documents and /agents/instructions because they had the same
+// defect for the same reason. It is deliberately NOT generic beyond that: it takes
+// a row id and answers a question about one row, which is all either page needs.
+
+import { useCallback, useMemo, useState } from 'react';
+
+export const useBusyCounts = () => {
+    const [counts, setCounts] = useState(() => new Map());
+
+    // Stable across renders so a caller may hold it in a ref or a dep array.
+    const mark = useCallback((rowId, on) => setCounts(prev => {
+        const current = prev.get(rowId) || 0;
+        const next = current + (on ? 1 : -1);
+        // A decrement below zero can only mean an unbalanced caller. Clamp rather
+        // than store a negative: a negative count reads as "not busy" through the
+        // `> 0` test anyway, and keeping it would make every later increment on
+        // that row start from a deficit and silently suppress the spinner.
+        if (next <= 0) {
+            if (!prev.has(rowId)) return prev;
+            const map = new Map(prev);
+            map.delete(rowId);
+            return map;
+        }
+        const map = new Map(prev);
+        map.set(rowId, next);
+        return map;
+    }), []);
+
+    // Recreated whenever `counts` changes, so a consumer's `useMemo` keyed on this
+    // function re-runs whenever a count moved. Deliberately NOT "exactly when a
+    // row's busy state moved": a 2→1 decrement makes a new Map and therefore a new
+    // identity while every row's boolean is unchanged, so the consumer recomputes
+    // for nothing. That is a wasted memo, never a stale one, and narrowing it would
+    // mean tracking the previous booleans — more moving parts than the churn costs.
+    // A no-op release does NOT churn: `mark` returns the same Map and React bails.
+    const isBusy = useMemo(() => (rowId) => (counts.get(rowId) || 0) > 0, [counts]);
+
+    return { mark, isBusy, counts };
+};
+
+export default useBusyCounts;


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-03T01:13:33Z
- chore: init swarm session feature/3101-documents-registry-page-polish-pass-1

## Files changed
```
 src/Agents/DocumentAgentChips.jsx                  |   6 +
 src/Agents/DocumentLinkPopover.jsx                 |  65 +++++-
 src/Agents/DocumentTargetChips.jsx                 | 168 ++++++++++++++
 src/Agents/DocumentsPage.jsx                       | 137 +++++++++--
 src/Agents/InstructionsPage.jsx                    |  23 +-
 src/Agents/InstructionsTableView.jsx               |  11 +-
 src/Agents/__tests__/DocumentsPage.test.jsx        | 212 +++++++++++++++++
 src/Agents/__tests__/documentRegistryUtils.test.js | 133 +++++++++++
 src/Agents/__tests__/documentsApi.test.js          | 244 +++++++++++++++++++-
 src/Agents/actions/documentsApi.js                 | 252 ++++++++++++++++-----
 src/Agents/agentRegistryUtils.js                   | 158 +++++++++++--
 src/Agents/commitModes.jsx                         | 174 ++++++++++++++
 src/hooks/__tests__/useBusyCounts.test.jsx         | 140 ++++++++++++
 src/hooks/useBusyCounts.js                         |  65 ++++++
 14 files changed, 1679 insertions(+), 109 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)