### PR TITLE
applyLinkPlan's rollback deletes a pre-existing link when its INSERT collides — the write-side mirror of req #3101's orphan fix

### DIFF
--- a/src/Agents/__tests__/documentRegistryUtils.test.js
+++ b/src/Agents/__tests__/documentRegistryUtils.test.js
@@ -733,6 +733,22 @@ describe('restErrorMessage — the document keys (req #3051)', () => {
         expect(restErrorMessage(err, 'fallback')).toMatch(/already linked to this agent/);
     });
 
+    // req #3294. The mirror of the owner key — one `principles` link per AGENT
+    // where `uq_agent_documents_owner` is one `owned` link per DOCUMENT — and the
+    // last key on this table that fell through to the bare fallback.
+    //
+    // Reachable despite no control in this app ASSIGNING the role: the popover
+    // seeds its chips from the stored set and strips only `owned`, so a link the
+    // MCP daemon marked `principles` carries that member back out through the
+    // re-POST that every role edit performs.
+    it('maps a second guiding-principles document to its own wording', () => {
+        const err = conflict(1062, 'uq_agent_documents_principles', 'agent_documents');
+        expect(restErrorMessage(err, 'fallback')).toMatch(/guiding-principles document/);
+        expect(restErrorMessage(err, 'fallback')).toMatch(/at most one per agent/);
+        // It must NOT be mistaken for the owner key, which is a different repair.
+        expect(restErrorMessage(err, 'fallback')).not.toMatch(/already owns/);
+    });
+
     // THE COLLISION THIS PINS: `constraint` arrives UNQUALIFIED — every table has
     // a `PRIMARY` — so agent_instructions.PRIMARY and agent_documents.PRIMARY are
     // indistinguishable without also reading `table`. Without that check this

--- a/src/Agents/__tests__/documentsApi.test.js
+++ b/src/Agents/__tests__/documentsApi.test.js
@@ -25,6 +25,7 @@ import {
     linkAgentDocument, linkAgentDocuments, unlinkAgentDocument,
     applyLinkPlan, setAgentDocumentLink, LinkRollbackError,
 } from '../actions/documentsApi';
+import { parseRoles, isDuplicateLink } from '../agentRegistryUtils';
 
 const URI = 'https://api.test/darwin_dev';
 const TOKEN = 'id-token';
@@ -709,5 +710,448 @@ describe('setAgentDocumentLink', () => {
             prev, next: { ...prev, relationship: 'autoload,referenced' },
         });
         expect(calls()[1].body[0].sort_order).toBe(12);
