### PR TITLE
Swarm Start table: token cost breakout + column cleanup

### DIFF
--- a/src/SwarmStarts/SwarmStartsPage.jsx
+++ b/src/SwarmStarts/SwarmStartsPage.jsx
@@ -98,13 +98,6 @@ export default function SwarmStartsPage() {
         { field: 'wall_seconds', headerName: 'Wall Clock Time', width: 140, type: 'number',
             valueFormatter: formatDuration },
         {
-            field: 'auto_start',
-            headerName: 'Auto-Start',
-            width: 100,
-            type: 'boolean',
-            valueGetter: (_v, row) => Boolean(row.auto_start),
-        },
-        {
             // req #2955 (backed by #2949's swarm_starts.ai_model column) — the
             // launcher's model, i.e. the model that incurred this start's cost.
             field: 'ai_model',
@@ -151,7 +144,7 @@ export default function SwarmStartsPage() {
         {
             field: 'requirements_list',
             headerName: 'Requirements',
-            width: 360,
+            width: 270,
             sortable: false,
             // valueGetter feeds quick-filter and CSV export with a newline-
             // joined string ("2685 — display\n2686 — stats\n…"). Filter
@@ -202,16 +195,19 @@ export default function SwarmStartsPage() {
                 );
             },
         },
-        // Token columns — hidden by default, revealable via column-visibility toolbar.
+        // Req #3325 — the same four token factors shown in the single
+        // swarm-start viewer (SwarmStartDetail's Token totals), in the order
+        // requested: Input, Output, Cache Read, Cache Write. Shown directly
+        // as visible columns here (not hidden-by-default, and not folded
+        // into one combined total).
         { field: 'tokens_input', headerName: 'Input', width: 100, type: 'number',
-            valueFormatter: formatNum },
-        { field: 'tokens_cache_write', headerName: 'Cache W', width: 110, type: 'number',
-            valueFormatter: formatNum },
-        { field: 'tokens_cache_read', headerName: 'Cache R', width: 120, type: 'number',
             valueFormatter: formatNum },
         { field: 'tokens_output', headerName: 'Output', width: 100, type: 'number',
             valueFormatter: formatNum },
-        { field: 'turn_count', headerName: 'Turns', width: 80, type: 'number' },
+        { field: 'tokens_cache_read', headerName: 'Cache Read', width: 120, type: 'number',
+            valueFormatter: formatNum },
+        { field: 'tokens_cache_write', headerName: 'Cache Write', width: 120, type: 'number',
+            valueFormatter: formatNum },
         {
             // req #2943 — which machine ran this /swarm-start. Name resolved
             // client-side from the machines cache; NULL / unresolved → em-dash.
@@ -243,18 +239,12 @@ export default function SwarmStartsPage() {
         return Math.max(REQ_BASE_HEIGHT, 28 + REQ_LINE_HEIGHT * capped);
     }, [requirementsByStart]);
 
-    // Hide the four token columns by default; users can reveal via the toolbar.
+    // Req #3325 — the four token columns are visible by default now (they
+    // used to be hidden-by-default raw columns); no columnVisibilityModel
+    // needed.
     const initialState = useMemo(() => ({
         pagination: { paginationModel: { pageSize: 25 } },
         sorting: { sortModel: [{ field: 'started_at', sort: 'desc' }] },
-        columns: {
-            columnVisibilityModel: {
-                tokens_input: false,
-                tokens_cache_write: false,
-                tokens_cache_read: false,
-                tokens_output: false,
-            },
-        },
     }), []);
 
     if (isLoading) {

--- a/src/SwarmStarts/SwarmStartsStatsView.jsx
+++ b/src/SwarmStarts/SwarmStartsStatsView.jsx
@@ -36,6 +36,7 @@ import {
 } from 'recharts';
 
 import { parsePhaseBreakdown } from '../utils/phaseTelemetry';
+import { swarmStartTokenTotal } from './tokenTotals';
 import { AI_MODELS, AI_MODEL_COLOR, aiModelLabel } from '../SwarmView/modelChipStyles';
 import { EFFORTS, EFFORT_COLOR, effortLabel } from '../SwarmView/effortChipStyles';
 
@@ -74,12 +75,6 @@ const DEFAULT_THROUGHPUT_RANGE = 'All';
 
 // session_count histogram buckets: each integer 0..5 is its own bucket, 6+ collapsed.
 const SESSION_BUCKETS = ['0', '1', '2', '3', '4', '5', '6+'];
-
-const rowTokenTotal = (row) =>
-    (Number(row.tokens_input) || 0) +
-    (Number(row.tokens_cache_write) || 0) +
-    (Number(row.tokens_cache_read) || 0) +
-    (Number(row.tokens_output) || 0);
 
 // Pure aggregator — rows → stats object. Exported for unit testing.
 export function computeSwarmStartStats(rows) {
@@ -159,7 +154,10 @@ export function computeSwarmStartStats(rows) {
         cacheWriteTotal += Number(row.tokens_cache_write) || 0;
         cacheReadTotal += Number(row.tokens_cache_read) || 0;
         outputTotal += Number(row.tokens_output) || 0;
-        const tokenTotal = rowTokenTotal(row);
+        // ?? 0 preserves this file's pre-existing "untracked contributes
+        // nothing to the running sum" behavior explicitly — the shared
+        // helper itself returns null for an all-null row (see tokenTotals.js).
+        const tokenTotal = swarmStartTokenTotal(row) ?? 0;
 
         // Sessions histogram
         const sessKey = sessionCount >= 6 ? '6+' : String(sessionCount);

--- a/src/SwarmStarts/__tests__/SwarmStartsPage.tokens.test.jsx
+++ b/src/SwarmStarts/__tests__/SwarmStartsPage.tokens.test.jsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+//
+// Req #3325 — the Swarm Start table shows Input / Cache Write / Cache Read /
+// Output as real, visible columns (matching SwarmStartDetail's Token totals
+// factors), Auto-Start and Turns are gone, and Requirements is 270px (25%
+// narrower than the prior 360px).
+//
+// The DataGrid is STUBBED for the same reason StepsPage.test.jsx / EpicsPage
+// stub it: jsdom gives every element a zero-size box, so the real grid
+// virtualizes down to no cells. The stub runs each column through the real
+// contract (valueGetter → valueFormatter → renderCell) so a column that
+// mis-uses that contract still fails here — this is not a mock of the
+// feature's logic, only of the virtualized-scrolling container around it.
+//
+// Row fixtures are the exact values seeded into darwin_dev.swarm_starts
+// (ids 315-319) for manual UI review, so this test is checking the same
+// numbers a human reviewer sees on screen.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-router-dom', async (importOriginal) => ({
+    ...(await importOriginal()),
+    useNavigate: () => () => {},
+}));
+
+let capturedColumns = null;
+
+vi.mock('@mui/x-data-grid', () => ({
+    GridToolbar: () => null,
+    DataGrid: ({ rows, columns }) => {
+        capturedColumns = columns;
+        return (
+            <div data-testid="grid">
+                {rows.map((row) => (
+                    <div key={row.id} data-testid={`grid-row-${row.id}`}>
+                        {columns.map((col) => {
+                            const raw = row[col.field];
+                            const value = col.valueGetter ? col.valueGetter(raw, row, col) : raw;
+                            const formatted = col.valueFormatter
+                                ? col.valueFormatter(value, row, col) : value;
+                            return (
+                                <span key={col.field} data-testid={`cell-${col.field}-${row.id}`}>
+                                    {col.renderCell
+                                        ? col.renderCell({ row, value, id: row.id, field: col.field })
+                                        : String(formatted ?? '')}
+                                </span>
+                            );
+                        })}
+                    </div>
+                ))}
+            </div>
+        );
+    },
+}));
+
+// The exact rows seeded into darwin_dev.swarm_starts (ids 315-319) for manual
+// UI review of this requirement.
+const SEEDED_ROWS = [
+    { id: 315, arguments: 'req 3325', ai_model: 'opus', effort: 'high', auto_start: 1,
+      session_count: 1, wall_seconds: 800, turn_count: 22,
+      tokens_input: 500, tokens_cache_write: 200000,
+      tokens_cache_read: 8000000, tokens_output: 25000 },
+    { id: 316, arguments: 'swarm 1 2 3 4', ai_model: 'sonnet', effort: 'medium', auto_start: 0,
+      session_count: 4, wall_seconds: 2702, turn_count: 63,
+      tokens_input: 256, tokens_cache_write: 806689,
+      tokens_cache_read: 25671100, tokens_output: 84614 },
+    { id: 317, arguments: '', ai_model: 'haiku', effort: 'low', auto_start: 0,
+      session_count: 1, wall_seconds: 180, turn_count: 8,
+      tokens_input: 100, tokens_cache_write: 5000,
+      tokens_cache_read: 200000, tokens_output: 3000 },
+    { id: 318, arguments: 'mapping deployed', ai_model: 'fable', effort: 'high', auto_start: 0,
+      session_count: 2, wall_seconds: 3100, turn_count: 75,
+      tokens_input: 1200, tokens_cache_write: 3000000,
+      tokens_cache_read: 90000000, tokens_output: 150000 },
+    { id: 319, arguments: 'issues darwin 8', ai_model: 'opus', effort: 'high', auto_start: 0,
+      session_count: 1, wall_seconds: 600, turn_count: 18,
+      tokens_input: null, tokens_cache_write: null,
+      tokens_cache_read: null, tokens_output: null },
+];
+
+const EMPTY = [];
+vi.mock('../../hooks/useDataQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        useAllSwarmStarts: () => ({ data: SEEDED_ROWS, isLoading: false }),
+        useSessions: () => ({ data: EMPTY }),
+        useAllSwarmStartSessions: () => ({ data: EMPTY }),
+        useMachines: () => ({ data: EMPTY }),
+    };
+});
+
+import SwarmStartsPage from '../SwarmStartsPage';
+import AuthContext from '../../Context/AuthContext';
+
+let roots = [];
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AuthContext.Provider value={{ profile: { userName: 'tester', timezone: 'UTC' } }}>
+                    <SwarmStartsPage />
+                </AuthContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    return { container };
+}
+
+const cellText = (container, field, id) =>
+    container.querySelector(`[data-testid="cell-${field}-${id}"]`)?.textContent;
+
+describe('SwarmStartsPage token columns render the seeded values (req #3325)', () => {
+    afterEach(() => {
+        act(() => { roots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+        capturedColumns = null;
+        vi.clearAllMocks();
+    });
+
+    it('removes the Auto-Start and Turns columns entirely', () => {
+        mount();
+        const fields = capturedColumns.map((c) => c.field);
+        expect(fields).not.toContain('auto_start');
+        expect(fields).not.toContain('turn_count');
+        const headers = capturedColumns.map((c) => c.headerName);
+        expect(headers).not.toContain('Auto-Start');
+        expect(headers).not.toContain('Turns');
+    });
+
+    it('narrows the Requirements column to 270 (25% off 360)', () => {
+        mount();
+        const reqCol = capturedColumns.find((c) => c.field === 'requirements_list');
+        expect(reqCol.width).toBe(270);
+    });
+
+    it('shows Input / Cache Write / Cache Read / Output as real, labeled columns', () => {
+        mount();
+        const byField = Object.fromEntries(capturedColumns.map((c) => [c.field, c]));
+        expect(byField.tokens_input.headerName).toBe('Input');
+        expect(byField.tokens_cache_write.headerName).toBe('Cache Write');
+        expect(byField.tokens_cache_read.headerName).toBe('Cache Read');
+        expect(byField.tokens_output.headerName).toBe('Output');
+    });
+
+    it.each(SEEDED_ROWS.filter((r) => r.id !== 319))(
+        'renders the exact seeded token counts for row $id ($ai_model)',
+        (row) => {
+            const { container } = mount();
+            expect(cellText(container, 'tokens_input', row.id))
+                .toBe(row.tokens_input.toLocaleString());
+            expect(cellText(container, 'tokens_cache_write', row.id))
+                .toBe(row.tokens_cache_write.toLocaleString());
+            expect(cellText(container, 'tokens_cache_read', row.id))
+                .toBe(row.tokens_cache_read.toLocaleString());
+            expect(cellText(container, 'tokens_output', row.id))
+                .toBe(row.tokens_output.toLocaleString());
+        },
+    );
+
+    it('renders an em-dash in every token column for the all-null legacy row (id 319)', () => {
+        const { container } = mount();
+        expect(cellText(container, 'tokens_input', 319)).toBe('—');
+        expect(cellText(container, 'tokens_cache_write', 319)).toBe('—');
+        expect(cellText(container, 'tokens_cache_read', 319)).toBe('—');
+        expect(cellText(container, 'tokens_output', 319)).toBe('—');
+    });
+});

--- a/src/SwarmStarts/__tests__/tokenTotals.test.js
+++ b/src/SwarmStarts/__tests__/tokenTotals.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { swarmStartTokenTotal } from '../tokenTotals';
+
+describe('swarmStartTokenTotal', () => {
+    it('returns null when every token field is null/undefined', () => {
+        expect(swarmStartTokenTotal({
+            tokens_input: null, tokens_cache_write: null,
+            tokens_cache_read: null, tokens_output: undefined,
+        })).toBeNull();
+    });
+
+    it('sums all four factors', () => {
+        expect(swarmStartTokenTotal({
+            tokens_input: 100, tokens_cache_write: 200,
+            tokens_cache_read: 300, tokens_output: 400,
+        })).toBe(1000);
+    });
+
+    it('treats a partially-populated row as tracked — missing factors contribute 0', () => {
+        expect(swarmStartTokenTotal({
+            tokens_input: 100, tokens_cache_write: null,
+            tokens_cache_read: null, tokens_output: null,
+        })).toBe(100);
+    });
+
+    it('treats an all-zero row as a real, tracked total of 0 (not the null/untracked case)', () => {
+        expect(swarmStartTokenTotal({
+            tokens_input: 0, tokens_cache_write: 0,
+            tokens_cache_read: 0, tokens_output: 0,
+        })).toBe(0);
+    });
+
+    it('coerces string token counts (as the API returns them) the same as numbers', () => {
+        expect(swarmStartTokenTotal({
+            tokens_input: '100', tokens_cache_write: '200',
+            tokens_cache_read: '300', tokens_output: '400',
+        })).toBe(1000);
+    });
+});

--- a/src/SwarmStarts/tokenTotals.js
+++ b/src/SwarmStarts/tokenTotals.js
@@ -1,0 +1,15 @@
+// Sums a swarm_start row's four raw token factors (input, cache write, cache
+// read, output). `null` when every factor is null/undefined — an unmeasured
+// invocation is not the same fact as a zero-token one, and callers (the table's
+// dash rendering, the stats page's running sums) need to be able to tell the
+// two apart rather than picking one meaning for both. A caller that wants the
+// old "untracked contributes 0" behavior for a running sum should write
+// `swarmStartTokenTotal(row) ?? 0` explicitly at the call site.
+export function swarmStartTokenTotal(row) {
+    const { tokens_input, tokens_cache_write, tokens_cache_read, tokens_output } = row;
+    const hasAny = tokens_input != null || tokens_cache_write != null ||
+        tokens_cache_read != null || tokens_output != null;
+    if (!hasAny) return null;
+    return (Number(tokens_input) || 0) + (Number(tokens_cache_write) || 0) +
+        (Number(tokens_cache_read) || 0) + (Number(tokens_output) || 0);
+}


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3325-swarm-start-table-token-cost-1
- wip(Darwin): 2026-08-04T09:31:56Z
- chore: init swarm session feature/3325-swarm-start-table-token-cost-1

## Files changed
```
 src/SwarmStarts/SwarmStartsPage.jsx                |  34 ++--
 src/SwarmStarts/SwarmStartsStatsView.jsx           |  12 +-
 .../__tests__/SwarmStartsPage.tokens.test.jsx      | 179 +++++++++++++++++++++
 src/SwarmStarts/__tests__/tokenTotals.test.js      |  39 +++++
 src/SwarmStarts/tokenTotals.js                     |  15 ++
 5 files changed, 250 insertions(+), 29 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)