### PR TITLE
Pipeline page remembers your last view/viewport

### DIFF
--- a/src/SwarmView/pipelines/PipelineCardsView.jsx
+++ b/src/SwarmView/pipelines/PipelineCardsView.jsx
@@ -23,7 +23,8 @@ import { claimForPipeline, holderView } from './orchestrationHolder';
 const EMPTY_SUMMARY = { total: 0, done: 0, running: 0, pending: 0 };
 
 export default function PipelineCardsView({ pipelines, summaries, reqCounts,
-    showReqCounts = false, machines, claims = [], onOpen, hiddenStatusCounts = [] }) {
+    showReqCounts = false, machines, claims = [], onOpen, lastOpenedId = null,
+    hiddenStatusCounts = [] }) {
     if (!pipelines.length) {
         // "No pipelines yet" is a claim about the DATA, and it is false whenever
         // a status filter is what emptied the view — the page's own accounting
@@ -54,17 +55,46 @@ export default function PipelineCardsView({ pipelines, summaries, reqCounts,
                 // shows "0/0" rather than the name alone: at the plan level, "no
                 // counted requirements" IS an answer, not a missing one.
                 const counts = showReqCounts ? reqCounts?.get(p.id) : null;
+                // req #3311 — "remember my last selected pipeline". The mark is
+                // the visible half of that memory: a reader who comes back to
+                // this list should be able to SEE which plan they were working
+                // on, not merely have it recorded somewhere. It is deliberately
+                // an ACCENT and not a selection state — the card is still a plain
+                // link, nothing is pre-selected, and the browser's Back is
+                // untouched.
+                const lastViewed = p.id === lastOpenedId;
                 return (
-                    <Card key={p.id} variant="outlined" data-testid={`pipeline-card-${p.id}`}>
+                    <Card key={p.id} variant="outlined" data-testid={`pipeline-card-${p.id}`}
+                          sx={lastViewed ? {
+                              borderColor: 'primary.main',
+                              // The border is what carries the mark on a card
+                              // whose chips are already carrying status, machine
+                              // and holder. A second colour fill would compete
+                              // with the status chip, which is the one thing on a
+                              // card that MUST read first.
+                              boxShadow: (theme) => `0 0 0 1px ${theme.palette.primary.main}`,
+                          } : undefined}>
                         <CardActionArea onClick={() => onOpen(p.id)}>
                             <CardContent>
                                 <Box sx={{ display: 'flex', alignItems: 'flex-start',
                                             gap: 1, mb: 1 }}>
-                                    <Typography variant="subtitle1" sx={{ flex: 1,
+                                    {/* `minWidth: 0` so the title ABSORBS the
+                                        mark's width instead of being pushed
+                                        into an extra wrapped line by it. A flex
+                                        item defaults to `min-width: auto` —
+                                        "never below your content" — and cards
+                                        share a grid row, so one card growing
+                                        taller grows the whole row. */}
+                                    <Typography variant="subtitle1" sx={{ flex: 1, minWidth: 0,
                                                                           fontWeight: 600 }}>
                                         {p.title}
                                         {counts ? ` ${counts.met}/${counts.total}` : ''}
                                     </Typography>
+                                    {lastViewed && (
+                                        <Chip size="small" color="primary" variant="outlined"
+                                              label="Last viewed" sx={{ flexShrink: 0 }}
+                                              data-testid={`pipeline-card-lastviewed-${p.id}`} />
+                                    )}
                                     <Chip size="small" label={p.pipeline_status}
                                           {...pipelineStatusChipProps(p.pipeline_status)} />
                                 </Box>

--- a/src/SwarmView/pipelines/PipelinePlanTable.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanTable.jsx
@@ -46,6 +46,8 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CheckIcon from '@mui/icons-material/Check';
 
+import { useScrollMemory } from '../../hooks/useScrollMemory';
+import { scrollStorageKey } from '../../utils/viewportMemory';
 import { fmtCost, STEP_DONE, STEP_RUNNING } from './pipelineModel';
 import {
     planRenderRows,
@@ -350,6 +352,49 @@ export default function PipelinePlanTable({ plan, pipeline, timezone, focusStepI
         if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }, [focusStepId, renderRows]);
 
+    // ── THIS TABLE'S OWN VIEWPORT SURVIVES LEAVING IT (req #3311) ───────────
+    // The Plan mode's camera has been remembered since req #3252; the Table
+    // mode's scroll position was not, and on the live 64-step plan that is the
+    // same defect wearing a scrollbar — open a step's requirement, come back,
+    // and you are at row 1. Every return path is covered without being listed,
+    // because a return is just this component mounting: a link out and Back, the
+    // header's Table|Plan toggle (which unmounts this with no navigation at all),
+    // a bead click, a reload.
+    //
+    // KEYED ON THE PLAN, exactly as the camera is: two plans open in one tab keep
+    // their own positions, and an unidentified plan persists nothing rather than
+    // inheriting another's.
+    const planScrollKey = pipeline?.id != null
+        ? scrollStorageKey('pipeline-plan-table', pipeline.id) : null;
+    // A DEEP LINK OWNS THE SCROLL POSITION FOR ITS ONE LANDING. `?step=` scrolls
+    // its row to centre in the effect above, and a restore racing that would put
+    // the reader somewhere neither of them asked for. So the RESTORE is suppressed
+    // and the RECORD is not — where the link left them IS where they are, and a
+    // null key here (the tempting one-liner) would drop their position instead of
+    // deferring to the link. Same doctrine PipelinePlanVisualizer applies to
+    // `?epic=`: a link asks to see one thing once and must never overwrite what
+    // the reader chose.
+    const linkOwnsScroll = focusStepId != null;
+    useScrollMemory(planScrollKey, window, { restore: !linkOwnsScroll });
+    // ── AND SO DOES THE HORIZONTAL ONE ─────────────────────────────────────
+    // A separate key because it is a separate scroller: eleven NOWRAP columns run
+    // ~1640px, so the TableContainer scrolls sideways under a page that scrolls
+    // down, and a reader who moved right to read `Depends on` has moved their
+    // viewport just as much as one who scrolled down. Its element arrives through
+    // STATE rather than a ref — see useScrollMemory's own note: a ref's `.current`
+    // cannot appear in a dependency list, so the effect would never re-run when
+    // the node lands.
+    //
+    // DEEP-LINK SUPPRESSED ON THE SAME TERMS as the vertical one, and it is not
+    // symmetry for its own sake: `scrollIntoView` above defaults to
+    // `inline: 'nearest'`, and a table ROW is wider than this scrollport, so the
+    // focus scroll moves this axis too. Restoring against it would fight it
+    // exactly as on the other axis.
+    const [tableEl, setTableEl] = useState(null);
+    useScrollMemory(pipeline?.id != null
+        ? scrollStorageKey('pipeline-plan-table-x', pipeline.id) : null,
+    tableEl, { restore: !linkOwnsScroll });
+
     // Column count for the banner colSpan — must track the Cost column's
     // visibility or the banner under-spans and leaves a ragged edge.
     // 10 fixed columns since the Name column landed (req #3119).
@@ -403,7 +448,7 @@ export default function PipelinePlanTable({ plan, pipeline, timezone, focusStepI
                 )}
             </Box>
 
-            <TableContainer component={Paper} variant="outlined">
+            <TableContainer component={Paper} variant="outlined" ref={setTableEl}>
                 <Table size="small" data-testid="pipeline-plan-table">
                     <TableHead>
                         <TableRow>

--- a/src/SwarmView/pipelines/PipelinesPage.jsx
+++ b/src/SwarmView/pipelines/PipelinesPage.jsx
@@ -38,6 +38,8 @@ import {
     useOrchestrationClaims,
 } from '../../hooks/useDataQueries';
 import { useViewPreference } from '../../hooks/useViewPreference';
+import { useScrollMemory } from '../../hooks/useScrollMemory';
+import { scrollStorageKey } from '../../utils/viewportMemory';
 import normalizeView from '../../Components/ViewerHeader/normalizeView';
 import ViewerHeader from '../../Components/ViewerHeader/ViewerHeader';
 import ChipFilter from '../../Components/ChipFilter';
@@ -58,6 +60,22 @@ import {
 } from './pipelineViewModel';
 
 const VIEW_STORAGE_KEY = 'darwin-swarm-pipelines-view';
+
+// req #3311 — "the list viewport ... is remembered". ONE position for this page:
+// both views scroll the document, and a reader who switches Cards↔Table is
+// looking at the same plans in a different shape, not at a second list.
+const LIST_SCROLL_KEY = scrollStorageKey('pipelines-list');
+
+// req #3311 — "remember my last selected pipeline". A PREFERENCE, not a position,
+// so it takes `useViewPreference`'s hybrid (per-tab sessionStorage, localStorage
+// only as the seed a brand-new tab starts from) rather than the strictly per-tab
+// storage `viewportMemory.js` argues for. The distinction is that module's own:
+// a position answers "where was I in THIS artifact a moment ago" and is
+// meaningless to a tab that was never there, while "the plan I am working on" is
+// durable and reads correctly with no context at all — which is also the ask's
+// "in local storage". Seeding is read ONCE at mount, so a second tab still never
+// disturbs a live one.
+const LAST_PIPELINE_STORAGE_KEY = 'darwin-swarm-pipelines-last-opened';
 
 // req #3220 — per-tab only (sessionStorage), matching useViewPreference's own
 // per-tab-first rationale (memory/view-switchable-pages.md). Needed because the
@@ -119,6 +137,15 @@ export default function PipelinesPage() {
 
     const [view, setView] = useViewPreference(VIEW_STORAGE_KEY, 'cards');
     const activeView = normalizeView(view, VIEWS);
+    // req #3311 — the plan this reader last opened, marked on return so "my last
+    // selected pipeline" is something they can SEE rather than an invisible
+    // bookmark. `''` is the never-opened default; anything unparseable (a value
+    // from an older build, or one typed into devtools) resolves to null and marks
+    // nothing, because this value indexes a row and a NaN would match none.
+    const [lastOpenedPref, setLastOpened] = useViewPreference(
+        LAST_PIPELINE_STORAGE_KEY, '');
+    const lastOpenedId = Number.isFinite(Number(lastOpenedPref)) && lastOpenedPref !== ''
+        ? Number(lastOpenedPref) : null;
     // req #3225 — the SAME preference the plan detail header's toggle writes.
     // This page carries no control of its own for it (the toggle lives where
     // the requirement puts it, in the header's row of toggle groups); it only
@@ -181,6 +208,16 @@ export default function PipelinesPage() {
     const isLoading = pipelinesLoading || stepsLoading || linksLoading
         || reqsLoading || machinesLoading;
 
+    // req #3311 — GATED ON THE SPINNER, and that gate is the whole subtlety. A
+    // position cannot be restored onto a page that is 40px of CircularProgress:
+    // every scroller clamps on assignment, so an early restore does not fail, it
+    // lands at 0 and reads as the feature not working. A null key parks the hook
+    // until the rows exist; the effect then re-runs with the real key and
+    // restores against a page that has height. Nothing is lost in the meantime —
+    // a spinner emits no scroll events, so there is no position to commit and the
+    // stored one is never overwritten with a 0.
+    useScrollMemory(isLoading ? null : LIST_SCROLL_KEY);
+
     const summaries = useMemo(
         () => pipelineSummaries({ pipelines, steps, stepRequirements, requirements }),
         [pipelines, steps, stepRequirements, requirements]);
@@ -201,7 +238,14 @@ export default function PipelinesPage() {
         () => hiddenPipelineStatusCounts(pipelines, statusFilter),
         [pipelines, statusFilter]);
 
-    const open = (id) => navigate(`/swarm/pipeline/${id}`);
+    const open = (id) => {
+        // Recorded BEFORE the navigation, which is the only ordering that works:
+        // `navigate` unmounts this page, and the write is what the return visit
+        // reads. It is the plan's own id as a string — `useViewPreference` stores
+        // strings, and `lastOpenedId` below is the one place it becomes a number.
+        setLastOpened(String(id));
+        navigate(`/swarm/pipeline/${id}`);
+    };
 
     if (isLoading) {
         return (
@@ -267,6 +311,7 @@ export default function PipelinesPage() {
                         claims={orchestrationClaims}
                         timezone={timezone}
                         onOpen={open}
+                        lastOpenedId={lastOpenedId}
                         hiddenStatusCounts={hiddenStatusCounts}
                     />
                 ) : (
@@ -278,6 +323,7 @@ export default function PipelinesPage() {
                         machines={machines}
                         claims={orchestrationClaims}
                         onOpen={open}
+                        lastOpenedId={lastOpenedId}
                         hiddenStatusCounts={hiddenStatusCounts}
                     />
                 )}

--- a/src/SwarmView/pipelines/PipelinesTableView.jsx
+++ b/src/SwarmView/pipelines/PipelinesTableView.jsx
@@ -45,7 +45,7 @@ function PipelinesNoRowsOverlay({ hiddenStatusCounts = [] }) {
 
 export default function PipelinesTableView({ pipelines, summaries, reqCounts,
     showReqCounts = false, machines, claims = [], timezone, onOpen,
-    hiddenStatusCounts = [] }) {
+    lastOpenedId = null, hiddenStatusCounts = [] }) {
     const rows = useMemo(() => pipelines.map((p) => {
         const s = summaries.get(p.id) || EMPTY_SUMMARY;
         // req #3224 — the WHOLE-PLAN reservation only. An epic-scoped one is the
@@ -197,7 +197,38 @@ export default function PipelinesTableView({ pipelines, summaries, reqCounts,
                 pageSizeOptions={[25, 50, 100]}
                 disableRowSelectionOnClick
                 onRowClick={(params) => onOpen(params.row.id)}
-                sx={{ cursor: 'pointer' }}
+                // req #3311 — the Cards view's "Last viewed" accent, in the
+                // idiom a DataGrid has for it: a row class, exactly as
+                // InstructionsTableView marks a closed instruction. A chip
+                // column would cost the widest table on the page 120px to say
+                // one thing about one row.
+                getRowClassName={(params) => (params.row.id === lastOpenedId
+                    ? 'pipelines-row--lastviewed' : '')}
+                sx={{
+                    cursor: 'pointer',
+                    // The tint goes on the CELLS, not the row, and it is
+                    // TRANSLUCENT (`action.selected` is an alpha colour). Both
+                    // matter: v8 paints `:hover` on `.MuiDataGrid-row` and
+                    // `.Mui-selected` on the cell, so a cell rule sits above
+                    // hover — an OPAQUE tint here would kill hover feedback on
+                    // the one row this feature has made most clickable, while a
+                    // translucent one lets it blend through. The cell rule also
+                    // catches the trailing filler cell DataGrid renders, so the
+                    // tint runs the full width rather than stopping at the last
+                    // column.
+                    '& .pipelines-row--lastviewed .MuiDataGrid-cell': {
+                        backgroundColor: 'action.selected',
+                    },
+                    // The left accent, on the ID cell BY FIELD and not by
+                    // position. `:first-of-type` looks right and matches
+                    // nothing: `GridRow` renders a `cellOffsetLeft`
+                    // presentation div ahead of the cells, so it — not a cell —
+                    // is the first div among the row's children, and the rule
+                    // would be silently dead. `data-field` is on every cell.
+                    '& .pipelines-row--lastviewed .MuiDataGrid-cell[data-field="id"]': {
+                        boxShadow: (theme) => `inset 3px 0 0 ${theme.palette.primary.main}`,
+                    },
+                }}
             />
         </Box>
     );

--- a/src/SwarmView/pipelines/__tests__/PipelinesPage.lastViewed.test.jsx
+++ b/src/SwarmView/pipelines/__tests__/PipelinesPage.lastViewed.test.jsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+//
+// Req #3311 — "remember my last selected pipeline".
+//
+// The storage and lifecycle contracts are pinned by `scrollMemory.test.js` and
+// `useScrollMemory.test.jsx`. What only an integration test can reach is the
+// round trip the user actually performs: open a plan, come back, and SEE which
+// one you were on. A page that recorded the id perfectly and rendered no mark
+// would pass every unit test and deliver nothing.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../../../RestApi/RestApi', () => ({
+    default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })),
+}));
+
+const PIPELINES = [
+    { id: 2, title: 'Darwin', pipeline_status: 'active', machine_fk: null },
+    { id: 5, title: 'Substrate', pipeline_status: 'active', machine_fk: null },
+];
+
+vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    const empty = () => ({ data: [], isLoading: false, isError: false });
+    return {
+        ...actual,
+        useAllPipelines: () => ({ data: PIPELINES, isLoading: false, isError: false }),
+        useAllPipelineSteps: empty,
+        useAllPipelineStepRequirements: empty,
+        useAllRequirements: empty,
+        useMachines: empty,
+        useOrchestrationClaims: empty,
+    };
+});
+
+import PipelinesPage from '../PipelinesPage';
+import AuthContext from '../../../Context/AuthContext';
+
+const LAST_KEY = 'darwin-swarm-pipelines-last-opened';
+
+let roots = [];
+
+function mount() {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    act(() => {
+        root.render(
+            <AuthContext.Provider value={{ profile: { userName: 'tester', timezone: 'UTC' } }}>
+                <MemoryRouter initialEntries={['/swarm/pipelines']}>
+                    <PipelinesPage />
+                </MemoryRouter>
+            </AuthContext.Provider>,
+        );
+    });
+    roots.push(root);
+    return { unmount: () => act(() => root.unmount()) };
+}
+
+const node = (testId) => document.body.querySelector(`[data-testid="${testId}"]`);
+const openCard = (id) => act(() => {
+    node(`pipeline-card-${id}`).querySelector('button, [role="button"]')
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+});
+
+describe('PipelinesPage — the last selected pipeline', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+        localStorage.clear();
+        roots = [];
+    });
+    afterEach(() => {
+        act(() => { roots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+        sessionStorage.clear();
+        localStorage.clear();
+    });
+
+    it('marks nothing on a first-ever visit', () => {
+        mount();
+        expect(node('pipeline-card-2')).not.toBeNull();
+        expect(node('pipeline-card-lastviewed-2')).toBeNull();
+        expect(node('pipeline-card-lastviewed-5')).toBeNull();
+    });
+
+    it('records the plan it opens, and marks it on return', () => {
+        const first = mount();
+        openCard(5);
+        first.unmount();
+        document.body.innerHTML = '';
+
+        mount();
+        expect(node('pipeline-card-lastviewed-5')).not.toBeNull();
+        // EXACTLY ONE mark. A predicate that matched loosely — a string id
+        // against a numeric one, say — would light every card up and say
+        // nothing at all.
+        expect(node('pipeline-card-lastviewed-2')).toBeNull();
+    });
+
+    it('moves the mark when a different plan is opened', () => {
+        const first = mount();
+        openCard(5);
+        openCard(2);
+        first.unmount();
+        document.body.innerHTML = '';
+
+        mount();
+        expect(node('pipeline-card-lastviewed-2')).not.toBeNull();
+        expect(node('pipeline-card-lastviewed-5')).toBeNull();
+    });
+
+    // THE ASK'S OWN CONSTRAINT: "in local storage", and "this shouldn't affect
+    // separate tabs". `useViewPreference` is both halves — the live value is
+    // per-tab sessionStorage, and localStorage is only the seed a NEW tab starts
+    // from, read once at its own mount.
+    it('writes both the per-tab value and the new-tab seed', () => {
+        mount();
+        openCard(5);
+        expect(sessionStorage.getItem(LAST_KEY)).toBe('5');
+        expect(localStorage.getItem(LAST_KEY)).toBe('5');
+    });
+
+    it('marks the seeded plan in a tab that has never opened one', () => {
+        // A brand-new tab: localStorage carries yesterday's choice, this tab's
+        // sessionStorage is empty.
+        localStorage.setItem(LAST_KEY, '2');
+        mount();
+        expect(node('pipeline-card-lastviewed-2')).not.toBeNull();
+    });
+
+    // The value indexes a row, so anything that is not an id must mark NOTHING
+    // rather than match by accident. It comes out of web storage, so an older
+    // build's value and a hand-typed one are both reachable.
+    // `'0'` and `'  '` both parse to the NUMBER 0, which is not an id any row
+    // carries — so they belong here with the junk rather than being trusted.
+    it.each(['', '  ', '0', 'constructor', 'NaN', '{}', '5abc'])(
+        'marks nothing for a stored %s', (raw) => {
+            sessionStorage.setItem(LAST_KEY, raw);
+            mount();
+            expect(node('pipeline-card-lastviewed-2')).toBeNull();
+            expect(node('pipeline-card-lastviewed-5')).toBeNull();
+        });
+
+    it('marks nothing when the remembered plan is no longer listed', () => {
+        sessionStorage.setItem(LAST_KEY, '999');
+        mount();
+        // Asserted against the cards that EXIST. Looking for
+        // `pipeline-card-lastviewed-999` could never fail — there is no row 999
+        // to render one — so it would pass with the mark on every card.
+        expect(node('pipeline-card-2')).not.toBeNull();
+        expect(node('pipeline-card-lastviewed-2')).toBeNull();
+        expect(node('pipeline-card-lastviewed-5')).toBeNull();
+    });
+});

--- a/src/hooks/__tests__/useScrollMemory.test.jsx
+++ b/src/hooks/__tests__/useScrollMemory.test.jsx
@@ -1,0 +1,395 @@
+// @vitest-environment jsdom
+//
+// Req #3311 — the LIFECYCLE half of scroll memory.
+//
+// `scrollMemory.test.js` pins the storage contract. This pins the things only the
+// hook can get wrong, each of which is SILENT when it does:
+//   · a scroll with no commit writes NOTHING (the fling that never settles)
+//   · unmount commits anyway — the main path this feature exists for, since the
+//     reader's last act before leaving is usually the scroll being remembered
+//   · a restore that lands SHORT must not overwrite the position it failed to
+//     apply (the echo), and must keep trying while the content grows
+//   · a reader who scrolls during a restore WINS, and is recorded
+//   · a commit that straddles a key change files the position under the key it
+//     was TAKEN under (this page survives an in-place plan switch without
+//     remounting)
+//   · a null key persists nothing AND restores nothing
+//
+// ── THE DOUBLE CLAMPS AND EMITS, BECAUSE A REAL SCROLLER DOES ─────────────
+// jsdom implements no layout, so `scrollTop` on a real node is a getter pinned
+// at 0 and every assertion here would pass vacuously. But a double whose
+// position is a plain field is just as useless in the other direction: the two
+// behaviours this hook is BUILT AROUND are that a write CLAMPS to the content
+// height and that it EMITS a `scroll` event. Both are modelled below.
+//
+// ── FRAMES ARE QUEUED, NOT SYNCHRONOUS ────────────────────────────────────
+// Running an rAF callback inline would apply the restore BEFORE the effect
+// attaches its listener — an ordering no browser produces, and one that hides
+// the echo the hook exists to recognise. `runFrames` drains the queue after the
+// render, one frame at a time, honouring cancellation.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import { useScrollMemory } from '../useScrollMemory';
+import { readScroll, scrollStorageKey, writeScroll } from '../../utils/viewportMemory';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const KEY = scrollStorageKey('test-surface', 1);
+const OTHER = scrollStorageKey('test-surface', 2);
+
+/** A scrolling element that clamps to its content and fires `scroll`. */
+function makeTarget({ maxX = 0, maxY = 0 } = {}) {
+    return {
+        _x: 0,
+        _y: 0,
+        maxX,
+        maxY,
+        handlers: {},
+        get scrollLeft() { return this._x; },
+        set scrollLeft(v) { this.scrollTo(v, this._y); },
+        get scrollTop() { return this._y; },
+        set scrollTop(v) { this.scrollTo(this._x, v); },
+        scrollTo(x, y) {
+            const nx = Math.max(0, Math.min(x, this.maxX));
+            const ny = Math.max(0, Math.min(y, this.maxY));
+            if (nx === this._x && ny === this._y) return;
+            this._x = nx;
+            this._y = ny;
+            this.handlers.scroll?.();
+        },
+        /** The content got taller — a DataGrid finishing its measure pass. */
+        grow(maxY) { this.maxY = maxY; },
+        addEventListener(type, fn) { this.handlers[type] = fn; },
+        removeEventListener(type) { delete this.handlers[type]; },
+    };
+}
+
+let queue = [];
+let nextFrameId = 1;
+let cancelledFrames = new Set();
+
+/** Drain `n` animation frames, one at a time, honouring cancellation. */
+function runFrames(n = 1) {
+    for (let i = 0; i < n; i += 1) {
+        const due = queue;
+        queue = [];
+        due.forEach(({ id, cb }) => { if (!cancelledFrames.has(id)) cb(0); });
+    }
+}
+
+function mount(props) {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    function Probe({ storageKey, target, restore }) {
+        useScrollMemory(storageKey, target, { restore });
+        return null;
+    }
+    const render = (p) => act(() => {
+        root.render(<Probe storageKey={p.storageKey} target={p.target}
+                           restore={p.restore !== false} />);
+    });
+    render(props);
+    return { rerender: render, unmount: () => act(() => root.unmount()) };
+}
+
+describe('useScrollMemory', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+        queue = [];
+        nextFrameId = 1;
+        cancelledFrames = new Set();
+        vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+            const id = nextFrameId;
+            nextFrameId += 1;
+            queue.push({ id, cb });
+            return id;
+        });
+        vi.spyOn(globalThis, 'cancelAnimationFrame')
+            .mockImplementation((id) => { cancelledFrames.add(id); });
+    });
+    afterEach(() => {
+        vi.restoreAllMocks();
+        sessionStorage.clear();
+    });
+
+    describe('restore', () => {
+        it('applies a stored position the content can reach', () => {
+            writeScroll(KEY, { x: 40, y: 900 });
+            const target = makeTarget({ maxX: 500, maxY: 2000 });
+            const h = mount({ storageKey: KEY, target });
+            runFrames(1);
+            expect({ x: target.scrollLeft, y: target.scrollTop }).toEqual({ x: 40, y: 900 });
+            h.unmount();
+        });
+
+        it('leaves the target alone when nothing is stored', () => {
+            const target = makeTarget({ maxY: 2000 });
+            target.scrollTo(0, 8);
+            const h = mount({ storageKey: KEY, target });
+            runFrames(4);
+            expect(target.scrollTop).toBe(8);
+            h.unmount();
+        });
+
+        // THE MAJOR ONE. A scroll assignment emits a `scroll` event, so a restore
+        // that the scroller CLAMPS would otherwise record the clamped value and
+        // commit it on unmount — destroying the position it failed to apply, and
+        // destroying it worse on every subsequent visit rather than recovering.
+        it('a restore the content cannot reach does NOT overwrite the stored position', () => {
+            writeScroll(KEY, { x: 0, y: 2000 });
+            const target = makeTarget({ maxY: 300 });     // still loading: short
+            const h = mount({ storageKey: KEY, target });
+            runFrames(30);
+            expect(target.scrollTop).toBe(300);            // clamped, as a browser would
+            h.unmount();
+            expect(readScroll(KEY)).toEqual({ x: 0, y: 2000 });
+        });
+
+        // The reason the retry exists: a DataGrid auto-heights through a
+        // ResizeObserver round trip, so the content is short for a few frames
+        // after the rows render.
+        it('keeps trying while the content is still growing', () => {
+            writeScroll(KEY, { x: 0, y: 900 });
+            const target = makeTarget({ maxY: 100 });
+            const h = mount({ storageKey: KEY, target });
+            runFrames(2);
+            expect(target.scrollTop).toBe(100);            // short so far
+            target.grow(2000);                             // layout settles
+            runFrames(2);
+            expect(target.scrollTop).toBe(900);            // and it lands
+            h.unmount();
+        });
+
+        it('gives up after a bounded number of frames', () => {
+            writeScroll(KEY, { x: 0, y: 900 });
+            const target = makeTarget({ maxY: 100 });
+            const h = mount({ storageKey: KEY, target });
+            runFrames(40);                                 // well past the budget
+            target.grow(2000);
+            runFrames(10);
+            expect(target.scrollTop).toBe(100);            // no longer retrying
+            h.unmount();
+        });
+
+        // A retry that fought the reader would be worse than no retry at all.
+        it('a reader who scrolls during the restore WINS, and is recorded', () => {
+            writeScroll(KEY, { x: 0, y: 900 });
+            const target = makeTarget({ maxY: 100 });
+            const h = mount({ storageKey: KEY, target });
+            runFrames(1);
+            target.grow(2000);
+            target.scrollTo(0, 50);                        // the reader takes over
+            runFrames(10);
+            expect(target.scrollTop).toBe(50);
+            h.unmount();
+            expect(readScroll(KEY)).toEqual({ x: 0, y: 50 });
+        });
+
+        it('stops applying after unmount — the frames are cancelled', () => {
+            writeScroll(KEY, { x: 0, y: 900 });
+            const target = makeTarget({ maxY: 100 });
+            const h = mount({ storageKey: KEY, target });
+            runFrames(1);
+            h.unmount();
+            target.grow(2000);
+            runFrames(10);
+            expect(target.scrollTop).toBe(100);            // never re-applied
+        });
+
+        // The restore is read once per key, so a second plan's position is
+        // applied when the key changes under a component that never remounts.
+        it('restores the NEW key when the key changes in place', () => {
+            writeScroll(OTHER, { x: 0, y: 120 });
+            const target = makeTarget({ maxY: 2000 });
+            const h = mount({ storageKey: KEY, target });
+            runFrames(2);
+            h.rerender({ storageKey: OTHER, target });
+            runFrames(2);
+            expect(target.scrollTop).toBe(120);
+            h.unmount();
+        });
+    });
+
+    describe('record and commit', () => {
+        it('a scroll alone writes nothing; unmount writes once', () => {
+            const target = makeTarget({ maxY: 2000 });
+            const h = mount({ storageKey: KEY, target });
+            target.scrollTo(0, 500);
+            expect(readScroll(KEY)).toBeNull();
+            h.unmount();
+            expect(readScroll(KEY)).toEqual({ x: 0, y: 500 });
+        });
+
+        it('writes only the LAST position of a burst', () => {
+            const target = makeTarget({ maxX: 500, maxY: 2000 });
+            const h = mount({ storageKey: KEY, target });
+            target.scrollTo(0, 100);
+            target.scrollTo(0, 200);
+            target.scrollTo(12, 300);
+            h.unmount();
+            expect(readScroll(KEY)).toEqual({ x: 12, y: 300 });
+        });
+
+        it('unmount with no scroll at all writes nothing — never a 0,0 clobber', () => {
+            writeScroll(KEY, { x: 5, y: 600 });
+            const target = makeTarget({ maxX: 500, maxY: 2000 });
+            const h = mount({ storageKey: KEY, target });
+            runFrames(3);
+            h.unmount();
+            expect(readScroll(KEY)).toEqual({ x: 5, y: 600 });
+        });
+
+        // The echo is consumed ONCE, not permanently muted: the reader's own
+        // scrolling after a successful restore still records.
+        it('records a real scroll that follows a successful restore', () => {
+            writeScroll(KEY, { x: 0, y: 600 });
+            const target = makeTarget({ maxY: 2000 });
+            const h = mount({ storageKey: KEY, target });
+            runFrames(3);
+            expect(target.scrollTop).toBe(600);
+            target.scrollTo(0, 1400);
+            h.unmount();
+            expect(readScroll(KEY)).toEqual({ x: 0, y: 1400 });
+        });
+
+        // `pagehide` covers the returns where nothing unmounts: a reload, a tab
+        // close, a Back served from the bfcache.
+        it('commits on pagehide, without an unmount', () => {
+            const target = makeTarget({ maxY: 2000 });
+            const h = mount({ storageKey: KEY, target });
+            target.scrollTo(0, 250);
+            act(() => { window.dispatchEvent(new Event('pagehide')); });
+            expect(readScroll(KEY)).toEqual({ x: 0, y: 250 });
+            h.unmount();
+        });
+
+        it('files the position under the key it was TAKEN under', () => {
+            const target = makeTarget({ maxY: 2000 });
+            const h = mount({ storageKey: KEY, target });
+            target.scrollTo(0, 400);
+            // The plan changes in place. The pending position belongs to the
+            // OUTGOING plan and must not be filed under the incoming one.
+            h.rerender({ storageKey: OTHER, target });
+            expect(readScroll(KEY)).toEqual({ x: 0, y: 400 });
+            expect(readScroll(OTHER)).toBeNull();
+            h.unmount();
+        });
+
+        it('stops listening after unmount', () => {
+            const target = makeTarget({ maxY: 2000 });
+            const h = mount({ storageKey: KEY, target });
+            h.unmount();
+            expect(target.handlers.scroll).toBeUndefined();
+        });
+    });
+
+    describe('restore: false — a deep link owns this landing', () => {
+        // Suppressing the whole hook would be the tempting one-liner and it
+        // silently drops the reader's position for the whole visit.
+        it('does not restore, but still records', () => {
+            writeScroll(KEY, { x: 0, y: 900 });
+            const target = makeTarget({ maxY: 2000 });
+            const h = mount({ storageKey: KEY, target, restore: false });
+            runFrames(4);
+            expect(target.scrollTop).toBe(0);
+            target.scrollTo(0, 1250);                      // where the link left them
+            h.unmount();
+            expect(readScroll(KEY)).toEqual({ x: 0, y: 1250 });
+        });
+    });
+
+    describe('a null key persists nothing and restores nothing', () => {
+        it('does not restore', () => {
+            writeScroll(KEY, { x: 40, y: 900 });
+            const target = makeTarget({ maxX: 500, maxY: 2000 });
+            const h = mount({ storageKey: null, target });
+            runFrames(4);
+            expect(target.scrollTop).toBe(0);
+            h.unmount();
+        });
+
+        it('does not record, and never touches the stored value', () => {
+            writeScroll(KEY, { x: 40, y: 900 });
+            const target = makeTarget({ maxX: 500, maxY: 2000 });
+            const h = mount({ storageKey: null, target });
+            expect(target.handlers.scroll).toBeUndefined();
+            h.unmount();
+            expect(readScroll(KEY)).toEqual({ x: 40, y: 900 });
+        });
+
+        // The gate the pipelines list uses: park while the page is a spinner,
+        // then restore for real once the rows exist.
+        it('restores when the key arrives later', () => {
+            writeScroll(KEY, { x: 0, y: 300 });
+            const target = makeTarget({ maxY: 2000 });
+            const h = mount({ storageKey: null, target });
+            runFrames(2);
+            expect(target.scrollTop).toBe(0);
+            h.rerender({ storageKey: KEY, target });
+            runFrames(2);
+            expect(target.scrollTop).toBe(300);
+            h.unmount();
+        });
+    });
+
+    describe('a null target waits for its element', () => {
+        // What a `useState`-held callback ref holds until its node lands. It must
+        // NOT fall back to the window, or one surface's position would be filed
+        // under another's key.
+        it('persists nothing while the element is absent', () => {
+            writeScroll(KEY, { x: 9, y: 9 });
+            const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+            const h = mount({ storageKey: KEY, target: null });
+            runFrames(4);
+            expect(scrollTo).not.toHaveBeenCalled();
+            h.unmount();
+            expect(readScroll(KEY)).toEqual({ x: 9, y: 9 });
+        });
+    });
+
+    describe('the document scroller', () => {
+        // The default target. jsdom has no layout, so these assert the CALL and
+        // the READ — that the window branch is taken, that `scrollTo(x, y)` gets
+        // its arguments in the order that cannot be written backwards silently,
+        // and that the offsets come from `scrollX/scrollY` rather than the
+        // element vocabulary.
+        let scroll;
+        beforeEach(() => {
+            scroll = { x: 0, y: 0 };
+            vi.spyOn(window, 'scrollTo').mockImplementation((x, y) => {
+                scroll = { x, y };
+            });
+            Object.defineProperty(window, 'scrollX',
+                { configurable: true, get: () => scroll.x });
+            Object.defineProperty(window, 'scrollY',
+                { configurable: true, get: () => scroll.y });
+        });
+        afterEach(() => {
+            // `vi.restoreAllMocks` does not undo `defineProperty`. jsdom's own
+            // values are plain data properties on the window.
+            Object.defineProperty(window, 'scrollX', { configurable: true, value: 0 });
+            Object.defineProperty(window, 'scrollY', { configurable: true, value: 0 });
+        });
+
+        it('restores through window.scrollTo(x, y)', () => {
+            writeScroll(KEY, { x: 3, y: 77 });
+            const h = mount({ storageKey: KEY, target: undefined });
+            runFrames(1);
+            expect(window.scrollTo).toHaveBeenCalledWith(3, 77);
+            h.unmount();
+        });
+
+        it('records the window offsets on scroll', () => {
+            const h = mount({ storageKey: KEY, target: undefined });
+            scroll = { x: 11, y: 220 };
+            act(() => { window.dispatchEvent(new Event('scroll')); });
+            h.unmount();
+            expect(readScroll(KEY)).toEqual({ x: 11, y: 220 });
+        });
+    });
+});

--- a/src/hooks/useScrollMemory.js
+++ b/src/hooks/useScrollMemory.js
@@ -1,0 +1,205 @@
+// useScrollMemory.js — the LIFECYCLE half of scroll memory (req #3311), exactly
+// as `useSavedViewport.js` is the lifecycle half of camera memory (req #3252).
+// `utils/viewportMemory.js` holds the whole mechanism and the doctrine; this file
+// is only the component lifecycle, and it exists because that is the half that is
+// silently wrong when hand-rolled.
+//
+// ── THERE IS NO LIST OF RETURN PATHS, AND THAT IS THE POINT ────────────────
+// Darwin already had three scroll restores (`maps_scrollY`, `calview_scrollY`,
+// `visualizer_scrollY`) and all three are the SAME shape: every navigating click
+// site does its own `sessionStorage.setItem(key, String(window.scrollY))` before
+// calling `navigate()`. That has to be exhaustive today AND stay exhaustive as
+// links are added — `SwarmVisualizerView.jsx` alone carries four copies of the
+// line — and it cannot cover a return that involves no navigation at all, which
+// is precisely how the plan page's Table|Plan toggle and its bead-click handshake
+// leave and re-enter a surface. Recording on `scroll` and committing on unmount
+// covers every one of them without naming any.
+//
+// ── record/commit, NOT A WRITE PER SCROLL EVENT ────────────────────────────
+// `useSavedViewport`'s argument, one surface over: a scroll listener fires at
+// frame rate on a trackpad fling, and `sessionStorage.setItem` is synchronous and
+// serializing. So `record()` costs one ref assignment and `commit()` writes once,
+// at the boundary — unmount, or `pagehide` for the returns where nothing unmounts
+// (a reload, a tab close, a Back served from the bfcache).
+//
+// ── THE RESTORE RETRIES, AND ITS OWN ECHO IS NEVER RECORDED ────────────────
+// A scroller cannot be scrolled to a position its content is not yet tall enough
+// to reach: the browser CLAMPS on assignment, so an early restore does not fail,
+// it silently lands short. The tree is painted one frame after mount, but MUI's
+// own layout still has round trips left (a DataGrid auto-heights from `rowsMeta`
+// through a ResizeObserver), so a fixed two-frame delay is a guess about when
+// somebody else's layout settles. Instead the restore ASKS: apply, read back, and
+// try again next frame while the answer disagrees, up to `RESTORE_FRAMES`.
+//
+// THE ECHO IS THE DANGEROUS HALF, and it is why the two are one mechanism. A
+// scroll assignment emits a `scroll` event, so a restore that lands SHORT would
+// otherwise record the clamped value and commit it on unmount — destroying the
+// very position it failed to apply, and destroying it worse on each visit rather
+// than self-correcting. So a scroll event carrying exactly the position this hook
+// just produced is CONSUMED: not recorded, and not treated as the reader taking
+// over. Anything else is the reader, and it both records and cancels the retry —
+// which is what stops the retry fighting somebody who scrolled during it.
+//
+// ── record/commit, NOT A WRITE PER SCROLL EVENT ────────────────────────────
+// (continued below at `record`.)
+
+import { useCallback, useEffect, useRef } from 'react';
+
+import { readScroll, writeScroll } from '../utils/viewportMemory';
+
+// ~200ms at 60fps. Long enough for a DataGrid's measure-and-remeasure, short
+// enough that a genuinely unreachable position (the list really did get shorter)
+// stops costing frames almost immediately — and a reader's own scroll ends it
+// early regardless.
+const RESTORE_FRAMES = 12;
+
+// `window` reports its offsets as `scrollX/scrollY`, an element as
+// `scrollLeft/scrollTop`. This is the only place the two differ.
+const readPos = (target) => (target === window
+    ? { x: window.scrollX, y: window.scrollY }
+    : { x: target.scrollLeft, y: target.scrollTop });
+
+// `scrollTo(x, y)` and NOT a pair of property assignments, even on an element.
+// Both axes have to move as ONE operation: two assignments are two scroll
+// events, and the first carries a half-applied position that the echo test
+// below would not recognise — so it would read as the reader scrolling, cancel
+// the retry, and record a position nobody chose. `Element.scrollTo` has the same
+// signature as `window.scrollTo` and is on every browser this app supports; the
+// property fallback is for a target that has none (a test double, an exotic
+// scroller).
+const applyPos = (target, pos) => {
+    if (typeof target.scrollTo === 'function') target.scrollTo(pos.x, pos.y);
+    else { target.scrollLeft = pos.x; target.scrollTop = pos.y; }
+};
+
+const samePos = (a, b) => !!a && !!b && a.x === b.x && a.y === b.y;
+
+/**
+ * Save-and-restore for one scrolling surface.
+ *
+ * @param {?string} key  storage key from `scrollStorageKey()`. `null` disables
+ *                       persistence entirely — which is what a surface with no
+ *                       resolved identity must do, and also how a caller says
+ *                       "not yet" (still loading) or "not this time" (a deep link
+ *                       owns the scroll position this landing).
+ * @param {?Element|Window} [target]  the scrolling element. OMIT it for the
+ *                       document scroller. Pass `null` — which is what a
+ *                       `useState`-held callback ref holds until its node lands —
+ *                       and persistence waits for the element rather than
+ *                       silently falling back to the window and filing one
+ *                       surface's position under another's key.
+ *
+ *                       An ELEMENT and not a ref, deliberately: a ref's `.current`
+ *                       cannot appear in a dependency list, so an effect keyed on
+ *                       one never re-runs when the node arrives. This is
+ *                       `PipelinePlanVisualizer`'s own `const [containerEl,
+ *                       setContainer] = useState(null)` idiom, for that reason.
+ * @param {{restore?: boolean}} [opts]  `restore: false` keeps RECORDING and skips
+ *                       the one restore — what a deep link needs. `?step=`
+ *                       scrolls its row to centre, so a restore racing it puts
+ *                       the reader somewhere neither asked for; but where the
+ *                       link left them IS where they are, so their position must
+ *                       still be remembered from that moment on. Suppressing the
+ *                       whole hook instead would silently drop it. Same shape as
+ *                       `PipelinePlanVisualizer`'s `suppressSaveRef`: the default
+ *                       is the ordinary behaviour and exactly one path opts out.
+ */
+export function useScrollMemory(key, target = window, { restore = true } = {}) {
+    // The pending position, and the key it was taken under. Taking the key at
+    // RECORD time rather than at COMMIT time is `useSavedViewport`'s rule and it
+    // matters for the same reason: this page survives an in-place switch from one
+    // plan to the next without remounting, so a commit that straddles the switch
+    // must not file the outgoing position under the incoming plan's key.
+    const pendingRef = useRef(null);
+
+    const commit = useCallback(() => {
+        const p = pendingRef.current;
+        if (!p) return;
+        pendingRef.current = null;
+        writeScroll(p.key, p);
+    }, []);
+
+    useEffect(() => {
+        if (!key || !target) return undefined;
+
+        const saved = restore ? readScroll(key) : null;
+        let rafId = 0;
+        let framesLeft = RESTORE_FRAMES;
+        // ── TWO GUARDS, BECAUSE A SCROLL EVENT HAS TWO POSSIBLE TIMINGS ────
+        // Browsers QUEUE the event (dispatched in the rendering steps, before
+        // animation-frame callbacks), so it arrives long after the assignment
+        // returns and `echo` — the position the scroller actually took, clamped
+        // — is what recognises it. But a scroller that dispatches SYNCHRONOUSLY
+        // re-enters `onScroll` from inside `applyPos`, i.e. before `echo` can be
+        // assigned at all, and the echo test alone would then read that event as
+        // the reader and record a clamped position. `applying` covers exactly
+        // that window. Neither guard subsumes the other, and getting this wrong
+        // is invisible: what breaks is a stored position, one visit later.
+        let applying = false;
+        let echo = null;
+
+        const stopRestoring = () => {
+            if (rafId) cancelAnimationFrame(rafId);
+            rafId = 0;
+            echo = null;
+        };
+
+        const attempt = () => {
+            rafId = 0;
+            applying = true;
+            applyPos(target, saved);
+            applying = false;
+            // Read BACK, never assume: this is both the retry's exit test and
+            // the value a queued echo is recognised by.
+            echo = readPos(target);
+            if (!samePos(echo, saved) && --framesLeft > 0) {
+                rafId = requestAnimationFrame(attempt);
+            } else {
+                // Done restoring. The echo survives exactly ONE more frame:
+                // long enough for its own event to arrive (scroll events are
+                // dispatched before animation-frame callbacks), short enough
+                // that a reader who later scrolls back to that same position
+                // is recorded normally instead of swallowed.
+                rafId = requestAnimationFrame(() => { rafId = 0; echo = null; });
+            }
+        };
+
+        const onScroll = () => {
+            const pos = readPos(target);
+            if (applying || samePos(pos, echo)) {
+                // Ours. Consume it once — a later event at the same position is
+                // the reader, and by then there is nothing different to record
+                // anyway.
+                echo = null;
+                return;
+            }
+            // The reader has taken over. Their position wins over any restore
+            // still in flight.
+            stopRestoring();
+            pendingRef.current = { key, x: pos.x, y: pos.y };
+        };
+
+        // LISTEN FIRST, then restore. The other order loses the echo of a
+        // restore that fires synchronously, which is exactly the case the echo
+        // test exists for.
+        //
+        // `passive` — this listener never prevents default, and saying so keeps
+        // it off the critical path of a scroll gesture.
+        target.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('pagehide', commit);
+        if (saved) rafId = requestAnimationFrame(attempt);
+
+        return () => {
+            stopRestoring();
+            target.removeEventListener('scroll', onScroll);
+            window.removeEventListener('pagehide', commit);
+            // LOAD-BEARING, not a tidy-up: unmount is the single most likely
+            // moment for this feature to be exercised at all, because the
+            // reader's last act before leaving is usually the scroll being
+            // remembered.
+            commit();
+        };
+    }, [key, target, restore, commit]);
+}
+
+export default useScrollMemory;

--- a/src/utils/__tests__/scrollMemory.test.js
+++ b/src/utils/__tests__/scrollMemory.test.js
@@ -1,0 +1,199 @@
+// Req #3311 — the SCROLL half of viewportMemory's contract.
+//
+// A separate file from `viewportMemory.test.js` (which pins the camera half)
+// because the two answer different questions and only one of them has a
+// fingerprint. The storage stub, and the reason for stubbing rather than using
+// jsdom's own, is that file's: several cases below need storage BEHAVING BADLY,
+// and a real one cannot be made to.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+    SCROLL_SCHEMA_VERSION,
+    readScroll,
+    scrollStorageKey,
+    writeScroll,
+} from '../viewportMemory';
+
+const KEY = scrollStorageKey('pipeline-plan-table', 2);
+const POS = { x: 240, y: 1180 };
+
+/** A minimal in-memory sessionStorage; `fail` makes every method throw. */
+function installStorage({ fail = false } = {}) {
+    const map = new Map();
+    const boom = () => { throw new DOMException('quota', 'QuotaExceededError'); };
+    const stub = {
+        getItem: fail ? boom : (k) => (map.has(k) ? map.get(k) : null),
+        setItem: fail ? boom : (k, v) => { map.set(k, String(v)); },
+        removeItem: fail ? boom : (k) => { map.delete(k); },
+    };
+    vi.stubGlobal('sessionStorage', stub);
+    return map;
+}
+
+describe('scroll memory', () => {
+    let store;
+    beforeEach(() => { store = installStorage(); });
+    afterEach(() => { vi.unstubAllGlobals(); });
+
+    describe('scrollStorageKey', () => {
+        it('namespaces by surface, and by record id when there is one', () => {
+            expect(scrollStorageKey('pipelines-list'))
+                .toBe('darwin-scroll-pipelines-list');
+            expect(scrollStorageKey('pipeline-plan-table', 2))
+                .toBe('darwin-scroll-pipeline-plan-table-2');
+        });
+
+        // The two surfaces on the plan page — the page scroll and the table's own
+        // horizontal one — must never land on one key, or each would restore the
+        // other's offset.
+        it('keeps two record ids and two surfaces apart', () => {
+            expect(scrollStorageKey('pipeline-plan-table', 2))
+                .not.toBe(scrollStorageKey('pipeline-plan-table', 3));
+            expect(scrollStorageKey('pipeline-plan-table', 2))
+                .not.toBe(scrollStorageKey('pipeline-plan-table-x', 2));
+        });
+
+        // The prefix is deliberately not the camera's: a `{x,y}` read as a
+        // `{x,y,k}` would be refused, but a collision is a bug either way and the
+        // namespaces are what stop one.
+        it('does not collide with the camera namespace', () => {
+            expect(scrollStorageKey('pipeline-plan', 2)).not.toBe('darwin-viewport-pipeline-plan-2');
+        });
+
+        // `0` is a real record id and `??`-style guards get this wrong.
+        it('treats a zero record id as a record id, not as absent', () => {
+            expect(scrollStorageKey('s', 0)).toBe('darwin-scroll-s-0');
+        });
+    });
+
+    describe('round trip', () => {
+        it('returns exactly what was written', () => {
+            writeScroll(KEY, POS);
+            expect(readScroll(KEY)).toEqual(POS);
+        });
+
+        it('reads back the origin — 0,0 is a real position, not "nothing stored"', () => {
+            writeScroll(KEY, { x: 0, y: 0 });
+            expect(readScroll(KEY)).toEqual({ x: 0, y: 0 });
+        });
+
+        it('keeps two records independent', () => {
+            const other = scrollStorageKey('pipelines-list');
+            writeScroll(KEY, POS);
+            writeScroll(other, { x: 0, y: 42 });
+            expect(readScroll(KEY)).toEqual(POS);
+            expect(readScroll(other)).toEqual({ x: 0, y: 42 });
+        });
+
+        it('a later write replaces the earlier one', () => {
+            writeScroll(KEY, POS);
+            writeScroll(KEY, { x: 1, y: 2 });
+            expect(readScroll(KEY)).toEqual({ x: 1, y: 2 });
+        });
+
+        // Sub-pixel offsets are what a trackpad and a zoomed browser both
+        // produce; rounding them here would be a second, silent rule.
+        it('preserves a fractional offset', () => {
+            writeScroll(KEY, { x: 0.5, y: 12.25 });
+            expect(readScroll(KEY)).toEqual({ x: 0.5, y: 12.25 });
+        });
+    });
+
+    describe('validation — never trust what came out of storage', () => {
+        const put = (value) => store.set(KEY,
+            typeof value === 'string' ? value : JSON.stringify(value));
+        const rec = (over) => ({ v: SCROLL_SCHEMA_VERSION, ...POS, ...over });
+
+        it('refuses unparseable JSON', () => {
+            put('{not json');
+            expect(readScroll(KEY)).toBeNull();
+        });
+
+        it.each([['null', 'null'], ['a bare number', '7'], ['a string', '"hi"'], ['an array', '[]']])(
+            'refuses %s', (_label, raw) => {
+                put(raw);
+                expect(readScroll(KEY)).toBeNull();
+            });
+
+        // `window.scrollTo(0, NaN)` is SPECIFIED to normalize to 0 rather than
+        // throw, so a corrupt record would scroll the reader to the top and read
+        // as the feature simply not working. That silence is why this is checked.
+        it.each(['x', 'y'])('refuses a non-finite %s', (field) => {
+            put(rec({ [field]: null }));
+            expect(readScroll(KEY)).toBeNull();
+            put(rec({ [field]: 'NaN' }));
+            expect(readScroll(KEY)).toBeNull();
+        });
+
+        it('refuses a missing field', () => {
+            const r = rec();
+            delete r.y;
+            put(r);
+            expect(readScroll(KEY)).toBeNull();
+        });
+
+        // Nothing here can WRITE a negative (see below), so one in storage can
+        // only be corruption. Browsers clamp a negative offset to 0 rather than
+        // rejecting it, so restoring one would be silent and wrong.
+        it.each([[-1, 0], [0, -1]])('refuses a negative offset (%s, %s)', (x, y) => {
+            put(rec({ x, y }));
+            expect(readScroll(KEY)).toBeNull();
+        });
+
+        it('refuses a record from a different schema version', () => {
+            put(rec({ v: SCROLL_SCHEMA_VERSION + 1 }));
+            expect(readScroll(KEY)).toBeNull();
+            put(rec({ v: undefined }));
+            expect(readScroll(KEY)).toBeNull();
+        });
+
+        it('refuses to write a position it would refuse to read', () => {
+            writeScroll(KEY, { x: NaN, y: 0 });
+            writeScroll(KEY, { x: 0, y: Infinity });
+            expect(store.has(KEY)).toBe(false);
+        });
+
+        // Safari reports a NEGATIVE offset during rubber-band overscroll, so a
+        // fling to the top then a click is an ORDINARY gesture that produces
+        // one. Refusing the record would discard a perfectly good `x` with it,
+        // because a record is read whole — and it would leave a write nobody
+        // can ever read. 0 is what the gesture means.
+        it('clamps a negative offset on write rather than storing an unreadable record', () => {
+            writeScroll(KEY, { x: 12, y: -30 });
+            expect(readScroll(KEY)).toEqual({ x: 12, y: 0 });
+            writeScroll(KEY, { x: -5, y: -5 });
+            expect(readScroll(KEY)).toEqual({ x: 0, y: 0 });
+        });
+    });
+
+    describe('no key means no persistence', () => {
+        // How a caller says "this surface has no identity yet" (a plan id that
+        // has not resolved) and "not this landing" (a deep link owns the
+        // position). Either way it must not read or write anyone else's.
+        it.each([null, undefined, ''])('reads null and writes nothing for %s', (key) => {
+            writeScroll(key, POS);
+            expect(store.size).toBe(0);
+            expect(readScroll(key)).toBeNull();
+        });
+    });
+
+    describe('storage unavailable (Safari private mode, quota)', () => {
+        // A convenience, not a feature that can fail loudly. Every path degrades
+        // to "there is no saved position", which is the first-ever visit.
+        beforeEach(() => { installStorage({ fail: true }); });
+
+        it('never throws, and reads as absent', () => {
+            expect(() => writeScroll(KEY, POS)).not.toThrow();
+            expect(readScroll(KEY)).toBeNull();
+        });
+    });
+
+    describe('storage missing entirely', () => {
+        it('never throws when there is no sessionStorage at all', () => {
+            vi.stubGlobal('sessionStorage', undefined);
+            expect(readScroll(KEY)).toBeNull();
+            expect(() => writeScroll(KEY, POS)).not.toThrow();
+        });
+    });
+});

--- a/src/utils/viewportMemory.js
+++ b/src/utils/viewportMemory.js
@@ -1,4 +1,7 @@
-// viewportMemory.js — "the canvas I come back to is the canvas I left" (req #3252).
+// viewportMemory.js — "the canvas I come back to is the canvas I left" (req #3252),
+// and, since req #3311, the LIST I come back to is the list I left. The camera
+// half is everything down to `clearViewport`; the scroll half is the section
+// after it, and the doctrine below governs both.
 //
 // THE DEFECT THIS EXISTS FOR. A pan/zoom canvas holds its camera in component
 // state. Every way of leaving the page unmounts that component, so the camera is
@@ -183,3 +186,112 @@ export function clearViewport(key) {
         // See writeViewport.
     }
 }
+
+// ── SCROLL POSITIONS — the same doctrine, a different surface (req #3311) ────
+//
+// A pan/zoom camera and a scroll offset are the SAME FACT about two kinds of
+// surface: where in this artifact was I, a moment ago. Req #3252 answered it for
+// the one Darwin surface that has a camera; req #3311 asks it of the two that
+// have scrollbars — the pipelines LIST and the plan detail's Table mode — and
+// the ask names both with one word ("the list viewport ... the viewport in a
+// visualizer"). So this lives here rather than in a second module: everything
+// above about per-tab storage, about validating a value that came out of web
+// storage, and about a position being a convenience that must never fail loudly,
+// applies verbatim and would otherwise be restated.
+//
+// ── NO FINGERPRINT, AND THAT IS THE DIFFERENCE ─────────────────────────────
+// A camera is `{x, y, k}` over a WORLD, and a stale one lands somewhere
+// unrelated with nothing to see but a wrong-looking drawing — hence the
+// fingerprint above. A scroll offset is bounded by the scroller itself: every
+// browser clamps `scrollTop` to `scrollHeight - clientHeight` on assignment, so
+// the worst a stale offset can do is land at the end of a shorter list. That is
+// a benign miss, and a fingerprint over "the content" would have to be recomputed
+// from data this module cannot see. Validate the SHAPE and let the browser bound
+// the value.
+export const SCROLL_STORAGE_PREFIX = 'darwin-scroll-';
+
+// Bumped only if the record's SHAPE changes; a mismatch drops the record. See
+// VIEWPORT_SCHEMA_VERSION for why dropping beats migrating here.
+export const SCROLL_SCHEMA_VERSION = 1;
+
+/**
+ * The storage key for one scrolling surface.
+ *
+ * `recordId` is optional: a page-level list (`/swarm/pipelines`) has exactly one
+ * scroll position, while a per-artifact surface (one plan's table) needs one per
+ * record, for the same reason the camera is keyed on the plan — two plans open in
+ * one tab must not inherit each other's position.
+ *
+ * @param {string} surface e.g. `pipelines-list`
+ * @param {string|number} [recordId]
+ */
+export const scrollStorageKey = (surface, recordId) => (recordId == null
+    ? `${SCROLL_STORAGE_PREFIX}${surface}`
+    : `${SCROLL_STORAGE_PREFIX}${surface}-${recordId}`);
+
+/**
+ * The scroll offset stored under `key`, or null.
+ *
+ * VALIDATED, NEVER TRUSTED, for the reason readViewport gives: this is JSON out
+ * of web storage and it is handed to `scrollTo`. A NaN there is not an error —
+ * `window.scrollTo(0, NaN)` is specified to normalize the value to 0, so a
+ * corrupt record would silently scroll the reader to the top and read as the
+ * feature simply not working.
+ *
+ * @param {?string} key
+ * @returns {?{x: number, y: number}}
+ */
+export function readScroll(key) {
+    if (!key) return null;
+    try {
+        const raw = sessionStorage.getItem(key);
+        if (raw == null) return null;
+        const rec = JSON.parse(raw);
+        if (!rec || typeof rec !== 'object' || Array.isArray(rec)) return null;
+        if (rec.v !== SCROLL_SCHEMA_VERSION) return null;
+        const { x, y } = rec;
+        if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+        // A negative offset is not a position any scroller can be in. Browsers
+        // clamp it to 0 rather than rejecting it, so it would restore silently
+        // and wrongly.
+        if (x < 0 || y < 0) return null;
+        return { x, y };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Store `pos` under `key`.
+ *
+ * NEGATIVES ARE CLAMPED, NOT REFUSED, and the asymmetry with `readScroll` is
+ * deliberate. Safari reports a NEGATIVE offset during rubber-band overscroll, so
+ * a fling to the top followed straight away by a click is an ordinary gesture
+ * that produces `y = -30` — and refusing the record would throw away a perfectly
+ * good `x` with it, because a record is read whole. 0 is what that gesture
+ * actually means. On the READ side a negative is still refused, because by then
+ * it can only have come from corruption: nothing here can write one.
+ *
+ * @param {?string} key
+ * @param {{x: number, y: number}} pos
+ */
+export function writeScroll(key, pos) {
+    if (!key || !pos) return;
+    if (!Number.isFinite(pos.x) || !Number.isFinite(pos.y)) return;
+    try {
+        sessionStorage.setItem(key, JSON.stringify({
+            v: SCROLL_SCHEMA_VERSION,
+            x: Math.max(0, pos.x),
+            y: Math.max(0, pos.y),
+        }));
+    } catch {
+        // See writeViewport: a position that cannot be stored is never worth
+        // breaking the page over.
+    }
+}
+
+// There is deliberately NO `clearScroll`. `clearViewport` exists because a
+// camera has a "go back to the default view" affordance that must forget where
+// the reader was; a scroll position has no such control and needs none —
+// scrolling to the top IS the reset, and it is recorded like any other move. An
+// exported function with no caller is an API somebody has to keep working.


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3311-pipeline-page-remembers-your-last-1
- wip(Darwin): 2026-08-03T09:15:02Z
- chore: init swarm session feature/3311-pipeline-page-remembers-your-last-1

## Files changed
```
 src/SwarmView/pipelines/PipelineCardsView.jsx      |  36 +-
 src/SwarmView/pipelines/PipelinePlanTable.jsx      |  47 ++-
 src/SwarmView/pipelines/PipelinesPage.jsx          |  48 ++-
 src/SwarmView/pipelines/PipelinesTableView.jsx     |  35 +-
 .../__tests__/PipelinesPage.lastViewed.test.jsx    | 160 +++++++++
 src/hooks/__tests__/useScrollMemory.test.jsx       | 395 +++++++++++++++++++++
 src/hooks/useScrollMemory.js                       | 205 +++++++++++
 src/utils/__tests__/scrollMemory.test.js           | 199 +++++++++++
 src/utils/viewportMemory.js                        | 114 +++++-
 9 files changed, 1231 insertions(+), 8 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)