+    });
+});
+
+// ===========================================================================
+// A STATEFUL agent_documents (req #3294).
+//
+// `scriptCalls` above answers by CALL INDEX, which is enough to ask "what does
+// the rollback do when call 4 fails" and structurally unable to ask "what is in
+// the table afterwards". The defect this section exists for is invisible to it:
+// every call succeeds, the plan is correctly rejected, and a row nobody touched
+// is gone. Only real state can catch that, so the table is real here and the
+// assertions are about ROWS, not about call sequences.
+//
+// It models the three things about this junction that decide the answer, and no
+// more: the composite PRIMARY key, `uq_agent_documents_owner` (one `owned` per
+// DOCUMENT), and `uq_agent_documents_principles` (one `principles` per AGENT).
+// ===========================================================================
+
+const jKey = (agent_fk, document_fk) => `${agent_fk}:${document_fk}`;
+
+/**
+ * A 409 shaped exactly as Lambda-Rest sends one — verified against
+ * `compose_conflict_response` in rest_api_utils.py, not assumed. `error` is
+ * UPPERCASE, and `constraint` arrives UNQUALIFIED because `constraint_name`
+ * rsplits MySQL 8's `for key 'agent_documents.PRIMARY'` on the dot.
+ */
+const conflict = (constraint) => Promise.reject({
+    data: null,
+    httpStatus: {
+        httpMethod: 'POST',
+        httpStatus: 409,
+        httpMessage: `Duplicate entry for key '${constraint}'`,
+        httpDetail: {
+            error: 'CONFLICT', errno: 1062, constraint,
+            table: 'agent_documents',
+            message: `Duplicate entry for key '${constraint}'`,
+        },
+    },
+});
+
+const hasRole = (rel, role) => parseRoles(rel).includes(role);
+
+/**
+ * Install a stateful `agent_documents` behind call_rest_api.
+ *
+ * @param initial rows already in the junction before the test runs
+ * @param fault   (callIndex, method, body) => undefined | 'refuse' | 'lost'
+ *                  'refuse' — the statement never ran; the table is untouched.
+ *                  'lost'   — the statement COMMITTED and the response was lost.
+ *                The two are indistinguishable to the caller and have opposite
+ *                consequences, which is the whole reason the rollback exists.
+ */
+const makeJunction = (initial = [], fault = () => undefined) => {
+    const rows = new Map();
+    for (const r of initial) rows.set(jKey(r.agent_fk, r.document_fk), { ...r });
+    let i = 0;
+
+    call_rest_api.mockImplementation((url, method, body) => {
+        i += 1;
+        const table = url.split('/').pop();
+        // A wrong-table call would otherwise be silently accepted and make every
+        // assertion below meaningless.
+        if (table !== 'agent_documents') {
+            return Promise.reject(new Error(`simulator models agent_documents only, got ${table}`));
+        }
+        const verdict = fault(i, method, body);
+        // A mistyped verdict must not fall through to the SUCCESS path — a test
+        // reading as a failure test while asserting the happy path is worse than
+        // no test.
+        if (verdict !== undefined && verdict !== 'refuse' && verdict !== 'lost') {
+            return Promise.reject(new Error(`unknown fault verdict: ${verdict}`));
+        }
+        if (verdict === 'refuse') return rejectWith(500, 'SQL FAILED');
+
+        if (method === 'DELETE') {
+            const k = jKey(body.agent_fk, body.document_fk);
+            // rest_delete.py: `affected_rows == 0` is 404, otherwise 200 'OK'.
+            // NOT 204 — this table's DELETE has always answered 200.
+            if (!rows.has(k)) return rejectWith(404, 'NOT FOUND');
+            rows.delete(k);
+            if (verdict === 'lost') return rejectWith(500, 'SQL FAILED');
+            return Promise.resolve(ok(200));
+        }
+
+        // POST is ONE multi-value INSERT, and it is modelled the way InnoDB
+        // actually applies one: ROW BY ROW, clustered index (the composite PK)
+        // before the secondaries, against a working set that already carries the
+        // rows earlier in the SAME statement — so a batch that collides with
+        // ITSELF is caught, and a batch where row 1 trips a unique key and row 2
+        // trips the PK reports row 1's constraint, as MySQL would.
+        //
+        // It still applies ATOMICALLY: the working set is discarded on any
+        // violation and `rows` is untouched, matching _rest_post_bulk's
+        // conn.rollback(). Validate-all-then-apply-all would have got the
+        // atomicity right and the ORDER wrong.
+        const incoming = body.map(r => ({ ...r }));
+        const staged = new Map(rows);
+        for (const r of incoming) {
+            const k = jKey(r.agent_fk, r.document_fk);
+            if (staged.has(k)) return conflict('PRIMARY');
+            const seen = [...staged.values()];
+            if (hasRole(r.relationship, 'owned')
+                && seen.some(x => x.document_fk === r.document_fk && hasRole(x.relationship, 'owned'))) {
+                return conflict('uq_agent_documents_owner');
+            }
+            if (hasRole(r.relationship, 'principles')
+                && seen.some(x => x.agent_fk === r.agent_fk && hasRole(x.relationship, 'principles'))) {
+                return conflict('uq_agent_documents_principles');
+            }
+            staged.set(k, r);
+        }
+        rows.clear();
+        for (const [k, r] of staged) rows.set(k, r);
+        if (verdict === 'lost') return rejectWith(500, 'SQL FAILED');
+        return Promise.resolve(ok(201, { inserted: incoming.length }));
+    });
+
+    return {
+        get: (agent_fk, document_fk) => rows.get(jKey(agent_fk, document_fk)) || null,
+        has: (agent_fk, document_fk) => rows.has(jKey(agent_fk, document_fk)),
+        size: () => rows.size,
+        /** A write by SOMEBODY ELSE, bypassing the API — another tab, or the daemon. */
+        insert: (r) => rows.set(jKey(r.agent_fk, r.document_fk), { ...r }),
+        snapshot: () => [...rows.values()]
+            .map(r => ({ ...r }))
+            .sort((a, b) => a.agent_fk - b.agent_fk || a.document_fk - b.document_fk),
+    };
+};
+
+/** A stored row, as the junction holds it (already serialized). */
+const row = (agent_fk, relationship, extra = {}) => ({
+    agent_fk, document_fk: 10, relationship, notes: null, sort_order: 1, ...extra,
+});
+
+describe('the stateful junction models what it claims to', () => {
+    it('409s on the composite PRIMARY key, leaving the incumbent row alone', async () => {
+        const j = makeJunction([row(5, 'referenced', { notes: 'mine' })]);
+        await expect(linkAgentDocument(URI, TOKEN, row(5, 'curated'))).rejects.toMatchObject({
+            httpStatus: { httpStatus: 409, httpDetail: { errno: 1062, constraint: 'PRIMARY' } },
+        });
+        expect(j.get(5, 10).relationship).toBe('referenced');
+        expect(j.get(5, 10).notes).toBe('mine');
+    });
+
+    it('409s on uq_agent_documents_owner for a SECOND owner of one document', async () => {
+        makeJunction([row(2, 'owned')]);
+        await expect(linkAgentDocument(URI, TOKEN, row(5, 'owned'))).rejects.toMatchObject({
+            httpStatus: { httpDetail: { constraint: 'uq_agent_documents_owner' } },
+        });
+    });
+
+    it('409s on uq_agent_documents_principles for a SECOND principles doc of one agent', async () => {
+        makeJunction([row(2, 'principles')]);
+        await expect(
+            linkAgentDocument(URI, TOKEN, { ...row(2, 'principles'), document_fk: 11 }),
+        ).rejects.toMatchObject({
+            httpStatus: { httpDetail: { constraint: 'uq_agent_documents_principles' } },
+        });
+    });
+
+    it('catches a batch that collides with ITSELF, and lands none of it', async () => {
+        // One multi-value INSERT is not a loop of inserts: MySQL sees row 2
+        // against a clustered index that already holds row 1, and the statement
+        // fails as a unit. A simulator that validated only against the
+        // pre-statement rows would accept this and quietly bless a bad batch.
+        const j = makeJunction();
+        await expect(linkAgentDocuments(URI, TOKEN, [
+            row(5, 'owned'),
+            { ...row(6, 'owned'), document_fk: 10 },
+        ])).rejects.toMatchObject({
+            httpStatus: { httpDetail: { constraint: 'uq_agent_documents_owner' } },
+        });
+        expect(j.size()).toBe(0);          // atomic — row 1 did not land either
+    });
+
+    it('404s a DELETE that matched nothing, and removes the row when it did', async () => {
+        const j = makeJunction([row(2, 'referenced')]);
+        await expect(unlinkAgentDocument(URI, TOKEN, 2, 10)).resolves.toBe(true);
+        expect(j.has(2, 10)).toBe(false);
+        await expect(unlinkAgentDocument(URI, TOKEN, 2, 10)).resolves.toBe(false);
+    });
+
+    it("'lost' commits the statement and THEN fails — the shape the rollback exists for", async () => {
+        const j = makeJunction([], () => 'lost');
+        await expect(linkAgentDocument(URI, TOKEN, row(5, 'owned'))).rejects.toBeTruthy();
+        expect(j.has(5, 10)).toBe(true);          // it landed anyway
+    });
+});
+
+describe('applyLinkPlan on real state — the pre-existing link survives (req #3294)', () => {
+    it('does NOT delete a link its INSERT collided with', async () => {
+        // THE ACCEPTANCE TEST. A plan built from a cache that has gone stale: the
+        // UI believed agent 5 had no link to document 10, so it planned a CREATE.
+        // Another writer put one there in the meantime — a second tab or the MCP
+        // daemon, never a different user: `agent_documents` is derived-scoped
+        // through `agents.creator_fk`, so this is a same-identity race, not a
+        // cross-tenant one. The INSERT hits the composite PK and 409s.
+        //
+        // Every call in this test succeeds at what it was asked to do. Before the
+        // fix the rollback then issued its 404-TOLERANT cleanup DELETE against a
+        // row this step did not create, that DELETE SUCCEEDED, and the link was
+        // gone — with no `lost` entry (this step removed nothing) and no
+        // `orphaned` entry (the cleanup worked), so the user was told only that
+        // their edit was rejected.
+        const incumbent = row(5, 'referenced', { notes: 'put here by another tab', sort_order: 7 });
+        const j = makeJunction([incumbent]);
+
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 5, document_fk: 10, prev: null, next: row(5, 'curated'),
+        }]).catch(e => e);
+
+        // The link is STILL THERE, and unchanged in every field.
+        expect(j.get(5, 10)).toEqual(incumbent);
+        expect(j.size()).toBe(1);
+
+        // No cleanup DELETE was ever issued for it.
+        expect(calls().filter(c => c.method === 'DELETE')).toHaveLength(0);
+
+        // The user gets the real answer — their edit was rejected — and nothing
+        // claims the database is broken, because it is not.
+        expect(err).not.toBeInstanceOf(LinkRollbackError);
+        expect(err.httpStatus.httpStatus).toBe(409);
+    });
+
+    it('does NOT delete the row a THIRD PARTY wrote into the key it just vacated', async () => {
+        // THE POPOVER-SAVE RACE, and the highest-value shape of this defect: it is
+        // reachable from one click on a control the user uses constantly.
+        //
+        // setAgentDocumentLink is a one-step plan, so a role edit is a DELETE and
+        // a fresh INSERT across two non-atomic Lambda invocations. The DELETE
+        // COMMITS — the user's own row is genuinely gone — and in the window
+        // before the re-INSERT another writer (a second tab, or the MCP daemon)
+        // claims that same composite key. Our INSERT then 409s on the PK.
+        //
+        // Before the fix the rollback deleted THAT row: measured, the junction
+        // ended holding the user's original 'referenced' link and the third
+        // party's row was destroyed, while the thrown error said only "that
+        // document is already linked to this agent".
+        const incumbent = row(3, 'referenced', { notes: 'mine' });
+        const j = makeJunction([incumbent], (i, method) => {
+            // Between the DELETE and the POST, somebody else takes the key.
+            if (i === 1 && method === 'DELETE') {
+                queueMicrotask(() => j.insert(row(3, 'owned', { notes: 'THIRD PARTY' })));
+            }
+            return undefined;
+        });
+
+        const err = await setAgentDocumentLink(URI, TOKEN, {
+            prev: incumbent, next: { ...incumbent, relationship: 'curated' },
+        }).catch(e => e);
+
+        // THE THIRD PARTY'S ROW SURVIVES, untouched.
+        expect(j.get(3, 10)).toEqual(row(3, 'owned', { notes: 'THIRD PARTY' }));
+        expect(j.size()).toBe(1);
+
+        // The only DELETE issued was the leading one. No cleanup went near it.
+        expect(calls().filter(c => c.method === 'DELETE')).toHaveLength(1);
+
+        // And the report is honest about the one thing that DID change: the
+        // user's own link was removed and could not be put back, because the
+        // restore collides with the row now sitting in that slot.
+        expect(err).toBeInstanceOf(LinkRollbackError);
+        expect(err.lost).toHaveLength(1);
+        expect(err.lost[0].cleanupFailed).toBe(false);
+        expect(err.orphaned).toHaveLength(0);
+        expect(err.message).toMatch(/now missing/);
+        expect(err.message).toMatch(/Reload the page/);
+        // Not "still carries the rejected value" — the slot holds neither `prev`
+        // nor `next` but a third value, and that phrasing would be a lie.
+        expect(err.message).not.toMatch(/still carr/);
+    });
+
+    it('rolls the EARLIER steps back correctly around a collision mid-plan', async () => {
+        // The suppression must not cost the rest of the plan its rollback. Step 1
+        // legitimately re-classifies agent 2; step 2 collides with a pre-existing
+        // agent-5 link. Agent 5's row must survive AND agent 2 must be put back.
+        const incumbent = row(5, 'referenced', { notes: 'not ours' });
+        const before = row(2, 'owned,autoload', { notes: 'why 2 owns it', sort_order: 3 });
+        const j = makeJunction([before, incumbent]);
+
+        const err = await applyLinkPlan(URI, TOKEN, [
+            { agent_fk: 2, document_fk: 10, prev: before, next: { ...before, relationship: 'autoload' } },
+            { agent_fk: 5, document_fk: 10, prev: null, next: row(5, 'owned') },
+        ]).catch(e => e);
+
+        expect(j.get(5, 10)).toEqual(incumbent);          // untouched
+        expect(j.get(2, 10)).toEqual(before);             // restored to its ORIGINAL roles
+        expect(j.size()).toBe(2);
+        expect(err).not.toBeInstanceOf(LinkRollbackError);
+    });
+
+    it('STILL cleans up when the INSERT committed and only its response was lost', async () => {
+        // The other half of the same decision, and the reason the suppression is
+        // keyed on a definite 1062 rather than on "the INSERT failed". Here the row
+        // really is this step's, so the cleanup must go ahead and remove it.
+        const j = makeJunction([], (i, method) => (method === 'POST' ? 'lost' : undefined));
+
+        await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 5, document_fk: 10, prev: null, next: row(5, 'owned'),
+        }]).catch(e => e);
+
+        expect(j.size()).toBe(0);                          // the orphan was removed
+        expect(calls().map(c => c.method)).toEqual(['POST', 'DELETE']);
+    });
+
+    it('does NOT suppress the cleanup for uq_agent_documents_owner', async () => {
+        // THE DELIBERATE NON-SUPPRESSION. Same errno, same table, different
+        // situation: a second ownership claim means the INSERT genuinely did not
+        // land, so there is nothing of ours behind it and the cleanup must be
+        // allowed to run. Told apart by CONSTRAINT NAME, never by accident.
+        const owner = row(2, 'owned', { notes: 'incumbent owner' });
+        const j = makeJunction([owner]);
+
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 5, document_fk: 10, prev: null, next: row(5, 'owned'),
+        }]).catch(e => e);
+
+        // The cleanup WAS issued (and 404s harmlessly, since nothing landed).
+        const deletes = calls().filter(c => c.method === 'DELETE');
+        expect(deletes).toHaveLength(1);
+        expect(deletes[0].body).toEqual({ agent_fk: 5, document_fk: 10 });
+
+        // The incumbent owner is untouched and the table is exactly as it started.
+        expect(j.snapshot()).toEqual([owner]);
+        expect(err.httpStatus.httpDetail.constraint).toBe('uq_agent_documents_owner');
+        expect(err).not.toBeInstanceOf(LinkRollbackError);
+    });
+
+    it('does NOT suppress the cleanup for uq_agent_documents_principles either', async () => {
+        // The same reasoning on the mirror key (one principles doc per AGENT).
+        const held = { ...row(2, 'principles'), document_fk: 11 };
+        const j = makeJunction([held]);
+
+        await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10, prev: null, next: row(2, 'principles'),
+        }]).catch(e => e);
+
+        expect(calls().filter(c => c.method === 'DELETE')).toHaveLength(1);
+        expect(j.snapshot()).toEqual([held]);
+    });
+
+    it('completes an ownership transfer, leaving exactly the two rows it should', async () => {
+        // The happy path, asserted on ROWS rather than on a call sequence: agent 2
+        // hands document 10 to agent 5. The order is forced —
+        // uq_agent_documents_owner rejects the claim while the incumbent still
+        // holds `owned` — and the simulator enforces that, so a plan in the wrong
+        // order would fail here rather than pass silently.
+        const j = makeJunction([row(2, 'owned,autoload', { sort_order: 3 })]);
+
+        await applyLinkPlan(URI, TOKEN, [
+            { agent_fk: 2, document_fk: 10, prev: row(2, 'owned,autoload', { sort_order: 3 }),
+              next: row(2, 'autoload', { sort_order: 3 }) },
+            { agent_fk: 5, document_fk: 10, prev: null, next: row(5, 'owned') },
+        ]);
+
+        expect(j.snapshot()).toEqual([
+            row(2, 'autoload', { sort_order: 3 }),
+            row(5, 'owned'),
+        ]);
+    });
+
+    it('leaves the table byte-for-byte as it started when the transfer is refused', async () => {
+        // The failure the rollback exists for, measured end to end. Agent 2
+        // releases `owned`, agent 5's claim is refused, and the junction must end
+        // where it began — not merely "a POST was issued".
+        const start = [row(2, 'owned,autoload', { notes: 'why 2 owns it', sort_order: 3 })];
+        const j = makeJunction(start, (i, method) => (i === 3 && method === 'POST' ? 'refuse' : undefined));
+
+        const err = await applyLinkPlan(URI, TOKEN, [
+            { agent_fk: 2, document_fk: 10, prev: start[0], next: { ...start[0], relationship: 'autoload' } },
+            { agent_fk: 5, document_fk: 10, prev: null, next: row(5, 'owned') },
+        ]).catch(e => e);
+
+        expect(j.snapshot()).toEqual(start);
+        expect(err).not.toBeInstanceOf(LinkRollbackError);
+    });
+
+    it('reports a LOSS, and does not invent one, when the restore truly cannot land', async () => {
+        // The rollback's worst case on real state: the release commits, the claim
+        // is refused, and the restore is refused too. The row really is gone, and
+        // that — not the ownership conflict — is what the user must be told.
+        const start = [row(2, 'owned,autoload', { sort_order: 3 })];
+        const j = makeJunction(start, (i, method) => (method === 'POST' ? 'refuse' : undefined));
+
+        const err = await applyLinkPlan(URI, TOKEN, [{
+            agent_fk: 2, document_fk: 10, prev: start[0], next: { ...start[0], relationship: 'autoload' },
+        }]).catch(e => e);
+
+        expect(j.size()).toBe(0);
+        expect(err).toBeInstanceOf(LinkRollbackError);
+        expect(err.lost).toHaveLength(1);
+        expect(err.orphaned).toHaveLength(0);
+        expect(err.message).toMatch(/now missing/);
+    });
+});
+
+describe('isDuplicateLink', () => {
+    const err409 = (constraint, table, errno = 1062) => ({
+        httpStatus: { httpStatus: 409, httpDetail: { errno, constraint, table } },
+    });
+
+    it('is true only for 1062 on the composite PRIMARY key of the NAMED table', () => {
+        expect(isDuplicateLink(err409('PRIMARY', 'agent_documents'), 'agent_documents')).toBe(true);
+    });
+
+    it('is FALSE when the table argument is missing — never a wildcard', () => {
+        // The trap this closes: `err.httpDetail.table === undefined` compares
+        // equal to a forgotten argument, so without an explicit guard a caller
+        // that omitted the table would match EVERY table's PRIMARY key — the
+        // exact over-match the argument exists to prevent.
+        const err = { httpStatus: { httpStatus: 409, httpDetail: { errno: 1062, constraint: 'PRIMARY' } } };
+        expect(isDuplicateLink(err, undefined)).toBe(false);
+        expect(isDuplicateLink(err, '')).toBe(false);
+        expect(isDuplicateLink(err409('PRIMARY', 'agent_documents'), undefined)).toBe(false);
+    });
+
+    it('is FALSE for the same key on a different table', () => {
+        // `constraint` arrives unqualified and every table has a PRIMARY, so
+        // ignoring `table` would suppress a cleanup on evidence about another one.
+        expect(isDuplicateLink(err409('PRIMARY', 'agent_instructions'), 'agent_documents')).toBe(false);
+    });
+
+    it('is FALSE for the OTHER 1062s this table raises', () => {
+        // Both mean the INSERT did not land, so both must leave the cleanup on.
+        expect(isDuplicateLink(err409('uq_agent_documents_owner', 'agent_documents'), 'agent_documents')).toBe(false);
+        expect(isDuplicateLink(err409('uq_agent_documents_principles', 'agent_documents'), 'agent_documents')).toBe(false);
+    });
+
+    it('is FALSE for a non-1062 conflict and for any non-409 status', () => {
+        // 1452 is a missing parent — a different problem with a different repair.
+        expect(isDuplicateLink(err409('PRIMARY', 'agent_documents', 1452), 'agent_documents')).toBe(false);
+        expect(isDuplicateLink({ httpStatus: { httpStatus: 500 } }, 'agent_documents')).toBe(false);
+        expect(isDuplicateLink({ httpStatus: { httpStatus: 404 } }, 'agent_documents')).toBe(false);
+    });
+
+    it('is FALSE — never a throw — on a malformed or missing error', () => {
+        // It is read from inside a catch block; throwing there would replace a
+        // recoverable failure with an unhandled one.
+        expect(isDuplicateLink(undefined, 'agent_documents')).toBe(false);
+        expect(isDuplicateLink(null, 'agent_documents')).toBe(false);
+        expect(isDuplicateLink(new Error('boom'), 'agent_documents')).toBe(false);
+        expect(isDuplicateLink({ httpStatus: { httpStatus: 409 } }, 'agent_documents')).toBe(false);
+        expect(isDuplicateLink({ httpStatus: { httpStatus: 409, httpDetail: null } }, 'agent_documents')).toBe(false);
     });
 });

