### PR TITLE
Plan visualizer: below k~0.3 the next-up halo is smaller than the stroke it needs — that band needs a different MARK

### DIFF
--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -114,7 +114,8 @@ import {
     CHW_EPIC, ZOOM_MIN_RATIO, ZOOM_MAX_RATIO,
     readableDefaultScale, DEFAULT_STEP_WIDTH, EPIC_CHIP_BG_ALPHA,
     NEXT_HALO_RADIUS, NEXT_HALO_STROKE, NEXT_HALO_OPACITY, NEXT_HALO_DASH,
-    nextHaloMagnify, labelsLegible, drawsLabelKind, BEAD_LANE_OFFSET,
+    nextHaloMagnify, nextMarkIsDot, nextMarkDotRadius,
+    labelsLegible, drawsLabelKind, BEAD_LANE_OFFSET,
     buildMachineColorView, reqIdStyle, reqIdKeyEntries, normalizeColorKey,
     DEFAULT_COLOR_KEY, PLAN_KEY_MAX_W, pinnedLevelOf, DEFAULT_PLAN_LEVEL_PREF,
     EPIC_PAUSE_BUBBLE_D, pauseBubbleColor, stickyRulerY, rulerScreenBottom,
@@ -1572,8 +1573,20 @@ export default function PipelinePlanVisualizer({
     // expression the label gate reads. The invariant is "the scale the halo
     // sizes itself against is the scale the labels are gated on", and two
     // expressions that agree today are how that quietly stops being true.
-    const haloM = nextHaloMagnify(curK);
-    const haloDash = haloM === 1 ? NEXT_HALO_DASH : NEXT_HALO_DASH.map((d) => d * haloM);
+    // req #3299 — below the ring's reach (`nextHaloMagnify`'s ceiling is
+    // already maxed out, so the ring's ON-SCREEN size resumes shrinking with
+    // `curK`), a DIFFERENT MARK takes over: a filled dot, counter-scaled so
+    // its screen size is fixed rather than a world size the camera shrinks.
+    // See `nextMarkIsDot`/`nextMarkDotRadius` in pipelinePlanLayout.js for the
+    // derivation. Decided BEFORE `haloM`/`haloDash` so those — unused on the
+    // dot branch, and `NEXT_HALO_DASH.map` allocates a fresh array every frame
+    // on the capped branch this replaces — are only computed for the branch
+    // that needs them.
+    const haloIsDot = nextMarkIsDot(curK);
+    const haloM = haloIsDot ? 1 : nextHaloMagnify(curK);
+    const haloDash = haloIsDot || haloM === 1 ? NEXT_HALO_DASH
+        : NEXT_HALO_DASH.map((d) => d * haloM);
+    const dotRadius = haloIsDot ? nextMarkDotRadius(curK) : 0;
 
     rows.forEach((row) => {
         const n = layout.nodes.get(row.id);
@@ -1605,11 +1618,21 @@ export default function PipelinePlanVisualizer({
         // labels, so the magnification's target is the mark's own size at that
         // scale and the two branches meet. See `nextHaloMagnify`.
         if (style.next) {
-            worldNodes.push(
+            // req #3299 — the dot does NOT recolour the bead: it is its own
+            // node, in the halo's own colour, replacing only the RING's
+            // geometry below the floor the ring itself cannot reach. The
+            // bead's fill (state) and ring (run mode) below still draw at
+            // their own — now sub-pixel — world size, untouched.
+            worldNodes.push(haloIsDot ? (
+                <Circle key={`next-${row.id}`} name="next-halo" x={n.x} y={n.y}
+                        radius={dotRadius} fill={style.haloColor}
+                        opacity={NEXT_HALO_OPACITY} listening={false} />
+            ) : (
                 <Circle key={`next-${row.id}`} name="next-halo" x={n.x} y={n.y}
                         radius={NEXT_HALO_RADIUS * haloM} stroke={style.haloColor}
                         strokeWidth={NEXT_HALO_STROKE * haloM} opacity={NEXT_HALO_OPACITY}
-                        dash={haloDash} listening={false} />);
+                        dash={haloDash} listening={false} />
+            ));
         }
         worldNodes.push(
             <Group key={`bead-${row.id}`} name={style.pulse ? 'pulse-bead' : undefined}>
@@ -2303,7 +2326,15 @@ export default function PipelinePlanVisualizer({
                                 <LegendDot ring={P.manualRing} label="Manual" />
                                 {/* "next up" and not "eligible now" because the
                                     mark answers the question in the plan's own
-                                    words: these are the steps that run next. */}
+                                    words: these are the steps that run next.
+                                    Below k ≈ 0.3 the canvas swaps this dashed
+                                    ring for a filled dot of the same on-screen
+                                    size, in the SAME colour (req #3299,
+                                    `nextMarkIsDot` in pipelinePlanLayout.js) —
+                                    the ring cannot survive that deep a
+                                    zoom-out, the fact it marks does not
+                                    change, so the key does not grow a second
+                                    swatch for it. */}
                                 <LegendDot ring={P.eligibleRing} label="next up"
                                            dashed animated="pipeKeyBreathe" />
                             </KeyGroup>

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -20,6 +20,8 @@ import {
     NEXT_HALO_RADIUS, NEXT_HALO_STROKE, NEXT_HALO_DASH, EPIC_CHIP_CHAR_W,
     NEXT_HALO_SCREEN_RADIUS, NEXT_HALO_MAX_OUTER, NEXT_HALO_MAX_MAGNIFY,
     NEXT_HALO_CLEARANCES, nextHaloMagnify, labelsLegible, drawsLabelKind,
+    NEXT_MARK_MIN_STROKE_PX, NEXT_MARK_FLOOR_K, NEXT_MARK_SCREEN_RADIUS,
+    nextMarkIsDot, nextMarkDotRadius,
     readableDefaultScale, BEAD_RING_W_EMPHASIS, BEAD_OUTER_RADIUS,
     EPIC_CHIP_FONT, EPIC_CHIP_H, EPIC_CHIP_MIN_H, EPIC_CHIP_MIN_CHARS,
     EPIC_CHIP_PAD_W, EPIC_CHIP_MIN_FONT,
@@ -3056,6 +3058,16 @@ describe('the next-step halo survives Overview (req #3271)', () => {
     // two ceilings by doing exactly this by hand: "never reaches another bead"
     // cleared beads and crossed the epic chip's strip and its own launch-unit
     // box on all four sides, through the whole of Overview.
+    //
+    // THIS COVERS THE RING ONLY (req #3299). Below `NEXT_MARK_FLOOR_K` the
+    // component draws the deep-zoom-out DOT instead — deliberately NOT bound
+    // by this clearance list, since it is sized in screen space rather than
+    // world space (see the "different MARK" block in pipelinePlanLayout.js).
+    // It is k-INDEPENDENT BY CONSTRUCTION — it bounds the ring's worst-case
+    // WORLD envelope (`outerAt(NEXT_HALO_MAX_MAGNIFY)`), which is why it can
+    // claim "at any k" with no `k` sweep anywhere in it. The dot has no world
+    // envelope, so it is out of this case's reach by design, not by where a
+    // sweep happens to fall.
     it('crosses no world furniture, at any k the zoom can reach', () => {
         const worstOuter = outerAt(NEXT_HALO_MAX_MAGNIFY);
         // The substrate fixture in all four label/layout combinations, PLUS the
@@ -3575,6 +3587,121 @@ describe('the next-step halo survives the level CROSSINGS (req #3280)', () => {
             expect(strokePx(k)).toBeCloseTo(
                 NEXT_HALO_STROKE * NEXT_HALO_MAX_MAGNIFY * k, 10);
         }
+    });
+
+    // ── The follow-on: a different MARK below the band above (req #3299) ────
+    // The case above proved WHERE the ring stops reading; this proves the
+    // fix — a fixed-screen-size dot below that same floor, on the SAME
+    // REACHABLE sweep and the SAME live-plan zoom floor, so both halves of the
+    // story are measured against one sweep rather than two.
+    describe('the deep-zoom-out DOT covers what the ring cannot (req #3299)', () => {
+        const strokePx = (k) => NEXT_HALO_STROKE * nextHaloMagnify(k) * k;
+
+        it('the dot band IS the band the ring cannot reach — found by '
+            + 'SEARCHING the swept range, not by restating the closed form '
+            + '(same discipline as the sibling case above)', () => {
+            const unreadable = new Set(
+                REACHABLE.filter((k) => strokePx(k) < NEXT_MARK_MIN_STROKE_PX));
+            const dotted = new Set(REACHABLE.filter((k) => nextMarkIsDot(k)));
+            expect(unreadable.size, 'ring-unreadable samples').toBeGreaterThan(10);
+            expect(dotted.size, 'dot-drawn samples').toBe(unreadable.size);
+            for (const k of unreadable) expect(dotted.has(k), `k=${k}`).toBe(true);
+        });
+
+        it('is derived from the ring\'s own acceptance floor, not chosen', () => {
+            expect(NEXT_MARK_FLOOR_K).toBeCloseTo(
+                NEXT_MARK_MIN_STROKE_PX / (NEXT_HALO_STROKE * NEXT_HALO_MAX_MAGNIFY), 10);
+            expect(NEXT_MARK_FLOOR_K).toBeGreaterThan(0.29);
+            expect(NEXT_MARK_FLOOR_K).toBeLessThan(0.31);
+            // The formula only means what it claims to on the CAPPED branch
+            // (`strokePx(k) = STROKE × MAX_MAGNIFY × k` there) — true only
+            // while the floor itself sits below where the magnification caps
+            // (`K_READABLE / NEXT_HALO_MAX_MAGNIFY`). If a future change moved
+            // `K_READABLE` low enough to violate this, the floor would stop
+            // meaning "where the ring drops under the acceptance stroke".
+            expect(NEXT_MARK_FLOOR_K).toBeLessThan(K_READABLE / NEXT_HALO_MAX_MAGNIFY);
+        });
+
+        it('draws the ring at and above the floor, the dot only below it — '
+            + 'the k >= 0.3 band this requirement must not move', () => {
+            const atOrAbove = REACHABLE.filter((k) => k >= NEXT_MARK_FLOOR_K);
+            const below = REACHABLE.filter((k) => k < NEXT_MARK_FLOOR_K);
+            expect(atOrAbove.length).toBeGreaterThan(0);
+            expect(below.length).toBeGreaterThan(0);
+            for (const k of atOrAbove) expect(nextMarkIsDot(k), `k=${k}`).toBe(false);
+            for (const k of below) expect(nextMarkIsDot(k), `k=${k}`).toBe(true);
+            // The exact boundary itself stays on the ring — `nextMarkIsDot` is
+            // a strict `<`, so a camera parked exactly at the floor is not a
+            // special case needing its own branch.
+            expect(nextMarkIsDot(NEXT_MARK_FLOOR_K)).toBe(false);
+        });
+
+        it('holds the dot at a FIXED screen radius across the whole '
+            + 'reachable deep-zoom-out range, including the live zoom floor', () => {
+            const below = REACHABLE.filter((k) => nextMarkIsDot(k));
+            expect(below.length, 'reachable samples below the floor')
+                .toBeGreaterThan(10);
+            for (const k of [...below, LIVE_ZOOM_FLOOR]) {
+                expect(nextMarkDotRadius(k) * k, `dot screen radius at k=${k}`)
+                    .toBeCloseTo(NEXT_MARK_SCREEN_RADIUS, 10);
+            }
+        });
+
+        it('meets the ring\'s own outer edge AT the floor — no size jump '
+            + 'crossing it, the same join `NEXT_HALO_SCREEN_RADIUS` makes at '
+            + '`K_READABLE`', () => {
+            const ringOuterAt = (k) => NEXT_HALO_MAX_OUTER * k; // capped branch
+            expect(NEXT_MARK_SCREEN_RADIUS)
+                .toBeCloseTo(ringOuterAt(NEXT_MARK_FLOOR_K), 10);
+            // And therefore continuous across a fine sweep straddling it, not
+            // just at the one named point — the gap shrinks WITH eps rather
+            // than sitting under one fixed tolerance regardless of it, which
+            // is what actually distinguishes "continuous" from "close enough
+            // at the scale I happened to check".
+            for (const eps of [0.01, 0.001, 0.0001]) {
+                const above = ringOuterAt(NEXT_MARK_FLOOR_K + eps);
+                const below = nextMarkDotRadius(NEXT_MARK_FLOOR_K - eps)
+                    * (NEXT_MARK_FLOOR_K - eps);
+                expect(Math.abs(above - below), `eps=${eps}`)
+                    .toBeLessThan(NEXT_HALO_MAX_OUTER * eps * 1.01);
+            }
+        });
+
+        it('never merges with the bead\'s own ring — clears it by at least '
+            + 'the acceptance stroke at every k it draws at, including the '
+            + 'top of its own band where the bead is largest', () => {
+            const below = REACHABLE.filter((k) => nextMarkIsDot(k));
+            expect(below.length).toBeGreaterThan(10);
+            // The true worst case is the supremum of the dot's domain
+            // (k -> NEXT_MARK_FLOOR_K from below, where the bead is largest)
+            // — added explicitly rather than trusting a sample grid to land
+            // on it, since `REACHABLE`'s nearest sample (k ~= 0.2934) is not
+            // actually the tightest point.
+            for (const k of [...below, LIVE_ZOOM_FLOOR, NEXT_MARK_FLOOR_K - 1e-9]) {
+                const fringe = nextMarkDotRadius(k) * k - BEAD_OUTER_RADIUS * k;
+                expect(fringe, `clearance to the bead at k=${k}`)
+                    .toBeGreaterThanOrEqual(NEXT_MARK_MIN_STROKE_PX);
+            }
+        });
+
+        it('is comfortably readable at the live zoom floor, where the ring '
+            + 'was proved unreadable', () => {
+            // The ring's entire outer edge was under 3 screen px there (the
+            // sibling case above). The dot clears the ring's own acceptance
+            // floor by a wide margin at the SAME k.
+            expect(NEXT_MARK_SCREEN_RADIUS).toBeGreaterThan(NEXT_MARK_MIN_STROKE_PX);
+            expect(nextMarkDotRadius(LIVE_ZOOM_FLOOR) * LIVE_ZOOM_FLOOR)
+                .toBeCloseTo(NEXT_MARK_SCREEN_RADIUS, 10);
+        });
+
+        it('nextMarkDotRadius does not divide by zero on a bad k', () => {
+            for (const bad of [NaN, 0, -1, Infinity]) {
+                expect(Number.isFinite(nextMarkDotRadius(bad)), `k=${bad}`).toBe(true);
+            }
+            expect(nextMarkIsDot(NaN)).toBe(false);
+            expect(nextMarkIsDot(0)).toBe(false);
+            expect(nextMarkIsDot(-1)).toBe(false);
+        });
     });
 });
 

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -3438,6 +3438,134 @@ export function nextHaloMagnify(k) {
     return Math.min(want, NEXT_HALO_MAX_MAGNIFY);
 }
 
+// ── Below the ring's reach: a different MARK (req #3299) ───────────────────
+// #3271/#3280 made the halo hold a flat 10px screen radius from `K_READABLE`
+// down to `K_READABLE / NEXT_HALO_MAX_MAGNIFY` (k = 0.4 on the live plan) by
+// magnifying it. Below that the magnification is already AT its ceiling —
+// `NEXT_HALO_CLEARANCES` forbids growing the ring's WORLD radius any further,
+// on pain of running into the launch-unit box — so the mark's ON-SCREEN size
+// resumes shrinking with `k`: `stroke(k) = NEXT_HALO_STROKE * NEXT_HALO_MAX_MAGNIFY * k`,
+// linear in `k` with nothing left to counteract it.
+//
+// THE ACCEPTANCE FLOOR: a stroke needs to read as an outline rather than as a
+// blur, and 1.2 world/screen px is that floor (half the weight of the flat
+// band's own 1.6px stroke — the flattest a form this thin can go and still be
+// legible, measured against the flat band already shipping). Solving
+// `stroke(k) >= NEXT_MARK_MIN_STROKE_PX` for `k` gives the derived floor below
+// — DERIVED, not chosen, so a future change to the stroke width or the
+// magnification ceiling moves this floor with it rather than silently
+// disagreeing (the same discipline `NEXT_HALO_MAX_OUTER` and
+// `NEXT_HALO_SCREEN_RADIUS` already follow). On the live plan this floor is
+// k = 0.3 — matching the measured split in
+// `pipelinePlanLayout.test.js` ("cannot reach the deep zoom-out band, and
+// says where it stops").
+//
+// BELOW IT NO RING CAN WORK, at any ceiling: `NEXT_HALO_CLEARANCES` bounds the
+// ring's WORLD size, and world size buys nothing once the ENTIRE mark is under
+// a handful of screen px — the ring is already smaller than the stroke it
+// would need (`NEXT_HALO_MAX_OUTER * k` is under 3 screen px at the live
+// zoom floor, asserted alongside the split above). So the fix is not a bigger
+// or thicker ring; it is a DIFFERENT MARK, built the opposite way round:
+//
+//   - THE RING is sized in WORLD units and scaled by the camera, which is
+//     exactly why it disappears — it was always going to, past some k.
+//   - THE DOT below is sized in SCREEN units and counter-scaled against the
+//     camera (`NEXT_MARK_SCREEN_RADIUS / k` as a world radius, so the camera's
+//     own `× k` cancels it back to a fixed on-screen size) — a FLAT mark that
+//     cannot vanish because nothing about it depends on how far zoomed out the
+//     camera is. This is the "screen-space marker anchored at the bead" the
+//     requirement asked to be investigated, not a tuning of the ring.
+//
+// IT DOES NOT RECOLOUR THE BEAD, and the colour language is untouched: the
+// dot is drawn as its OWN node, in the halo's existing colour
+// (`style.haloColor` — eligible green, or suppressed red), replacing only the
+// RING's geometry below this floor. The bead's own fill (state) and ring (run
+// mode) keep drawing at their own — now sub-pixel — world size beneath it,
+// exactly as they always have; nothing here adds a fourth channel or repaints
+// an existing one. What changes is FORM, the same axis the ring-vs-bead
+// separation already spends: a filled dot needs no minimum stroke width to
+// read, so it has no floor at all, whereas a stroked ring fundamentally does.
+//
+// OVERLAP WITH NEIGHBOURS IS ACCEPTED, not solved here. Beads sit ~26 world px
+// apart, i.e. a handful of screen px at the zoom floor, so any mark that reads
+// at that scale necessarily spans several columns — the clearance list above
+// cannot bound it because the clearances are stated in world units and this
+// mark deliberately is not. Concretely, at the live zoom floor (k = 0.0829)
+// the dot's WORLD radius is `NEXT_MARK_SCREEN_RADIUS / k` ≈ 97.7 world px
+// against that ~26px pitch — several columns each side, wider than the ring
+// it replaces ever reached even at its own ceiling. That trade only matters
+// when many neighbouring steps are eligible at once, which is not the common
+// case this deep in Overview; a plan where it is stays legible as "a lot is
+// eligible here", which is still true.
+//
+// `ZOOM_MIN_RATIO` is left AT 0.25 (not tightened, not loosened): the
+// requirement asked whether it is the right floor "measured against what a
+// reader can actually do at the scales it admits", and what a reader can now
+// do at the floor is see which steps are eligible, which they could not
+// before. Raising the floor would remove scales this fix just made useful;
+// lowering it is a separate, unmeasured question this fix does not answer.
+export const NEXT_MARK_MIN_STROKE_PX = 1.2;
+export const NEXT_MARK_FLOOR_K = NEXT_MARK_MIN_STROKE_PX
+    / (NEXT_HALO_STROKE * NEXT_HALO_MAX_MAGNIFY);
+// The dot's fixed on-screen radius — DERIVED, not chosen, for the same reason
+// `NEXT_HALO_SCREEN_RADIUS` is (line ~3320 above): a chosen number here makes
+// the two branches disagree at the crossing, exactly the "mark HALVES in one
+// wheel-click" defect req #3280 was filed to remove, reintroduced at a new
+// threshold. Below the floor the ring's magnification is already capped, so
+// its WORLD outer edge is pinned at `NEXT_HALO_MAX_OUTER` and its SCREEN outer
+// edge is `NEXT_HALO_MAX_OUTER * k` — shrinking, which is the whole defect,
+// but CONTINUOUS, so matching the dot's fixed screen size to that edge AT the
+// floor makes the two branches meet with no step:
+//
+//     NEXT_MARK_SCREEN_RADIUS === NEXT_HALO_MAX_OUTER * NEXT_MARK_FLOOR_K
+//
+// (mirrors `NEXT_HALO_SCREEN_RADIUS === NEXT_HALO_RADIUS * K_READABLE` at the
+// OTHER join). This also fixes a second defect found in review: the dot is
+// drawn UNDER the bead's own Group (same draw order the ring always used), so
+// it is only visible as the annulus outside the bead's own outer edge —
+// `NEXT_MARK_SCREEN_RADIUS - BEAD_OUTER_RADIUS * k`. A CHOSEN 4px radius put
+// that annulus under the 1.2px acceptance floor for k in (0.249, 0.300) —
+// solid, same eligible green as the bead's own ring, reading as "the ring got
+// thicker" rather than as a second mark, exactly what the ring's own dashing
+// exists to prevent (see the comment above `NEXT_HALO_RADIUS`). The derived
+// value clears the bead by >= 4.7px at every k this mark draws at (worst case
+// is the top of the band, k -> NEXT_MARK_FLOOR_K, where the bead is largest);
+// asserted in pipelinePlanLayout.test.js rather than left as an accident of
+// the chosen number.
+export const NEXT_MARK_SCREEN_RADIUS = NEXT_HALO_MAX_OUTER * NEXT_MARK_FLOOR_K;
+
+/**
+ * Is `k` below the ring's reach, i.e. must the deep-zoom-out DOT be drawn
+ * instead of the halo ring (req #3299)?
+ *
+ * `false` everywhere the ring already reads (`k >= NEXT_MARK_FLOOR_K`,
+ * `NEXT_MARK_FLOOR_K` itself included) — the whole of the k >= 0.3 band this
+ * requirement is forbidden from moving stays on the ring, byte-identical.
+ *
+ * @param {number} k  the world→screen scale actually being drawn at
+ * @returns {boolean}
+ */
+export function nextMarkIsDot(k) {
+    return Number.isFinite(k) && k > 0 && k < NEXT_MARK_FLOOR_K;
+}
+
+/**
+ * The deep-zoom-out dot's WORLD radius for this frame — the value that,
+ * multiplied by the camera's own `k`, always renders at
+ * `NEXT_MARK_SCREEN_RADIUS` screen px regardless of how small `k` gets.
+ *
+ * Only meaningful where `nextMarkIsDot(k)` is true; the caller picks the
+ * branch, this only sizes it.
+ *
+ * @param {number} k  the world→screen scale actually being drawn at
+ * @returns {number} a world radius, or `NEXT_MARK_SCREEN_RADIUS` unscaled if
+ *   `k` is non-finite or non-positive (never reached under a real camera, but
+ *   never a division by zero either)
+ */
+export function nextMarkDotRadius(k) {
+    return Number.isFinite(k) && k > 0 ? NEXT_MARK_SCREEN_RADIUS / k : NEXT_MARK_SCREEN_RADIUS;
+}
+
 // ── Epic focus geometry (req #3204) ─────────────────────────────────────────
 // Clicking an epic's name fits that epic's steps to the viewport. This is pure
 // geometry over a layout that is already computed, so it lives beside the


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-03T08:22:27Z
- chore: init swarm session feature/3299-plan-visualizer-below-k03-the-next-1

## Files changed
```
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx |  43 ++++++-
 .../pipelines/__tests__/pipelinePlanLayout.test.js | 127 ++++++++++++++++++++
 src/SwarmView/pipelines/pipelinePlanLayout.js      | 128 +++++++++++++++++++++
 3 files changed, 292 insertions(+), 6 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)