### PR TITLE
Aggregator card: eradicate every message — no empty-state text, no explanatory prose, no carve-outs

### DIFF
--- a/src/TaskPlanView/SwarmStartCard.jsx
+++ b/src/TaskPlanView/SwarmStartCard.jsx
@@ -7,6 +7,10 @@
 //     the user to the requirement editor in "new" mode — nothing is saved until the
 //     user picks a category in the editor (the aggregator has no default category).
 //   • Other interactions (status cycle, coord cycle, title edit, delete) mirror CategoryCard.
+//   • req #3286 — the card renders NO MESSAGES, in any state. Chips, rows, the sort
+//     menu and the template row are the whole card; an empty chip renders an empty
+//     body. Removing text never removes behaviour: the pipeline exclusion below is
+//     untouched and simply goes unexplained on this surface, by design.
 
 import React, { useState, useEffect, useContext, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -44,7 +48,6 @@ import AppContext from '../Context/AppContext';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import IconButton from '@mui/material/IconButton';
@@ -208,34 +211,26 @@ const SwarmStartCard = () => {
     // req #3180 — a launch chip's count applies the SAME rule as its list, from
     // the same Set, so the header can never disagree with the rows beneath it.
     //
-    // LOAD-BEARING: `hidden[s]` is the count dropped from that chip's LIST only
-    // because both sources are the same population — `useAllRequirements` here
-    // and `useRequirementsByStatus` above both read /requirements with NO
-    // category predicate and NO closed-category guard. RequirementsTableView
-    // does filter through `categoryMap`, and copying that here would look like
-    // an improvement while desynchronizing the count from the list AND
-    // overcounting the note, in one edit. See `tallyRequirementStatuses`.
+    // LOAD-BEARING: a chip's badge matches the rows beneath it only because both
+    // sources are the same population — `useAllRequirements` here and
+    // `useRequirementsByStatus` above both read /requirements with NO category
+    // predicate and NO closed-category guard. RequirementsTableView does filter
+    // through `categoryMap`, and copying that here would look like an improvement
+    // while desynchronizing the count from the list. See `tallyRequirementStatuses`.
     //
-    // req #3248 removed this notice + hidden-tracking on master (its only
-    // consumer was the explanatory sentence, and the user asked for that
-    // sentence gone after daily use) — kept here instead on the user's
-    // explicit direction during req #3242/#3258's merge, to revisit later
-    // rather than drop it a second time. `hidden` now also covers what the
-    // req #3258 toggle (not just the unconditional launch exclusion) removed.
-    const { statusCountMap, hiddenCountMap } = React.useMemo(() => {
-        const { counts, hidden } = tallyRequirementStatuses(
+    // req #3286 — the card reads `counts` ONLY. `tallyRequirementStatuses` still
+    // returns `hidden` (a pure util with its own tests, and the count arithmetic
+    // depends on it), but the card no longer tracks it: its one consumer was the
+    // explanatory sentence, and this card renders no sentences. Reading `hidden`
+    // again here means a message is being reintroduced.
+    const statusCountMap = React.useMemo(() => {
+        const { counts } = tallyRequirementStatuses(
             allRequirementsForCounts, SWARM_START_STATUSES, pipelinedIds, hidePipelined);
         if (Array.isArray(serverMetRequirements)) {
             counts.met = eligibleMetRequirements?.length ?? serverMetRequirements.length;
-            hidden.met = serverMetRequirements.length - counts.met;
         }
-        return { statusCountMap: counts, hiddenCountMap: hidden };
+        return counts;
     }, [allRequirementsForCounts, serverMetRequirements, eligibleMetRequirements, pipelinedIds, hidePipelined]);
-
-    // How many rows the exclusion removed from the chip currently on screen.
-    // Surfaced in the card body — a hidden row the user is never told about is
-    // the defect this requirement is about.
-    const hiddenCount = excludeFromThisChip ? (hiddenCountMap[effectiveStatus] ?? 0) : 0;
 
     // Template rows (id === '') always sort last so they stay anchored at the
     // bottom of the card on every re-sort.
@@ -575,28 +570,21 @@ const SwarmStartCard = () => {
                         categoryColorMap,
                         strikethroughMet: false, // req #2584 — recent-Met list, not crossed-off
                     }}>
-                        {requirementsArray.filter(r => r.id !== '').length === 0 && (
-                            <Typography variant="body2" sx={{ color: 'text.disabled', p: 1 }}>
-                                No {requirementStatusLabel(effectiveStatus).toLowerCase()} requirements
-                            </Typography>
-                        )}
-                        {/* req #3180 note, kept per user direction during the req #3242/#3258
-                            merge (req #3248 removed it on master; the user asked to keep it and
-                            revisit later rather than drop it a second time). Rendered whether or
-                            not the list is empty, because a partly-filtered chip is just as
-                            misleading as an empty one — "N more …" would presuppose rows above
-                            it, which is wrong in the guaranteed opening state (Swarm-Ready,
-                            fully hidden). */}
-                        {hiddenCount > 0 && (
-                            <Typography variant="body2"
-                                        sx={{ color: 'text.secondary', px: 1, pb: 1, fontStyle: 'italic' }}
-                                        data-testid="swarm-start-pipelined-note">
-                                {hiddenCount} {requirementStatusLabel(effectiveStatus).toLowerCase()}{' '}
-                                requirement{hiddenCount === 1 ? ' is' : 's are'} carried by a pipeline
-                                step — launched from the plan, not from here. See Pipelines, or launch
-                                one directly by id.
-                            </Typography>
-                        )}
+                        {/* req #3286 — THE CARD RENDERS NO MESSAGES. Two used to sit here:
+                            the "No <status> requirements" empty state and the req #3180
+                            pipelined-exclusion note. Both are gone unconditionally. An empty
+                            chip renders an empty card body — chips, rows, the sort menu and
+                            the template row are the card.
+
+                            THE NOTE HAS BEEN REMOVED ONCE BEFORE AND CAME BACK, which is why
+                            the guard is a test and not a convention: req #3248 deleted it on
+                            master (Darwin PR #911, merge 0623939 — verified), and req
+                            #3242/#3258's merge (e52da54) restored it on the user's explicit
+                            direction, to revisit rather than drop it twice. This is that
+                            revisit, and the answer is no message. The empty state is older
+                            than both and was never in scope until now.
+                            The EXCLUSION ITSELF IS UNCHANGED: see `excludeFromThisChip` above.
+                            Do not reintroduce prose here to explain a filter. */}
                         {requirementsArray.map((requirement, requirementIndex) => (
                             <RequirementRow
                                 key={requirement.id}

--- a/src/TaskPlanView/__tests__/SwarmStartCard.noMessages.test.jsx
+++ b/src/TaskPlanView/__tests__/SwarmStartCard.noMessages.test.jsx
@@ -1,0 +1,374 @@
+// @vitest-environment jsdom
+//
+// Req #3286 — THE AGGREGATOR CARD RENDERS NO MESSAGES, IN ANY STATE.
+//
+// This is the requirement's acceptance criterion made mechanical. A
+// string-absence assertion would not do: this card's pipelined note was already
+// deleted once (req #3248, Darwin PR #911) and restored by the req #3242/#3258
+// merge, so the guard has to catch the NEXT sentence, not the last one. It
+// ENUMERATES what the real card puts on screen and requires each item to be a
+// control label or a datum:
+//
+//   • one of the five chip labels
+//   • a badge count — `\d+`, or MUI's `99+` overflow form (Badge's `max`
+//     defaults to 99, and the Met chip's count runs to four digits on live data)
+//   • a row's own title, in the title editor
+//
+// Anything else — an empty state, a filter explanation, a hint — fails. Prose
+// is swept for in every place a READER could see it: text nodes, the two
+// attributes that render text without one (`placeholder`, `title`), and
+// form-control values. `aria-label` is NOT swept — see the note on
+// `cardAttributeText` for why that is the right line.
+//
+// KNOWN LIMIT, deliberate: the sort Menu, the row Tooltips, RequirementDeleteDialog
+// and `showError` snackbars all render into portals on `document.body`, outside
+// the card subtree walked here. The requirement keeps all four, so this proves
+// "no message in the card's own DOM" — not "no text anywhere near the card".
+//
+// States exercised: every one of the five chips, each with rows and with none,
+// plus the fully-pipeline-excluded state (the guaranteed opening state on the
+// live plan: Swarm-Ready, every row hidden) which is what the removed note
+// described, the four-digit Met count, and first paint before any query resolves.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DndProvider } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
+
+// Query doubles. `undefined` is a real state here (first paint / in-flight),
+// distinct from `[]` (resolved and empty) — the card renders a spinner for the
+// former and a body for the latter, and both must be message-free.
+let activeRows;
+let metRows;
+let allRows;
+let pipelinedIds;
+const EMPTY = [];
+vi.mock('../../hooks/useDataQueries', () => ({
+    useRequirementsByStatus: () => ({ data: activeRows }),
+    useRequirementsDone: () => ({ data: metRows }),
+    useSessions: () => ({ data: EMPTY }),
+    useCategoryColors: () => ({ data: EMPTY }),
+    useAllRequirements: () => ({ data: allRows }),
+    usePipelinedRequirementIds: () => pipelinedIds,
+}));
+
+vi.mock('../../RestApi/RestApi', () => ({
+    default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })),
+}));
+
+import SwarmStartCard from '../SwarmStartCard';
+import AuthContext from '../../Context/AuthContext';
+import AppContext from '../../Context/AppContext';
+import { useSwarmStartCardStore } from '../../stores/useSwarmStartCardStore';
+import { useShowClosedStore } from '../../stores/useShowClosedStore';
+import { requirementStatusLabel } from '../../SwarmView/statusChipStyles';
+
+const STATUSES = ['authoring', 'approved', 'swarm_ready', 'development', 'met'];
+const CHIP_LABELS = new Set(STATUSES.map(requirementStatusLabel));
+
+let roots = [];
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
+                            <SwarmStartCard />
+                        </DndProvider>
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    return { container };
+}
+
+async function flush() {
+    await act(async () => {
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+        await new Promise((r) => setTimeout(r, 0));
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+    });
+}
+
+// Every non-blank text node inside the card, in document order.
+//
+// Zero-width characters are stripped before the blank check: MUI's outlined
+// TextField puts a U+200B in the notched-outline legend of every row's title
+// editor, which is layout scaffolding rather than anything a reader can see.
+// Only invisible characters are stripped — no real copy can hide behind this.
+const stripInvisible = (s) => s.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
+
+// Text inside a form control is the row's TITLE — the requirement's own data,
+// typed by the user, not copy the card authored. (React seeds the multiline
+// title editor's <textarea> with a text child.) It is NOT skipped: it is checked
+// against the fixture's titles below, so a sentence cannot be smuggled in as a
+// control's value either.
+const isFormControlValue = (node) =>
+    Boolean(node.parentElement && node.parentElement.closest('textarea, input'));
+
+function cardEl(container) {
+    const card = container.querySelector('[data-testid="swarm-start-card"]');
+    expect(card, 'the card itself must render').not.toBeNull();
+    return card;
+}
+
+function cardTextNodes(card) {
+    const walker = document.createTreeWalker(card, NodeFilter.SHOW_TEXT);
+    const out = [];
+    for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+        if (isFormControlValue(n)) continue;
+        const text = stripInvisible(n.textContent || '');
+        if (text) out.push(text);
+    }
+    return out;
+}
+
+// Text a reader sees WITHOUT a text node: `placeholder` renders in an empty
+// field, `title` renders as a native tooltip, and a control's `value` is the
+// field's contents. A message hidden in any of the three would sail past a
+// text-node-only walker, so they are swept with the same allowlist.
+//
+// `aria-label` is deliberately NOT swept: it is not visible, and on this card it
+// carries the accessible NAME of icon-only controls (`Open requirement 42`) —
+// the same category as the row Tooltips the requirement explicitly keeps.
+function cardAttributeText(card) {
+    const out = [];
+    for (const el of card.querySelectorAll('[placeholder], [title]')) {
+        for (const attr of ['placeholder', 'title']) {
+            const v = stripInvisible(el.getAttribute(attr) || '');
+            if (v) out.push(v);
+        }
+    }
+    for (const el of card.querySelectorAll('textarea, input')) {
+        // MUI's TextareaAutosize renders a SECOND, off-screen textarea purely to
+        // measure height, seeded with `value || placeholder || 'x'`. The literal
+        // 'x' (TextareaAutosize.js:105) is measurement scaffolding, not copy, and
+        // is the ONLY thing skipped here.
+        //
+        // The skip is keyed on that sentinel VALUE, not on the shadow's markers.
+        // Excluding every `aria-hidden` control — even requiring all three markers
+        // (`aria-hidden` + `readOnly` + `tabIndex=-1`, TextareaAutosize.js:213-224)
+        // — leaves a real hole: a hand-written `<textarea aria-hidden readOnly
+        // tabIndex={-1} value="No swarm-ready requirements">` carries all three and
+        // would sail through. Measured: it did. Keying on 'x' closes that, and
+        // nothing legitimate is lost — when the shadow mirrors a real value it
+        // mirrors a row title, which the allowlist accepts anyway, and when it
+        // mirrors a placeholder the visible field's own attribute is swept above.
+        const isAutosizeShadow = el.getAttribute('aria-hidden') === 'true'
+            && el.readOnly && el.tabIndex === -1 && el.value === 'x';
+        if (isAutosizeShadow) continue;
+        const v = stripInvisible(el.value || '');
+        if (v) out.push(v);
+    }
+    return out;
+}
+
+// What the card is allowed to show: a chip label, a badge count, or a row title.
+//
+// The badge count accepts MUI's overflow form too. `Badge`'s `max` defaults to
+// 99, and `counts.met` is the whole Met population (1041 rows on live data as of
+// 2026-08-02) until the trailing-24h query overlays it — so `99+` is a REAL
+// rendering of a legitimate datum, in exactly the in-flight/failed-fetch state
+// this file exercises. A bare `\d+` predicate would fail on it and invite the
+// next reader to loosen the rule.
+const isControlOrDatum = (text, titles) =>
+    CHIP_LABELS.has(text) || /^\d+\+?$/.test(text) || titles.has(text);
+
+function expectNoMessages(container, label) {
+    // Row titles come from the fixture the test itself seeded — allowlisted by
+    // exact value, never by shape, so "No authoring requirements" can't match.
+    const titles = new Set(
+        [...(Array.isArray(activeRows) ? activeRows : []),
+         ...(Array.isArray(metRows) ? metRows : [])]
+            .map(r => r.title).filter(Boolean));
+    const card = cardEl(container);
+    const seen = [...cardTextNodes(card), ...cardAttributeText(card)];
+    const offenders = seen.filter(t => !isControlOrDatum(t, titles));
+    expect(offenders, `${label} — the aggregator card must render no message text`).toEqual([]);
+}
+
+const req = (id, status, overrides = {}) => ({
+    id,
+    title: `Requirement ${id}`,
+    requirement_status: status,
+    coordination_type: 'implemented',
+    ai_model: 'opus',
+    effort: 'high',
+    category_fk: 5,
+    ...overrides,
+});
+
+describe('SwarmStartCard renders no messages (req #3286)', () => {
+    beforeEach(() => {
+        roots = [];
+        activeRows = EMPTY;
+        metRows = EMPTY;
+        allRows = EMPTY;
+        pipelinedIds = new Set();
+        useShowClosedStore.setState({ hidePipelinedRequirements: false });
+    });
+    afterEach(() => {
+        act(() => { roots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+        vi.clearAllMocks();
+    });
+
+    it('renders no text while the queries are still in flight (first paint)', async () => {
+        activeRows = undefined;
+        metRows = undefined;
+        allRows = undefined;
+        useSwarmStartCardStore.setState({ selectedStatus: 'swarm_ready' });
+        const { container } = mount();
+        await flush();
+        // The spinner is a control-state indicator and carries no text; it is
+        // explicitly kept by the requirement.
+        expect(container.querySelector('.MuiCircularProgress-root')).not.toBeNull();
+        expectNoMessages(container, 'first paint');
+    });
+
+    // The acceptance criterion: click every chip, including ones with no rows.
+    for (const status of STATUSES) {
+        it(`renders no text on the ${status} chip with rows`, async () => {
+            const rows = [req(10, status), req(11, status)];
+            activeRows = rows;
+            metRows = status === 'met' ? rows : EMPTY;
+            allRows = rows;
+            useSwarmStartCardStore.setState({ selectedStatus: status });
+            const { container } = mount();
+            await flush();
+            expect(container.querySelectorAll('[data-testid^="requirement-"]').length)
+                .toBeGreaterThan(0);
+            // The rows still show their data — the walker skips form-control
+            // values, so prove here that the titles are actually on screen and
+            // the exclusion above isn't hiding the card's real content.
+            const titles = [...container.querySelectorAll('[data-testid^="requirement-"] textarea')]
+                .map(t => t.value);
+            expect(titles).toContain('Requirement 10');
+            expectNoMessages(container, `${status} chip, populated`);
+        });
+
+        it(`renders no text on the empty ${status} chip`, async () => {
+            useSwarmStartCardStore.setState({ selectedStatus: status });
+            const { container } = mount();
+            await flush();
+            // Empty body === the template row alone, and nothing else.
+            expect(container.querySelector('[data-testid="requirement-template"]')).not.toBeNull();
+            expect(container.querySelectorAll('[data-testid^="requirement-"]').length).toBe(1);
+            expectNoMessages(container, `${status} chip, empty`);
+        });
+    }
+
+    // The state the removed req #3180 note described: every row on a launch chip
+    // excluded because a pipeline step carries it. The exclusion still happens —
+    // it is simply not narrated.
+    it('renders no text when the pipeline exclusion empties a launch chip', async () => {
+        const rows = [req(10, 'swarm_ready'), req(11, 'swarm_ready')];
+        activeRows = rows;
+        allRows = rows;
+        pipelinedIds = new Set([10, 11]);
+        useSwarmStartCardStore.setState({ selectedStatus: 'swarm_ready' });
+        const { container } = mount();
+        await flush();
+        // Behaviour intact: both rows excluded, badge agrees with the list.
+        // Read the badge BUBBLE, not the Badge root — the testid lands on the
+        // root, whose textContent is the chip label plus the count, so a
+        // substring check there would pass on the wrong number.
+        expect(container.querySelectorAll('[data-testid^="requirement-"]').length).toBe(1);
+        const bubble = container.querySelector(
+            '[data-testid="swarm-start-chip-badge-swarm_ready"] .MuiBadge-badge');
+        expect(bubble.textContent).toBe('0');
+        expect(bubble.className).toContain('MuiBadge-invisible');
+        expectNoMessages(container, 'launch chip fully excluded');
+    });
+
+    it('renders no text when the exclusion hides only some rows', async () => {
+        const rows = [req(10, 'swarm_ready'), req(11, 'swarm_ready'), req(12, 'swarm_ready')];
+        activeRows = rows;
+        allRows = rows;
+        pipelinedIds = new Set([11]);
+        useSwarmStartCardStore.setState({ selectedStatus: 'swarm_ready' });
+        const { container } = mount();
+        await flush();
+        expect(container.querySelector('[data-testid="requirement-11"]')).toBeNull();
+        expect(container.querySelector('[data-testid="requirement-10"]')).not.toBeNull();
+        expectNoMessages(container, 'launch chip partly excluded');
+    });
+
+    // The live Met population is four digits (1041 rows, 2026-08-02), and
+    // `counts.met` carries all of it until the trailing-24h query overlays it.
+    // MUI clamps the badge to `99+` — a datum, and the state a naive `^\d+$`
+    // allowlist would have called a message.
+    it('renders no text when the Met badge overflows to 99+', async () => {
+        allRows = Array.from({ length: 120 }, (_, i) => req(1000 + i, 'met'));
+        activeRows = EMPTY;
+        metRows = undefined; // trailing-24h query not resolved → no overlay
+        useSwarmStartCardStore.setState({ selectedStatus: 'swarm_ready' });
+        const { container } = mount();
+        await flush();
+        const bubble = container.querySelector(
+            '[data-testid="swarm-start-chip-badge-met"] .MuiBadge-badge');
+        expect(bubble.textContent).toBe('99+');
+        expectNoMessages(container, 'Met badge overflow');
+    });
+
+    it('renders no text on the Met chip when the trailing-24h window is empty', async () => {
+        allRows = [req(10, 'development')];
+        activeRows = EMPTY;
+        metRows = EMPTY;
+        useSwarmStartCardStore.setState({ selectedStatus: 'met' });
+        const { container } = mount();
+        await flush();
+        expectNoMessages(container, 'empty Met window');
+    });
+
+    it('renders no text when the global hide-pipelined toggle empties an observation chip', async () => {
+        const rows = [req(10, 'development'), req(11, 'development')];
+        activeRows = rows;
+        allRows = rows;
+        pipelinedIds = new Set([10, 11]);
+        useShowClosedStore.setState({ hidePipelinedRequirements: true });
+        useSwarmStartCardStore.setState({ selectedStatus: 'development' });
+        const { container } = mount();
+        await flush();
+        expect(container.querySelectorAll('[data-testid^="requirement-"]').length).toBe(1);
+        expectNoMessages(container, 'development chip hidden by toggle');
+    });
+
+    it('renders no text when a failed fetch leaves the card without data', async () => {
+        // A rejected query surfaces as `data: undefined`, identical to first paint —
+        // the card must not grow an error sentence in that state.
+        activeRows = undefined;
+        metRows = undefined;
+        allRows = undefined;
+        useSwarmStartCardStore.setState({ selectedStatus: 'approved' });
+        const { container } = mount();
+        await flush();
+        expectNoMessages(container, 'failed fetch');
+    });
+
+    it('keeps every chip control while rendering no message text', async () => {
+        useSwarmStartCardStore.setState({ selectedStatus: 'swarm_ready' });
+        const { container } = mount();
+        await flush();
+        for (const status of STATUSES) {
+            expect(container.querySelector(`[data-testid="swarm-start-chip-${status}"]`),
+                `${status} chip must survive`).not.toBeNull();
+        }
+        expect(container.querySelector('[data-testid="swarm-start-card-menu"]')).not.toBeNull();
+        expectNoMessages(container, 'controls intact');
+    });
+});


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3286-aggregator-card-eradicate-every-1
- wip(Darwin): 2026-08-03T02:42:59Z
- chore: init swarm session feature/3286-aggregator-card-eradicate-every-1

## Files changed
```
 src/TaskPlanView/SwarmStartCard.jsx                |  78 ++---
 .../__tests__/SwarmStartCard.noMessages.test.jsx   | 374 +++++++++++++++++++++
 2 files changed, 407 insertions(+), 45 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)