### PR TITLE
map_coordinates read-path hardening: composite index, batched fetch, doc drift

### DIFF
--- a/src/CyclemeterImport/CyclemeterImport.jsx
+++ b/src/CyclemeterImport/CyclemeterImport.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useContext, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -53,6 +54,7 @@ const EXTRACTORS = {
 
 const CyclemeterImport = () => {
     const navigate = useNavigate();
+    const queryClient = useQueryClient();
     const { darwinUri } = useContext(AppContext);
     const { idToken, profile } = useContext(AuthContext);
 
@@ -478,6 +480,16 @@ const CyclemeterImport = () => {
         } finally {
             setSaving(false);
             abortRef.current = null;
+            // req #3166: THE invalidation site for GPS tracks, and the reason
+            // useMapCoordinates can safely cache them with staleTime: Infinity.
+            // Step 2 writes every map_run BEFORE step 3 writes a single
+            // coordinate, so a user who opens /maps mid-import can cache a run
+            // with an empty or half-written track. Under the old 30 s staleTime
+            // that healed itself; under Infinity it would be frozen for the
+            // session with no user-reachable refresh. In `finally` on purpose —
+            // a CANCELLED or FAILED import is precisely when a partial track is
+            // sitting in the cache.
+            queryClient.invalidateQueries({ queryKey: ['map_coordinates'] });
         }
     };
 

--- a/src/MapExport/ExportDialog.jsx
+++ b/src/MapExport/ExportDialog.jsx
@@ -20,6 +20,8 @@ import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 
 import call_rest_api from '../RestApi/RestApi';
+// req #3166 — THE batched GET /map_coordinates, shared with the aggregator hook.
+import { fetchCoordinatesForRuns } from '../services/mapCoordinatesBatch';
 import { generateKml, downloadFile } from '../cyclemeter';
 import { reconstructRun } from '../utils/mapDataUtils';
 import ExportMapPreview from './ExportMapPreview';
@@ -99,18 +101,29 @@ const ExportDialog = ({ open, onClose, runs, routes, partners = [], runPartners 
             const allCoords = [];
             let totalCoords = 0;
 
+            // req #3166: BATCHED, and no longer one serial request per run. A
+            // KML export of a large filter used to issue `runs.length` requests
+            // one after another — 200 sequential round trips before the first
+            // byte of KML. mapCoordinatesBatch packs many runs per request under
+            // a measured row budget, so the same export is a handful of calls.
+            const tracks = await fetchCoordinatesForRuns({
+                fetchJson: async (uri) => {
+                    try {
+                        const result = await call_rest_api(uri, 'GET', '', idToken);
+                        return result.data || [];
+                    } catch (coordErr) {
+                        // 404 = no coordinates in this batch — an empty result,
+                        // not a failure (matches fetchEntity behavior).
+                        if (coordErr?.httpStatus?.httpStatus === 404) return [];
+                        throw coordErr;
+                    }
+                },
+                darwinUri,
+                runIds: runs.map(run => run.id),
+            });
+
             for (const run of runs) {
-                let coords = [];
-                try {
-                    const coordResult = await call_rest_api(
-                        `${darwinUri}/map_coordinates?map_run_fk=${run.id}&fields=latitude,longitude,altitude&sort=seq:asc`,
-                        'GET', '', idToken
-                    );
-                    coords = coordResult.data || [];
-                } catch (coordErr) {
-                    // 404 = no coordinates for this run — skip gracefully (matches fetchEntity behavior)
-                    if (coordErr?.httpStatus?.httpStatus !== 404) throw coordErr;
-                }
+                const coords = tracks.get(Number(run.id)) || [];
                 totalCoords += coords.length;
                 allCoords.push(coords);
 

--- a/src/MapExport/__tests__/ExportDialog.batchedCoordinates.test.jsx
+++ b/src/MapExport/__tests__/ExportDialog.batchedCoordinates.test.jsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+//
+// ExportDialog's coordinate fetch — req #3166.
+//
+// This is the THIRD caller of services/mapCoordinatesBatch.js and the one whose
+// rewrite carried the most risk: it went from a SERIAL per-run loop (200 rides =
+// 200 sequential round trips before the first byte of KML) to a prefetched Map
+// lookup. Two properties had to survive that, and neither is visible by reading:
+//
+//   • `allCoords` and `totalCoords` are still built by iterating `runs` IN
+//     ORDER, so the KML preview's polylines and the stats panel's coordinate
+//     count still correspond to the rides the user filtered to. The batch
+//     returns a Map keyed by run id, in id order — a different order.
+//   • its `fetchJson` wrapper differs from the other two callers': it maps 404
+//     to [] itself, and `call_rest_api` RETURNS rather than throws on a
+//     transport failure.
+//
+// ExportMapPreview is stubbed — it mounts Leaflet, which needs a real layout
+// engine. It is not what this file is about.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../../RestApi/RestApi', () => ({ default: vi.fn() }));
+vi.mock('../ExportMapPreview', () => ({
+    default: ({ routeCoordinates }) => (
+        <div data-testid="preview-stub">{routeCoordinates.map(t => t.length).join(',')}</div>
+    ),
+}));
+
+import call_rest_api from '../../RestApi/RestApi';
+import ExportDialog from '../ExportDialog';
+
+const DARWIN_URI = 'https://api.example.com/darwin_dev';
+
+const makeRun = (id) => ({
+    id,
+    run_id: 900 + id,
+    map_route_fk: null,
+    activity_id: 4,
+    activity_name: 'Ride',
+    start_time: `2026-01-0${id} 08:00:00`,
+    run_time_sec: 3600,
+    stopped_time_sec: 0,
+    distance_mi: 10,
+    ascent_ft: 100,
+    descent_ft: 100,
+    calories: 300,
+    max_speed_mph: 20,
+    avg_speed_mph: 10,
+    notes: null,
+    source: 'cyclemeter',
+});
+
+// Answers the count probe and the batched read from a {runId: rowCount} map,
+// recording every URI. Coordinates encode their run id in the latitude so a
+// track can be traced back to the ride it belongs to.
+const serve = (rowsByRun, { failReads = false } = {}) => {
+    const uris = [];
+    call_rest_api.mockImplementation(async (uri) => {
+        uris.push(uri);
+        const ids = uri.match(/map_run_fk=\(([^)]*)\)/)[1].split(',').map(Number);
+        if (uri.includes('count(*)')) {
+            const rows = ids.filter(id => rowsByRun[id] > 0)
+                .map(id => ({ 'count(*)': rowsByRun[id], map_run_fk: id }));
+            if (rows.length === 0) {
+                const err = new Error('Not found');
+                err.httpStatus = { httpStatus: 404 };
+                throw err;
+            }
+            return { data: rows, httpStatus: { httpStatus: 200 } };
+        }
+        if (failReads) return { data: {}, httpStatus: { httpStatus: 503 } };
+        return {
+            data: ids.flatMap(id => Array.from({ length: rowsByRun[id] || 0 }, (_, i) => ({
+                map_run_fk: id,
+                latitude: 37 + id / 100,
+                longitude: -122 - i / 1000,
+                altitude: 10,
+            }))),
+            httpStatus: { httpStatus: 200 },
+        };
+    });
+    return uris;
+};
+
+let container;
+let root;
+
+const renderDialog = (runs) => {
+    act(() => {
+        root.render(
+            <ExportDialog
+                open
+                onClose={() => {}}
+                runs={runs}
+                routes={[]}
+                darwinUri={DARWIN_URI}
+                idToken="token-1"
+                filterDescription="All activities"
+            />
+        );
+    });
+};
+
+// The dialog renders into a MUI portal, so query the document, not the container.
+const byTestId = (id) => document.body.querySelector(`[data-testid="${id}"]`);
+
+const generate = () => act(() => {
+    byTestId('generate-kml-button').dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+    );
+});
+
+const waitUntil = async (cond) => {
+    for (let i = 0; i < 200; i++) {
+        if (cond()) return;
+        await act(async () => { await new Promise(r => setTimeout(r, 5)); });
+    }
+    throw new Error('timed out waiting for condition');
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+});
+
+describe('ExportDialog — batched coordinate fetch (req #3166)', () => {
+    it('fetches three rides in ONE batched read, not three serial ones', async () => {
+        const uris = serve({ 1: 4, 2: 2, 3: 3 });
+        renderDialog([makeRun(1), makeRun(2), makeRun(3)]);
+        generate();
+
+        await waitUntil(() => byTestId('export-stats-panel'));
+
+        const reads = uris.filter(u => !u.includes('count(*)'));
+        expect(uris).toHaveLength(2);          // one probe + one read
+        expect(reads[0]).toContain('map_run_fk=(1,2,3)');
+        expect(reads[0]).toContain('&sort=map_run_fk:asc,seq:asc');
+        // The KML path asks for the DEFAULT track fields — no `seq`, matching
+        // what it requested before req #3166 (reconstructRun never reads it).
+        // exportService, which writes seq into the export file, passes its own
+        // list; that divergence is deliberate and is asserted in its own test.
+        expect(reads[0]).toContain('&fields=map_run_fk,latitude,longitude,altitude');
+    });
+
+    it('counts every coordinate exactly once across all rides', async () => {
+        serve({ 1: 4, 2: 2, 3: 3 });
+        renderDialog([makeRun(1), makeRun(2), makeRun(3)]);
+        generate();
+
+        await waitUntil(() => byTestId('export-stats-panel'));
+
+        const text = byTestId('export-stats-panel').textContent;
+        expect(text).toContain('9');   // 4 + 2 + 3 GPS coordinates
+        expect(text).toContain('3');   // total activities
+    });
+
+    it('keeps each track attached to its own ride, in `runs` order', async () => {
+        // Distinct lengths per run, and the runs are passed OUT of id order. The
+        // batch returns them keyed and sorted by id — a different order — so the
+        // preview receiving 3,4,2 is the evidence the mapping did not shift.
+        serve({ 1: 4, 2: 2, 3: 3 });
+        renderDialog([makeRun(3), makeRun(1), makeRun(2)]);
+        generate();
+
+        await waitUntil(() => byTestId('preview-stub'));
+        expect(byTestId('preview-stub').textContent).toBe('3,4,2');
+    });
+
+    it('exports a ride with no GPS as an empty track rather than failing', async () => {
+        serve({ 1: 4, 2: 0 });
+        renderDialog([makeRun(1), makeRun(2)]);
+        generate();
+
+        await waitUntil(() => byTestId('preview-stub'));
+        expect(byTestId('preview-stub').textContent).toBe('4,0');
+        expect(byTestId('export-stats-panel').textContent).toContain('4');
+    });
+
+    it('generates from an empty result when NO ride has coordinates (probe 404s)', async () => {
+        const uris = serve({ 1: 0, 2: 0 });
+        renderDialog([makeRun(1), makeRun(2)]);
+        generate();
+
+        await waitUntil(() => byTestId('preview-stub'));
+        expect(byTestId('preview-stub').textContent).toBe('0,0');
+        // The probe said there is nothing; no track read was issued.
+        expect(uris.filter(u => !u.includes('count(*)'))).toHaveLength(0);
+    });
+
+    it('surfaces a transport failure instead of exporting rides with no tracks', async () => {
+        // call_rest_api RETURNS {data: {}, httpStatus: 503} rather than throwing.
+        // Before req #3166's assertRows guard that `{}` would have flowed through
+        // as "no coordinates" and produced a silently empty KML.
+        serve({ 1: 4 }, { failReads: true });
+        renderDialog([makeRun(1)]);
+        generate();
+
+        await waitUntil(() => document.body.textContent.includes('did not return rows'));
+        expect(byTestId('export-stats-panel')).toBeNull();
+        // ...and the message names run counts, never the API URL.
+        expect(document.body.textContent).not.toContain(DARWIN_URI);
+    });
+});

--- a/src/hooks/__tests__/useMapCoordinatesForRuns.test.jsx
+++ b/src/hooks/__tests__/useMapCoordinatesForRuns.test.jsx
@@ -1,14 +1,25 @@
 // @vitest-environment jsdom
 //
-// Req #3158 — the aggregator card's coordinates hook. The review findings this
-// file pins down mechanically:
-//   • the per-run fetches are CAPPED at 15 in flight (exportService parity),
-//     never one unbounded burst per filtered ride;
-//   • every per-run result lands in useMapCoordinates' own cache entry
-//     (mapCoordinateKeys.byRun, identical fields+sort in the URI), which is
-//     the cache-sharing claim with RouteMapThumbnail;
-//   • a failed per-run fetch fails the aggregate loudly (isError), instead of
-//     quietly rendering fewer tracks than rides.
+// The /maps aggregator card's coordinates hook — req #3158, batched by req #3166.
+//
+// The pre-#3166 version of this file pinned a per-run fan-out capped at 15 in
+// flight. That cap is gone because the fan-out is: the hook now asks Lambda-Rest
+// for many runs per request via the `?map_run_fk=(1,2,3)` IN filter
+// (services/mapCoordinatesBatch.js). What survives unchanged, and is re-asserted
+// here against the new shape:
+//   • every fetched run still lands in useMapCoordinates' own cache entry
+//     (mapCoordinateKeys.byRun), in the same row shape — the cache-sharing claim
+//     with RouteMapThumbnail, which the batched read has to actively preserve
+//     since a batch response maps to no single per-run key;
+//   • a run ALREADY in that cache costs no request at all, which is the other
+//     half of the sharing;
+//   • a failed fetch fails the aggregate loudly (isError) rather than quietly
+//     rendering fewer tracks than rides;
+//   • the client-wide retry does not multiply into the inner fetches;
+//   • a filter change keeps the previous tracks on screen.
+//
+// Unit coverage of the batching itself — row budgets, packing, URI grammar —
+// lives in services/__tests__/mapCoordinatesBatch.test.js.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import React from 'react';
@@ -62,6 +73,27 @@ const waitUntil = async (cond) => {
     throw new Error('timed out waiting for condition');
 };
 
+const idsIn = (uri) => uri.match(/map_run_fk=\(([^)]*)\)/)[1].split(',').map(Number);
+
+// Serves both the count probe and the batched track read from a
+// {runId: rowCount} description, mirroring what rest_get_table.py returns.
+const serveRuns = (rowsByRun, { failOn } = {}) => {
+    const uris = [];
+    mockFetchEntity = async (uri) => {
+        uris.push(uri);
+        if (failOn && failOn(uri)) throw new Error('boom');
+        const ids = idsIn(uri);
+        if (uri.includes('count(*)')) {
+            return ids.filter(id => (rowsByRun[id] || 0) > 0)
+                .map(id => ({ 'count(*)': rowsByRun[id], map_run_fk: id }));
+        }
+        return ids.flatMap(id => Array.from({ length: rowsByRun[id] || 0 }, () => ({
+            map_run_fk: id, latitude: '37.1', longitude: '-122.1', altitude: null,
+        })));
+    };
+    return uris;
+};
+
 beforeEach(() => {
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -76,48 +108,128 @@ afterEach(() => {
     client.clear();
 });
 
-describe('useMapCoordinatesForRuns (req #3158)', () => {
-    it('fetches one track per run with at most 15 requests in flight', async () => {
+describe('useMapCoordinatesForRuns (req #3158, batched by req #3166)', () => {
+    it('fetches 20 runs in two requests, not twenty', async () => {
         const runIds = Array.from({ length: 20 }, (_, i) => i + 1);
-        const uris = [];
-        let active = 0;
-        let maxActive = 0;
-        mockFetchEntity = async (uri) => {
-            uris.push(uri);
-            active += 1;
-            maxActive = Math.max(maxActive, active);
-            await new Promise(r => setTimeout(r, 5));
-            active -= 1;
-            return [{ latitude: '37.1', longitude: '-122.1' }];
-        };
+        const uris = serveRuns(Object.fromEntries(runIds.map(id => [id, 3])));
 
         renderProbe(runIds);
         await waitUntil(() => latest?.isSuccess);
 
-        expect(uris.length).toBe(20);
-        expect(maxActive).toBeLessThanOrEqual(15);
-        expect(latest.data.length).toBe(20);
-        expect(uris[0]).toContain('/map_coordinates?map_run_fk=');
-        expect(uris[0]).toContain('fields=latitude,longitude,altitude');
-        expect(uris[0]).toContain('sort=seq:asc');
+        expect(latest.data).toHaveLength(20);
+        expect(latest.data.every(track => track.length === 3)).toBe(true);
+        // One grouped-count probe + one batched read covering every run.
+        expect(uris).toHaveLength(2);
+        expect(uris[0]).toContain('fields=count(*),map_run_fk');
+        expect(idsIn(uris[1])).toEqual(runIds);
+        expect(uris[1]).toContain('&fields=map_run_fk,latitude,longitude,altitude');
+        expect(uris[1]).toContain('&sort=map_run_fk:asc,seq:asc');
     });
 
-    it('populates the per-run cache entries the thumbnails read', async () => {
-        const track = [{ latitude: '37.1', longitude: '-122.1' }];
-        mockFetchEntity = async () => track;
+    it('returns tracks in run-id order regardless of response order', async () => {
+        serveRuns({ 3: 1, 9: 2, 5: 3 });
+
+        renderProbe([9, 3, 5]);
+        await waitUntil(() => latest?.isSuccess);
+
+        // sorted ids are [3, 5, 9] -> lengths [1, 3, 2]
+        expect(latest.data.map(t => t.length)).toEqual([1, 3, 2]);
+    });
+
+    it('populates the per-run cache entries the thumbnails read, without map_run_fk', async () => {
+        serveRuns({ 7: 1, 8: 1 });
 
         renderProbe([7, 8]);
         await waitUntil(() => latest?.isSuccess);
 
-        expect(client.getQueryData(mapCoordinateKeys.byRun(7))).toEqual(track);
-        expect(client.getQueryData(mapCoordinateKeys.byRun(8))).toEqual(track);
+        const expected = [{ latitude: '37.1', longitude: '-122.1', altitude: null }];
+        expect(client.getQueryData(mapCoordinateKeys.byRun(7))).toEqual(expected);
+        expect(client.getQueryData(mapCoordinateKeys.byRun(8))).toEqual(expected);
     });
 
-    it('reports isError when any per-run fetch fails', async () => {
+    it('spends no request on a run a thumbnail already cached', async () => {
+        const cached = [{ latitude: '40.0', longitude: '-120.0', altitude: null }];
+        client.setQueryData(mapCoordinateKeys.byRun(7), cached);
+        const uris = serveRuns({ 7: 5, 8: 1 });
+
+        renderProbe([7, 8]);
+        await waitUntil(() => latest?.isSuccess);
+
+        expect(latest.data[0]).toBe(cached);
+        for (const uri of uris) expect(idsIn(uri)).toEqual([8]);
+    });
+
+    it('JOINS a thumbnail fetch already in flight instead of batching that run again', async () => {
+        // RouteCardView mounts MapAggregatorCard and the RouteCards in the same
+        // commit, so on a cold cache the thumbnails are mid-fetch when this hook
+        // runs. getQueryData cannot see that — it returns undefined for a query
+        // fetching for the first time, identical to an absent one — and treating
+        // it as absent fetches every visible run's rows TWICE.
+        let releaseThumb;
+        const thumbTrack = [{ latitude: '41.0', longitude: '-119.0', altitude: null }];
+        let thumbFetches = 0;
+
+        // Stand in for RouteMapThumbnail's own useMapCoordinates query on run 7.
+        client.fetchQuery({
+            queryKey: mapCoordinateKeys.byRun(7),
+            queryFn: () => new Promise(resolve => {
+                thumbFetches += 1;
+                releaseThumb = () => resolve(thumbTrack);
+            }),
+            staleTime: Infinity,
+        });
+
+        const uris = serveRuns({ 7: 500, 8: 1 });
+        renderProbe([7, 8]);
+        await act(async () => { await new Promise(r => setTimeout(r, 10)); });
+        releaseThumb();
+        await waitUntil(() => latest?.isSuccess);
+
+        expect(latest.data[0]).toEqual(thumbTrack);
+        expect(thumbFetches).toBe(1);
+        // Run 7 appears in NO batched request — only run 8 was ever asked for.
+        for (const uri of uris) expect(idsIn(uri)).toEqual([8]);
+    });
+
+    it('keeps batches that succeeded when a later one fails, so a retry is cheap', async () => {
+        // Without per-batch seeding, one rejection discards every completed
+        // batch and the client-wide retry: 2 re-reads the whole set three times.
+        client = new QueryClient({ defaultOptions: { queries: { retry: 1, retryDelay: 1 } } });
+        const runIds = Array.from({ length: 40 }, (_, i) => i + 1);
+        const rowsByRun = Object.fromEntries(runIds.map(id => [id, 15_000]));
+        const readIds = [];
         mockFetchEntity = async (uri) => {
-            if (uri.includes('map_run_fk=2')) throw new Error('boom');
-            return [{ latitude: '37.1', longitude: '-122.1' }];
+            const ids = idsIn(uri);
+            if (uri.includes('count(*)')) {
+                return ids.map(id => ({ 'count(*)': rowsByRun[id], map_run_fk: id }));
+            }
+            readIds.push(ids);
+            if (ids.includes(40)) throw new Error('boom');
+            return ids.flatMap(id => [{ map_run_fk: id, latitude: '37.1', longitude: '-122.1' }]);
         };
+
+        renderProbe(runIds);
+        await waitUntil(() => latest?.isError);
+
+        // Run 1 landed on the first attempt and was seeded, so the retry never
+        // asked for it again.
+        expect(readIds[0]).toContain(1);
+        expect(readIds.slice(1).flat()).not.toContain(1);
+        expect(client.getQueryData(mapCoordinateKeys.byRun(1))).toHaveLength(1);
+    });
+
+    it('gives a run with no coordinates an empty track rather than failing', async () => {
+        serveRuns({ 1: 2, 2: 0 });
+
+        renderProbe([1, 2]);
+        await waitUntil(() => latest?.isSuccess);
+
+        expect(latest.data[0]).toHaveLength(2);
+        expect(latest.data[1]).toEqual([]);
+    });
+
+    it('reports isError when a batched fetch fails', async () => {
+        serveRuns({ 1: 1, 2: 1, 3: 1 }, { failOn: (uri) => !uri.includes('count(*)') });
 
         renderProbe([1, 2, 3]);
         await waitUntil(() => latest?.isError);
@@ -126,41 +238,50 @@ describe('useMapCoordinatesForRuns (req #3158)', () => {
         expect(latest.data).toBeUndefined();
     });
 
-    it('does not multiply the client-wide retry into the per-run fetches', async () => {
-        // Production defaults: retry 2 on the client. Without retry: false on
-        // the inner fetchQuery, a persistently failing run costs 3 inner × 3
-        // outer = 9 requests before isError. With it: one per outer attempt.
+    it('does not multiply the client-wide retry into the inner fetches', async () => {
+        // Production defaults: retry 2 on the client. The inner reads are plain
+        // fetchEntity calls with no query of their own, so a persistently
+        // failing read costs exactly one request per outer attempt — 3, never 9.
         client = new QueryClient({ defaultOptions: { queries: { retry: 2, retryDelay: 1 } } });
-        let failingCalls = 0;
-        mockFetchEntity = async (uri) => {
-            if (uri.includes('map_run_fk=2')) { failingCalls += 1; throw new Error('boom'); }
-            return [{ latitude: '37.1', longitude: '-122.1' }];
-        };
+        let readAttempts = 0;
+        serveRuns({ 1: 1, 2: 1 }, {
+            failOn: (uri) => {
+                if (uri.includes('count(*)')) return false;
+                readAttempts += 1;
+                return true;
+            },
+        });
 
-        renderProbe([1, 2, 3]);
+        renderProbe([1, 2]);
         await waitUntil(() => latest?.isError);
 
-        expect(failingCalls).toBe(3);
+        expect(readAttempts).toBe(3);
     });
 
     it('keeps the previous tracks on screen while a new run set loads', async () => {
-        mockFetchEntity = async () => [{ latitude: '37.1', longitude: '-122.1' }];
+        serveRuns({ 1: 1, 2: 1 });
 
         renderProbe([1, 2]);
         await waitUntil(() => latest?.isSuccess);
         expect(latest.data).toHaveLength(2);
 
+        // Run 3 is the only uncached id, so exactly one probe + one read remain
+        // outstanding while the placeholder holds.
         let release;
-        mockFetchEntity = () => new Promise(resolve => {
-            release = () => resolve([{ latitude: '38.1', longitude: '-121.1' }]);
-        });
+        const pending = new Promise(resolve => { release = resolve; });
+        mockFetchEntity = async (uri) => {
+            await pending;
+            const ids = idsIn(uri);
+            if (uri.includes('count(*)')) return ids.map(id => ({ 'count(*)': 1, map_run_fk: id }));
+            return ids.map(id => ({ map_run_fk: id, latitude: '38.1', longitude: '-121.1' }));
+        };
         renderProbe([1, 2, 3]);
 
-        // New key, fetch in flight — previous data still served as placeholder.
         expect(latest.isPlaceholderData).toBe(true);
         expect(latest.data).toHaveLength(2);
 
-        await waitUntil(() => { release?.(); return latest?.data?.length === 3; });
+        release();
+        await waitUntil(() => latest?.data?.length === 3);
         expect(latest.isPlaceholderData).toBe(false);
     });
 

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -7,6 +7,8 @@ import { devServers, sessions, swarmStarts, swarmStartSessions, swarmUndos, swar
 // `fetchEntity` is shared with the factory so both layers handle REST errors
 // identically (req #2593).
 import { fetchEntity } from './factory/createEntityQueries';
+// req #3166 — THE batched GET /map_coordinates, shared with the export paths.
+import { fetchCoordinatesForRuns, buildRunTrackUri, COORD_TRACK_FIELDS } from '../services/mapCoordinatesBatch';
 // req #3180 — THE browser's one derivation of pipeline-step membership.
 import { pipelinedRequirementIds } from '../utils/pipelineMembership';
 
@@ -409,66 +411,112 @@ export function useMapRoutes(creatorFk, { fields = 'id,route_id,name', enabled =
     });
 }
 
-export function useMapCoordinates(runId, { fields = 'latitude,longitude,altitude', enabled = true } = {}) {
+// A finished ride's GPS track NEVER changes — the importer writes coordinates
+// once and nothing in Darwin edits them, which is why no invalidation site for
+// mapCoordinateKeys exists anywhere in src/. So the client-wide staleTime of 30 s
+// and refetchOnWindowFocus: true buy nothing here and cost a great deal: the
+// RouteCardView "All" page size mounts up to 300 RouteMapThumbnails, and every
+// one of them re-requested its whole track on each tab refocus and each remount
+// past the 30 s mark (req #3166 item 3). Infinity + no refocus refetch makes a
+// track load exactly once per cache lifetime, and matches what
+// useMapCoordinatesForRuns already did for the same rows.
+export function useMapCoordinates(runId, { fields = COORD_TRACK_FIELDS, enabled = true } = {}) {
     const { darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
 
-    const uri = `${darwinUri}/map_coordinates?map_run_fk=${runId}&fields=${fields}&sort=seq:asc`;
+    const uri = buildRunTrackUri(darwinUri, runId, fields);
     const queryKey = mapCoordinateKeys.byRun(runId);
 
     return useQuery({
         queryKey,
         queryFn: () => fetchEntity(uri, idToken),
         enabled: enabled && !!runId && !!idToken,
+        staleTime: Infinity,
+        refetchOnWindowFocus: false,
     });
 }
 
-// Same cap exportService.BATCH_SIZE applies to this exact endpoint — the only
-// other place that fetches coordinates for a whole run set.
-const COORD_FETCH_BATCH_SIZE = 15;
-
-// Combined tracks for a set of runs (req #3158 — the /maps aggregator card).
-// ONE aggregate query per distinct run-id set; inside it the per-run
-// GET /map_coordinates calls run in batches of 15, never as an unbounded
-// burst across the whole filtered table. Each per-run fetch goes through
-// queryClient.fetchQuery against useMapCoordinates' own cache entry
-// (mapCoordinateKeys.byRun, identical fields), so the card and the per-ride
-// thumbnails share one cached track per run, in both directions. A finished
-// ride's GPS track never changes (no invalidation site exists for
-// mapCoordinateKeys anywhere), hence staleTime: Infinity — no N-request
-// refetch burst on tab refocus or remount. Any failed per-run fetch fails the
-// whole aggregate loudly (isError) instead of quietly dropping tracks.
-// Deliberately takes no `fields` option: the cache sharing is only correct
-// while every writer of these entries requests the same row shape.
+// Combined tracks for a set of runs (req #3158 — the /maps aggregator card;
+// batched by req #3166).
+//
+// ONE aggregate query per distinct run-id set, and inside it a BATCHED read:
+// services/mapCoordinatesBatch.js asks Lambda-Rest for many runs per request via
+// the `?map_run_fk=(1,2,3)` IN filter, packed against a measured row budget. At
+// 200 runs that is ~3 requests where the per-run fan-out made 200 — the point of
+// req #3166 item 2.
+//
+// Cache sharing with the per-ride thumbnails survives the change and is the
+// reason for the shape here. Every run the batch fetches is written back into
+// mapCoordinateKeys.byRun, in the same row shape useMapCoordinates would have
+// stored (same `buildRunTrackUri` field list, `map_run_fk` stripped), so the card
+// and RouteMapThumbnail still share one cached track per run in both directions.
+// Deliberately takes no `fields` option: that sharing is only correct while every
+// writer of these entries requests the same row shape.
+//
+// THE SHARING HAS THREE CASES, NOT TWO, AND THE THIRD IS THE EXPENSIVE ONE TO
+// MISS. RouteCardView renders MapAggregatorCard and the RouteCards in the SAME
+// commit, so on a cold cache this hook runs while N RouteMapThumbnails are
+// already fetching those very runs. `getQueryData` returns undefined for a query
+// that is fetching for the first time — indistinguishable from an absent one — so
+// treating "no data" as "must batch" fetches every visible run's rows TWICE. At
+// the "All" page size (up to 300 runs, the case req #3166 item 3 names) that is
+// 100% duplication: fewer requests than the old fan-out, but more bytes and more
+// Lambda invocations than before the change. So an in-flight per-run query is
+// JOINED via ensureQueryData — no new request, and it settles into the same entry.
+//
+// staleTime: Infinity for the same immutability reason as useMapCoordinates
+// above. Any failed batch fails the whole aggregate loudly (isError) instead of
+// quietly rendering fewer tracks than rides.
 export function useMapCoordinatesForRuns(runIds = [], { enabled = true } = {}) {
     const { darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
     const queryClient = useQueryClient();
 
-    const sortedIds = [...runIds].sort((a, b) => a - b);
+    const sortedIds = [...runIds].map(Number).sort((a, b) => a - b);
     return useQuery({
         queryKey: ['map_coordinates', 'aggregate', sortedIds],
         queryFn: async () => {
-            const tracks = [];
-            for (let i = 0; i < sortedIds.length; i += COORD_FETCH_BATCH_SIZE) {
-                const batch = sortedIds.slice(i, i + COORD_FETCH_BATCH_SIZE);
-                const batchTracks = await Promise.all(batch.map(runId =>
-                    queryClient.fetchQuery({
-                        queryKey: mapCoordinateKeys.byRun(runId),
-                        queryFn: () => fetchEntity(`${darwinUri}/map_coordinates?map_run_fk=${runId}&fields=latitude,longitude,altitude&sort=seq:asc`, idToken),
-                        staleTime: Infinity,
-                        // The client-wide retry: 2 would apply INSIDE each run's
-                        // fetch too, multiplying with the aggregate query's own
-                        // retries (3 × 3 = 9 requests, ~12 s of spinner, for one
-                        // persistently failing run). The outer query already
-                        // retries, and its re-run only refetches the runs that
-                        // failed — everything else is served from cache.
-                        retry: false,
-                    })
-                ));
-                tracks.push(...batchTracks);
+            const byRun = new Map();
+            const missing = [];
+            const inFlight = [];
+            for (const runId of sortedIds) {
+                const state = queryClient.getQueryState(mapCoordinateKeys.byRun(runId));
+                if (state?.data) byRun.set(runId, state.data);
+                else if (state?.fetchStatus === 'fetching') inFlight.push(runId);
+                else missing.push(runId);
             }
-            return tracks;
+
+            // Joins the thumbnail's own in-flight promise; issues a request only
+            // if that query has since settled without data.
+            await Promise.all(inFlight.map(async (runId) => {
+                byRun.set(runId, await queryClient.ensureQueryData({
+                    queryKey: mapCoordinateKeys.byRun(runId),
+                    queryFn: () => fetchEntity(buildRunTrackUri(darwinUri, runId), idToken),
+                    staleTime: Infinity,
+                }));
+            }));
+
+            if (missing.length > 0) {
+                // fetchEntity directly rather than queryClient.fetchQuery: a
+                // batch response spans many runs, so it maps to no single per-run
+                // cache key. `onTracks` seeds each batch AS IT LANDS, so the
+                // client-wide retry: 2 re-reads only what never arrived — without
+                // it, one failed batch would discard every successful one and
+                // triple the whole transfer.
+                await fetchCoordinatesForRuns({
+                    fetchJson: uri => fetchEntity(uri, idToken),
+                    darwinUri,
+                    runIds: missing,
+                    onTracks: (tracks) => {
+                        for (const [runId, track] of tracks) {
+                            queryClient.setQueryData(mapCoordinateKeys.byRun(runId), track);
+                            byRun.set(runId, track);
+                        }
+                    },
+                });
+            }
+
+            return sortedIds.map(runId => byRun.get(runId) || []);
         },
         enabled: enabled && runIds.length > 0 && !!idToken,
         staleTime: Infinity,

--- a/src/services/__tests__/exportService.test.js
+++ b/src/services/__tests__/exportService.test.js
@@ -177,13 +177,23 @@ describe('fetchExportData', () => {
             expect(coordCalls).toHaveLength(0);
         });
 
-        it('fetches coordinates per-run when mapsGps is true', async () => {
+        // req #3166: coordinates come back BATCHED — one grouped-count probe
+        // sizes the reads, then many runs per read via the `?col=(1,2,3)` IN
+        // filter. The export's own row shape (which carries `seq`, unlike the
+        // aggregator's) is what these assertions protect.
+        it('fetches coordinates in ONE batched read when mapsGps is true', async () => {
+            const RUNS = [10, 11].map(id => ({ id, run_id: id, map_route_fk: null, activity_id: 4, activity_name: 'Ride', start_time: '2026-01-01', run_time_sec: 3600, stopped_time_sec: 0, distance_mi: 10, ascent_ft: 100, descent_ft: 100, calories: 300, max_speed_mph: 20, avg_speed_mph: 10, notes: null, source: 'cyclemeter', create_ts: 't', update_ts: null }));
             mockApi({
                 '/map_routes': [],
-                '/map_runs': [{ id: 10, run_id: 1, map_route_fk: null, activity_id: 4, activity_name: 'Ride', start_time: '2026-01-01', run_time_sec: 3600, stopped_time_sec: 0, distance_mi: 10, ascent_ft: 100, descent_ft: 100, calories: 300, max_speed_mph: 20, avg_speed_mph: 10, notes: null, source: 'cyclemeter', create_ts: 't', update_ts: null }],
-                'map_coordinates?map_run_fk=10': [
+                '/map_runs': RUNS,
+                'fields=count(*),map_run_fk': [
+                    { 'count(*)': 2, map_run_fk: 10 },
+                    { 'count(*)': 1, map_run_fk: 11 },
+                ],
+                'map_coordinates?map_run_fk=(10,11)': [
                     { map_run_fk: 10, seq: 1, latitude: 37.123, longitude: -122.456, altitude: 100 },
                     { map_run_fk: 10, seq: 2, latitude: 37.124, longitude: -122.457, altitude: 101 },
+                    { map_run_fk: 11, seq: 1, latitude: 38.1, longitude: -121.4, altitude: 50 },
                 ],
                 '/map_views': [],
                 '/map_partners': [],
@@ -194,10 +204,44 @@ describe('fetchExportData', () => {
                 ...SELECTED, mapsGps: true,
             });
 
-            expect(result.unassignedRuns[0].coordinates).toHaveLength(2);
-            expect(result.unassignedRuns[0].coordinates[0]).toEqual({
+            const byId = new Map(result.unassignedRuns.map(r => [r.id, r]));
+            expect(byId.get(10).coordinates).toHaveLength(2);
+            expect(byId.get(10).coordinates[0]).toEqual({
                 seq: 1, latitude: 37.123, longitude: -122.456, altitude: 100,
             });
+            expect(byId.get(11).coordinates).toHaveLength(1);
+
+            // Two runs, two coordinate requests total (probe + read) — not one
+            // per run, and never a whole-table fetch.
+            const coordCalls = call_rest_api.mock.calls
+                .map(c => c[0])
+                .filter(url => url.includes('map_coordinates'));
+            expect(coordCalls).toHaveLength(2);
+            expect(coordCalls[0]).toContain('fields=count(*),map_run_fk');
+            expect(coordCalls[1]).toContain('&fields=map_run_fk,seq,latitude,longitude,altitude');
+            expect(coordCalls[1]).toContain('&sort=map_run_fk:asc,seq:asc');
+        });
+
+        it('omits a run the batch reported no coordinates for', async () => {
+            mockApi({
+                '/map_routes': [],
+                '/map_runs': [{ id: 10, run_id: 1, map_route_fk: null, activity_id: 4, activity_name: 'Ride', start_time: '2026-01-01', run_time_sec: 3600, stopped_time_sec: 0, distance_mi: 10, ascent_ft: 100, descent_ft: 100, calories: 300, max_speed_mph: 20, avg_speed_mph: 10, notes: null, source: 'cyclemeter', create_ts: 't', update_ts: null }],
+                '/map_views': [],
+                '/map_partners': [],
+                '/map_run_partners': [],
+            });   // the count probe 404s -> no coordinates anywhere
+
+            const result = await fetchExportData(DARWIN_URI, 'user-123', ID_TOKEN, PROFILE, {
+                ...SELECTED, mapsGps: true,
+            });
+
+            expect(result.unassignedRuns[0].coordinates).toBeUndefined();
+            // The probe answered "nothing here", so no track read was issued.
+            const coordCalls = call_rest_api.mock.calls
+                .map(c => c[0])
+                .filter(url => url.includes('map_coordinates'));
+            expect(coordCalls).toHaveLength(1);
+            expect(coordCalls[0]).toContain('fields=count(*),map_run_fk');
         });
 
         it('exports map views, partners, and run_partners', async () => {

--- a/src/services/__tests__/mapCoordinatesBatch.test.js
+++ b/src/services/__tests__/mapCoordinatesBatch.test.js
@@ -1,0 +1,357 @@
+// Req #3166 — the batched GET /map_coordinates.
+//
+// What this file pins down, in the order the module does it:
+//   • the URIs are the ones Lambda-Rest's generic GET actually understands —
+//     `?col=(1,2,3)` for the IN filter, `map_run_fk` projected so the flat
+//     response can be split back, and a TWO-column sort because `seq:asc` alone
+//     interleaves runs;
+//   • batches are packed against MEASURED row counts, so response size stays
+//     under Lambda's 6 MB ceiling no matter which rides the user filtered to —
+//     the one real hazard batching introduces (req #3078);
+//   • a run with no coordinates costs no request and still gets an entry;
+//   • a failure anywhere propagates, so a caller never silently renders fewer
+//     tracks than runs.
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+    COORD_ID_BUDGET,
+    COORD_REQUEST_CONCURRENCY,
+    COORD_ROW_BUDGET,
+    buildCountUri,
+    buildRunTrackUri,
+    buildTrackUri,
+    chunkList,
+    fetchCoordinatesForRuns,
+    groupTracksByRun,
+    packRunsByRowBudget,
+    parseRowCounts,
+} from '../mapCoordinatesBatch';
+
+const DARWIN_URI = 'https://api.example.com/darwin_dev';
+
+const countsOf = (entries) => new Map(entries);
+
+describe('URI construction', () => {
+    it('asks for many runs in one request using the IN-filter grammar', () => {
+        expect(buildCountUri(DARWIN_URI, [4, 5, 6])).toBe(
+            `${DARWIN_URI}/map_coordinates?map_run_fk=(4,5,6)&fields=count(*),map_run_fk`
+        );
+    });
+
+    it('projects map_run_fk and sorts by run THEN seq', () => {
+        const uri = buildTrackUri(DARWIN_URI, [4, 5]);
+        expect(uri).toBe(
+            `${DARWIN_URI}/map_coordinates?map_run_fk=(4,5)`
+            + '&fields=map_run_fk,latitude,longitude,altitude'
+            + '&sort=map_run_fk:asc,seq:asc'
+        );
+    });
+
+    it('carries a caller-specific field list (the export path needs seq)', () => {
+        expect(buildTrackUri(DARWIN_URI, [4], 'seq,latitude,longitude,altitude'))
+            .toContain('&fields=map_run_fk,seq,latitude,longitude,altitude');
+    });
+
+    it('builds the SINGLE-run read useMapCoordinates uses, so the two cannot drift', () => {
+        // Both writers of a mapCoordinateKeys.byRun entry come through here.
+        expect(buildRunTrackUri(DARWIN_URI, 4)).toBe(
+            `${DARWIN_URI}/map_coordinates?map_run_fk=4`
+            + '&fields=latitude,longitude,altitude&sort=seq:asc'
+        );
+        // ...and the batched projection is the same list plus the discriminator,
+        // which groupTracksByRun strips.
+        expect(buildTrackUri(DARWIN_URI, [4]))
+            .toContain('fields=map_run_fk,latitude,longitude,altitude');
+    });
+});
+
+describe('parseRowCounts', () => {
+    it('reads the grouped-count shape, parentheses and all', () => {
+        const counts = parseRowCounts([
+            { 'count(*)': 1202, map_run_fk: 36642 },
+            { 'count(*)': 287, map_run_fk: 36643 },
+        ]);
+        expect(counts.get(36642)).toBe(1202);
+        expect(counts.get(36643)).toBe(287);
+    });
+
+    it('survives a 404-mapped empty response', () => {
+        expect(parseRowCounts([]).size).toBe(0);
+        expect(parseRowCounts(undefined).size).toBe(0);
+    });
+});
+
+describe('packRunsByRowBudget', () => {
+    it('fills a batch up to the row budget and then starts another', () => {
+        const counts = countsOf([[1, 600], [2, 600], [3, 600], [4, 600]]);
+        expect(packRunsByRowBudget([1, 2, 3, 4], counts, { rowBudget: 1200 }))
+            .toEqual([[1, 2], [3, 4]]);
+    });
+
+    it('never lets one batch exceed the budget when it can be split', () => {
+        const counts = countsOf([[1, 900], [2, 900], [3, 900]]);
+        const batches = packRunsByRowBudget([1, 2, 3], counts, { rowBudget: 1000 });
+        expect(batches).toEqual([[1], [2], [3]]);
+    });
+
+    it('gives a run bigger than the whole budget its own request rather than dropping it', () => {
+        // No LIMIT/OFFSET exists in this API (req #3078), so one oversized run
+        // cannot be split. Alone in a batch it is exactly the request the
+        // per-run code already made — never worse than the status quo.
+        const counts = countsOf([[1, 50_000], [2, 600]]);
+        expect(packRunsByRowBudget([1, 2], counts, { rowBudget: 20_000 }))
+            .toEqual([[1], [2]]);
+    });
+
+    it('caps ids per request independently of the row budget', () => {
+        const ids = Array.from({ length: 5 }, (_, i) => i + 1);
+        const counts = countsOf(ids.map(id => [id, 1]));
+        expect(packRunsByRowBudget(ids, counts, { rowBudget: 1_000_000, idBudget: 2 }))
+            .toEqual([[1, 2], [3, 4], [5]]);
+    });
+
+    it('spends no request on a run the probe reported zero rows for', () => {
+        const counts = countsOf([[1, 600], [3, 600]]);   // run 2 has no coordinates
+        expect(packRunsByRowBudget([1, 2, 3], counts, { rowBudget: 20_000 }))
+            .toEqual([[1, 3]]);
+    });
+
+    it('produces no batches at all when nothing has coordinates', () => {
+        expect(packRunsByRowBudget([1, 2], new Map(), {})).toEqual([]);
+    });
+});
+
+describe('groupTracksByRun', () => {
+    it('splits a flat response per run and drops the discriminator', () => {
+        const tracks = groupTracksByRun([
+            { map_run_fk: 1, latitude: 37.1, longitude: -122.1, altitude: null },
+            { map_run_fk: 1, latitude: 37.2, longitude: -122.2, altitude: null },
+            { map_run_fk: 2, latitude: 38.1, longitude: -121.1, altitude: 10 },
+        ]);
+        // map_run_fk MUST be gone: these rows are written into the
+        // mapCoordinateKeys.byRun entries RouteMapThumbnail reads, so they have
+        // to match what the per-run read returns key for key.
+        expect(tracks.get(1)).toEqual([
+            { latitude: 37.1, longitude: -122.1, altitude: null },
+            { latitude: 37.2, longitude: -122.2, altitude: null },
+        ]);
+        expect(tracks.get(2)).toEqual([{ latitude: 38.1, longitude: -121.1, altitude: 10 }]);
+    });
+
+    it('preserves the order the response arrived in (seq order per run)', () => {
+        const rows = Array.from({ length: 5 }, (_, i) => ({ map_run_fk: 9, latitude: i }));
+        expect(groupTracksByRun(rows).get(9).map(r => r.latitude)).toEqual([0, 1, 2, 3, 4]);
+    });
+});
+
+describe('chunkList', () => {
+    it('splits evenly and keeps the remainder', () => {
+        expect(chunkList([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+        expect(chunkList([], 2)).toEqual([]);
+    });
+});
+
+describe('fetchCoordinatesForRuns', () => {
+    // A fetchJson that answers both the probe and the track read from a
+    // {runId: rowCount} description, and records every URI it was asked for.
+    const makeFetch = (rowsByRun, { failOn } = {}) => {
+        const uris = [];
+        const fetchJson = vi.fn(async (uri) => {
+            uris.push(uri);
+            if (failOn && failOn(uri)) throw new Error('boom');
+            const ids = uri.match(/map_run_fk=\(([^)]*)\)/)[1].split(',').map(Number);
+            if (uri.includes('count(*)')) {
+                return ids
+                    .filter(id => (rowsByRun[id] || 0) > 0)
+                    .map(id => ({ 'count(*)': rowsByRun[id], map_run_fk: id }));
+            }
+            return ids.flatMap(id => Array.from({ length: rowsByRun[id] || 0 }, (_, i) => ({
+                map_run_fk: id, latitude: id + i / 1000, longitude: -122, altitude: null,
+            })));
+        });
+        return { fetchJson, uris };
+    };
+
+    it('collapses 200 per-run requests into a probe plus a handful of batches', async () => {
+        // The production shape: 200 runs at the measured 600-row average.
+        const runIds = Array.from({ length: 200 }, (_, i) => i + 1);
+        const rowsByRun = Object.fromEntries(runIds.map(id => [id, 600]));
+        const { fetchJson, uris } = makeFetch(rowsByRun);
+
+        const tracks = await fetchCoordinatesForRuns({ fetchJson, darwinUri: DARWIN_URI, runIds });
+
+        expect(tracks.size).toBe(200);
+        expect(tracks.get(1)).toHaveLength(600);
+        expect(tracks.get(200)).toHaveLength(600);
+
+        const probes = uris.filter(u => u.includes('count(*)'));
+        const reads = uris.filter(u => !u.includes('count(*)'));
+        // 200 ids / 150 per URL = 2 probes. Reads: packing is GREEDY, so a batch
+        // takes 33 runs (33 x 600 = 19,800; a 34th would overrun 20,000) and 200
+        // runs need 7 — one more than the 6 perfect packing would give. Greedy
+        // is the right trade: it is single-pass and keeps batches contiguous in
+        // id order, and the extra request is one in seven against a saving of
+        // 200 to 9.
+        expect(probes).toHaveLength(Math.ceil(200 / COORD_ID_BUDGET));
+        expect(reads).toHaveLength(7);
+        expect(uris.length).toBe(9);
+    });
+
+    it('keeps every batch under the row budget', async () => {
+        const runIds = Array.from({ length: 40 }, (_, i) => i + 1);
+        // Wildly uneven, the way real rides are: a few long tours among short rides.
+        const rowsByRun = Object.fromEntries(runIds.map(id => [id, id % 10 === 0 ? 9000 : 400]));
+        const { fetchJson, uris } = makeFetch(rowsByRun);
+
+        await fetchCoordinatesForRuns({ fetchJson, darwinUri: DARWIN_URI, runIds });
+
+        for (const uri of uris.filter(u => !u.includes('count(*)'))) {
+            const ids = uri.match(/map_run_fk=\(([^)]*)\)/)[1].split(',').map(Number);
+            const rows = ids.reduce((sum, id) => sum + rowsByRun[id], 0);
+            // Single-run batches are the documented escape; multi-run ones are bound.
+            if (ids.length > 1) expect(rows).toBeLessThanOrEqual(COORD_ROW_BUDGET);
+        }
+    });
+
+    it('returns an empty track for a run with no coordinates, and asks for it once', async () => {
+        const { fetchJson, uris } = makeFetch({ 1: 600, 2: 0, 3: 600 });
+
+        const tracks = await fetchCoordinatesForRuns({
+            fetchJson, darwinUri: DARWIN_URI, runIds: [1, 2, 3],
+        });
+
+        expect(tracks.get(2)).toEqual([]);
+        expect(tracks.get(1)).toHaveLength(600);
+        // Run 2 appears in the probe (it has to, to be counted) but in no read.
+        const reads = uris.filter(u => !u.includes('count(*)'));
+        expect(reads).toHaveLength(1);
+        expect(reads[0]).toContain('map_run_fk=(1,3)');
+    });
+
+    it('makes no request at all when nothing has coordinates', async () => {
+        const { fetchJson, uris } = makeFetch({ 1: 0, 2: 0 });
+
+        const tracks = await fetchCoordinatesForRuns({
+            fetchJson, darwinUri: DARWIN_URI, runIds: [1, 2],
+        });
+
+        expect(tracks.get(1)).toEqual([]);
+        expect(tracks.get(2)).toEqual([]);
+        expect(uris.filter(u => !u.includes('count(*)'))).toHaveLength(0);
+    });
+
+    it('makes no request at all for an empty run set', async () => {
+        const { fetchJson } = makeFetch({});
+        const tracks = await fetchCoordinatesForRuns({
+            fetchJson, darwinUri: DARWIN_URI, runIds: [],
+        });
+        expect(tracks.size).toBe(0);
+        expect(fetchJson).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates and orders run ids', async () => {
+        const { fetchJson, uris } = makeFetch({ 5: 10, 7: 10 });
+        await fetchCoordinatesForRuns({ fetchJson, darwinUri: DARWIN_URI, runIds: [7, 5, 7] });
+        expect(uris[0]).toContain('map_run_fk=(5,7)');
+    });
+
+    it('propagates a failed batch instead of returning fewer tracks than runs', async () => {
+        const { fetchJson } = makeFetch(
+            { 1: 600, 2: 600 },
+            { failOn: (uri) => !uri.includes('count(*)') },
+        );
+        await expect(fetchCoordinatesForRuns({
+            fetchJson, darwinUri: DARWIN_URI, runIds: [1, 2],
+        })).rejects.toThrow('boom');
+    });
+
+    it('fails loudly when a caller resolves a non-array (call_rest_api 503 shape)', async () => {
+        // call_rest_api RETURNS {data: {}, httpStatus: 503} on a transport
+        // failure instead of throwing, and the export wrappers forward
+        // `result.data`. Silently treating that as "no coordinates" would export
+        // a ride with no track and say nothing.
+        const fetchJson = async () => ({});
+        await expect(fetchCoordinatesForRuns({
+            fetchJson, darwinUri: DARWIN_URI, runIds: [1],
+        })).rejects.toThrow(/did not return rows/);
+    });
+
+    it('propagates a failed probe rather than reading an unbounded batch', async () => {
+        const { fetchJson } = makeFetch(
+            { 1: 600 },
+            { failOn: (uri) => uri.includes('count(*)') },
+        );
+        await expect(fetchCoordinatesForRuns({
+            fetchJson, darwinUri: DARWIN_URI, runIds: [1],
+        })).rejects.toThrow('boom');
+    });
+
+    it('holds concurrency down at its DEFAULT — one request is one Lambda invocation and one DB connection', async () => {
+        // Asserted against COORD_REQUEST_CONCURRENCY rather than an explicit
+        // argument: passing `concurrency: 4` here would let the exported default
+        // drift to any value with this test still green.
+        const runIds = Array.from({ length: 60 }, (_, i) => i + 1);
+        const rowsByRun = Object.fromEntries(runIds.map(id => [id, COORD_ROW_BUDGET]));
+        let active = 0;
+        let maxActive = 0;
+        const fetchJson = async (uri) => {
+            active += 1;
+            maxActive = Math.max(maxActive, active);
+            await new Promise(r => setTimeout(r, 1));
+            active -= 1;
+            const ids = uri.match(/map_run_fk=\(([^)]*)\)/)[1].split(',').map(Number);
+            if (uri.includes('count(*)')) {
+                return ids.map(id => ({ 'count(*)': rowsByRun[id], map_run_fk: id }));
+            }
+            return ids.map(id => ({ map_run_fk: id, latitude: 1, longitude: 2, altitude: null }));
+        };
+
+        await fetchCoordinatesForRuns({ fetchJson, darwinUri: DARWIN_URI, runIds });
+
+        expect(COORD_REQUEST_CONCURRENCY).toBeLessThanOrEqual(8);
+        expect(maxActive).toBeGreaterThan(1);
+        expect(maxActive).toBeLessThanOrEqual(COORD_REQUEST_CONCURRENCY);
+    });
+
+    it('hands each batch over AS IT LANDS, so a later failure cannot discard it', async () => {
+        // The per-run fan-out this replaced was incrementally durable for free.
+        // Without onTracks firing per batch, one rejection throws away every
+        // completed batch and the client-wide retry: 2 re-reads everything 3x.
+        const runIds = Array.from({ length: 40 }, (_, i) => i + 1);
+        const rowsByRun = Object.fromEntries(runIds.map(id => [id, 15_000]));
+        const delivered = new Set();
+        const { fetchJson } = makeFetch(rowsByRun, {
+            // Fail only the batch containing the very last run.
+            failOn: (uri) => !uri.includes('count(*)')
+                && uri.match(/map_run_fk=\(([^)]*)\)/)[1].split(',').map(Number).includes(40),
+        });
+
+        await expect(fetchCoordinatesForRuns({
+            fetchJson,
+            darwinUri: DARWIN_URI,
+            runIds,
+            concurrency: 1,
+            onTracks: (tracks) => { for (const id of tracks.keys()) delivered.add(id); },
+        })).rejects.toThrow('boom');
+
+        // Everything before the failing batch survived the rejection.
+        expect(delivered.size).toBeGreaterThan(0);
+        expect(delivered.has(1)).toBe(true);
+        expect(delivered.has(40)).toBe(false);
+    });
+
+    it('settles zero-coordinate runs through onTracks too, so a retry never re-probes them', async () => {
+        const delivered = new Map();
+        const { fetchJson } = makeFetch({ 1: 600, 2: 0 });
+
+        await fetchCoordinatesForRuns({
+            fetchJson,
+            darwinUri: DARWIN_URI,
+            runIds: [1, 2],
+            onTracks: (tracks) => { for (const [id, t] of tracks) delivered.set(id, t); },
+        });
+
+        expect(delivered.get(2)).toEqual([]);
+        expect(delivered.get(1)).toHaveLength(600);
+    });
+});

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -1,4 +1,6 @@
 import call_rest_api from '../RestApi/RestApi';
+// req #3166 — THE batched GET /map_coordinates, shared with the aggregator hook.
+import { fetchCoordinatesForRuns } from './mapCoordinatesBatch';
 
 /**
  * Fetch all user data for selected apps and assemble into nested hierarchy.
@@ -117,29 +119,36 @@ export async function fetchExportData(darwinUri, userName, idToken, profile, sel
             safeGet(`${darwinUri}/map_run_partners`),
         ]);
 
-        // GPS coordinates: fetched per-run when mapsGps is selected.
-        // Bulk fetch of all coordinates exceeds Lambda timeout (100k+ rows).
+        // GPS coordinates when mapsGps is selected. Fetching the whole table in
+        // one request exceeds the Lambda timeout AND its 6 MB response ceiling
+        // (1.5M rows in production), so the read is BATCHED — many runs per
+        // request, packed under a measured row budget by
+        // services/mapCoordinatesBatch.js (req #3166). That replaced a 15-wide
+        // per-run fan-out: at production scale (2,547 runs, ~1.53M rows) an
+        // export of every ride goes from ~2,547 requests to ~104 — 87 batched
+        // reads plus 17 count probes.
+        //
+        // `seq` is in the projection here and not in the aggregator's, because
+        // the export FILE carries it; the batch helper takes the field list so
+        // both callers keep their own row shape, and the shared row budget still
+        // covers the extra column (~2.3 MB per request against a 6 MB ceiling).
         const coordsByRun = {};
         if (selectedApps.mapsGps && runs.length > 0) {
-            const BATCH_SIZE = 15;
-            for (let i = 0; i < runs.length; i += BATCH_SIZE) {
-                const batch = runs.slice(i, i + BATCH_SIZE);
-                const results = await Promise.all(
-                    batch.map(run =>
-                        safeGet(`${darwinUri}/map_coordinates?map_run_fk=${run.id}&sort=seq:asc`)
-                    )
-                );
-                batch.forEach((run, idx) => {
-                    const coords = results[idx];
-                    if (coords.length > 0) {
-                        coordsByRun[run.id] = coords.map(c => ({
-                            seq: c.seq,
-                            latitude: c.latitude,
-                            longitude: c.longitude,
-                            altitude: c.altitude,
-                        }));
-                    }
-                });
+            const tracks = await fetchCoordinatesForRuns({
+                fetchJson: safeGet,
+                darwinUri,
+                runIds: runs.map(run => run.id),
+                fields: 'seq,latitude,longitude,altitude',
+            });
+            for (const [runId, coords] of tracks) {
+                if (coords.length > 0) {
+                    coordsByRun[runId] = coords.map(c => ({
+                        seq: c.seq,
+                        latitude: c.latitude,
+                        longitude: c.longitude,
+                        altitude: c.altitude,
+                    }));
+                }
             }
         }
 

--- a/src/services/mapCoordinatesBatch.js
+++ b/src/services/mapCoordinatesBatch.js
@@ -1,0 +1,281 @@
+// Batched GET /map_coordinates — req #3166.
+//
+// THE PREMISE THE REQUIREMENT WAS WRITTEN ON IS FALSE, AND IT MAKES THIS EASIER.
+// #3166 says "no IN-filter in Lambda-Rest generic GET, so the aggregator fetches
+// per run". `rest_get_table.py` has supported `?col=(1,2,3)` -> `col IN (...)`
+// all along, parameterized, and two production call sites already use it
+// (BuildVisualizer/useBuildVisualizerData.js,
+// SwarmView/detail/useEpicPipelineLocation.js). Nothing had to change in
+// Lambda-Rest; only a client that knows how to ASK for N runs at once, which is
+// this module.
+//
+// WHY A ROW BUDGET AND NOT A RUN COUNT — the one real hazard here.
+// Batching trades request count for response size, and response size is the
+// documented cliff on this stack: Lambda caps a synchronous response at 6 MB
+// (memory/lambda-patterns.md, req #3078), above which the caller sees a 502 with
+// no useful diagnosis. Coordinate rows per run are NOT uniform, so "N runs per
+// request" has an unbounded worst case that depends entirely on which rides the
+// user filtered to. Measured on production 2026-08-03: 1,528,251 rows over 2,547
+// runs — 600.0 average, but 4,370 in the largest single run, a 7x spread, and a
+// longer tour imported tomorrow widens it further.
+//
+// So a batch is packed against a MEASURED row count, obtained from one grouped-
+// count probe, and never against a guess about run size. That makes the response
+// ceiling a property of this module rather than of the user's filter.
+//
+// COST, counted rather than estimated (and asserted in this module's tests).
+// At 200 runs of the production-average 600 rows the aggregator goes from 200
+// requests to 9 — 7 track reads plus 2 count probes. Packing is greedy, so a
+// batch takes 33 runs (a 34th would overrun the budget) and 200 runs need 7
+// reads where perfect packing would need 6; the probe count is 200 ids over
+// COORD_ID_BUDGET. A whole-library export (2,547 runs, ~1.53M rows) is ~87 reads
+// + 17 probes = ~104 requests. Against the requirement's ~13x estimate that is
+// ~22x for the aggregator.
+
+// Rows in ONE batched response. At the 92 bytes/row measured against production
+// data (`JSON_OBJECT` of map_run_fk + latitude + longitude + altitude, the exact
+// payload rest_get_table.py emits) this is ~1.8 MB — a 3x margin under Lambda's
+// 6 MB ceiling, which is deliberate: the margin absorbs both a future column and
+// a run whose altitude values are all non-null. The export path passes a FIFTH
+// column (`seq`), which the same budget still covers at ~2.3 MB. Raising this
+// trades that margin for a request count that is already negligible.
+//
+// TWO THINGS THIS BUDGET SILENTLY DEPENDS ON, both worth knowing before moving it:
+//   • `group_concat_max_len` on RDS parameter group `mysql84-darwin` is 10 MB.
+//     MySQL's DEFAULT is 1024 bytes and overflow is TRUNCATED TO A WARNING, not
+//     an error — which would hand the client a short, invalid-JSON array. The
+//     batch raises the per-request GROUP_CONCAT payload ~33x (55 KB -> 1.8 MB),
+//     so this stopped being a theoretical dependency. Asserted by
+//     Lambda-Rest/tests/test_map_coordinates_batched_read.py.
+//   • A single run larger than the budget gets its own request and OVERRUNS it
+//     (see packRunsByRowBudget). That is bounded only by the largest run in the
+//     data: at the measured 4,370-row maximum it is ~400 KB, but a ~60,000-row
+//     import would reach the 6 MB ceiling and 502. Splitting a run needs
+//     LIMIT/OFFSET, which this API does not have (req #3078).
+export const COORD_ROW_BUDGET = 20_000;
+
+// Run ids in ONE URL, for both the probe and the track read. 150 ids is ~900
+// characters of query string, far inside API Gateway's 8 KB request-line limit,
+// and it bounds the `IN (...)` list MySQL has to plan.
+export const COORD_ID_BUDGET = 150;
+
+// Batched reads in flight at once. Each one is now heavy (up to COORD_ROW_BUDGET
+// rows) and each is one Lambda invocation holding one fresh RDS connection, so
+// this stays well below the per-run fan-out's old cap of 15.
+export const COORD_REQUEST_CONCURRENCY = 4;
+
+// The row shape every coordinate consumer shares. Cache entries under
+// mapCoordinateKeys.byRun are only interchangeable while every writer asks for
+// the same fields, so the aggregator and RouteMapThumbnail both use this.
+export const COORD_TRACK_FIELDS = 'latitude,longitude,altitude';
+
+export function chunkList(items, size) {
+    const out = [];
+    for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+    return out;
+}
+
+// One grouped count per run. Returns 404 (-> []) when NO run in the list has a
+// single coordinate, which is a real case — a manually entered ride carries no
+// GPS at all — and is why the caller must tolerate a missing entry rather than
+// treat it as an error.
+export function buildCountUri(darwinUri, runIds) {
+    return `${darwinUri}/map_coordinates?map_run_fk=(${runIds.join(',')})&fields=count(*),map_run_fk`;
+}
+
+// `map_run_fk` is projected so the flat response can be split back per run, and
+// the sort is TWO columns because one is not enough: `seq:asc` alone would
+// interleave runs, and the split would then have to re-sort every track.
+// `map_run_fk:asc,seq:asc` makes each run's rows contiguous AND in recorded
+// order within each run — verified against darwin_dev.
+//
+// BOTH HALVES ARE LOAD-BEARING AND NEITHER IS FREE. `rest_get_table.py` places
+// `sort=` INSIDE the `GROUP_CONCAT`, where MySQL sorts with its own tree and
+// never consults the access path — measured on production 2026-08-03, the plan
+// for the real statement reports `used_key_parts: ["map_run_fk"]`, `key_len 4`,
+// so `idx_map_coordinates_run_seq`'s second column is not used and the sort
+// happens regardless. Do NOT drop either sort key on the theory that the index
+// supplies the order: the batched plan drives from `map_runs` via
+// `uq_creator_run (creator_fk, run_id)`, so arrival order follows `run_id`, and
+// that agrees with `map_run_fk` only by coincidence in the current data.
+export function buildTrackUri(darwinUri, runIds, fields = COORD_TRACK_FIELDS) {
+    return `${darwinUri}/map_coordinates?map_run_fk=(${runIds.join(',')})`
+        + `&fields=map_run_fk,${fields}&sort=map_run_fk:asc,seq:asc`;
+}
+
+// The SINGLE-run read, shared with useMapCoordinates so the two writers of a
+// mapCoordinateKeys.byRun cache entry cannot drift apart in URI or row shape.
+export function buildRunTrackUri(darwinUri, runId, fields = COORD_TRACK_FIELDS) {
+    return `${darwinUri}/map_coordinates?map_run_fk=${runId}&fields=${fields}&sort=seq:asc`;
+}
+
+// Grouped-count rows arrive as {"count(*)": n, "map_run_fk": id}. The key really
+// does contain the parentheses — rest_get_table.py builds the JSON key from the
+// literal `fields=` token.
+export function parseRowCounts(countRows = []) {
+    const counts = new Map();
+    for (const row of countRows) {
+        const runId = Number(row?.map_run_fk);
+        const rows = Number(row?.['count(*)']);
+        if (Number.isFinite(runId) && Number.isFinite(rows)) counts.set(runId, rows);
+    }
+    return counts;
+}
+
+// Greedy pack, in id order so batches stay contiguous and readable in the network
+// panel. Two escapes from the budget, both deliberate:
+//   • a run the probe reported ZERO rows for (or did not report at all) is left
+//     out of every batch — there is nothing to fetch, and asking would spend a
+//     request to be told 404;
+//   • a run BIGGER than the whole budget gets a batch to itself and overruns it.
+//     Splitting one run across requests would need LIMIT/OFFSET, which this API
+//     does not have (req #3078), and a lone oversized run is exactly the request
+//     the per-run code already made — so this is never worse than the status quo.
+export function packRunsByRowBudget(runIds, rowCounts, {
+    rowBudget = COORD_ROW_BUDGET,
+    idBudget = COORD_ID_BUDGET,
+} = {}) {
+    const batches = [];
+    let current = [];
+    let currentRows = 0;
+
+    for (const runId of runIds) {
+        const rows = rowCounts.get(runId) || 0;
+        if (rows === 0) continue;
+        const wouldOverflow = current.length > 0
+            && (currentRows + rows > rowBudget || current.length >= idBudget);
+        if (wouldOverflow) {
+            batches.push(current);
+            current = [];
+            currentRows = 0;
+        }
+        current.push(runId);
+        currentRows += rows;
+    }
+    if (current.length > 0) batches.push(current);
+    return batches;
+}
+
+// Split a flat batched response back into one track per run, dropping the
+// `map_run_fk` discriminator. Dropping it is not cosmetic: these rows are written
+// straight into the mapCoordinateKeys.byRun cache entries that RouteMapThumbnail
+// and RouteDetailView read through useMapCoordinates, so they have to be
+// identical to what the per-run read returns, key for key.
+export function groupTracksByRun(rows = []) {
+    const tracks = new Map();
+    for (const row of rows) {
+        const runId = Number(row?.map_run_fk);
+        if (!Number.isFinite(runId)) continue;
+        const { map_run_fk, ...coordinate } = row;
+        if (!tracks.has(runId)) tracks.set(runId, []);
+        tracks.get(runId).push(coordinate);
+    }
+    return tracks;
+}
+
+// Every caller's `fetchJson` is supposed to resolve an array (404 -> []), but
+// two of the three do NOT throw on every non-2xx: `call_rest_api` RETURNS a
+// {data: {}, httpStatus: 503} object on a transport/CORS failure, and both
+// export wrappers pass `result.data || []` straight through — so a 503 arrives
+// here as `{}`, not as a rejection. Iterating that would be a TypeError deep in
+// parseRowCounts; treating it as empty would be worse, silently exporting a
+// ride with no track. Fail at the boundary.
+//
+// The message names the run ids and NOT the URI: ExportDialog surfaces
+// `err.message` straight into its on-screen error banner, and an API endpoint
+// with the caller's database in it does not belong there.
+function assertRows(rows, runIds, kind) {
+    if (!Array.isArray(rows)) {
+        throw new Error(
+            `map_coordinates ${kind} did not return rows for ${runIds.length} run(s)`
+        );
+    }
+    return rows;
+}
+
+// Run `tasks` with at most `limit` in flight, preserving result order.
+async function withConcurrency(tasks, limit) {
+    const results = new Array(tasks.length);
+    let next = 0;
+    const workers = Array.from({ length: Math.min(limit, tasks.length) }, async () => {
+        while (next < tasks.length) {
+            const index = next++;
+            results[index] = await tasks[index]();
+        }
+    });
+    await Promise.all(workers);
+    return results;
+}
+
+/**
+ * Coordinates for a set of runs, in as few requests as the row budget allows.
+ *
+ * Transport-agnostic on purpose: `fetchJson` is the caller's own GET, so the
+ * TanStack hook passes `fetchEntity`, the export service passes its `safeGet`,
+ * and the export dialog passes a `call_rest_api` wrapper — one batching
+ * implementation, three callers, no shared React or query-client dependency.
+ * `fetchJson` MUST resolve a 404 to `[]` (all three already do); anything else it
+ * rejects with propagates, so a failed batch fails the whole call LOUDLY rather
+ * than silently returning fewer tracks than runs.
+ *
+ * `onTracks` is called with each batch's runs AS THAT BATCH LANDS, before any
+ * later batch has been awaited, and it is what makes a retry cheap. The
+ * per-run fan-out this replaced was incrementally durable for free — each run
+ * seeded its own cache entry on success, so a retry re-fetched only the
+ * failures. A single `await` over every batch loses that: one rejection
+ * discards six successful batches, and the client-wide `retry: 2` then re-reads
+ * all 120,000 rows three times. Handing each batch over on arrival restores it.
+ *
+ * @returns {Promise<Map<number, object[]>>} an entry for EVERY requested run id,
+ *   including runs with no coordinates at all (empty array).
+ */
+export async function fetchCoordinatesForRuns({
+    fetchJson,
+    darwinUri,
+    runIds = [],
+    fields = COORD_TRACK_FIELDS,
+    rowBudget = COORD_ROW_BUDGET,
+    idBudget = COORD_ID_BUDGET,
+    concurrency = COORD_REQUEST_CONCURRENCY,
+    onTracks,
+}) {
+    const ids = [...new Set(runIds.map(Number).filter(Number.isFinite))].sort((a, b) => a - b);
+    const tracks = new Map(ids.map(id => [id, []]));
+    if (ids.length === 0) return tracks;
+
+    const deliver = (batchTracks) => {
+        for (const [runId, track] of batchTracks) {
+            if (tracks.has(runId)) tracks.set(runId, track);
+        }
+        if (onTracks) onTracks(batchTracks);
+    };
+
+    const countResponses = await withConcurrency(
+        chunkList(ids, idBudget).map(chunk => async () => assertRows(
+            await fetchJson(buildCountUri(darwinUri, chunk)), chunk, 'count probe',
+        )),
+        concurrency,
+    );
+    const rowCounts = parseRowCounts(countResponses.flat());
+
+    // A run the probe counted at zero is settled NOW: it needs no read, and
+    // handing it over here means a later batch failure cannot make a retry
+    // re-probe it either.
+    deliver(new Map(ids.filter(id => !rowCounts.get(id)).map(id => [id, []])));
+
+    await withConcurrency(
+        packRunsByRowBudget(ids, rowCounts, { rowBudget, idBudget }).map(batch => async () => {
+            const rows = assertRows(
+                await fetchJson(buildTrackUri(darwinUri, batch, fields)), batch, 'batched read',
+            );
+            const grouped = groupTracksByRun(rows);
+            // Keyed off the BATCH, not off the response: a run whose rows
+            // vanished between probe and read still gets a settled empty track
+            // rather than being left to look un-fetched.
+            deliver(new Map(batch.map(id => [id, grouped.get(id) || []])));
+        }),
+        concurrency,
+    );
+
+    return tracks;
+}

--- a/src/strava/StravaImport.jsx
+++ b/src/strava/StravaImport.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useContext, useCallback, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -95,6 +96,7 @@ const columns = [
 ];
 
 const StravaImport = () => {
+    const queryClient = useQueryClient();
     const { darwinUri } = useContext(AppContext);
     const { idToken } = useContext(AuthContext);
     const navigate = useNavigate();
@@ -426,6 +428,12 @@ const StravaImport = () => {
         } finally {
             setImporting(false);
             abortRef.current = null;
+            // req #3166: see CyclemeterImport for the full reasoning. A run row
+            // is POSTed before its coordinates, so an interrupted import can
+            // leave a half-written track in a cache that useMapCoordinates now
+            // holds with staleTime: Infinity. In `finally` so a cancel and a
+            // failure clear it too.
+            queryClient.invalidateQueries({ queryKey: ['map_coordinates'] });
         }
     };
 


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3166-map-coordinates-read-path-hardening-1
- wip(Darwin): 2026-08-03T18:03:25Z
- chore: init swarm session feature/3166-map-coordinates-read-path-hardening-1

## Files changed
```
 src/CyclemeterImport/CyclemeterImport.jsx          |  12 +
 src/MapExport/ExportDialog.jsx                     |  35 +-
 .../ExportDialog.batchedCoordinates.test.jsx       | 216 +++++++++++++
 .../__tests__/useMapCoordinatesForRuns.test.jsx    | 227 ++++++++++---
 src/hooks/useDataQueries.js                        | 126 +++++---
 src/services/__tests__/exportService.test.js       |  54 +++-
 src/services/__tests__/mapCoordinatesBatch.test.js | 357 +++++++++++++++++++++
 src/services/exportService.js                      |  51 +--
 src/services/mapCoordinatesBatch.js                | 281 ++++++++++++++++
 src/strava/StravaImport.jsx                        |   8 +
 10 files changed, 1238 insertions(+), 129 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)