### PR TITLE
Plan visualizer: the next-up halo is still sub-pixel at the BOTTOM of L2, and halves across the L1/L2 boundary

### DIFF
--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -112,9 +112,9 @@ import {
     epicFocusTransform, stepFocusTransform, factoryDefaultScale, clampPlanTransform,
     PLAN_VIZ_PALETTE as P, PLAN_VIZ_FONT as F, BEAD_RADIUS, BEAD_HIT_RADIUS,
     CHW_EPIC, ZOOM_MIN_RATIO, ZOOM_MAX_RATIO,
-    K_READABLE, DEFAULT_STEP_WIDTH, EPIC_CHIP_BG_ALPHA,
+    readableDefaultScale, DEFAULT_STEP_WIDTH, EPIC_CHIP_BG_ALPHA,
     NEXT_HALO_RADIUS, NEXT_HALO_STROKE, NEXT_HALO_OPACITY, NEXT_HALO_DASH,
-    nextHaloMagnify, BEAD_LANE_OFFSET,
+    nextHaloMagnify, labelsLegible, drawsLabelKind, BEAD_LANE_OFFSET,
     buildMachineColorView, reqIdStyle, reqIdKeyEntries, normalizeColorKey,
     DEFAULT_COLOR_KEY, PLAN_KEY_MAX_W, pinnedLevelOf, DEFAULT_PLAN_LEVEL_PREF,
     EPIC_PAUSE_BUBBLE_D, pauseBubbleColor, stickyRulerY, rulerScreenBottom,
@@ -565,7 +565,11 @@ export default function PipelinePlanVisualizer({
     // K_READABLE is derived from the smallest required text (the req ids) and an
     // 11px floor; see pipelinePlanLayout. On a plan that already fits at a legible
     // size this is inert — kFit wins and nothing about the old view changes.
-    const kDefault = Math.max(kFit, K_READABLE);
+    // Hoisted into pipelinePlanLayout by req #3280 — see `readableDefaultScale`
+    // for why the formula could not stay inline: the invariant "the landing view
+    // always draws its labels" is only assertable against the number this file
+    // actually lands on.
+    const kDefault = readableDefaultScale(kFit);
     // The zoom behavior's own configured floor, computed ONCE here so this
     // and the `.scaleExtent` call below read the SAME number rather than two
     // copies of a formula that only agree today because `kDefault` happens to
@@ -590,6 +594,27 @@ export default function PipelinePlanVisualizer({
     const pinnedLevel = pinnedLevelOf(levelPref);
     const autoLevelName = semanticLevel(kDefault > 0 ? curK / kDefault : 1);
     const level = pinnedLevel || autoLevelName;
+    // ── …AND WHETHER THE READER COULD USE IT (req #3280) ────────────────────
+    // The ladder above is a RATIO and legibility is ABSOLUTE, so on a large plan
+    // the level that starts drawing per-step text begins at a scale where none
+    // of it can be read: measured on live pipeline 2, L2 starts at k = 0.400 and
+    // renders the requirement ids at 5.5px. The ladder is deliberately NOT moved
+    // (req #3168 anchored it on `kDefault`; PIPE-09 pins its wheel behaviour) —
+    // it keeps saying which kinds this view is FOR, and this says whether they
+    // are worth drawing. `drawsKind` below requires both.
+    //
+    // PINNING IS INCLUDED, not exempted, and that is a deliberate trade with a
+    // visible cost. A reader who pins L2 or L3 while zoomed out past
+    // `K_READABLE` is asking for detail at a scale that cannot carry it — on the
+    // live plan, ids at 5.5px and the L3 title slot at 3.8px one wheel-click out
+    // from where the plan lands — and drawing it is not an answer. THE COST:
+    // below that scale all three chips of the level selector produce the same
+    // canvas, so the control is inert there. Exempting the pin instead would
+    // break the halo's guarantee (`nextHaloMagnify` stops magnifying at exactly
+    // this scale, so an exempt pin would put a 2× mark under drawn labels), and
+    // re-coupling the halo to the pin is the two-predicate arrangement req #3280
+    // exists to delete.
+    const legible = labelsLegible(curK);
 
     // The d3-zoom behavior (KonvaSwarmCanvas pattern).
     useEffect(() => {
@@ -1030,22 +1055,18 @@ export default function PipelinePlanVisualizer({
     //   · The three early returns it replaces were three places to get the ladder
     //     wrong, and the attribute would have been a fourth.
     //
-    // STEP LABELS ARE GATED LIKE REQUIREMENT MARKS (req #3221) — a step name is
-    // per-step detail the same as a requirement id, so it shares that gate
-    // rather than drawing unconditionally. This does not clear Overview down to
-    // bare beads and arcs: the ruler's slot ticks, the batch letters and the
-    // epic band names are drawn elsewhere in this component and are not asked
-    // through `drawsKind` at all, so they keep drawing at every level — the
-    // `return true` fallback below exists for THEM, not as a default nobody
-    // reaches. This gate is draw-only: `computePlanLayout` reserves the step
-    // label's rect at every level regardless (the zero-overlap invariant is
-    // asserted against it unconditionally), so hiding it here never moves
-    // anything else.
-    const drawsKind = useCallback((kind) => {
-        if (kind === 'step' || kind === 'req') return level !== 'out';
-        if (kind === 'title') return level === 'in';
-        return true;
-    }, [level]);
+    // THE RULE ITSELF MOVED TO `pipelinePlanLayout` (req #3280) — see
+    // `drawsLabelKind`, which carries what it decides and why. It went there
+    // because the halo's ceiling depends on this answer and a rule that lives in
+    // a component cannot be asserted against a function that does not: the pair
+    // is now one sweep in the layout tests. What stays here is the binding of
+    // that rule to THIS frame's level and scale, and the attribute.
+    // A PLAIN FUNCTION, not a `useCallback` (review finding). It was one, and
+    // once `curK` joined what it closes over the memo could never hit — the
+    // identity changed on every frame of a zoom. Nothing depends on that
+    // identity: both call sites are in the render body below and it appears in
+    // no dependency array, so the wrapper only read as if it memoised something.
+    const drawsKind = (kind) => drawsLabelKind(kind, level, curK);
     const drawnKinds = ['step', 'req', 'title'].filter(drawsKind).join(',');
 
     // Report the level actually being rendered so the toolbar's selector can
@@ -1053,7 +1074,15 @@ export default function PipelinePlanVisualizer({
     // handshake. In an EFFECT, not during render: this calls a setState on the
     // PARENT, and doing that in a child's render body is the React warning that
     // ends in a cross-component update loop.
-    useEffect(() => { onEffectiveLevel?.(level); }, [level, onEffectiveLevel]);
+    //
+    // THE LEVEL ACTUALLY RENDERED, not the ladder's answer (req #3280). Below
+    // `K_READABLE` none of the three gated kinds is drawn, so what is on screen
+    // IS Overview whatever the ratio says — and the soft mark exists to tell a
+    // reader on Auto what they are looking at. `data-level` keeps carrying the
+    // ladder's own answer a few hundred lines down, because that is a different
+    // fact and PIPE-09 reads it.
+    const drawnLevel = legible ? level : 'out';
+    useEffect(() => { onEffectiveLevel?.(drawnLevel); }, [drawnLevel, onEffectiveLevel]);
 
     const t = transform || { x: 0, y: 0, k: kDefault };
 
@@ -1516,9 +1545,15 @@ export default function PipelinePlanVisualizer({
 
     // The next-step halo's magnification for THIS frame (req #3271). Computed
     // once per render rather than per row: it depends only on the scale being
-    // drawn at and on whether this level draws labels, and `dash` is an array
-    // prop — a fresh one per bead would hand react-konva a changed reference for
-    // every halo on every frame of a zoom.
+    // drawn at, and `dash` is an array prop — a fresh one per bead would hand
+    // react-konva a changed reference for every halo on every frame of a zoom.
+    //
+    // IT IS NOT ASKED WHETHER THE LABELS ARE DRAWN (req #3280). It used to be,
+    // and passing `drawsKind('step')` — a predicate that is binary on the LEVEL
+    // — is what stepped the mark from 2.0× to 1.0× in one wheel-click at the
+    // L1/L2 boundary. Both sides now turn on the same absolute scale, so the
+    // guarantee the argument encoded (a magnified halo never sits under a drawn
+    // label) holds by arithmetic and cannot be got wrong here.
     //
     // NOT a `useMemo`, and it cannot become one: the `!rows.length` early return
     // above sits between this and the last hook, so a hook here would be
@@ -1526,7 +1561,18 @@ export default function PipelinePlanVisualizer({
     // nothing is allocated at all; above it the array is rebuilt per render,
     // which costs one `setAttr` on a layer the halo animation is already
     // redrawing every frame.
-    const haloM = nextHaloMagnify(t.k, drawsKind('step'));
+    //
+    // THAT BAND IS WIDER SINCE req #3280 — m > 1 used to mean level 'out' and
+    // now means every k below `K_READABLE`, so the rebuild happens through the
+    // whole of the zoomed-out range rather than only at Overview. Same cost per
+    // render on the same already-animating layer; noted because the sentence
+    // above was written when the band was narrower and would otherwise read as
+    // a smaller claim than it is.
+    // `curK`, not `t.k` — the same number, deliberately read from the same
+    // expression the label gate reads. The invariant is "the scale the halo
+    // sizes itself against is the scale the labels are gated on", and two
+    // expressions that agree today are how that quietly stops being true.
+    const haloM = nextHaloMagnify(curK);
     const haloDash = haloM === 1 ? NEXT_HALO_DASH : NEXT_HALO_DASH.map((d) => d * haloM);
 
     rows.forEach((row) => {
@@ -1550,9 +1596,14 @@ export default function PipelinePlanVisualizer({
         // with it, so on the live plan Overview drew a 0.8px stroke with 1.2px
         // dashes: present in the scene graph, absent on the screen. `haloM`
         // magnifies the whole mark — radius, stroke and dash by ONE factor, so
-        // its shape is invariant — into the room the labels vacate at that
-        // level. It is exactly 1 wherever the labels ARE drawn, so 'mid' and
-        // 'in' are untouched. See `nextHaloMagnify`.
+        // its shape is invariant — into the room the labels vacate below the
+        // legibility scale. It is exactly 1 wherever the labels ARE drawn, so
+        // 'in' and the readable half of 'mid' are untouched.
+        //
+        // req #3280 — and it reaches that 1 by ARRIVING at it rather than by
+        // switching to it. The room opens where `labelsLegible` closes the
+        // labels, so the magnification's target is the mark's own size at that
+        // scale and the two branches meet. See `nextHaloMagnify`.
         if (style.next) {
             worldNodes.push(
                 <Circle key={`next-${row.id}`} name="next-halo" x={n.x} y={n.y}

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -12,14 +12,15 @@ import { describe, it, expect } from 'vitest';
 import { SUBSTRATE_REBUILD_MODEL, MACHINES } from './substrateRebuildFixture';
 import { timedFuzzCorpus, FUZZ_NOW } from './timedFuzzPlans';
 import { buildPipelineModel, orderedPlan } from '../pipelineViewModel';
-import { semanticLevel } from '../../konvaSwarmModel';
+import { semanticLevel, SEMANTIC_OUT_MAX } from '../../konvaSwarmModel';
 import {
     computePlanLayout, beadStyle, stepLabelText, BEAD_RADIUS, BEAD_HIT_RADIUS,
     PLAN_VIZ_PALETTE, placeEpicChips, EPIC_CHIP_OPEN_LINK_W,
     STEP_WIDTH_FACTORS, isStepWidth, K_READABLE, PLAN_VIZ_FONT, READABLE_MIN_PX,
     NEXT_HALO_RADIUS, NEXT_HALO_STROKE, NEXT_HALO_DASH, EPIC_CHIP_CHAR_W,
     NEXT_HALO_SCREEN_RADIUS, NEXT_HALO_MAX_OUTER, NEXT_HALO_MAX_MAGNIFY,
-    NEXT_HALO_CLEARANCES, nextHaloMagnify, BEAD_RING_W_EMPHASIS, BEAD_OUTER_RADIUS,
+    NEXT_HALO_CLEARANCES, nextHaloMagnify, labelsLegible, drawsLabelKind,
+    readableDefaultScale, BEAD_RING_W_EMPHASIS, BEAD_OUTER_RADIUS,
     EPIC_CHIP_FONT, EPIC_CHIP_H, EPIC_CHIP_MIN_H, EPIC_CHIP_MIN_CHARS,
     EPIC_CHIP_PAD_W, EPIC_CHIP_MIN_FONT,
     REQ_STATUS_COLORS, REQ_STATUS_ORDER, REQ_STATUS_UNKNOWN_COLOR, reqStatusColor,
@@ -2928,20 +2929,29 @@ describe('the next-step halo survives Overview (req #3271)', () => {
         expect(beadStyle(eligibleRow, true).ringWidth).toBe(BEAD_RING_W_EMPHASIS);
     });
 
-    // THE 'in'/'mid' GUARANTEE, and the reason the label-clearance case above
-    // stays the binding one: wherever a step or requirement label is drawn, the
-    // halo is byte-identical to what it was before this existed.
+    // THE GUARANTEE, and the reason the label-clearance case above stays the
+    // binding one: wherever a step or requirement label is drawn, the halo is
+    // byte-identical to what it was before this existed.
+    //
+    // ASKED THROUGH `labelsLegible`, not through a boolean the caller hands in
+    // (req #3280). The old version passed `true` and asserted 1, which proved
+    // the function's first line and nothing about the canvas — the visualizer
+    // could have passed `false` at a level that draws labels and this stayed
+    // green. Reading the SAME predicate the renderer gates the labels on is what
+    // makes this a claim about what is on screen.
     it('is exactly 1 at every k where the labels are drawn', () => {
-        for (const k of K_SWEEP) {
-            expect(nextHaloMagnify(k, true), `k=${k}`).toBe(1);
+        for (const k of K_SWEEP.filter(labelsLegible)) {
+            expect(nextHaloMagnify(k), `k=${k}`).toBe(1);
         }
+        // Non-vacuity: the sweep must actually contain legible scales.
+        expect(K_SWEEP.filter(labelsLegible).length).toBeGreaterThan(5);
     });
 
     // Zooming IN never changes the mark either. Only the zoomed-OUT half of the
     // range, where the mark had shrunk below its target, is touched at all.
     it('is exactly 1 once the mark already meets its target on screen', () => {
         for (const k of K_SWEEP.filter((v) => v >= 1)) {
-            expect(nextHaloMagnify(k, false), `k=${k}`).toBe(1);
+            expect(nextHaloMagnify(k), `k=${k}`).toBe(1);
         }
     });
 
@@ -2949,30 +2959,36 @@ describe('the next-step halo survives Overview (req #3271)', () => {
     // world units, every one of these products collapses to `constant × k` and
     // the case fails at the first k in the sweep.
     it('holds the halo SCREEN-constant across a k sweep, until the cap bites', () => {
-        for (const k of K_SWEEP) {
-            const m = nextHaloMagnify(k, false);
+        for (const k of [...K_SWEEP, 0.45, 0.6, 0.75].sort((a, b) => a - b)) {
+            const m = nextHaloMagnify(k);
             if (m >= NEXT_HALO_MAX_MAGNIFY || m === 1) continue;
-            // The RADIUS product is an algebraic identity of the definition of
-            // `m` and can never fail — it is here to name the target, not to
-            // guard it. The STROKE and DASH products are the load-bearing
-            // assertions: they hold only while the screen radius the halo aims
-            // at is its own world radius, so retuning NEXT_HALO_SCREEN_RADIUS
-            // in isolation breaks them.
+            // ALL THREE ARE THE SAME IDENTITY times a different constant, and
+            // saying so is the correction (review finding on this block: the
+            // previous comment claimed the stroke and dash products were
+            // "load-bearing" against the radius one being an identity, which is
+            // not true — each reduces to
+            // `NEXT_HALO_SCREEN_RADIUS / NEXT_HALO_RADIUS === K_READABLE`).
+            // They are kept as a REGRESSION PIN on the shape rather than as a
+            // proof: if the mark ever stops scaling by ONE factor — a stroke
+            // counter-scaled on its own is the specific fix #3271 rejected —
+            // the three stop agreeing and this reddens. The claim that the
+            // freeze scale is derived is asserted directly, once, below.
             expect(NEXT_HALO_RADIUS * m * k, `radius px at k=${k}`)
                 .toBeCloseTo(NEXT_HALO_SCREEN_RADIUS, 10);
             expect(NEXT_HALO_STROKE * m * k, `stroke px at k=${k}`)
-                .toBeCloseTo(NEXT_HALO_STROKE, 10);
+                .toBeCloseTo(NEXT_HALO_STROKE * K_READABLE, 10);
             for (const [i, d] of NEXT_HALO_DASH.entries()) {
-                expect(d * m * k, `dash[${i}] px at k=${k}`).toBeCloseTo(d, 10);
+                expect(d * m * k, `dash[${i}] px at k=${k}`)
+                    .toBeCloseTo(d * K_READABLE, 10);
             }
         }
         // The sweep must actually EXERCISE the screen-constant branch, or the
         // loop above passes by skipping everything (review-proofing).
-        const exercised = K_SWEEP.filter((k) => {
-            const m = nextHaloMagnify(k, false);
+        const exercised = [...K_SWEEP, 0.45, 0.6, 0.75].filter((k) => {
+            const m = nextHaloMagnify(k);
             return m > 1 && m < NEXT_HALO_MAX_MAGNIFY;
         });
-        expect(exercised.length).toBeGreaterThan(0);
+        expect(exercised.length).toBeGreaterThan(2);
     });
 
     // ONE factor for the whole mark, so the shape is invariant: the halo can
@@ -2998,7 +3014,7 @@ describe('the next-step halo survives Overview (req #3271)', () => {
         const swept = [LIVE_ZOOM_FLOOR,
             ...K_SWEEP.filter((v) => v < 0.5 && v > LIVE_ZOOM_FLOOR)];
         for (const k of swept) {
-            const gapPx = (innerAt(nextHaloMagnify(k, false)) - BEAD_OUTER_RADIUS) * k;
+            const gapPx = (innerAt(nextHaloMagnify(k)) - BEAD_OUTER_RADIUS) * k;
             const unfixedPx = (innerAt(1) - BEAD_OUTER_RADIUS) * k;
             expect(unfixedPx, `world-constant gap px at k=${k}`).toBeLessThan(0.2);
             expect(gapPx, `gap px at k=${k}`).toBeGreaterThan(0.9);
@@ -3017,15 +3033,18 @@ describe('the next-step halo survives Overview (req #3271)', () => {
             // mark this requirement replaced.
             expect(gapPx / unfixedPx, `gap ratio at k=${k}`).toBeGreaterThan(30);
         }
-        // At the scale the plan OPENS in, the gap is comfortably supra-pixel —
+        // At fit-to-width on a 1440px panel the gap is comfortably supra-pixel —
         // that is the claim this case exists to make, distinct from the floor.
-        const kOpen = 1440 / 3620.2;
-        expect((innerAt(nextHaloMagnify(kOpen, false)) - BEAD_OUTER_RADIUS) * kOpen,
-            'gap px at the opening view').toBeGreaterThan(4);
+        // (Called "the opening view" until req #3280's review; the plan actually
+        // lands on `kDefault` = 0.8, one wheel-click in from here. See the
+        // `turns the measured Overview scales` case below.)
+        const kFitWide = 1440 / 3620.2;
+        expect((innerAt(nextHaloMagnify(kFitWide)) - BEAD_OUTER_RADIUS) * kFitWide,
+            'gap px at fit-to-width, 1440px panel').toBeGreaterThan(4);
         // And the world gap never closes at any k, magnified or not.
         let prevGap = null;
         for (const k of [...K_SWEEP].sort((a, b) => b - a)) {
-            const gap = innerAt(nextHaloMagnify(k, false)) - BEAD_OUTER_RADIUS;
+            const gap = innerAt(nextHaloMagnify(k)) - BEAD_OUTER_RADIUS;
             expect(gap, `k=${k}`).toBeGreaterThan(0);
             if (prevGap !== null) expect(gap, `k=${k}`).toBeGreaterThanOrEqual(prevGap);
             prevGap = gap;
@@ -3196,7 +3215,7 @@ describe('the next-step halo survives Overview (req #3271)', () => {
     });
 
     it('is monotone — zooming out never shrinks the mark', () => {
-        const ms = K_SWEEP.map((k) => nextHaloMagnify(k, false));
+        const ms = K_SWEEP.map((k) => nextHaloMagnify(k));
         for (let i = 1; i < ms.length; i += 1) {
             expect(ms[i], `k=${K_SWEEP[i]}`).toBeLessThanOrEqual(ms[i - 1]);
         }
@@ -3204,7 +3223,7 @@ describe('the next-step halo survives Overview (req #3271)', () => {
 
     it('falls back to 1 on a scale that is not a usable number', () => {
         for (const k of [0, -1, NaN, Infinity, -Infinity, undefined, null]) {
-            expect(nextHaloMagnify(k, false), `k=${k}`).toBe(1);
+            expect(nextHaloMagnify(k), `k=${k}`).toBe(1);
         }
     });
 
@@ -3217,20 +3236,30 @@ describe('the next-step halo survives Overview (req #3271)', () => {
     // the bead's own ring.
     it('turns the measured Overview scales into a mark that can be seen', () => {
         // The three scales that matter on the live plan: fit-to-width on a
-        // 1200px and a 1440px panel (both level 'out' — the plan OPENS there),
-        // and the ceiling of 'out' itself.
+        // 1200px and a 1440px panel (both level 'out'), and the ceiling of
+        // 'out' itself.
+        //
+        // NOT "where the plan OPENS", which is what this said and what #3271's
+        // source comments said (corrected in review of req #3280). `resetView`
+        // lands on `kDefault` = 0.8 — `recenterModeRef` initialises to
+        // 'readable' — so the landing view is ratio 1, level 'mid'. These are
+        // the scales one wheel-click OUT of it, which is where the defect was;
+        // nothing about the assertions below depended on the difference.
         const LIVE_WORLD_W = 3620.2;
         const kOutCeiling = K_READABLE * 0.5;            // 0.4, 'out' by definition
         const cases = [1200 / LIVE_WORLD_W, 1440 / LIVE_WORLD_W, kOutCeiling];
         for (const k of cases) {
-            expect(nextHaloMagnify(k, true), `labels drawn at k=${k}`).toBe(1);
+            // No label is drawn at any of them — which is WHY the mark is free
+            // to grow there, and is now asserted rather than assumed (req #3280
+            // made the two the same question).
+            expect(labelsLegible(k), `labels legible at k=${k}`).toBe(false);
             // What it used to be, at that same k: a sub-pixel dashed outline
             // whose inner edge sat a tenth of a pixel from the bead's own ring.
             expect(NEXT_HALO_STROKE * k, `old stroke px at k=${k}`).toBeLessThan(0.81);
             expect((innerAt(1) - BEAD_OUTER_RADIUS) * k, `old gap px at k=${k}`)
                 .toBeLessThan(0.11);
             // What it is now — a dashed ring, clear of the bead.
-            const m = nextHaloMagnify(k, false);
+            const m = nextHaloMagnify(k);
             expect(NEXT_HALO_STROKE * m * k, `stroke px at k=${k}`).toBeGreaterThan(1.3);
             expect(NEXT_HALO_RADIUS * m * k, `radius px at k=${k}`).toBeGreaterThan(8);
             expect(NEXT_HALO_DASH[0] * m * k, `dash px at k=${k}`).toBeGreaterThan(1.9);
@@ -3241,6 +3270,310 @@ describe('the next-step halo survives Overview (req #3271)', () => {
             const cycles = (2 * Math.PI * NEXT_HALO_RADIUS * m * k)
                 / (NEXT_HALO_DASH[0] + NEXT_HALO_DASH[1]);
             expect(cycles, `dash cycles at k=${k}`).toBeGreaterThan(6);
+        }
+    });
+});
+
+// ── …AND IT HAS TO SURVIVE THE CROSSING TOO (req #3280) ─────────────────────
+// #3271 fixed L1 under an instruction not to touch L2, and what that left is two
+// defects rather than one: the sub-pixel mark it was filed to remove was still
+// reachable — the whole band from k = 0.400 up to K_READABLE, i.e. everything
+// between fit-to-width and the scale the plan LANDS on — and the mark HALVED
+// crossing into it. Both come from the same place — the halo's bound was
+// the LABEL PREDICATE, which is binary on a level derived from a RATIO, while
+// legibility is ABSOLUTE. These cases pin the two questions being asked of ONE
+// absolute scale.
+describe('the next-step halo survives the level CROSSINGS (req #3280)', () => {
+    const innerAt = (m) => (NEXT_HALO_RADIUS - NEXT_HALO_STROKE / 2) * m;
+    // Live pipeline 2: 136 rows into a 3620.2px world, so `kFit` is 0.33–0.40 on
+    // a 1200–1440px panel and `kDefault = max(kFit, K_READABLE)` is 0.8.
+    const LIVE_WORLD_W = 3620.2;
+    const LIVE_K_DEFAULT = K_READABLE;
+    const LIVE_ZOOM_FLOOR = (1200 / LIVE_WORLD_W) * ZOOM_MIN_RATIO;
+    // Every k the camera can reach on that plan, at a resolution fine enough to
+    // see a one-wheel-click step: 600 samples over [floor, kDefault × 8].
+    const REACHABLE = Array.from({ length: 601 }, (_, i) =>
+        LIVE_ZOOM_FLOOR + (i / 600) * (LIVE_K_DEFAULT * ZOOM_MAX_RATIO - LIVE_ZOOM_FLOOR));
+
+    // THE INVARIANT THE WHOLE FIX RESTS ON, and the one #3271 held by handing a
+    // boolean across a module boundary. It is now arithmetic: the labels turn on
+    // at `K_READABLE` and the magnification turns off at `K_READABLE`, so no
+    // caller can put a grown halo under a drawn label — including a reader who
+    // PINS L3 at Overview, which is exactly what a level-derived predicate could
+    // not protect against.
+    // ASKED THROUGH THE PREDICATE THE RENDERER ACTUALLY USES, over every
+    // (kind × level × k) it can be asked at — pinned levels included, which is
+    // the combination a level-derived gate could not protect and the reason
+    // `drawsLabelKind` moved into this module (req #3280). A `&& labelsLegible`
+    // deleted from it reddens here rather than shipping a halo drawn through a
+    // step name.
+    it('never magnifies at a scale where a label is drawn', () => {
+        const KINDS = ['step', 'req', 'title'];
+        const LEVELS = ['out', 'mid', 'in'];
+        const bad = [];
+        let drawn = 0;
+        for (const k of REACHABLE) {
+            for (const level of LEVELS) {
+                for (const kind of KINDS) {
+                    if (!drawsLabelKind(kind, level, k)) continue;
+                    drawn += 1;
+                    if (nextHaloMagnify(k) !== 1) {
+                        bad.push(`${kind} drawn at ${level}, k=${k.toFixed(4)},`
+                            + ` m=${nextHaloMagnify(k)}`);
+                    }
+                }
+            }
+        }
+        expect(bad.slice(0, 8)).toEqual([]);
+        // Non-vacuity, both ways: the sweep must contain combinations that DRAW
+        // and scales that MAGNIFY, or the loop above is asserting about nothing.
+        expect(drawn, 'kind × level × k combinations that draw')
+            .toBeGreaterThan(500);
+        expect(REACHABLE.filter((k) => nextHaloMagnify(k) > 1).length)
+            .toBeGreaterThan(20);
+        // The ungated kinds keep drawing everywhere, at every level and scale —
+        // the halo's clearances are what bound it against THEM, and a predicate
+        // that started gating them would silently change what those clearances
+        // are protecting.
+        for (const k of [LIVE_ZOOM_FLOOR, 0.4, K_READABLE, 6]) {
+            for (const level of LEVELS) {
+                expect(drawsLabelKind('batch', level, k), `batch at ${level}`).toBe(true);
+                expect(drawsLabelKind('slot', level, k), `slot at ${level}`).toBe(true);
+            }
+        }
+    });
+
+    // The LEVEL half is untouched — the ladder still decides which kinds a view
+    // is for, and req #3280 only added a second condition. At a legible scale
+    // the predicate is exactly what it was before this requirement.
+    it('leaves the ladder itself alone at a legible scale', () => {
+        for (const k of [K_READABLE, 1, 2, 6.4]) {
+            expect(['step', 'req', 'title'].filter((x) => drawsLabelKind(x, 'out', k)))
+                .toEqual([]);
+            expect(['step', 'req', 'title'].filter((x) => drawsLabelKind(x, 'mid', k)))
+                .toEqual(['step', 'req']);
+            expect(['step', 'req', 'title'].filter((x) => drawsLabelKind(x, 'in', k)))
+                .toEqual(['step', 'req', 'title']);
+        }
+        // And below it, every gated kind goes dark at every level.
+        for (const k of [LIVE_ZOOM_FLOOR, 0.2, 0.4, 0.799]) {
+            for (const level of ['out', 'mid', 'in']) {
+                expect(['step', 'req', 'title'].filter((x) => drawsLabelKind(x, level, k)),
+                    `level ${level} at k=${k}`).toEqual([]);
+            }
+        }
+    });
+
+    // DEFECT 2, DIRECTLY. The L1/L2 boundary is `SEMANTIC_OUT_MAX × kDefault` —
+    // 0.400 on the live plan — and one wheel-click either side of it took the
+    // mark from 9.98px of radius to 4.99px. Stated as a bound on the STEP
+    // between ADJACENT samples across the whole reachable range, so it catches a
+    // discontinuity wherever one is introduced, not only at the boundary that
+    // happened to have one.
+    //
+    // THE BOUND IS THE SAMPLE SPACING, not a tuned tolerance. The apparent
+    // radius is `12.5 × m(k) × k`, and on each of the three branches its
+    // log-slope in `k` is 0 or 1 — the mark either holds still or tracks the
+    // zoom — so `|Δr| / r` can never exceed `Δk / k`. A tolerance chosen by hand
+    // would have to be loose enough for the steepest branch and would then be
+    // blind to a jump smaller than that; this one shrinks with the sweep.
+    // Measured against the defect: the old mark HALVED at the boundary — 100%
+    // of the smaller radius — where the bound there is 2.6%.
+    //
+    // THE `1e-9` IS NOT SLACK TO BE TIGHTENED. On two of the three branches
+    // (`r = 25k` below the cap and `r = 12.5k` above K_READABLE) the apparent
+    // radius tracks `k` exactly, so `rel` EQUALS `bound` and the case passes
+    // only on that epsilon. That is the case at its most sensitive, not a fudge:
+    // removing the epsilon reddens a correct implementation.
+    it('changes size continuously — no crossing halves the mark', () => {
+        const jumps = [];
+        for (let i = 1; i < REACHABLE.length; i += 1) {
+            const [a, b] = [REACHABLE[i - 1], REACHABLE[i]];
+            const ra = NEXT_HALO_RADIUS * nextHaloMagnify(a) * a;
+            const rb = NEXT_HALO_RADIUS * nextHaloMagnify(b) * b;
+            const rel = Math.abs(rb - ra) / Math.min(ra, rb);
+            const bound = (b - a) / a;
+            if (rel > bound + 1e-9) {
+                jumps.push(`k=${a.toFixed(4)}→${b.toFixed(4)}: ${ra}→${rb}`
+                    + ` (${(rel * 100).toFixed(1)}% > ${(bound * 100).toFixed(1)}%)`);
+            }
+        }
+        expect(jumps.slice(0, 8)).toEqual([]);
+        // The sweep straddles the boundary the defect was at, or it is asserting
+        // continuity over a range that never crosses anything.
+        const kBoundary = SEMANTIC_OUT_MAX * LIVE_K_DEFAULT;
+        expect(REACHABLE.some((k) => k < kBoundary)).toBe(true);
+        expect(REACHABLE.some((k) => k > kBoundary && k < K_READABLE)).toBe(true);
+        expect(REACHABLE.some((k) => k > K_READABLE)).toBe(true);
+    });
+
+    // The SAME continuity, asserted where the defect was measured rather than
+    // over a sweep: the boundary itself, sampled one wheel-click apart. d3-zoom's
+    // wheel factor is 2^(-deltaY/500) and the requirement's own table is a
+    // 0.399/0.400 pair, so a tighter pair than any gesture can produce.
+    it('crosses the measured L1/L2 boundary with no visible change', () => {
+        const kBoundary = SEMANTIC_OUT_MAX * LIVE_K_DEFAULT;           // 0.400
+        expect(kBoundary).toBeCloseTo(0.4, 10);
+        expect(semanticLevel(0.399 / LIVE_K_DEFAULT)).toBe('out');
+        expect(semanticLevel(0.400 / LIVE_K_DEFAULT)).toBe('mid');
+        const px = (k) => ({
+            radius: NEXT_HALO_RADIUS * nextHaloMagnify(k) * k,
+            stroke: NEXT_HALO_STROKE * nextHaloMagnify(k) * k,
+            dash: NEXT_HALO_DASH[0] * nextHaloMagnify(k) * k,
+            gap: (innerAt(nextHaloMagnify(k)) - BEAD_OUTER_RADIUS) * k,
+        });
+        const below = px(0.399);
+        const above = px(0.400);
+        for (const key of Object.keys(below)) {
+            expect(above[key] / below[key], `${key} across the boundary`)
+                .toBeCloseTo(1, 2);
+        }
+        // And the requirement's own MEASURED row for the L2 side, which is what
+        // it was filed on: 5.00px radius / 0.80px stroke / 1.20px dash / 0.10px
+        // gap. Every one of them is now the L1 side's number instead.
+        expect(above.radius).toBeCloseTo(10.0, 2);
+        expect(above.stroke).toBeCloseTo(1.6, 2);
+        expect(above.dash).toBeCloseTo(2.4, 2);
+        expect(above.gap).toBeGreaterThan(4.5);
+    });
+
+    // DEFECT 1. The bottom of L2 — everything from the boundary up to the scale
+    // the labels arrive at — is where the 0.80px stroke lived, and it is the
+    // band #3271 was forbidden from touching. It is now flat: one apparent size
+    // for the whole band, which is the size the mark has at the TOP of it.
+    it('holds one apparent mark from the L1/L2 boundary to the labels', () => {
+        const kBoundary = SEMANTIC_OUT_MAX * LIVE_K_DEFAULT;
+        const band = REACHABLE.filter((k) => k >= kBoundary && k < K_READABLE);
+        expect(band.length, 'the band is swept').toBeGreaterThan(5);
+        for (const k of band) {
+            const m = nextHaloMagnify(k);
+            expect(NEXT_HALO_RADIUS * m * k, `radius px at k=${k}`)
+                .toBeCloseTo(NEXT_HALO_SCREEN_RADIUS, 6);
+            expect(NEXT_HALO_STROKE * m * k, `stroke px at k=${k}`)
+                .toBeCloseTo(NEXT_HALO_STROKE * K_READABLE, 6);
+            // The acceptance number, stated as itself.
+            expect(NEXT_HALO_STROKE * m * k, `stroke px at k=${k}`)
+                .toBeGreaterThanOrEqual(1.2);
+            // ...and no label is drawn anywhere in it, so nothing is crossed.
+            expect(labelsLegible(k), `labels at k=${k}`).toBe(false);
+        }
+        // The band's TOP is where the unmagnified mark takes over, at the same
+        // size — the identity that makes the two branches meet.
+        expect(NEXT_HALO_RADIUS * nextHaloMagnify(K_READABLE) * K_READABLE)
+            .toBeCloseTo(NEXT_HALO_SCREEN_RADIUS, 10);
+    });
+
+    // The freeze scale is DERIVED from the legibility scale, not typed beside
+    // it. A hand-tuned NEXT_HALO_SCREEN_RADIUS is precisely what put a step at
+    // the top of the band, so the two are pinned to each other rather than to
+    // their values.
+    it('freezes at exactly the scale the labels turn on', () => {
+        expect(NEXT_HALO_SCREEN_RADIUS).toBeCloseTo(NEXT_HALO_RADIUS * K_READABLE, 10);
+        expect(labelsLegible(K_READABLE)).toBe(true);
+        expect(labelsLegible(K_READABLE - 1e-9)).toBe(false);
+        expect(nextHaloMagnify(K_READABLE)).toBe(1);
+        expect(nextHaloMagnify(K_READABLE - 1e-9)).toBeCloseTo(1, 8);
+    });
+
+    // The predicate is measured on the SMALLEST required text and the module's
+    // own 11px floor — no new number entered the module for this.
+    it('is the 11px floor applied to the requirement ids, not a new constant', () => {
+        expect(PLAN_VIZ_FONT.req * K_READABLE).toBeCloseTo(READABLE_MIN_PX, 10);
+        // The step label is the bigger of the two gated kinds, so the same gate
+        // never hides text the reader could have read while showing text they
+        // could not.
+        expect(PLAN_VIZ_FONT.label).toBeGreaterThan(PLAN_VIZ_FONT.req);
+        expect(PLAN_VIZ_FONT.label * K_READABLE).toBeGreaterThan(READABLE_MIN_PX);
+        for (const k of [0, -1, NaN, Infinity, -Infinity, undefined, null, '0.9']) {
+            expect(labelsLegible(k), `k=${k}`).toBe(false);
+        }
+    });
+
+    // THE LANDING VIEW IS ALWAYS LEGIBLE, at every plan size — so this gate can
+    // never make a plan OPEN without its labels, and the E2E's level assertions
+    // (which all read the default camera) are unmoved by it.
+    //
+    // ASKED OF `readableDefaultScale`, the function the renderer calls (req
+    // #3280 review). The first draft rebuilt `Math.max(kFit, K_READABLE)` here
+    // and asserted the result was `>= K_READABLE` — which is `max(a,b) >= b`,
+    // an identity that stays green if the component is changed to land on
+    // `kFit` and every plan wider than its panel opens with no labels at all.
+    // That is exactly the claim in this case's title, so the identity version
+    // asserted nothing. Hoisting the formula is what made it reachable.
+    it('never withholds the labels at the view a plan opens in', () => {
+        let bindingCases = 0;
+        for (const worldW of [200, 800, 3620.2, 12000]) {
+            for (const panelW of [800, 1200, 1440, 1800, 2560]) {
+                const kFit = panelW / worldW;
+                const where = `world ${worldW} panel ${panelW}`;
+                expect(labelsLegible(readableDefaultScale(kFit)), where).toBe(true);
+                // The plans where the floor is what saves it — i.e. where a
+                // renderer landing on `kFit` WOULD open illegibly. Counted, so
+                // the sweep cannot pass by containing only plans that are
+                // legible at fit-to-width anyway.
+                if (!labelsLegible(kFit)) bindingCases += 1;
+            }
+        }
+        expect(bindingCases, 'plans whose fit-to-width is NOT legible')
+            .toBeGreaterThan(4);
+        // Ratio 1 at the landing scale, on every plan — the ladder's own
+        // definition of the view a reader lands on.
+        expect(semanticLevel(1)).toBe('mid');
+        // The guard, which is the other half of "always": a non-finite kFit
+        // resolves to the floor instead of propagating NaN into every downstream
+        // scale (`labelsLegible(NaN)` is false, so a NaN default would open a
+        // plan with no labels and no error anywhere).
+        for (const bad of [NaN, Infinity, undefined, null, '1.2']) {
+            expect(readableDefaultScale(bad), `kFit=${bad}`).toBe(K_READABLE);
+            expect(labelsLegible(readableDefaultScale(bad))).toBe(true);
+        }
+        // And it is fit-to-width whenever fit-to-width is already legible —
+        // a floor, never an override (the req #3168 contract).
+        expect(readableDefaultScale(2.5)).toBe(2.5);
+        expect(readableDefaultScale(0.4)).toBe(K_READABLE);
+    });
+
+    // WHAT THIS COULD NOT REACH, as an assertion rather than as a note. The
+    // clearance ceiling caps the halo's OUTER edge at NEXT_HALO_MAX_OUTER world
+    // px; at the reachable zoom floor that whole edge is under three SCREEN px,
+    // so a >= 1.2px stroke is not something a bigger ring can buy there — the
+    // ring is smaller than the stroke it would need. The band needs a different
+    // MARK, which is a design decision and a follow-on requirement, and this
+    // case exists so the arithmetic is checked rather than remembered.
+    it('cannot reach the deep zoom-out band, and says where it stops', () => {
+        const strokePx = (k) => NEXT_HALO_STROKE * nextHaloMagnify(k) * k;
+        // WHERE IT STOPS, found by SEARCHING the swept range rather than by
+        // restating the algebra (review finding: the first draft computed
+        // `1.2 / (STROKE × MAX_MAGNIFY)` and then asserted the predicate that
+        // expression solves, which on the capped branch reduces to `k >= kHolds`
+        // — the definition). A search over the samples can disagree with the
+        // closed form, and if the branch structure ever changes it will.
+        const holds = REACHABLE.filter((k) => strokePx(k) >= 1.2);
+        const fails = REACHABLE.filter((k) => strokePx(k) < 1.2);
+        expect(holds.length, 'scales that meet the acceptance stroke')
+            .toBeGreaterThan(500);
+        expect(fails.length, 'scales that do not — the band this cannot reach')
+            .toBeGreaterThan(10);
+        // It is a clean split, not a scatter: every failing sample is below
+        // every holding one, so "below k ≈ 0.3" is the whole of the shortfall.
+        expect(Math.max(...fails)).toBeLessThan(Math.min(...holds));
+        expect(Math.min(...holds)).toBeGreaterThan(0.29);
+        expect(Math.min(...holds)).toBeLessThan(0.31);
+        // THE PROOF that no ceiling under NEXT_HALO_MAX_OUTER could have closed
+        // it: at the zoom floor the halo's ENTIRE outer edge is under three
+        // screen px, so the ring is smaller than the stroke it would need. This
+        // is the one assertion here that is about the geometry rather than about
+        // `m`, and it is why the remainder is a follow-on and not a retune.
+        expect(NEXT_HALO_MAX_OUTER * LIVE_ZOOM_FLOOR,
+            'the halo\'s entire outer edge, in screen px, at the zoom floor')
+            .toBeLessThan(3);
+        expect(strokePx(LIVE_ZOOM_FLOOR), 'stroke px at the zoom floor')
+            .toBeLessThan(0.4);
+        // Unchanged by this requirement, not regressed by it: below the ceiling
+        // the mark was `4k` before and is `4k` now.
+        for (const k of [LIVE_ZOOM_FLOOR, 0.15, 0.2, 0.25]) {
+            expect(strokePx(k)).toBeCloseTo(
+                NEXT_HALO_STROKE * NEXT_HALO_MAX_MAGNIFY * k, 10);
         }
     });
 });

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -776,6 +776,102 @@ export const pinnedLevelOf = (v) => PLAN_LEVEL_BY_PREF[normalizePlanLevelPref(v)
 export const READABLE_MIN_PX = 11;
 export const K_READABLE = READABLE_MIN_PX / PLAN_VIZ_FONT.req;
 
+/**
+ * Is the plan's smallest REQUIRED text legible at this scale (req #3280)?
+ *
+ * THE LEVEL LADDER ANSWERS A RELATIVE QUESTION AND LEGIBILITY IS AN ABSOLUTE
+ * ONE, and until this existed the ladder was asked both. `semanticLevel()` takes
+ * `curK / kDefault`, so "how far in from where you started" decides WHAT IS
+ * DRAWN — and on a large plan the level that starts drawing the step names and
+ * the requirement ids begins at an absolute `k` where neither can be read.
+ * MEASURED on live pipeline 2 (136 rows, world width 3620.2, `kDefault` 0.8):
+ * L2 begins at k = 0.400, which renders the step label at 6.6px and the
+ * requirement ids at 5.5px, against the 11px floor two lines above.
+ *
+ * So the two questions are separated, and the ladder is NOT MOVED — req #3168
+ * anchored it on `kDefault` deliberately and PIPE-09 pins its wheel behaviour.
+ * The level still says which kinds this view is FOR; this says whether the
+ * reader could actually use them. A kind is drawn only when both agree.
+ *
+ * THE REQUIREMENT IDS ARE THE TEXT THIS IS MEASURED ON, exactly as `K_READABLE`
+ * itself is: the step label is bigger and the title slot is a level-gated extra,
+ * so a scale that keeps the ids legible keeps everything a reader needs legible.
+ * One threshold for all three gated kinds, not one per font — three thresholds
+ * would be three places for the halo's magnification to step (see
+ * `nextHaloMagnify`, which freezes at exactly this scale and would have to
+ * choose one of them).
+ *
+ * IT IS TRUE AT THE VIEW EVERY PLAN OPENS IN, by construction — see
+ * `readableDefaultScale` below, which is the scale `resetView` lands on. A plan
+ * that already fits at a legible size never reaches this gate at all, so nothing
+ * about a small plan's view changes.
+ */
+export function labelsLegible(k) {
+    return Number.isFinite(k) && k >= K_READABLE;
+}
+
+/**
+ * THE SCALE A PLAN OPENS IN (req #3168) — fit-to-width, floored at legible.
+ *
+ * EXPORTED as a function rather than left as `Math.max(kFit, K_READABLE)` inline
+ * in the component (req #3280). The invariant that matters is "the landing view
+ * always draws its labels", and while the formula lived in the renderer the test
+ * for it could only rebuild the same `Math.max` and assert `max(a,b) >= b` — an
+ * identity, green even if the component were changed to land on `kFit` and every
+ * plan wider than its panel opened with no labels at all. A test can only reach
+ * the number the renderer actually uses.
+ *
+ * `factoryDefaultScale` is the SIBLING, not a duplicate: since req #3216 the
+ * header's Reset and the landing view are deliberately two different scales, and
+ * `recenterModeRef` picks between them. This one is the landing view.
+ *
+ * A non-finite `kFit` resolves to `K_READABLE` rather than propagating NaN —
+ * `size.w / layout.width` is a division the caller performs on measured values,
+ * and a NaN scale silently blanks the canvas rather than erroring.
+ */
+export function readableDefaultScale(kFit) {
+    return Number.isFinite(kFit) ? Math.max(kFit, K_READABLE) : K_READABLE;
+}
+
+/**
+ * THE LEVEL LADDER, AS ONE PREDICATE — is this label kind drawn (req #3221,
+ * absolute half added by req #3280)?
+ *
+ * IT LIVES HERE RATHER THAN IN THE RENDERER because the halo's whole guarantee
+ * is a relationship between this answer and `nextHaloMagnify`'s: a magnified
+ * halo reaches past the 14-world-px box a step label and the first requirement
+ * id sit in, so it may only grow where they are not drawn. While the predicate
+ * was three lines inside the component and the magnification was a function in
+ * this module, NOTHING COULD ASSERT THE PAIR — the component's own test would
+ * have had to rasterise a canvas to see it, which is precisely why the
+ * component publishes `data-drawn` at all. With both here, one sweep over
+ * (kind × level × k) proves it, and deleting the legibility condition reddens
+ * that sweep instead of shipping.
+ *
+ * Two conditions, and a kind is drawn only when both hold:
+ *   · the LEVEL — what this view is for. 'out' carries no per-step detail;
+ *     the title slot is 'in' only.
+ *   · LEGIBILITY — whether the reader could use it (`labelsLegible`). ONE
+ *     threshold for all three kinds, not one per font: `K_READABLE` is derived
+ *     from the SMALLEST of them, so a scale that keeps the requirement ids
+ *     legible keeps the step name and the title slot legible too — and three
+ *     per-font thresholds would be three scales at which the halo's
+ *     magnification has to stop, where it can only stop at one.
+ *
+ * `true` for everything else, and that fallback is load-bearing rather than a
+ * default nobody reaches: the ruler's slot ticks, the launch-unit letters and
+ * the epic band names are drawn at every level and are not gated at all.
+ *
+ * This is DRAW-ONLY. `computePlanLayout` reserves every label's rect at every
+ * level regardless — the zero-overlap invariant is asserted against it
+ * unconditionally — so a kind going dark never moves anything else.
+ */
+export function drawsLabelKind(kind, level, k) {
+    if (kind === 'step' || kind === 'req') return level !== 'out' && labelsLegible(k);
+    if (kind === 'title') return level === 'in' && labelsLegible(k);
+    return true;
+}
+
 // ── The time axis (req #3201) ───────────────────────────────────────────────
 // Sentinel slot prefixes. Sorting the composed keys lexicographically IS the
 // chronological order: '0' < '1' < '2', and ISO days sort as strings.
@@ -3164,8 +3260,11 @@ export const NEXT_HALO_DASH = [3, 3];
 // at 13.75 and the bead's ring caps the inner edge at 11.5, so the world stroke
 // can be at most 2 — exactly what it already is. Making the stroke
 // screen-constant while pinning the radius merges the two rings for all k < 0.8.
-// The only room is the room the LABELS vacate, which is why this is gated on
-// the label predicate and not on k alone.
+// The only room is the room the LABELS vacate, which is why the magnification
+// stops exactly where the labels start being drawn — `K_READABLE`, the same
+// scale `labelsLegible` gates them on (req #3280). It is one scale answering
+// both halves, so "the halo never crosses a drawn label" needs no coordination
+// between two predicates: it is true by arithmetic.
 //
 // ONE MAGNIFICATION FOR THE WHOLE MARK, never per-property. Radius, stroke and
 // dash all scale by the same `m`, so the halo is always the same SHAPE — the
@@ -3173,19 +3272,55 @@ export const NEXT_HALO_DASH = [3, 3];
 // the bead does not, the gap between the two rings can only OPEN. A fix that
 // counter-scaled the stroke alone would close it.
 //
-// `m` targets a fixed on-screen radius, so between the ceiling and k = 1 the
-// apparent thickness is a flat NEXT_HALO_STROKE px and the dash pitch a flat
-// NEXT_HALO_DASH px — the k = 1 appearance, held constant as you zoom out
-// instead of thinning to nothing. ON A LARGE PLAN THE CEILING BINDS FIRST and
-// that band is never reached: the live plan's 'out' is the whole reachable
-// range below k = 0.4, which asks for 2.5× at its top and 12.1× at the zoom
-// floor, against a ceiling of 2.0. Measured at the view the plan OPENS in
-// (1440px panel, kFit 0.398,
-// the view the plan OPENS in): radius 9.94px, stroke 1.59px, dash 2.39px, ten
-// dash cycles, and 4.67px of clear space to the bead — against 4.97 / 0.80 /
-// 1.19 / 0.10 before. The mark is unambiguous at the scale the question is
-// asked at, which is what was actually broken.
-export const NEXT_HALO_SCREEN_RADIUS = 12.5;
+// `m` targets a fixed on-screen radius, so below that scale the apparent
+// thickness is flat and the dash pitch is flat — one appearance, held constant
+// as you zoom out instead of thinning to nothing. THE CEILING BINDS BELOW
+// k = 0.4 and the flat band runs from there up to K_READABLE: on the live plan
+// the request is 2.0× at k = 0.4 (exactly the ceiling), 1.6× at k = 0.5, 1.0× at
+// k = 0.8, and 9.65× at the zoom floor (0.0829, a 1200px panel) against a
+// ceiling of 2.0. Measured at k = 0.398 — fit-to-width on a 1440px panel, one
+// wheel-click OUT from where the plan lands: radius 9.94px, stroke 1.59px, dash
+// 2.39px, ten dash cycles, and 4.67px of clear space to the bead — against
+// 4.97 / 0.80 / 1.19 / 0.10 before. The mark is unambiguous at the scale the
+// question is asked at, which is what was actually broken.
+//
+// **NOT the view the plan opens in, and #3271 said it was** (found in review of
+// req #3280). `resetView` lands on `kDefault` — `recenterModeRef` initialises to
+// 'readable' — so a plan OPENS at k = 0.8, ratio 1, level 'mid', ids at 11.0px.
+// The broken band is reached by zooming OUT from the landing view, not in. The
+// arithmetic below never depended on which end the reader arrives from; only
+// this description did.
+//
+// ── AND THE SCALE IT FREEZES AT IS DERIVED, NEVER CHOSEN (req #3280) ────────
+// #3271 aimed the mark at its own world radius, i.e. at the k = 1 appearance,
+// and switched the magnification off with the LABEL PREDICATE — which is binary
+// on the semantic level. That put a 2.0× → 1.0× step one wheel-click wide at the
+// L1/L2 boundary (k = 0.400 on the live plan): the mark HALVED as the reader
+// zoomed in, and what it halved to was the 0.80px stroke with 1.20px dashes,
+// 0.10px from the bead's own ring, that #3271 was filed to remove.
+//
+// The magnification now stops at `K_READABLE` — the scale at which the labels
+// start being drawn (`labelsLegible`) — and the screen size it holds is the size
+// the UNMAGNIFIED mark has AT that scale. That identity is the whole fix:
+//
+//     NEXT_HALO_SCREEN_RADIUS === NEXT_HALO_RADIUS * K_READABLE
+//     ⇒  m(K_READABLE⁻) = 1  =  m(K_READABLE⁺)
+//
+// so the two branches MEET rather than meeting-with-a-step.
+//
+// AND THE LEVEL BOUNDARIES ARE NOT CROSSINGS AT ALL ANY MORE — that is the
+// stronger statement, and the reason it holds on every plan size. `m` is a
+// function of `k` ALONE, continuous on each of its three pieces and at both
+// joins (`m(0.4) = 2` from either side; `m(K_READABLE) = 1` from either side),
+// so where the level ladder happens to put L1/L2 is irrelevant to it. The
+// live plan's boundary lands at k = 0.400, which IS one of the joins — the
+// arithmetic is continuous there anyway, and that is the coincidence the first
+// draft of this comment mistook for the reason.
+//
+// A CHOSEN number here would break that. 12.5 was chosen, and it is what made
+// the k = 0.8 halo (10.00px radius, the unmagnified mark) 25% smaller than the
+// k = 0.79 halo. The derivation is the invariant; the value 10 is its output.
+export const NEXT_HALO_SCREEN_RADIUS = NEXT_HALO_RADIUS * K_READABLE;
 // The halo's outer edge at m = 1: 13.5 against the 14 the text bound allows.
 const NEXT_HALO_OUTER = NEXT_HALO_RADIUS + NEXT_HALO_STROKE / 2;
 // HOW FAR IT MAY GROW: the SMALLEST clearance to any piece of world furniture
@@ -3193,9 +3328,17 @@ const NEXT_HALO_OUTER = NEXT_HALO_RADIUS + NEXT_HALO_STROKE / 2;
 // about it is how this got written twice and reviewed wrong twice:
 //
 //  - HALF A COLUMN PITCH was the first ceiling (2.37×). Wrong in the other
-//    direction: the live plan's Overview asks for 2.51 at kFit = 0.398, so the
-//    screen-constant branch would never once have executed on the very plan
-//    this was filed against.
+//    direction: under #3271's target the live plan asked for 2.51 at k = 0.398,
+//    so the screen-constant branch would never once have executed on the very
+//    plan this was filed against.
+//    **THAT MEASUREMENT NO LONGER REFUTES IT** (found in review of req #3280).
+//    The target is now `K_READABLE / k`, so the same k asks for 2.011 — below
+//    2.37 — and a 2.37 ceiling would leave the branch reachable. The candidate
+//    is still rejected, but on the SECOND ground below rather than this one:
+//    half a column pitch is a one-constraint answer that says nothing about the
+//    launch-unit box, which is the clearance that actually binds at 28. Kept
+//    with its refutation corrected rather than deleted, because this list exists
+//    so a future reader does not re-derive a ceiling that was already tried.
 //  - "NEVER REACHES ANOTHER BEAD" was the second (3.76×). It cleared beads and
 //    crossed everything else — the epic chip's strip at every k below 0.371
 //    (which INCLUDES the opening view on a 1200px panel), and its own launch
@@ -3267,21 +3410,28 @@ export const NEXT_HALO_MAX_MAGNIFY = NEXT_HALO_MAX_OUTER / NEXT_HALO_OUTER;
 
 /**
  * The magnification applied to the next-step halo's radius, stroke width and
- * dash pattern (req #3271). ALWAYS 1 where the step and requirement labels are
- * drawn: their boxes start 14px from the bead centre in both directions, and
- * that bound is what fixes NEXT_HALO_RADIUS in the first place. It is also 1
- * once the mark is already at or above its target size on screen, so zooming IN
- * never changes it — at 'in' and 'mid' the halo is byte-identical to what it
- * was before this function existed.
+ * dash pattern (req #3271, made continuous by req #3280).
  *
- * @param {number} k             the world→screen scale actually being drawn at
- * @param {boolean} labelsDrawn  does this level draw step/requirement labels?
- *                               (the visualizer's own `drawsKind('step')` — the
- *                               halo takes exactly the room the labels vacate)
- * @returns {number} a factor in [1, NEXT_HALO_MAX_MAGNIFY]
+ * A PURE FUNCTION OF `k`, and that is the fix rather than a tidy-up. #3271 took
+ * a second argument — "does this level draw the labels?" — because the halo may
+ * only grow into room the labels are not using, and a BOOLEAN bound produces a
+ * STEP: the mark halved in one wheel-click at whatever absolute scale the level
+ * ladder happened to put the boundary at. Since `labelsLegible` gates the labels
+ * on `K_READABLE` and this stops magnifying at `K_READABLE`, the two can no
+ * longer disagree, so the argument had nothing left to say. **Labels drawn ⇒
+ * `m === 1`** is now an arithmetic consequence, not a contract between two
+ * modules — which is what protects the 14-world-px text bound that fixes
+ * `NEXT_HALO_RADIUS` in the first place.
+ *
+ * It is 1 at and above `K_READABLE`, so zooming IN never changes the mark and
+ * the halo at 'in' — and across the top half of 'mid' — is byte-identical to
+ * what it was before either requirement existed.
+ *
+ * @param {number} k  the world→screen scale actually being drawn at
+ * @returns {number} a factor in [1, NEXT_HALO_MAX_MAGNIFY], monotone
+ *   non-increasing in `k` and continuous everywhere
  */
-export function nextHaloMagnify(k, labelsDrawn) {
-    if (labelsDrawn) return 1;
+export function nextHaloMagnify(k) {
     if (!Number.isFinite(k) || k <= 0) return 1;
     const want = NEXT_HALO_SCREEN_RADIUS / (NEXT_HALO_RADIUS * k);
     if (!(want > 1)) return 1;

--- a/tests/tests/pipelines.spec.ts
+++ b/tests/tests/pipelines.spec.ts
@@ -1928,6 +1928,17 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             //
             //    The ladder itself is asserted whole, because "gated at L1" is
             //    only meaningful next to the kinds that draw at every level.
+            //
+            //    SINCE REQ #3280 EACH OF THE THREE ALSO ASKS WHETHER IT IS
+            //    LEGIBLE — `k >= K_READABLE` — and these assertions are unmoved
+            //    by it for a structural reason rather than a lucky one: pinning
+            //    does not move the camera (step 2 asserts exactly that), so the
+            //    scale here is still the default `kDefault = max(kFit,
+            //    K_READABLE)`, which is `>= K_READABLE` on every plan at every
+            //    panel width. The absolute half of the gate is exercised in
+            //    `pipelinePlanLayout.test.js` (`the next-step halo survives the
+            //    level CROSSINGS`), which sweeps kind × level × k directly
+            //    against `drawsLabelKind` — the same function this canvas calls.
             const drawnAt = async (lvl: string, expected: string, message: string) => {
                 await page.getByTestId(`pipeline-viz-level-${lvl}`).click();
                 await expect(container, message).toHaveAttribute('data-drawn', expected);


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3280-plan-visualizer-the-next-up-halo-is-1
- wip(Darwin): 2026-08-03T03:00:18Z
- chore: init swarm session feature/3280-plan-visualizer-the-next-up-halo-is-1

## Files changed
```
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx | 105 ++++--
 .../pipelines/__tests__/pipelinePlanLayout.test.js | 399 +++++++++++++++++++--
 src/SwarmView/pipelines/pipelinePlanLayout.js      | 212 +++++++++--
 tests/tests/pipelines.spec.ts                      |  11 +
 4 files changed, 636 insertions(+), 91 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)