--- a/src/Agents/actions/documentsApi.js
+++ b/src/Agents/actions/documentsApi.js
@@ -46,7 +46,7 @@
 //   the 404-tolerant paths catch it explicitly rather than testing the status.
 
 import call_rest_api from '../../RestApi/RestApi';
-import { serializeRoles } from '../agentRegistryUtils';
+import { serializeRoles, isDuplicateLink } from '../agentRegistryUtils';
 
 const isOk = (status) => status === 200 || status === 201 || status === 204;
 
@@ -322,6 +322,15 @@ export async function applyLinkPlan(darwinUri, idToken, steps) {
      * did) turns the most ordinary failure of all, the database REFUSING the
      * DELETE with the row untouched, into the rollback deleting that row itself.
      *
+     * AND IT IS WITHDRAWN THE MOMENT THE UNKNOWN BECOMES KNOWN (req #3294). The
+     * flag is a standing assumption, not a record of the past: a 1062 on the
+     * composite PRIMARY key answers the question it was standing in for — the row
+     * pre-existed, this INSERT created nothing — so the assumption is cleared
+     * rather than carried into the rollback, where it would delete somebody else's
+     * link. Symmetrical with the 404 rule below, and for the same reason: where
+     * the database states a fact about whether the row is there, that fact governs
+     * — and both of the facts it states here rule an action OUT.
+     *
      * The one thing that is NOT optimistic on the restore side either is a 404 on
      * the leading DELETE. That is a definite answer — the row was already gone —
      * and resurrecting a row that did not exist is its own corruption, so
@@ -374,11 +383,47 @@ export async function applyLinkPlan(darwinUri, idToken, steps) {
             // and the response still fail (a flake after the INSERT landed), and
             // the rollback has to assume it might be there.
             record.cleanupNeeded = true;
-            await linkAgentDocument(darwinUri, idToken, {
-                ...step.next,
-                agent_fk: step.agent_fk,
-                document_fk: step.document_fk,
-            });
+            try {
+                await linkAgentDocument(darwinUri, idToken, {
+                    ...step.next,
+                    agent_fk: step.agent_fk,
+                    document_fk: step.document_fk,
+                });
+            } catch (err) {
+                // OPTIMISM IS FOR THE UNKNOWN, AND THIS IS NOT UNKNOWN (req #3294).
+                //
+                // A 1062 on the composite PRIMARY key is the database stating a
+                // FACT: the row was already there, so this INSERT created nothing
+                // and the row belongs to whoever did. NOT another user —
+                // `agent_documents` is in Lambda-Rest's JUNCTION_OWNERSHIP and
+                // every read and write is derived-scoped through
+                // `agents.creator_fk`, so the other writer is always the same
+                // identity: a second browser tab, the MCP daemon, or this tab's
+                // own cache having gone stale under a plan built from it. Leaving
+                // `cleanupNeeded` set would send the rollback's 404-TOLERANT
+                // DELETE at that row, and against a row that is genuinely there
+                // that DELETE SUCCEEDS AND REMOVES IT.
+                //
+                // The loss is then unreportable, which is what made it silent: this
+                // step removed nothing, so it is not `lost`; its cleanup worked, so
+                // it is not `orphaned`. The user is told only that their edit was
+                // rejected while a link they never touched is gone.
+                //
+                // It is the exact write-side mirror of the read-side rule on the
+                // leading DELETE above: a 404 there is a definite answer that rules
+                // a restore OUT, and a 1062 on PRIMARY here is a definite answer
+                // that rules the cleanup out.
+                //
+                // Scoped to `agent_documents` and to `PRIMARY` on purpose. The
+                // other two 1062s this table raises — `uq_agent_documents_owner`
+                // (a second owner for one document) and
+                // `uq_agent_documents_principles` (a second principles doc for one
+                // agent) — must NOT suppress anything: those INSERTs really did
+                // fail to land, so there is nothing of ours behind them and the
+                // cleanup goes ahead.
+                if (isDuplicateLink(err, 'agent_documents')) record.cleanupNeeded = false;
+                throw err;
+            }
         }
     };
 
