### PR TITLE
Default Viewport

### DIFF
--- a/src/SwarmView/pipelines/PipelinePlanToolbar.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanToolbar.jsx
@@ -133,14 +133,15 @@ export default function PipelinePlanToolbar({
                 widget TYPE, so the row reads as one control set) is unaffected
                 by it — it is still a small Chip.
 
-                Reset's behaviour: FACTORY DEFAULT, not the readable landing
-                scale the page opens on — one click always shows the whole plan's
-                vertical extent, from any pan or zoom. Width re-centres on every
-                change (it rescales every column) onto WHICHEVER of the two
-                scales is currently active — see `recenterModeRef` in
-                PipelinePlanVisualizer.jsx — so clicking Width right after Reset
-                keeps showing the whole plan instead of snapping back to the
-                readable scale out from under its own neighbour.
+                Reset's behaviour: FACTORY DEFAULT — one click always shows the
+                whole plan's vertical extent, from any pan or zoom. Since req
+                #3312 that is ALSO the view the page opens on, so Reset means
+                "back to where this plan started" rather than a second base view
+                the landing had to be told about: it and Width's recentre apply
+                one expression (`kFactoryDefault` in PipelinePlanVisualizer.jsx),
+                and the ref that used to pick between two scales is gone. What
+                the control still adds over the landing is the INTENT — it ends
+                any `?epic=` re-fit, exactly as a drag does.
 
                 No `data-viz-chrome` here, unlike in the key: that attribute
                 exempts a control from the canvas's two gesture filters, and

--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -476,16 +476,64 @@ export default function PipelinePlanVisualizer({
     // both places for the same reason: it means "the reader asked for this".
     const userMovedCameraRef = useRef(false);
 
+    // THE LAST MEASUREMENT TAKEN, beside the state it is written into (req
+    // #3312). The landing effect has to know whether `size` has caught up with
+    // the panel yet — the DOM is resized twice at mount and the second sizing
+    // decides the opening view — and this is the only formulation of that
+    // question with NO geometric assumptions in it. The obvious alternatives
+    // both encode one silently: comparing against `availH` assumes the box
+    // model (this Box has a 1px border, so `clientHeight` is never the height
+    // it was asked for, and `minHeight: 480` can override it outright), and
+    // comparing against a fresh `clientHeight` read assumes zero padding and no
+    // scrollbar. Either would be CORRECT TODAY and would turn a later `p: 1` on
+    // the panel into a permanent, silent refusal to land. Written on both
+    // writers below so the pair cannot drift; the guard then reads exactly what
+    // was measured, whatever box that was measured in.
+    const observedSizeRef = useRef({ w: 0, h: 0 });
     useLayoutEffect(() => {
         if (!containerEl) return undefined;
         const ro = new ResizeObserver((entries) => {
             const cr = entries[0]?.contentRect;
-            if (cr) setSize({ w: Math.round(cr.width), h: Math.round(cr.height) });
+            if (cr) {
+                const next = { w: Math.round(cr.width), h: Math.round(cr.height) };
+                observedSizeRef.current = next;
+                setSize(next);
+            }
         });
         ro.observe(containerEl);
-        setSize({ w: containerEl.clientWidth, h: containerEl.clientHeight });
+        const first = { w: containerEl.clientWidth, h: containerEl.clientHeight };
+        observedSizeRef.current = first;
+        setSize(first);
         return () => ro.disconnect();
     }, [containerEl]);
+    // "Has `size` caught up with the panel?" — ONE definition, read by the three
+    // effects that move the camera (req #3312). Each of them computes a fit from
+    // `size`, and the panel is sized twice at mount with two different heights,
+    // so each would otherwise aim at a panel the reader never sees for one
+    // delivery. A FUNCTION called inside effects, deliberately not a value
+    // derived in the render body: a ref read during render is not guaranteed to
+    // see the write that a concurrent render is about to make, while an effect
+    // runs after the commit that wrote it.
+    //
+    // ONE-DIRECTIONAL FRESHNESS is what makes it safe, and it is worth stating
+    // as the invariant rather than as "the two converge": each `setSize(x)`
+    // above is immediately preceded by `observedSizeRef.current = x` with no
+    // yield between, so the ref is always at least as fresh as the state and
+    // `size` can never be AHEAD of it. The predicate can therefore be wrong
+    // only in the safe direction — a spurious defer, resolved by the very
+    // `size` change every caller already depends on — never in the direction
+    // that lands on a panel the reader will not see.
+    //
+    // IT IS VACUOUSLY TRUE BEFORE THE FIRST MEASUREMENT (both sides start at
+    // `{0, 0}`), so it is a readiness guard and NOT an emptiness check, and
+    // each caller still needs its own: the landing effect tests `size.w === 0`
+    // directly, and the two focus effects lean on `applyFocus` returning false
+    // while `zoomRef.current` is null — which it is for exactly as long as
+    // `size.w` is 0 — so they record nothing and retry.
+    const sizeSettled = useCallback(() => {
+        const o = observedSizeRef.current;
+        return o.w === size.w && o.h === size.h;
+    }, [size.w, size.h]);
 
     useLayoutEffect(() => {
         if (!legendEl) { setLegendSize(null); return undefined; }
@@ -556,20 +604,28 @@ export default function PipelinePlanVisualizer({
     // panel; kFit is that view.
     const kFit = size.w > 0 ? size.w / layout.width : 0.7;
 
-    // ── The DEFAULT view is the readable one, not the whole one (req #3168) ──
-    // Fit-to-width is the right OVERVIEW and the wrong DEFAULT. It is a scale
-    // divided by plan size, so the bigger the plan the smaller the type — and the
-    // live 64-step plan opens at a k where the requirement ids are a few pixels
-    // tall. The page's whole job is reading a plan, and it was arriving unreadable
-    // on exactly the plans that need it.
+    // ── The READABLE scale (req #3168) — WAS the default view, req #3312 ────
+    // Introduced as the opening view: fit-to-width is the right OVERVIEW and
+    // was the wrong DEFAULT, because it is a scale divided by plan size, so the
+    // bigger the plan the smaller the type — the live 64-step plan opened at a
+    // k where the requirement ids were a few pixels tall.
+    //
+    // **REQ #3312 TOOK THE OPENING VIEW BACK OFF IT** and gave it to
+    // `kFactoryDefault` (below), on the user's own instruction: the page must
+    // open in the same viewport the header's Reset produces. So it does now
+    // arrive at a scale where a large plan's labels are not drawn — the exact
+    // condition #3168 describes above as the defect — and that is the ask, not
+    // a regression of it. Read the paragraph above as history.
+    //
+    // WHAT THIS NUMBER STILL IS, and it is not vestigial: the ANCHOR of the
+    // semantic level ladder and of the zoom behavior's `scaleExtent`, and the
+    // base scale both focus clamps measure against. Every ratio on this surface
+    // is still measured from it.
     //
     // K_READABLE is derived from the smallest required text (the req ids) and an
-    // 11px floor; see pipelinePlanLayout. On a plan that already fits at a legible
-    // size this is inert — kFit wins and nothing about the old view changes.
-    // Hoisted into pipelinePlanLayout by req #3280 — see `readableDefaultScale`
-    // for why the formula could not stay inline: the invariant "the landing view
-    // always draws its labels" is only assertable against the number this file
-    // actually lands on.
+    // 11px floor; see pipelinePlanLayout. Hoisted there by req #3280 — see
+    // `readableDefaultScale` for why the formula could not stay inline: a test
+    // can only reach the number the renderer actually uses.
     const kDefault = readableDefaultScale(kFit);
     // The zoom behavior's own configured floor, computed ONCE here so this
     // and the `.scaleExtent` call below read the SAME number rather than two
@@ -578,14 +634,41 @@ export default function PipelinePlanVisualizer({
     // finding — a future `kDefault` that could fall below `kFit` would
     // silently desync a duplicated expression; a shared variable cannot).
     const kZoomFloor = Math.min(kFit, kDefault) * ZOOM_MIN_RATIO;
-    const curK = transform ? transform.k : kDefault;
+    // ── THE SCALE THE PLAN OPENS AT (req #3312) ─────────────────────────────
+    // The whole plan's vertical extent, floored at the zoom behavior's own
+    // configured minimum — `factoryDefaultScale`'s own comment has the fit
+    // maths and why the floor is handed IN rather than re-derived. It is the
+    // number `resetView` applies, and since #3312 that is the ONLY recenter
+    // target: the landing view and the header's Reset are one expression, not
+    // two numbers a test has to prove agree. See `resetView` below.
+    //
+    // COMPUTED HERE, above `curK`, rather than beside `resetView` where it
+    // used to sit: the two fallbacks below are "the view the page opens in"
+    // for the frames before the zoom behavior has emitted anything, and they
+    // can only be that if the number exists by then.
+    const kFactoryDefault = factoryDefaultScale(layout, size, kFit, kZoomFloor);
+    // The camera's live scale, or — before the first transform — the one the
+    // landing effect is about to apply. Reading `kDefault` here made the very
+    // first frame report `mid` on a plan that opens at Overview, a level the
+    // reader never saw (req #3312).
+    const curK = transform ? transform.k : kFactoryDefault;
     // THE LEVEL LADDER RE-ANCHORS ON THE DEFAULT, not on the fit (req #3168).
     // semanticLevel() takes a RATIO, and the ratio means "how far in from where
     // you started". Leaving the denominator at kFit while the default moved would
     // open a large plan at 'Detail' and a small one at 'Plan' — the same gesture
     // reporting a different level for no reason the reader can see. Anchoring on
-    // kDefault keeps "the view you land on" = 'Plan' at every plan size, which is
-    // the contract PIPE-09 asserts.
+    // kDefault keeps ratio 1 = 'Plan' at every plan size, which is the contract
+    // PIPE-09 asserts.
+    //
+    // RATIO 1 IS NO LONGER THE VIEW A PLAN LANDS IN, and the anchor deliberately
+    // does NOT follow it (req #3312). The landing moved to `kFactoryDefault`, so
+    // a plan too tall to fit at the readable scale now opens BELOW ratio 1 and
+    // reports 'Overview' — which is an honest description of what is on screen
+    // there, bare beads and no labels, exactly what the header's Reset has
+    // produced on those plans since req #3216. Re-anchoring the ladder on the
+    // new landing scale instead would change what is DRAWN at every k and undo
+    // req #3280's legibility gate, for a requirement that asked about the
+    // CAMERA. The denominator stays where #3168 put it.
     // ── Auto, or PINNED (req #3168) ─────────────────────────────────────────
     // `KonvaBuildCanvas`'s own line, in this canvas's vocabulary:
     // `pinnedLevel != null ? pinnedLevel : autoLevel(ratio)`. Pinning changes
@@ -663,12 +746,19 @@ export default function PipelinePlanVisualizer({
             // and does not constrain it, so an out-of-extent k would sit there
             // looking fine until the user's first wheel event snapped it back.
             //
-            // Anchored on `kDefault`, not the fit scale (req #3168): the default
-            // view is `max(fit, K_READABLE)` and every ratio on this surface —
-            // the level ladder, this extent, and the focus clamp — is measured
-            // from the view the reader actually lands in. The lower bound keeps
-            // the fit scale in reach so `Overview` can still show the whole plan
-            // on a plan that opens zoomed in.
+            // Anchored on `kDefault`, not the fit scale (req #3168): every ratio
+            // on this surface — the level ladder, this extent, and the focus
+            // clamp — is measured from the same `max(fit, K_READABLE)`, so they
+            // cannot disagree about what "twice as far in" means.
+            //
+            // IT IS NO LONGER "THE VIEW THE READER LANDS IN", and this comment
+            // said so until req #3312 moved the landing onto `kFactoryDefault`
+            // (see `resetView` below). The anchor deliberately did not follow:
+            // moving it would rescale the level ladder and this extent for a
+            // requirement about the CAMERA. The lower bound keeps the fit scale
+            // in reach, which now matters in the other direction — a plan opens
+            // AT or below fit-to-width, so the room this bound protects is the
+            // room to zoom out from an already-wide view rather than into one.
             .scaleExtent([kZoomFloor, kDefault * ZOOM_MAX_RATIO])
             .constrain(bound)
             // A DRAG that starts on the key belongs to that control (req
@@ -741,55 +831,53 @@ export default function PipelinePlanVisualizer({
     }, [containerEl, size.w, size.h, kFit, kDefault, kZoomFloor, layout.width, layout.height,
         viewport]);
 
-    // ── Reset = FACTORY DEFAULT (req #3216 D1) ──────────────────────────────
-    // Deliberately NOT `kDefault` above — see `factoryDefaultScale`'s own
-    // comment in pipelinePlanLayout.js for why the readable landing scale and
-    // "reset" are two different numbers now. The fit math is pure and lives
-    // there, same as `epicFocusTransform`'s; this file only draws what it
-    // returns. `kZoomFloor` (computed above, alongside `kDefault`) is the
-    // SAME number the zoom behavior's own `scaleExtent` floor uses — passed
-    // in rather than re-derived, so the two can never desync (review finding:
-    // a duplicated `kFit * ZOOM_MIN_RATIO` only agreed with the behavior's
-    // real floor by algebraic coincidence).
-    const kFactoryDefault = factoryDefaultScale(layout, size, kFit, kZoomFloor);
-
-    // WHICH base a toggle-driven recenter targets (review finding): Width
-    // rescales every column and re-centres to keep the view sane on the new
-    // geometry (the effect below), and until this ref existed that recentre
-    // was hard-coded to `kDefault` — so clicking Width right after clicking
-    // Reset, its own neighbour in the same header group, silently undid the
-    // factory reset the user had just asked for. Flipping this to 'factory'
-    // on a Reset click and reading it back here means a toggle instead
-    // preserves whichever view the reader is IN, exactly as it always
-    // preserved `kDefault` when the two scales happened to be the same
-    // number. A drag or a wheel zoom never touches this ref: those don't run
-    // through this effect at all, so which gesture last moved the camera is
-    // still irrelevant to it, same as before this fix.
-    const recenterModeRef = useRef('readable');
-
-    // Reset to the current base view on first size and whenever a layout
-    // toggle changes the world dimensions wholesale (the POC re-rendered from
-    // scratch on those toggles). `stepWidth` joins that list for the same
-    // reason the other two are on it: it rescales every column, so the
-    // previous pan lands somewhere unrelated on the new geometry.
+    // ── THE BASE VIEW = FACTORY DEFAULT, LANDING AND RESET ALIKE ────────────
+    // Req #3216 D1 redefined Reset as the factory default — the whole plan's
+    // vertical extent, one click, from any pan or zoom — while the LANDING
+    // stayed on req #3168's readable scale `kDefault`. On live pipeline 2 that
+    // is 0.8 against a fit of ~0.4, so a plan opened zoomed in past
+    // fit-to-width with the world origin at the panel's top-left: "the default
+    // view is zoomed into the top epic's name", which is the defect req #3312
+    // was filed on. The two scales are now ONE — this recenters to
+    // `kFactoryDefault` for every caller.
+    //
+    // THE OLD CHOICE IS DELETED, NOT DEFAULTED. It was a `recenterModeRef`
+    // ('readable' | 'factory') written once, by the header's Reset click, so
+    // that a Width toggle recentering right after a Reset preserved the view
+    // the reader was in instead of snapping back to the readable scale. With
+    // one base view there is nothing left for it to choose between, and
+    // leaving it initialised to 'factory' would leave a live branch on a value
+    // nothing can produce. Landing === Reset is then STRUCTURAL — one
+    // expression, one function, both callers — rather than two numbers a test
+    // has to prove agree, which is the property this requirement asked for.
+    //
+    // `kDefault` is untouched and still earns its keep: it anchors the zoom
+    // behavior's `scaleExtent`, the semantic level ladder's ratio, and the
+    // epic/step focus clamps. Only the RECENTER TARGET moved.
+    //
+    // Applied on first size and whenever a layout toggle changes the world
+    // dimensions wholesale (the POC re-rendered from scratch on those
+    // toggles). `stepWidth` is on that list for the same reason the other two
+    // are: it rescales every column, so the previous pan lands somewhere
+    // unrelated on the new geometry.
     const resetView = useCallback(() => {
         const el = containerEl;
         const zb = zoomRef.current;
         if (!el || !zb || size.w === 0) return;
-        const k = recenterModeRef.current === 'factory' ? kFactoryDefault : kDefault;
-        select(el).call(zb.transform, zoomIdentity.scale(k));
-    }, [containerEl, size.w, kDefault, kFactoryDefault]);
+        select(el).call(zb.transform, zoomIdentity.scale(kFactoryDefault));
+    }, [containerEl, size.w, kFactoryDefault]);
     // ── THE LANDING VIEW (req #3252) ────────────────────────────────────────
     // What this canvas shows when it arrives at a given world. Two answers, in
     // order: the camera the reader left on this plan under THIS geometry, or —
     // failing that, and it is the first visit or the geometry moved — the base
-    // view `resetView` computes, byte-identical to what this effect did before.
+    // view `resetView` computes, which since req #3312 is the factory default
+    // the header's Reset lands on.
     //
     // THE RESTORE SUBSTITUTES FOR resetView, IT DOES NOT RACE IT. Same code
-    // path, same `zb.transform`, one of them runs. `resetView` itself is left
-    // alone and still means "the base view", which is what keeps the header's
-    // Reset honest: if the read lived inside `resetView`, a Reset click would
-    // read back the pan it was asked to discard and do nothing.
+    // path, same `zb.transform`, one of them runs. The stored-camera read stays
+    // OUT of `resetView`, which is what keeps the header's Reset honest: if it
+    // lived inside, a Reset click would read back the pan it was asked to
+    // discard and do nothing.
     //
     // ── WHEN IT LANDS: on a RESCALE, never on a mere resize or growth ───────
     // `landKey` is the plan plus the world's WIDTH, because width is what
@@ -817,6 +905,32 @@ export default function PipelinePlanVisualizer({
     // behaviour or no measured width there is nothing to apply a transform to,
     // and marking that as "landed" would strand the canvas at the identity
     // transform forever. `focusEpic`'s own retry contract, for the same reason.
+    //
+    // ── …AND SINCE req #3312 IT WAITS FOR THE PANEL'S REAL HEIGHT ───────────
+    // The landing scale is now `kFactoryDefault`, which reads `size.h`. Before
+    // #3312 it read `size.w` alone (through `kFit` → `kDefault`), and the panel
+    // is sized TWICE at mount with the SAME WIDTH and two different HEIGHTS —
+    // the `calc(100vh - 260px)` fallback in the JSX below, then `measureAvailH`
+    // — so a mount-time double measure that used to be invisible here now
+    // decides the view. `landKey` deliberately excludes the height (a resize
+    // must not re-land, req #3252), so the first land was final and it was made
+    // against a height the reader never sees: measured on this fixture at
+    // 1440x900, the fallback gave k = 0.4720 into a panel only 586px tall, i.e.
+    // ~54px of the plan below the fold on open AND a Reset click that then
+    // moved the camera — the exact divergence #3312 exists to delete. The 260
+    // is not merely approximate, it is KNOWN wrong: the comment on
+    // `measureAvailH` above says this page's header is not fixed.
+    //
+    // A READINESS GUARD, not a second landing trigger — the distinction matters
+    // and is why it asks "has `size` caught up with the last MEASUREMENT?"
+    // rather than "is `availH` set?" (which is already true on the bad render)
+    // or "does `size` match a fresh `clientHeight`?" (correct only while the
+    // panel has no padding — see `observedSizeRef` above). It cannot deadlock:
+    // `observedSizeRef` is written by the same two statements that call
+    // `setSize`, so state converges on it by construction, and the observer's
+    // next delivery re-runs this effect (`size` is on its dependency list).
+    // Exact equality, no tolerance: both sides are the identical value, one
+    // through a ref and one through state, never two measurements compared.
     const landKey = `${viewportKey}|${Math.round(layout.width)}`;
     const landedKeyRef = useRef(null);
     const committedFingerprintRef = useRef(null);
@@ -824,6 +938,7 @@ export default function PipelinePlanVisualizer({
         const el = containerEl;
         const zb = zoomRef.current;
         if (!el || zb == null || size.w === 0) return;
+        if (!sizeSettled()) return;
         const kMax = kDefault * ZOOM_MAX_RATIO;
         // CLAMPED BEFORE IT IS APPLIED, k first and then the translation — the
         // pan bound is computed FROM k, so clamping position first would
@@ -891,13 +1006,16 @@ export default function PipelinePlanVisualizer({
     // list any more. They were here as a hand-maintained enumeration of "things
     // that rescale the world", and `landKey` is that same fact DERIVED — it
     // cannot go stale when a ninth layout option is added, and a list can.
-    }, [resetView, containerEl, size, layout, kZoomFloor, kDefault,
+    }, [resetView, containerEl, size, layout, kZoomFloor, kDefault, sizeSettled,
         landKey, viewportFingerprint, viewport]);
 
+    // Reset targets the same view the plan lands on (req #3312), so all this
+    // adds over `resetView` is the INTENT: an explicit, in-the-moment
+    // instruction about where to look, which ends any `?epic=` re-fit exactly
+    // as a drag does (req #3252 review). Still a separate callback for that
+    // reason — the landing must NOT set the flag, or a `?epic=` deep link
+    // would be answered by the very effect that is supposed to precede it.
     const factoryReset = useCallback(() => {
-        recenterModeRef.current = 'factory';
-        // An explicit, in-the-moment instruction about where to look — so it
-        // ends any `?epic=` re-fit, exactly as a drag does (req #3252 review).
         userMovedCameraRef.current = true;
         resetView();
     }, [resetView]);
@@ -907,7 +1025,9 @@ export default function PipelinePlanVisualizer({
     // and every layout toggle, and depending on it directly would fire this on
     // those too — which is the mount/toggle effect above's job, not a factory
     // reset the user never asked for. 0 is the initial render — skip it, the
-    // mount effect above already puts the canvas at the readable default.
+    // landing effect above has already put the canvas at that same view, and
+    // firing here would additionally set `userMovedCameraRef` and cancel a
+    // `?epic=` deep link nobody dismissed.
     const factoryResetRef = useRef(factoryReset);
     factoryResetRef.current = factoryReset;
     useEffect(() => {
@@ -1085,7 +1205,12 @@ export default function PipelinePlanVisualizer({
     const drawnLevel = legible ? level : 'out';
     useEffect(() => { onEffectiveLevel?.(drawnLevel); }, [drawnLevel, onEffectiveLevel]);
 
-    const t = transform || { x: 0, y: 0, k: kDefault };
+    // The frames before the zoom behavior has emitted anything draw the view
+    // the landing effect is about to apply, not the readable scale it used to
+    // name — otherwise the plan paints once zoomed in and then jumps out to
+    // where it actually opens (req #3312). `x`/`y` stay at the origin because
+    // that is what `resetView` applies.
+    const t = transform || { x: 0, y: 0, k: kFactoryDefault };
 
     const cursorPointer = useCallback((e, on) => {
         const stage = e?.target?.getStage?.();
@@ -1256,12 +1381,20 @@ export default function PipelinePlanVisualizer({
         // commit, and the loser would be pre-empted mid-flight.
         if (focusStepId != null) return;
         if (userMovedCameraRef.current) return;
+        // The SAME readiness guard the landing effect takes (req #3312). Without
+        // it the two desynchronise at mount: this would start its 420ms ease
+        // against the provisional panel while the landing waited, and the
+        // landing's own `zoom.transform` would then interrupt that transition a
+        // render later. The `size` in the key below means the fit was already
+        // repeated on the settled panel, so this only removes the wasted first
+        // pass — not a behaviour the final camera depended on.
+        if (!sizeSettled()) return;
         const key = `${pipeline?.id}:${focusEpicId}:${size.w}x${size.h}`;
         if (epicFocusAppliedRef.current === key) return;
         const band = layout.bands.find((b) => b.epicId === focusEpicId);
         if (!band) return;
         if (focusEpic(band, { persist: false })) epicFocusAppliedRef.current = key;
-    }, [focusEpicId, focusStepId, pipeline?.id, size, layout, focusEpic]);
+    }, [focusEpicId, focusStepId, pipeline?.id, size, layout, focusEpic, sizeSettled]);
 
     // Req #3253 — the mount-time end of the `?step=` deep link, in PLAN mode.
     //
@@ -1283,12 +1416,14 @@ export default function PipelinePlanVisualizer({
     useEffect(() => {
         if (focusStepId == null) return;
         if (userMovedCameraRef.current) return;
+        if (!sizeSettled()) return;                      // the twin's guard, req #3312
         const key = `${pipeline?.id}:${focusStepId}:${size.w}x${size.h}`;
         if (stepFocusAppliedRef.current === key) return;
         const tr = stepFocusTransform(layout, focusStepId, size, kDefault, kZoomFloor);
         if (!tr) return;
         if (applyFocus(tr, { persist: false })) stepFocusAppliedRef.current = key;
-    }, [focusStepId, pipeline?.id, size, layout, kDefault, kZoomFloor, applyFocus]);
+    }, [focusStepId, pipeline?.id, size, layout, kDefault, kZoomFloor, applyFocus,
+        sizeSettled]);
 
     // Req #3235 code review — the resolved pipeline can legitimately hold no
     // band for this epic: the resolver answers "which pipeline hosts any of

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -3251,12 +3251,13 @@ describe('the next-step halo survives Overview (req #3271)', () => {
         // 1200px and a 1440px panel (both level 'out'), and the ceiling of
         // 'out' itself.
         //
-        // NOT "where the plan OPENS", which is what this said and what #3271's
-        // source comments said (corrected in review of req #3280). `resetView`
-        // lands on `kDefault` = 0.8 — `recenterModeRef` initialises to
-        // 'readable' — so the landing view is ratio 1, level 'mid'. These are
-        // the scales one wheel-click OUT of it, which is where the defect was;
-        // nothing about the assertions below depended on the difference.
+        // WHERE THE PLAN OPENS, again — after two corrections in opposite
+        // directions. This originally said so; reviewing req #3280 found it
+        // false, because `resetView` then landed on `kDefault` = 0.8 (ratio 1,
+        // level 'mid') and these were the scales one wheel-click OUT of it. Req
+        // #3312 moved the landing onto `factoryDefaultScale`, which is `<= kFit`
+        // — the first two cases below. Nothing about the assertions ever
+        // depended on the difference, which is why they survived both.
         const LIVE_WORLD_W = 3620.2;
         const kOutCeiling = K_READABLE * 0.5;            // 0.4, 'out' by definition
         const cases = [1200 / LIVE_WORLD_W, 1440 / LIVE_WORLD_W, kOutCeiling];
@@ -3501,40 +3502,51 @@ describe('the next-step halo survives the level CROSSINGS (req #3280)', () => {
         }
     });
 
-    // THE LANDING VIEW IS ALWAYS LEGIBLE, at every plan size — so this gate can
-    // never make a plan OPEN without its labels, and the E2E's level assertions
-    // (which all read the default camera) are unmoved by it.
+    // THE READABLE SCALE IS ALWAYS LEGIBLE, at every plan size — which is the
+    // whole of what `readableDefaultScale` promises, and what keeps this gate
+    // and that floor one number rather than two that have to agree.
+    //
+    // **THIS IS NO LONGER A CLAIM ABOUT THE VIEW A PLAN OPENS IN**, and it was
+    // titled as one until req #3312. The landing moved onto
+    // `factoryDefaultScale` so that opening a plan and clicking Reset produce
+    // the same viewport, and on a plan too tall to fit at `K_READABLE` that
+    // landing IS below this gate — bare beads, no labels, exactly what Reset
+    // has produced on those plans since req #3216. Every assertion below is
+    // kept verbatim, because each one is a real property of
+    // `readableDefaultScale` (still the ladder's anchor and the focus clamps'
+    // base) — only the sentence they were sold under was retired. Re-titled
+    // rather than deleted: the arithmetic is what a future reader needs, and
+    // the retired claim is what stops them re-deriving it.
     //
     // ASKED OF `readableDefaultScale`, the function the renderer calls (req
     // #3280 review). The first draft rebuilt `Math.max(kFit, K_READABLE)` here
     // and asserted the result was `>= K_READABLE` — which is `max(a,b) >= b`,
-    // an identity that stays green if the component is changed to land on
-    // `kFit` and every plan wider than its panel opens with no labels at all.
-    // That is exactly the claim in this case's title, so the identity version
-    // asserted nothing. Hoisting the formula is what made it reachable.
-    it('never withholds the labels at the view a plan opens in', () => {
+    // an identity that asserted nothing. Hoisting the formula is what made it
+    // reachable.
+    it('never withholds the labels at the readable scale', () => {
         let bindingCases = 0;
         for (const worldW of [200, 800, 3620.2, 12000]) {
             for (const panelW of [800, 1200, 1440, 1800, 2560]) {
                 const kFit = panelW / worldW;
                 const where = `world ${worldW} panel ${panelW}`;
                 expect(labelsLegible(readableDefaultScale(kFit)), where).toBe(true);
-                // The plans where the floor is what saves it — i.e. where a
-                // renderer landing on `kFit` WOULD open illegibly. Counted, so
-                // the sweep cannot pass by containing only plans that are
-                // legible at fit-to-width anyway.
+                // The plans where the floor is what raises it — i.e. where
+                // `kFit` itself is NOT legible. Counted, so the sweep cannot
+                // pass by containing only plans that are legible at
+                // fit-to-width anyway.
                 if (!labelsLegible(kFit)) bindingCases += 1;
             }
         }
         expect(bindingCases, 'plans whose fit-to-width is NOT legible')
             .toBeGreaterThan(4);
-        // Ratio 1 at the landing scale, on every plan — the ladder's own
-        // definition of the view a reader lands on.
+        // Ratio 1 is this scale, and the ladder is anchored on it — req #3168's
+        // choice, kept by req #3312 even though the landing moved off it (see
+        // the `curK / kDefault` comment in PipelinePlanVisualizer.jsx).
         expect(semanticLevel(1)).toBe('mid');
         // The guard, which is the other half of "always": a non-finite kFit
         // resolves to the floor instead of propagating NaN into every downstream
-        // scale (`labelsLegible(NaN)` is false, so a NaN default would open a
-        // plan with no labels and no error anywhere).
+        // scale — and `kDefault` feeds `scaleExtent` and both focus clamps, so a
+        // NaN here blanks the canvas with no error anywhere.
         for (const bad of [NaN, Infinity, undefined, null, '1.2']) {
             expect(readableDefaultScale(bad), `kFit=${bad}`).toBe(K_READABLE);
             expect(labelsLegible(readableDefaultScale(bad))).toBe(true);
@@ -5786,7 +5798,7 @@ describe('step focus geometry (req #3253)', () => {
     });
 });
 
-describe('reset = factory default scale (req #3216 D1)', () => {
+describe('the base view = factory default scale (req #3216 D1, req #3312)', () => {
     const kFit = 0.8;
     // The caller's own configured floor, passed in rather than re-derived
     // (review finding) — see the function's own comment for why. Computed
@@ -5846,6 +5858,96 @@ describe('reset = factory default scale (req #3216 D1)', () => {
         expect(factoryDefaultScale({ height: 500 }, undefined, kFit, kFloor)).toBe(kFit);
         expect(factoryDefaultScale({ height: 0 }, { w: 1000, h: 900 }, kFit, kFloor)).toBe(kFit);
         expect(factoryDefaultScale(null, { w: 1000, h: 900 }, kFit, kFloor)).toBe(kFit);
+    });
+
+    // ── THE LANDING VIEW IS THIS SCALE (req #3312) ──────────────────────────
+    // The ask, as arithmetic: "replace the default view with the same viewport
+    // you derive with the reset button". In the renderer that is structural —
+    // `resetView` applies ONE expression and both the landing effect and the
+    // header's Reset nonce call it, so there is no second number for a test to
+    // catch drifting. What IS reachable from here, and worth pinning, is what
+    // the reader consequently sees: on the plan this was filed against, a view
+    // the readable default could not give them.
+    //
+    // MEASURED GEOMETRY, not synthetic: the module's own Substrate Rebuild
+    // fixture through `computePlanLayout`, which is a real 34-step plan laying
+    // out to 2540.88 × 1356. The panel sizes are the real ones the page can
+    // present (the panel's own `minHeight: 480` up to a tall display). Every
+    // number below is READ from the layout rather than restated, so a change to
+    // the row pitch moves the fixture and the cases with it.
+    describe('is the view a plan opens in (req #3312)', () => {
+        const world = computePlanLayout(plan.rows, plan.batches);
+        // Exactly as PipelinePlanVisualizer derives them, so these cases
+        // exercise the real contract between the three numbers rather than a
+        // convenient floor.
+        const scales = (size) => {
+            const kFitHere = size.w / world.width;
+            const kDefaultHere = readableDefaultScale(kFitHere);
+            const floorHere = Math.min(kFitHere, kDefaultHere) * ZOOM_MIN_RATIO;
+            return {
+                kFitHere,
+                kDefaultHere,
+                floorHere,
+                kLand: factoryDefaultScale(world, size, kFitHere, floorHere),
+            };
+        };
+
+        for (const [panelW, panelH] of [[1200, 480], [1440, 720], [1800, 900]]) {
+            it(`shows the whole plan on open — ${panelW}x${panelH}`, () => {
+                const size = { w: panelW, h: panelH };
+                const { kFitHere, kDefaultHere, floorHere, kLand } = scales(size);
+
+                // THE ACCEPTANCE BAR: the whole vertical extent is on screen at
+                // the scale the plan opens at. The floor is not binding on any
+                // of these panels — asserted, so a case cannot pass by clamping
+                // instead of fitting.
+                expect(kLand, 'floor is not what produced this').toBeGreaterThan(floorHere);
+                expect(kLand * world.height).toBeLessThanOrEqual(size.h + 1e-9);
+
+                // AND IT IS STRICTLY FURTHER OUT THAN THE VIEW IT REPLACED.
+                // `kDefault` is 0.8 on all three panels; at that scale this world
+                // is 1084.8px tall with its origin in the panel's top-left
+                // corner, which is where "zoomed into the top epic's name" came
+                // from. Asserted rather than described, so the case still means
+                // something if the fixture grows.
+                expect(kLand).toBeLessThan(kDefaultHere);
+                expect(kDefaultHere * world.height,
+                    'the replaced view did NOT fit vertically').toBeGreaterThan(size.h);
+                // Width was never the binding axis here — the plan fits across
+                // at `kFit` on every one of these panels and still did not fit
+                // DOWN, which is the whole shape of the defect.
+                expect(kLand).toBeLessThanOrEqual(kFitHere);
+            });
+        }
+
+        // THE COST, asserted rather than described — a reader meets it on open
+        // and the memory doc claims it. On a plan this tall the landing is below
+        // the legibility gate, so the page opens as bare beads: precisely what
+        // the header's Reset has produced on plans this size since req #3216,
+        // and what was asked for. Stated here so a future change that quietly
+        // re-raises the landing has to come through this case.
+        it('opens below the label gate on a plan too tall to fit legibly', () => {
+            const { kDefaultHere, kLand } = scales({ w: 1440, h: 900 });
+            expect(labelsLegible(kLand)).toBe(false);
+            // The scale it replaced was legible — the trade, in one line.
+            expect(labelsLegible(kDefaultHere)).toBe(true);
+        });
+
+        // A SMALL PLAN IS UNTOUCHED. Where the world already fits both axes at
+        // fit-to-width, the landing is `kFit` — the same view #3168 gave it,
+        // labels and all — so this requirement costs nothing on plans that were
+        // never the problem.
+        it('is unchanged on a plan that already fits at a legible scale', () => {
+            const layout = { width: 900, height: 400 };
+            const size = { w: 1440, h: 900 };
+            const kFitHere = size.w / layout.width;          // 1.6
+            const kDefaultHere = readableDefaultScale(kFitHere);
+            const floorHere = Math.min(kFitHere, kDefaultHere) * ZOOM_MIN_RATIO;
+            const kLand = factoryDefaultScale(layout, size, kFitHere, floorHere);
+            expect(kLand).toBe(kFitHere);
+            expect(kLand).toBe(kDefaultHere);
+            expect(labelsLegible(kLand)).toBe(true);
+        });
     });
 });
 

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -512,12 +512,22 @@ const BEAD_R = 10;
 //
 // A lane is the unit this layout already uses for "content that may not be drawn
 // over", so the epic takes one: BAND_HEADER is now a full lane's height, and
-// nothing else is ever placed in it. That moves the fit threshold to k ≈ 0.39,
-// well below the 0.8 default and below fit-to-width on every real plan. Under
-// that — deep zoom-out, where the strip is genuinely shorter on screen than the
-// chip — `placeEpicChips` SCALES the chip down to its lane rather than
-// overflowing it or dropping it, so the guarantee holds at every k rather than
-// over a range.
+// nothing else is ever placed in it. That moves the fit threshold to k ≈ 0.39.
+//
+// **THE OPENING VIEW IS NO LONGER ABOVE THAT THRESHOLD** (req #3312, found in
+// review). The margin recorded here — "well below the 0.8 default and below
+// fit-to-width on every real plan" — was measured against a landing pinned at
+// `readableDefaultScale`; the landing is now `factoryDefaultScale`, and on the
+// 34-step fixture at 1280x720 that is k = 0.354-0.373, i.e. BELOW 0.39. What
+// makes the collision unreachable there is a DIFFERENT fact, and it is stated
+// rather than left implied: below `K_READABLE` no step label is drawn at all,
+// so there is nothing for the epic name to overlap. **That makes `K_READABLE`
+// load-bearing for this reservation** — lowering it would put drawn step labels
+// under a chip at the very scale a plan opens in. The scaling below is what
+// keeps the guarantee absolute either way: under the threshold — deep zoom-out,
+// where the strip is genuinely shorter on screen than the chip —
+// `placeEpicChips` SCALES the chip down to its lane rather than overflowing it
+// or dropping it, so it holds at every k rather than over a range.
 // 83, not 62, because THE HEADER IS NOT THE CLEAR STRIP. A lane-0 step label is
 // drawn 31px ABOVE its bead, and the bead sits 10px below the header — so the
 // label reaches 21px back UP into the header (a further STAGGER_GAP on top of
@@ -801,29 +811,44 @@ export const K_READABLE = READABLE_MIN_PX / PLAN_VIZ_FONT.req;
  * `nextHaloMagnify`, which freezes at exactly this scale and would have to
  * choose one of them).
  *
- * IT IS TRUE AT THE VIEW EVERY PLAN OPENS IN, by construction — see
- * `readableDefaultScale` below, which is the scale `resetView` lands on. A plan
- * that already fits at a legible size never reaches this gate at all, so nothing
- * about a small plan's view changes.
+ * IT IS TRUE AT `readableDefaultScale` BY CONSTRUCTION — that function's own
+ * floor IS this threshold. A plan that already fits at a legible size never
+ * reaches this gate at all, so nothing about a small plan's view changes.
+ *
+ * IT IS NOT TRUE AT THE VIEW A PLAN OPENS IN, and this comment said it was
+ * until req #3312 moved the landing off `readableDefaultScale` and onto
+ * `factoryDefaultScale`. On a plan too tall to fit at the readable scale the
+ * canvas now opens BELOW this threshold and draws no gated labels at all —
+ * which is what the header's Reset has done on those plans since req #3216, and
+ * is the view #3312 asked the page to open in. The gate itself is unchanged;
+ * only the claim about where the reader first meets it was.
  */
 export function labelsLegible(k) {
     return Number.isFinite(k) && k >= K_READABLE;
 }
 
 /**
- * THE SCALE A PLAN OPENS IN (req #3168) — fit-to-width, floored at legible.
+ * THE READABLE SCALE (req #3168) — fit-to-width, floored at legible.
+ *
+ * NO LONGER THE SCALE A PLAN OPENS IN, which is what this was introduced as and
+ * what its name still says. Req #3312 moved the landing onto
+ * `factoryDefaultScale` — the header's Reset — so that opening a plan and
+ * clicking Reset produce the same viewport. What this number still IS, and why
+ * it is not merely dead:
+ *
+ *   · the ANCHOR of the semantic level ladder (`semanticLevel(curK / kDefault)`)
+ *     and of the zoom behavior's `scaleExtent`, both of which req #3168 pinned
+ *     to it deliberately and PIPE-09 asserts;
+ *   · the base scale the epic and step focus transforms clamp against.
  *
  * EXPORTED as a function rather than left as `Math.max(kFit, K_READABLE)` inline
- * in the component (req #3280). The invariant that matters is "the landing view
- * always draws its labels", and while the formula lived in the renderer the test
- * for it could only rebuild the same `Math.max` and assert `max(a,b) >= b` — an
- * identity, green even if the component were changed to land on `kFit` and every
- * plan wider than its panel opened with no labels at all. A test can only reach
- * the number the renderer actually uses.
+ * in the component (req #3280), because a test can only reach the number the
+ * renderer actually uses — an inline formula could only be re-derived in the
+ * test and asserted against itself.
  *
- * `factoryDefaultScale` is the SIBLING, not a duplicate: since req #3216 the
- * header's Reset and the landing view are deliberately two different scales, and
- * `recenterModeRef` picks between them. This one is the landing view.
+ * `factoryDefaultScale` is the SIBLING, not a duplicate. The two were the
+ * landing and Reset respectively between req #3216 and req #3312; they are now
+ * the ladder's anchor and the base view.
  *
  * A non-finite `kFit` resolves to `K_READABLE` rather than propagating NaN —
  * `size.w / layout.width` is a division the caller performs on measured values,
@@ -3249,7 +3274,8 @@ export const NEXT_HALO_DASH = [3, 3];
 // pitch above are all multiplied by k. MEASURED on the live plan (pipeline 2,
 // 136 rows, world width 3620): `kDefault = max(kFit, K_READABLE)` is 0.8 at
 // every realistic panel width, so the 'out' level is by definition k < 0.4, and
-// the plan OPENS there on a 1440px panel (kFit = 0.398). At k = 0.4 this mark
+// since req #3312 the plan OPENS at or below that on a 1440px panel — the
+// landing is `factoryDefaultScale ≤ kFit = 0.398`. At k = 0.4 this mark
 // renders as a 0.8px stroke with 1.2px dashes at 85% opacity, and its inner
 // edge sits 0.1px from the bead's own eligible ring — a sub-pixel dashed
 // outline touching a solid one. It is not that the halo is not drawn at
@@ -3278,18 +3304,21 @@ export const NEXT_HALO_DASH = [3, 3];
 // k = 0.4 and the flat band runs from there up to K_READABLE: on the live plan
 // the request is 2.0× at k = 0.4 (exactly the ceiling), 1.6× at k = 0.5, 1.0× at
 // k = 0.8, and 9.65× at the zoom floor (0.0829, a 1200px panel) against a
-// ceiling of 2.0. Measured at k = 0.398 — fit-to-width on a 1440px panel, one
-// wheel-click OUT from where the plan lands: radius 9.94px, stroke 1.59px, dash
+// ceiling of 2.0. Measured at k = 0.398 — fit-to-width on a 1440px panel, at or
+// just above where the plan now lands: radius 9.94px, stroke 1.59px, dash
 // 2.39px, ten dash cycles, and 4.67px of clear space to the bead — against
 // 4.97 / 0.80 / 1.19 / 0.10 before. The mark is unambiguous at the scale the
 // question is asked at, which is what was actually broken.
 //
-// **NOT the view the plan opens in, and #3271 said it was** (found in review of
-// req #3280). `resetView` lands on `kDefault` — `recenterModeRef` initialises to
-// 'readable' — so a plan OPENS at k = 0.8, ratio 1, level 'mid', ids at 11.0px.
-// The broken band is reached by zooming OUT from the landing view, not in. The
-// arithmetic below never depended on which end the reader arrives from; only
-// this description did.
+// **WHICH IS THE VIEW THE PLAN OPENS IN AGAIN, after two corrections in
+// opposite directions.** #3271 said it was; reviewing req #3280 found that
+// false, because `resetView` then landed on `kDefault` = 0.8 (ratio 1, level
+// 'mid', ids at 11.0px) and the broken band was reached by zooming OUT of the
+// landing view rather than into it. Req #3312 moved the landing onto
+// `factoryDefaultScale`, so on the live plan the reader once again ARRIVES in
+// this band. The arithmetic below never depended on which end the reader comes
+// from — only these descriptions did, three times now, which is the argument
+// for stating the measured scale and letting the landing be named separately.
 //
 // ── AND THE SCALE IT FREEZES AT IS DERIVED, NEVER CHOSEN (req #3280) ────────
 // #3271 aimed the mark at its own world radius, i.e. at the k = 1 appearance,
@@ -3969,16 +3998,27 @@ function fitTransform(rect, size, kBase, neighbours, kFloor) {
     };
 }
 
-// ── Reset = FACTORY DEFAULT (req #3216 D1) ──────────────────────────────────
+// ── THE BASE VIEW = FACTORY DEFAULT (req #3216 D1, req #3312) ───────────────
 // "Reset" used to mean "back to `kDefault`", the READABLE landing scale (req
 // #3168, `K_READABLE` above) — fit-to-width floored at a legible text size.
-// The requirement redefines what the control returns to: fully zoomed out so
-// the whole plan's VERTICAL extent is visible, one click, from any pan or
-// zoom. "reset that lands somewhere the user still has to zoom out from is
-// not reset." On a plan with many epic bands the readable floor can sit
-// ABOVE the scale that needs, which is exactly the failure mode this
-// function exists to rule out — it is deliberately NOT `kDefault`, and
-// legibility is not a concern it weighs at all.
+// #3216 redefined what the control returns to: fully zoomed out so the whole
+// plan's VERTICAL extent is visible, one click, from any pan or zoom. "reset
+// that lands somewhere the user still has to zoom out from is not reset." On a
+// plan with many epic bands the readable floor can sit ABOVE the scale that
+// needs, which is exactly the failure mode this function exists to rule out —
+// it is deliberately NOT `kDefault`, and legibility is not a concern it weighs
+// at all.
+//
+// **AND SINCE req #3312 IT IS THE LANDING VIEW TOO.** #3216 left the two apart,
+// so a plan OPENED at `kDefault` — zoomed in past fit-to-width with the world
+// origin at the panel's top-left, i.e. on the top epic's name — and the reader
+// had to click Reset to see the plan they had just opened. There is now ONE
+// base view and this function computes it; the component's `resetView` applies
+// it for the landing and for the header's Reset alike, so the two cannot
+// disagree. THE COST, stated because a reader meets it on open: on a plan too
+// tall to fit at `K_READABLE` the landing is below `labelsLegible` and opens as
+// bare beads — precisely what Reset has shown on those plans since #3216, and
+// what was asked for.
 //
 // PURE and exported for the same reason `epicFocusTransform` is (the comment
 // two functions up): this is a fit computation over `layout`/`size`, testable

--- a/tests/tests/pipelines.spec.ts
+++ b/tests/tests/pipelines.spec.ts
@@ -32,6 +32,7 @@ import {
 import {
     computePlanLayout, REQ_LINE_H, K_READABLE, BEAD_HIT_RADIUS,
     epicFocusTransform, FOCUS_PAD, FOCUS_MAX_RATIO, ZOOM_MIN_RATIO,
+    factoryDefaultScale,
 } from '../../src/SwarmView/pipelines/pipelinePlanLayout.js';
 // PIPE-19 asserts the Autonomy row against the label table the card renders
 // through, not against a hand-copied string — the point of D5 is that the card
@@ -190,8 +191,10 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             // longer implies the default view: PIPE-14 pans, wheel-zooms and
             // focuses a band before re-opening the plan, and would then look for
             // an epic chip that its own earlier gesture had carried off screen.
-            // Every `goto` in this suite starts from the readable default, which
-            // is what these tests have always assumed.
+            // Every `goto` in this suite starts from the plan's base view, which
+            // is what these tests have always assumed. Since req #3312 that view
+            // is the FACTORY default (the whole plan's vertical extent), not the
+            // readable one — see `zoomToLegibleMid` for which tests that moved.
             //
             // Cleared by PREFIX rather than by key, because the key carries a
             // pipeline id and the fixture's ids are allocated at seed time.
@@ -232,6 +235,69 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
         const canvas = page.getByTestId('pipeline-plan-visualizer').locator('canvas').first();
         await expect(canvas).toBeVisible({ timeout: 15000 });
         return canvas;
+    }
+
+    /**
+     * Put the camera at a scale that is BOTH `'mid'` on the level ladder and
+     * above the absolute legibility floor, from wherever the plan happens to
+     * have landed — and do it without touching the level selector, which is the
+     * control under test in PIPE-16/17.
+     *
+     * ── WHY THIS EXISTS (req #3312) ────────────────────────────────────────
+     * Until #3312 the landing scale WAS `kDefault`, so ratio 1 → `'mid'` and
+     * `kDefault = max(kFit, K_READABLE) >= K_READABLE` → legible, on every plan
+     * at every panel width. The tests below leaned on that structurally and said
+     * so. #3312 replaced the landing with `factoryDefaultScale` — the whole
+     * plan's vertical extent, i.e. `<= kFit` — so on a plan taller than its
+     * panel the page now opens BELOW `K_READABLE`, where `drawsKind` gates all
+     * three of step/req/title off and every level draws the same canvas. That is
+     * the requirement's own intent, and it makes the landing camera useless as a
+     * baseline for asserting what the LEVEL controls.
+     *
+     * ── WHY IT IS DETERMINISTIC ON ANY PLAN ───────────────────────────────
+     * d3-zoom clamps a wheel to `scaleExtent`, whose ceiling is exactly
+     * `kDefault * ZOOM_MAX_RATIO` — so wheeling IN far enough SATURATES at a
+     * known ratio of 8, whatever the plan and whatever the landing scale. Each
+     * `deltaY = +400` click is then a known factor `2^(-400/500) = 0.5743`, and
+     * three of them put the ratio at `8 * 0.5743^3 = 1.5157`:
+     *
+     *   · `1.5157 ∈ [SEMANTIC_OUT_MAX, SEMANTIC_IN_MIN)` = [0.5, 1.9) → `'mid'`,
+     *     with 0.5 of clearance below and 0.38 above, and
+     *   · ratio >= 1 with `kDefault >= K_READABLE` → `k >= K_READABLE` → legible.
+     *
+     * Both hold by arithmetic rather than by measurement, which is what the old
+     * landing gave for free. The margins are wide (the `'in'` boundary is 1.9
+     * and the legibility one is ratio 1.0), so neither depends on the plan's
+     * aspect ratio, the panel height, or the seeded fixture's day-slot width.
+     *
+     * The pointer is parked at the canvas centre first: d3 zooms about the
+     * cursor, so this also leaves the camera in a defined place rather than
+     * wherever the previous action left the mouse.
+     */
+    async function zoomToLegibleMid(page: Page, canvas: Locator): Promise<void> {
+        const container = page.getByTestId('pipeline-plan-visualizer');
+        const box = (await canvas.boundingBox())!;
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        // Six clicks of -800 is a factor of 3.0314^6 = 776×. The span it has to
+        // cover is "landing ratio → the ceiling of 8", and the landing ratio has
+        // NO fixed floor: it is not `ZOOM_MIN_RATIO` (0.25 is the floor's ratio
+        // only while `kFit >= K_READABLE`; below that the floor is `0.3125 *
+        // kFit` and shrinks with the plan's width). Measured on this fixture it
+        // is 0.44 at 1280x720 and 0.59-0.73 at 1800x1000 — spans of 18× and
+        // 14×. 776 covers any landing down to ratio 0.010, which is far past
+        // anything a real plan and panel produce; d3 clamps the excess.
+        for (let i = 0; i < 6; i++) await page.mouse.wheel(0, -800);
+        await expect(container, 'wheeling in saturates at the scaleExtent ceiling')
+            .toHaveAttribute('data-level', 'in');
+        for (let i = 0; i < 3; i++) await page.mouse.wheel(0, 400);
+        await expect(container, 'three clicks back out lands at ratio 1.5157 → mid')
+            .toHaveAttribute('data-level', 'mid');
+        // The OTHER half of the guarantee, asserted rather than assumed: at this
+        // ratio the three gated kinds are legible, so a level really does decide
+        // what is drawn. `data-drawn` is empty at any scale below `K_READABLE`
+        // whatever the level says.
+        await expect(container, 'the camera is above the legibility floor')
+            .toHaveAttribute('data-drawn', 'step,req');
     }
 
     /** Step-row ids in RENDERED order (banner rows carry no step testid). */
@@ -626,11 +692,16 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             const box = (await canvas.boundingBox())!;
             await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
 
-            // Fit-to-width is ratio 1 → 'mid' (konvaSwarmModel's semanticLevel,
-            // the same ladder the swarm canvas uses). `data-level` is what the
-            // bottom-right status chip used to say in words before it was
-            // deleted outright (req #3216 D2) — the canvas still publishes the
-            // fact, just not as a permanent caption over the plan.
+            // A KNOWN 'mid' BASELINE, established rather than inherited (req
+            // #3312). This asserted 'mid' on the landing camera, which held
+            // while a plan landed at ratio 1 by construction; the landing is now
+            // the factory default, so the ratio it arrives at is a function of
+            // the plan's aspect ratio against the panel's and is 'mid' only by
+            // luck. `data-level` is what the bottom-right status chip used to
+            // say in words before it was deleted outright (req #3216 D2) — the
+            // canvas still publishes the fact, just not as a permanent caption
+            // over the plan.
+            await zoomToLegibleMid(page, canvas);
             await expect(container).toHaveAttribute('data-level', 'mid');
             const kMid = await scale();
             const atMid = await canvas.screenshot();
@@ -789,11 +860,13 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
 
         // The world-to-screen frame is READ from `data-transform`, not derived
         // from the canvas width (req #3168). It used to be `k = width / world`,
-        // which was only true while the default view was fit-to-width; the
-        // default is now `max(fit, K_READABLE)`, so on a narrow panel the
-        // component legitimately starts zoomed in and every derived coordinate
-        // would miss its target by a growing margin. The attribute is the
-        // component's own answer and cannot disagree with what it drew.
+        // which was only true while the default view was fit-to-width — #3168
+        // made it `max(fit, K_READABLE)` and #3312 made it the factory default,
+        // so the plan has legitimately started both zoomed IN and zoomed OUT of
+        // that expression, and either way every derived coordinate would miss
+        // its target by a growing margin. The attribute is the component's own
+        // answer and cannot disagree with what it drew — which is why it has
+        // survived two redefinitions of the opening camera without an edit.
         const frame = async () => {
             const canvas = await openPlanVisualizer(page, fixture.batchPipelineId);
             const box = (await canvas.boundingBox())!;
@@ -890,7 +963,7 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             // The component's own viewport, as the ResizeObserver rounds it.
             const box = (await canvas.boundingBox())!;
             const size = { w: Math.round(box.width), h: Math.round(box.height) };
-            // THE OPENING SCALE IS `max(fit, K_READABLE)`, not fit-to-width.
+            // THE FOCUS ANCHOR IS `max(fit, K_READABLE)`, not fit-to-width.
             // This test was written against the fit default and req #3168's
             // "Default size = readable" replaced it: fit is a scale divided by
             // plan size, so the bigger the plan the smaller the type, and the
@@ -898,6 +971,13 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             // the zoom extent does (`kDefault`), so the value below is what
             // `epicFocusTransform` must be handed — passing the fit scale here
             // would test a camera the component never uses.
+            //
+            // IT IS NO LONGER THE OPENING SCALE, and this said it was until req
+            // #3312 moved the landing onto `factoryDefaultScale`. The anchor did
+            // NOT move with it (`epicFocusTransform` is still handed `kDefault`,
+            // see the visualizer's `focusEpic`), so everything below the opening
+            // assertion is unchanged — only that one assertion had to follow the
+            // camera.
             const kFit = size.w / layout.width;
             const kBase = Math.max(kFit, K_READABLE);
             // …AND THE BEHAVIOUR'S OWN FLOOR, handed in the same way the
@@ -908,8 +988,18 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             // does not use, which is the desync the requirement closed.
             const kZoomFloor = Math.min(kFit, kBase) * ZOOM_MIN_RATIO;
 
+            // THE OPENING SCALE IS THE FACTORY DEFAULT (req #3312) — the same
+            // number the header's Reset applies, computed from the SAME inputs
+            // the component computes it from: the canvas's own measured box (the
+            // content box the ResizeObserver reports), the world, `kFit`, and
+            // the behaviour's own floor. That last point is what makes this
+            // assertion worth having rather than a restatement: the component
+            // must land on the SETTLED panel height, and computing the expected
+            // value from the box the browser actually rendered is what catches a
+            // landing taken against the pre-measurement fallback.
             const [, , k0] = await read();
-            expect(k0, 'the plan opens at the readable default').toBeCloseTo(kBase, 2);
+            expect(k0, 'the plan opens at the factory default — the Reset view')
+                .toBeCloseTo(factoryDefaultScale(layout, size, kFit, kZoomFloor), 2);
 
             // The band whose chip is on screen at the opening transform. The
             // floating chip hides itself when its band is off-screen, so this
@@ -1465,14 +1555,20 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
 
             // 2. The step-width control widens the WORLD, read from `data-world`.
             //
-            //    Deliberately NOT `data-transform`: on this plan the default
-            //    scale is already the readable floor (measured 0.8, i.e.
-            //    fit-to-width is BELOW it), so widening the columns lowers the
-            //    fit scale further and the transform does not move at all. That
-            //    is the readable default behaving correctly, and it makes the
-            //    transform blind to this control. The scroll rail used to be this
-            //    observable; the rails were removed on the user's directive
-            //    (2026-08-01), so the component publishes the world instead.
+            //    Deliberately NOT `data-transform`. The original reason was that
+            //    on this plan the landing scale was pinned at the readable floor
+            //    (measured 0.8, i.e. fit-to-width BELOW it), so widening the
+            //    columns lowered the fit scale further and the transform did not
+            //    move at all — making the transform blind to this control. **Req
+            //    #3312 retired that reason**: the landing is the factory default
+            //    now, which tracks `kFit`, so widening the world DOES move the
+            //    transform. `data-world` is still the right observable — it is
+            //    the thing this control actually changes, where the transform is
+            //    a consequence of it — and it is now the one that isolates the
+            //    control from the camera rather than the other way round. The
+            //    scroll rail used to be this observable; the rails were removed
+            //    on the user's directive (2026-08-01), so the component
+            //    publishes the world instead.
             const container = page.getByTestId('pipeline-plan-visualizer');
             await expect(page.getByTestId('pipeline-viz-rail-h'),
                 'the scroll rails are gone, not hidden').toHaveCount(0);
@@ -1504,11 +1600,12 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             //    cannot creep back in.
             await expect(page.getByTestId('pipeline-viz-next-steps')).toHaveCount(0);
 
-            // 4. Reset is the FACTORY DEFAULT (req #3216 D1), not a return to
-            //    the readable landing scale: fully zoomed out, the whole
-            //    plan's vertical extent visible, from any pan OR zoom — "reset
-            //    that lands somewhere the user still has to zoom out from is
-            //    not reset" (the requirement's own words). It also moved into
+            // 4. Reset is the FACTORY DEFAULT (req #3216 D1): fully zoomed out,
+            //    the whole plan's vertical extent visible, from any pan OR zoom
+            //    — "reset that lands somewhere the user still has to zoom out
+            //    from is not reset" (the requirement's own words). Since req
+            //    #3312 it is ALSO the view the plan opened in, asserted below.
+            //    It also moved into
             //    the header's zoom control group, out of the canvas's
             //    bottom-right corner it used to float in — the click below
             //    reaches the same test id in its new home with no locator
@@ -1518,7 +1615,21 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             const box = (await canvas.boundingBox())!;
             const worldH = async () => Number(
                 (await container.getAttribute('data-world'))!.split(',')[1]);
-            const atDefault = (await container.getAttribute('data-transform'))!;
+            //    THE BASE VIEW, CAPTURED ONCE IT HAS SETTLED. Step 2's Width
+            //    click re-lands the camera on the new world, and `data-world`
+            //    updates a commit BEFORE `data-transform` does — so reading the
+            //    attribute straight after that step's `expect.poll(worldW)` can
+            //    catch the pre-toggle transform, which 4a would then compare
+            //    against forever. Poll until it stops moving, exactly as PIPE-14
+            //    does around its own focus transition and for the same reason.
+            let prevT = '';
+            await expect.poll(async () => {
+                const cur = (await container.getAttribute('data-transform'))!;
+                const unchanged = cur === prevT;
+                prevT = cur;
+                return unchanged;
+            }, { timeout: 10000, intervals: [100] }).toBe(true);
+            const atDefault = prevT;
             await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
             await page.mouse.down();
             await page.mouse.move(box.x + box.width / 2 - 200, box.y + box.height / 2 - 150,
@@ -1539,6 +1650,29 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             expect(rk * (await worldH()),
                 "reset shows the plan's whole vertical extent, nothing left to "
                 + 'zoom out for').toBeLessThanOrEqual(box.height + 1);
+            // 4a. REQ #3312'S OWN ACCEPTANCE CRITERION, in one line: "replace
+            //     the default view with the same viewport you derive with the
+            //     reset button". `atDefault` was captured at the top of this
+            //     step, straight off the landing, before any gesture — so this
+            //     is literally "open the plan, move the camera, click Reset,
+            //     and you are back where you opened". Byte-equal, not close-to:
+            //     the two now apply ONE expression, so any divergence at all is
+            //     a defect rather than a rounding difference. It caught one in
+            //     review — the landing was computing its scale from the panel's
+            //     pre-measurement fallback height, which the header's own
+            //     comment records as knowably wrong, so the plan opened ~54px
+            //     taller than the panel and Reset then MOVED the camera.
+            //     Through `toHaveAttribute` rather than a bare `getAttribute`,
+            //     so it POLLS: `data-world` and `data-transform` update on
+            //     different commits (the world on the render where `layout`
+            //     changed, the transform one commit later after the landing
+            //     effect's passive flush), and `atDefault` is captured right
+            //     after step 2's `expect.poll(worldW)` — so an unpolled read
+            //     here could compare against a transform React had not written
+            //     yet and fail byte-equality on a correct build.
+            await expect(container,
+                'the plan opens in exactly the view Reset returns to (req #3312)')
+                .toHaveAttribute('data-transform', atDefault);
 
             // 4b. Reset's neighbour in the same header group must not undo
             //     it (code review finding on req #3216): Width re-centres on
@@ -1546,7 +1680,10 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             //     this was fixed that re-centre was hard-coded to the
             //     readable landing scale — so clicking Width right after
             //     Reset silently snapped the camera back to a view that may
-            //     no longer show the whole plan. The fit-to-height property
+            //     no longer show the whole plan. Req #3312 deleted the choice
+            //     entirely rather than leaving it defaulted, so there is now
+            //     one base view for the recentre to pick; this case is what
+            //     stops a second one growing back. The fit-to-height property
             //     Width does not touch (only column width changes, not band
             //     height) must survive the click.
             await page.getByTestId('pipeline-viz-width-medium').click();
@@ -1880,6 +2017,17 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             }
             await expect(page.getByTestId('pipeline-viz-level-auto'))
                 .toHaveAttribute('aria-pressed', 'true');
+            //    THE BASELINE CAMERA IS ESTABLISHED, NOT INHERITED (req #3312).
+            //    This asserted `data-level` = 'mid' on the landing camera, which
+            //    was structurally true while the plan landed on `kDefault`. It
+            //    now lands on the factory default — the whole vertical extent,
+            //    at or below fit-to-width — so on this fixture it arrives at
+            //    'out' with every gated label suppressed, and neither this
+            //    assertion nor step 4's could mean anything from there. See
+            //    `zoomToLegibleMid` for why its landing point is exact on any
+            //    plan. The level selector is deliberately not used to get there:
+            //    it is the control under test.
+            await zoomToLegibleMid(page, canvas);
             await expect(container).toHaveAttribute('data-level', 'mid');
 
             // 2. PINNING CHANGES WHAT IS DRAWN, NOT WHERE THE CAMERA IS. The
@@ -1933,9 +2081,14 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
             //    LEGIBLE — `k >= K_READABLE` — and these assertions are unmoved
             //    by it for a structural reason rather than a lucky one: pinning
             //    does not move the camera (step 2 asserts exactly that), so the
-            //    scale here is still the default `kDefault = max(kFit,
-            //    K_READABLE)`, which is `>= K_READABLE` on every plan at every
-            //    panel width. The absolute half of the gate is exercised in
+            //    scale here is whatever step 1 established. **That used to be
+            //    the landing scale `kDefault = max(kFit, K_READABLE)`, which is
+            //    `>= K_READABLE` on every plan at every panel width; req #3312
+            //    moved the landing below it, so the guarantee now comes from
+            //    `zoomToLegibleMid` — ratio 1.5157 against a `kDefault` that is
+            //    still floored at `K_READABLE`.** Step 1 asserts the legibility
+            //    directly (`data-drawn` non-empty) rather than leaving it to be
+            //    inferred here. The absolute half of the gate is exercised in
             //    `pipelinePlanLayout.test.js` (`the next-step halo survives the
             //    level CROSSINGS`), which sweeps kind × level × k directly
             //    against `drawsLabelKind` — the same function this canvas calls.
@@ -1968,6 +2121,13 @@ test.describe('Swarm Orchestration — pipelines UI', () => {
 
             await expect(page.getByTestId('pipeline-viz-reqlayout-toggle'),
                 'the Reqs control is gone, not hidden').toHaveCount(0);
+
+            // The camera first, for the same reason as PIPE-16 step 1 (req
+            // #3312): the plan now lands on the factory default, below
+            // `K_READABLE` on a plan this tall, and there L2 and L3 draw the
+            // identical empty canvas — so the screenshot comparison below would
+            // fail while the behaviour it tests is perfectly correct.
+            await zoomToLegibleMid(page, canvas);
 
             // L2 — ids under the beads.
             await page.getByTestId('pipeline-viz-level-2').click();


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-03T09:36:55Z
- wip(Darwin): 2026-08-03T09:32:45Z
- chore: init swarm session feature/3312-default-viewport-1

## Files changed
```
 src/SwarmView/pipelines/PipelinePlanToolbar.jsx    |  17 +-
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx | 275 +++++++++++++++------
 .../pipelines/__tests__/pipelinePlanLayout.test.js | 148 +++++++++--
 src/SwarmView/pipelines/pipelinePlanLayout.js      | 114 ++++++---
 tests/tests/pipelines.spec.ts                      | 225 ++++++++++++++---
 5 files changed, 608 insertions(+), 171 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)