@@ -397,8 +442,10 @@ export async function applyLinkPlan(darwinUri, idToken, steps) {
             let cleanupFailed = false;
             try {
                 // Remove whatever this step may have put here. 404-tolerant, so
-                // issuing it when there is nothing to remove costs one call and
-                // never fails.
+                // issuing it against an EMPTY slot costs one call and never fails
+                // — which is emphatically not the same as issuing it against an
+                // OCCUPIED one, where it succeeds and takes the row with it. That
+                // is why the decision is `cleanupNeeded` and never "just in case".
                 if (step.cleanupNeeded) {
                     await unlinkAgentDocument(darwinUri, idToken,
                         step.agent_fk, step.document_fk);

--- a/src/Agents/agentRegistryUtils.js
+++ b/src/Agents/agentRegistryUtils.js
@@ -878,6 +878,42 @@ export const planOwnerTransfer = ({
 };
 
 /**
+ * Did this rejection say, definitely, that the junction row ALREADY EXISTED?
+ *
+ * Not a message helper — a CONTROL-FLOW predicate. `applyLinkPlan`'s rollback
+ * uses it to decide whether the row it is about to delete is one of its own, and
+ * getting that wrong destroys a link nobody touched (req #3294). It lives beside
+ * `restErrorMessage` because both read the same req #3059 fields, and putting the
+ * classification in one place is the point.
+ *
+ * TRUE ONLY FOR THE COMPOSITE PRIMARY KEY. A junction here is keyed on
+ * (agent_fk, <target>_fk), so 1062 on `PRIMARY` is the one answer that means "the
+ * row you tried to insert is already sitting there" — and therefore that whoever
+ * put it there, it was not this write.
+ *
+ * `table` IS REQUIRED, deliberately. `constraint` arrives unqualified, every
+ * table has a `PRIMARY`, and a predicate that suppressed a cleanup on the wrong
+ * table would reintroduce the very defect it exists to close.
+ *
+ * The OTHER 1062s `agent_documents` can raise are different situations and must
+ * NOT match: `uq_agent_documents_owner` (a second ownership claim, over the
+ * VIRTUAL `owned_document_fk`) and `uq_agent_documents_principles` (a second
+ * guiding-principles document for one agent). Both mean the INSERT genuinely did
+ * not land, so nothing of the caller's is left behind and its cleanup has to go
+ * ahead. They are told apart here BY CONSTRAINT NAME rather than by accident,
+ * which is why this reads the name and not just the errno.
+ */
+export const isDuplicateLink = (err, table) => {
+    // Enforced, not merely documented: without this a forgotten argument compares
+    // `undefined === undefined` and matches EVERY table's PRIMARY key, which is
+    // the exact over-match the paragraph above rules out.
+    if (!table) return false;
+    if (err?.httpStatus?.httpStatus !== 409) return false;
+    const d = err.httpStatus.httpDetail || {};
+    return d.errno === 1062 && d.constraint === 'PRIMARY' && d.table === table;
+};
+
+/**
  * Turn a thrown call_rest_api rejection into something a human can act on.
  *
  * Lambda-Rest answers a constraint violation with HTTP 409 and a structured body
@@ -927,6 +963,19 @@ export const restErrorMessage = (err, fallback) => {
     if (errno === 1062 && constraint === 'uq_agent_documents_owner') {
         return 'Another agent already owns this document — at most one owner per document. '
             + 'Use "curated" for a second architect, or hand ownership over from the current owner.';
+    }
+    // req #3129's mirror key: at most one `principles` link per AGENT, where
+    // `uq_agent_documents_owner` is at most one `owned` link per DOCUMENT.
+    //
+    // Reachable even though no control in this app ASSIGNS the role. The popover
+    // seeds its chips from the stored set and filters out only `owned`
+    // (DocumentLinkPopover), so a link the MCP daemon marked `principles` carries
+    // that member straight back out through the re-POST — and every role edit is a
+    // DELETE and a fresh INSERT. If the daemon assigns another principles document
+    // to the same agent inside that window, this is the answer.
+    if (errno === 1062 && constraint === 'uq_agent_documents_principles') {
+        return 'This agent already has a guiding-principles document — at most one per agent. '
+            + 'Reload the page: it may have been assigned in another tab.';
     }
     if (errno === 1062 && constraint === 'PRIMARY' && table === 'agent_documents') {
         return 'That document is already linked to this agent.';


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3294-applylinkplans-rollback-deletes-a-1
- wip(Darwin): 2026-08-03T09:23:25Z
- chore: init swarm session feature/3294-applylinkplans-rollback-deletes-a-1

## Files changed
```
 src/Agents/__tests__/documentRegistryUtils.test.js |  16 +
 src/Agents/__tests__/documentsApi.test.js          | 444 +++++++++++++++++++++
 src/Agents/actions/documentsApi.js                 |  63 ++-
 src/Agents/agentRegistryUtils.js                   |  49 +++
 4 files changed, 564 insertions(+), 8 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)