### PR TITLE
Swarm Polish - Orchestrated

### DIFF
--- a/src/SwarmView/CategoryCard.jsx
+++ b/src/SwarmView/CategoryCard.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
-import { STATUS_SORT_PROCESS, processSort, processSortReverse, requirementHandSort } from './processSort';
+import { STATUS_SORT_PROCESS, requirementActiveSort, requirementHandSort, coerceSortMode } from './processSort';
 import RequirementRow from './RequirementRow';
 import RequirementDeleteDialog from './RequirementDeleteDialog';
 import call_rest_api from '../RestApi/RestApi';
@@ -85,13 +85,10 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
         }
     });
 
-    // Legacy categories may have sort_mode='created' — treat anything other than
-    // 'hand' / 'reverse' as 'process'. Three live values: 'hand' | 'process' | 'reverse'.
-    const [sortMode, setSortMode] = useState(
-        category.sort_mode === 'hand'
-            ? 'hand'
-            : category.sort_mode === 'reverse' ? 'reverse' : 'process'
-    );
+    // Three live values: 'hand' | 'process' | 'reverse'. `coerceSortMode` is the
+    // ONE reading of the column (req #3302) — see its docstring for the two
+    // copies that disagreed.
+    const [sortMode, setSortMode] = useState(coerceSortMode(category.sort_mode));
 
     // Status Sort menu item toggles direction when already active: process ↔ reverse.
     // Hand Sort menu item always sets 'hand' directly.
@@ -116,14 +113,14 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
         setSortMode(newMode);
 
         if (requirementsArray) {
-            // Hand mode honors persisted sort_order (req #2417). Newly empty
-            // sort_order rows fall to id-order via requirementHandSort's NULL→+∞
-            // tiebreak — same visual default as pre-#2417 createdSort.
-            const sortFn = newMode === 'hand'
-                ? requirementHandSort
-                : newMode === 'reverse' ? processSortReverse : processSort;
+            // req #3302 — the SAME comparator every other path uses. This used to
+            // call `requirementHandSort` bare for hand mode, skipping the status
+            // band that `activeSort` applies, so the order the user saw the
+            // instant they picked Hand Sort was not the order the next refetch,
+            // status-chip toggle or cross-card drop produced. `newMode`, not
+            // `sortMode` — this runs before the state update lands.
             const sorted = [...requirementsArray];
-            sorted.sort((a, b) => sortFn(a, b));
+            sorted.sort((a, b) => requirementActiveSort(newMode, a, b));
             setRequirementsArray(sorted);
         }
 
@@ -159,10 +156,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
                 if (sortModeMutationRef.current !== mutationId) return;
                 queryClient.setQueryData(openKey, previousOpen);
                 queryClient.setQueryData(allKey, previousAll);
-                const prior = category.sort_mode === 'hand'
-                    ? 'hand'
-                    : category.sort_mode === 'reverse' ? 'reverse' : 'process';
-                setSortMode(prior);
+                setSortMode(coerceSortMode(category.sort_mode));
                 showError(errorArg, message);
             };
 
@@ -720,40 +714,12 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
         });
     }
 
-    // STATUS_SORT_PROCESS, processSort, processSortReverse imported from ./processSort
-
-    const STATUS_SORT = { authoring: 0, approved: 0, swarm_ready: 0, development: 0, deferred: 1, met: 2, wontfix: 3 };
-
-    const activeSort = (a, b) => {
-        if (a.id === '') return 1;
-        if (b.id === '') return -1;
-        if (sortMode === 'process') return processSort(a, b);
-        if (sortMode === 'reverse') return processSortReverse(a, b);
-        // Three-group sort: active (0) < deferred (1) < met (2)
-        const aState = STATUS_SORT[a.requirement_status] ?? 0;
-        const bState = STATUS_SORT[b.requirement_status] ?? 0;
-        if (aState !== bState) return aState - bState;
-        if (a.requirement_status === 'met' && b.requirement_status === 'met') {
-            const aTime = a.completed_at ? new Date(a.completed_at).getTime() : 0;
-            const bTime = b.completed_at ? new Date(b.completed_at).getTime() : 0;
-            if (aTime !== bTime) return bTime - aTime;  // most recent first
-        }
-        if (a.requirement_status === 'deferred' && b.requirement_status === 'deferred') {
-            const aTime = a.deferred_at ? new Date(a.deferred_at).getTime() : 0;
-            const bTime = b.deferred_at ? new Date(b.deferred_at).getTime() : 0;
-            if (aTime !== bTime) return bTime - aTime;  // most recent first
-        }
-        if (a.requirement_status === 'wontfix' && b.requirement_status === 'wontfix') {
-            // wontfix timestamps via completed_at (terminal, like met — req #2783)
-            const aTime = a.completed_at ? new Date(a.completed_at).getTime() : 0;
-            const bTime = b.completed_at ? new Date(b.completed_at).getTime() : 0;
-            if (aTime !== bTime) return bTime - aTime;  // most recent first
-        }
-        // Hand mode (req #2417): sort_order ASC within the active group, NULL last,
-        // id tiebreak. Default (no sortMode change yet) also lands here and degrades
-        // gracefully — sort_order=NULL on every row → pure id ASC, unchanged from #2405.
-        return requirementHandSort(a, b);
-    }
+    // req #3302 — THE sort lives in ./processSort as `requirementActiveSort`.
+    // This was a local copy, and `changeSortMode` used a THIRD ordering that
+    // skipped the status band, so picking Hand Sort ordered the rows one way and
+    // the next refetch / chip toggle / cross-card drop re-ordered them another.
+    // One implementation now, called by every path that orders this card.
+    const activeSort = (a, b) => requirementActiveSort(sortMode, a, b);
 
     return (
         <Card key={categoryIndex} raised={true} ref={mergedRef}

--- a/src/SwarmView/RequirementRow.jsx
+++ b/src/SwarmView/RequirementRow.jsx
@@ -4,6 +4,7 @@ import { useTheme, darken, lighten } from '@mui/material/styles';
 
 import { useDrag, useDrop } from 'react-dnd';
 import { useRequirementActions } from '../hooks/useRequirementActions';
+import { elevatorStateFrom } from './detail/requirementSort';
 
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
@@ -440,7 +441,11 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
                         size="small"
                         variant="outlined"
                         clickable
-                        onClick={() => navigate(`/swarm/requirement/${requirement.id}`)}
+                        // req #3302 — hand the elevator the order this surface actually
+                        // rendered. A category card and the aggregator show different
+                        // lists of the same requirements, and only the surface knows which.
+                        onClick={() => navigate(`/swarm/requirement/${requirement.id}`,
+                                                { state: elevatorStateFrom(requirementsArray) })}
                         aria-label={`Open requirement ${requirement.id}`}
                         data-testid={`req-id-chip-${requirement.id}`}
                     />

--- a/src/SwarmView/RequirementsTableView.jsx
+++ b/src/SwarmView/RequirementsTableView.jsx
@@ -1,6 +1,8 @@
 import React, { useContext, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
+import Tooltip from '@mui/material/Tooltip';
+import { elevatorStateFrom } from './detail/requirementSort';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -17,7 +19,7 @@ import Typography from '@mui/material/Typography';
 import EditIcon from '@mui/icons-material/Edit';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import { useQueryClient } from '@tanstack/react-query';
-import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { DataGrid, GridToolbar, gridExpandedSortedRowIdsSelector } from '@mui/x-data-grid';
 
 import AuthContext from '../Context/AuthContext';
 import AppContext from '../Context/AppContext';
@@ -43,6 +45,15 @@ export const SWARM_TABLE_WIDTH = 1520;
 
 const FIELDS = 'id,title,requirement_status,category_fk,coordination_type,ai_model,effort,machine_fk,completed_at,create_ts';
 
+// req #3302 — FIXED ROWS, so `getRowHeight: () => 'auto'` could go. § D rule 2 of
+// memory/view-switchable-pages.md prohibits auto height by name: the row
+// virtualizer mis-measures after a re-sort and rows overlap or leave gaps. This
+// grid carries two `sortComparator`s and a sortable header on every column, so it
+// was the one place in the codebase most able to trigger it.
+//
+// A fixed row can still hold prose — the doc's own retirement of the
+// "truncate it or use auto height" dichotomy. Two shapes, because the two wrapping
+// cells want different things: prose CLAMPS to a line count, chips WRAP and scroll.
 const WRAP_CELL_SX = {
     whiteSpace: 'normal',
     wordBreak: 'break-word',
@@ -51,7 +62,41 @@ const WRAP_CELL_SX = {
     display: 'flex',
     alignItems: 'center',
     width: '100%',
+    // Fixed rows mean a cell can no longer grow the row it sits in; contain the
+    // overflow rather than letting it paint over the neighbouring row.
+    overflow: 'hidden',
 };
+
+// Prose that must not be truncated to one line. `-webkit-box` + line-clamp is the
+// only cross-browser two-line ellipsis, and it is why this cannot simply reuse
+// WRAP_CELL_SX's flex centring — the two display modes are mutually exclusive.
+// `.MuiDataGrid-cell` is a BLOCK with `line-height: calc(var(--height) - 1px)`,
+// which is what vertically centres every ordinary column. A clamped cell sets its
+// own `lineHeight`, so it loses that and floats to the top of the row unless it
+// centres itself — hence the flex wrapper around the clamp. The two cannot be one
+// element: `-webkit-box` and `flex` are mutually exclusive display modes.
+const CLAMP_WRAP_SX = {
+    display: 'flex',
+    alignItems: 'center',
+    height: '100%',
+    width: '100%',
+};
+
+const CLAMP_CELL_SX = {
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 2,
+    overflow: 'hidden',
+    whiteSpace: 'normal',
+    wordBreak: 'break-word',
+    lineHeight: 1.3,
+    width: '100%',
+};
+
+// `rowHeight` is a PRE-DENSITY figure: `useGridDimensions` computes the real
+// height as `floor(rowHeight × densityFactor)`, and `density="compact"` is 0.7.
+// 72 lands at 50px — two clamped lines at lineHeight 1.3 plus the cell padding.
+const ROW_HEIGHT = 72;
 
 const STATUS_SORT_ORDER = {
     authoring: 0, approved: 1, swarm_ready: 2, development: 3, deferred: 4, met: 5, wontfix: 6,
@@ -260,7 +305,37 @@ const RequirementsTableView = () => {
     const handleCellClick = (params) => {
         // Don't navigate when clicking the checkbox column
         if (params.field === '__check__') return;
-        navigate(`/swarm/requirement/${params.row.id}`);
+        // req #3302 — the THIRD surface that opens a requirement, and it hands the
+        // prev/next elevator its own order like the other two. Without this the
+        // arrows walk the requirement's CATEGORY, which is not what this view is
+        // showing: the grid's rows are filtered by the chips AND by the quick
+        // filter AND ordered by whichever column header the reader last clicked.
+        //
+        // `gridExpandedSortedRowIdsSelector` — FILTERED **and** sorted, across
+        // pages. NOT `api.getSortedRowIds()`, which reads `sortingState.sortedRows`
+        // and is sorted but UNFILTERED (verified in
+        // `@mui/x-data-grid/esm/hooks/features/sorting/gridSortingSelector.js`;
+        // the neighbouring `getRowIdFromRowIndex` doc says "sorted but unfiltered"
+        // outright). Handing over unfiltered ids would walk the elevator through
+        // rows the quick filter has hidden — the exact defect this handoff exists
+        // to remove, reintroduced one method call away from the fix.
+        //
+        // Across pages on purpose: pagination is how much you can SEE at once, not
+        // what you are looking at, and the reader can page past a boundary the
+        // arrows would otherwise stop at.
+        //
+        // Guarded because a selector needs the apiRef shape; losing the handoff
+        // falls back to the category query, never to a crash.
+        let ordered;
+        try {
+            ordered = params.api ? gridExpandedSortedRowIdsSelector({ current: params.api }) : null;
+        } catch {
+            ordered = null;
+        }
+        const state = Array.isArray(ordered) && ordered.length
+            ? elevatorStateFrom(ordered.map(id => ({ id })))
+            : undefined;
+        navigate(`/swarm/requirement/${params.row.id}`, state ? { state } : undefined);
     };
 
     const columns = [
@@ -276,7 +351,13 @@ const RequirementsTableView = () => {
             headerName: 'Title',
             width: 220,
             renderCell: (params) => (
-                <Box sx={WRAP_CELL_SX}>{params.value}</Box>
+                // The full title is the row's tooltip, so clamping hides nothing
+                // a reader cannot get back without leaving the page.
+                <Tooltip title={params.value || ''} enterDelay={600} enterNextDelay={300}>
+                    <Box sx={CLAMP_WRAP_SX}>
+                        <Box sx={CLAMP_CELL_SX}>{params.value}</Box>
+                    </Box>
+                </Tooltip>
             ),
         },
         {
@@ -361,6 +442,15 @@ const RequirementsTableView = () => {
                         ...WRAP_CELL_SX,
                         flexWrap: 'wrap',
                         gap: 0.5,
+                        // req #3302 — the row no longer grows to fit, so overflow
+                        // has to go SOMEWHERE. `hidden` would make every session
+                        // past the first line unreachable from this view, and the
+                        // chips are the only route from here to a session. A 24px
+                        // chip in a 50px row means the second line is always the
+                        // one that overflows, so this scrolls rather than clips.
+                        overflowY: 'auto',
+                        alignItems: 'flex-start',
+                        py: 0.5,
                     }}>
                         {list.map(s => {
                             const chipProps = swarmStatusChipProps(s.swarm_status);
@@ -452,7 +542,7 @@ const RequirementsTableView = () => {
                     rows={filteredRequirements}
                     columns={columns}
                     loading={reqLoading || catLoading}
-                    getRowHeight={() => 'auto'}
+                    rowHeight={ROW_HEIGHT}
                     slots={{ toolbar: GridToolbar }}
                     slotProps={{ toolbar: { showQuickFilter: true } }}
                     initialState={{

--- a/src/SwarmView/SwarmView.jsx
+++ b/src/SwarmView/SwarmView.jsx
@@ -11,7 +11,6 @@ import { useModelEffortDisplayStore } from '../stores/useModelEffortDisplayStore
 import { useRequirementDrillStore } from '../stores/useRequirementDrillStore';
 import { useProjects } from '../hooks/useDataQueries';
 import { projectKeys } from '../hooks/useQueryKeys';
-import { useViewPreference } from '../hooks/useViewPreference';
 
 import ProjectCloseDialog from './ProjectCloseDialog';
 import ProjectAddDialog from './ProjectAddDialog';
@@ -47,6 +46,8 @@ import FolderIcon from '@mui/icons-material/Folder';
 import CategoryIcon from '@mui/icons-material/Category';
 import { requirementStatusChipProps, requirementStatusLabel } from './statusChipStyles';
 import ChipFilter from '../Components/ChipFilter';
+import { SWARM_VIEWS } from './swarmViewLink';
+import { useSwarmViewSelection } from './useSwarmViewSelection';
 
 // req #2992 — fixed vocabulary, so options are module-level. Colors come from
 // requirementStatusChipProps, not the ChipFilter palette.
@@ -56,7 +57,17 @@ const requirementStatusOptions = ALL_REQUIREMENT_STATUSES.map(status => ({
     chipProps: requirementStatusChipProps(status),
 }));
 
-const SWARM_VIEW_STORAGE_KEY = 'darwin-swarm-view';
+// The CHROME for each view — its tooltip and its icon (§ C R3's canonical mapping).
+// Kept here rather than in `swarmViewLink.js` so that module stays free of MUI and
+// testable without a DOM; the VOCABULARY is still `SWARM_VIEWS`, and the toggle row
+// maps over that, so this object can only ever add presentation to a value the
+// validator already knows.
+const SWARM_VIEW_CHROME = {
+    cards:      { label: 'Cards View',      Icon: ViewModuleIcon },
+    table:      { label: 'Table View',      Icon: TableChartIcon },
+    visualizer: { label: 'Visualizer View', Icon: BubbleChartIcon },
+    trends:     { label: 'Trends View',     Icon: TimelineIcon },
+};
 
 const SwarmView = () => {
 
@@ -65,7 +76,21 @@ const SwarmView = () => {
     const queryClient = useQueryClient();
 
     const [projectsArray, setProjectsArray] = useState()
-    const [view, setView] = useViewPreference(SWARM_VIEW_STORAGE_KEY, 'cards');
+
+    // ── `?view=` makes the SURFACE addressable, not just the page (req #3168 R9) ──
+    // Which panel this page shows is a persisted PREFERENCE (§ H), so `/swarm`
+    // alone names the page and not a view of it: it opens whatever this reader
+    // last chose, or `cards` for a first-time visitor. That made Table,
+    // Visualizer and Trends unlinkable — no URL reliably landed on one — which is
+    // a real gap for a dev-server deep link, a bug report, and a link pasted into
+    // a review.
+    //
+    // The rules and their rationale live in `useSwarmViewSelection.js`, because
+    // they are stateful and a stateful rule inside this component is a rule no
+    // test can reach. `setView` is the MANUAL PICK (clears the link override and
+    // persists); `showViewTransiently` is a CROSS-VIEW HANDSHAKE (override only,
+    // never persisted).
+    const { view, setView, showTransiently: showViewTransiently } = useSwarmViewSelection();
 
     const activeTab = useSwarmTabStore(s => s.activeTab);
     const setActiveTab = useSwarmTabStore(s => s.setActiveTab);
@@ -271,26 +296,23 @@ const SwarmView = () => {
                             sx={{ flexShrink: 0 }}
                             data-testid="swarm-view-toggle"
                         >
-                            <Tooltip title="Cards View">
-                                <ToggleButton value="cards" data-testid="view-toggle-cards" sx={{ px: 2 }}>
-                                    <ViewModuleIcon fontSize="small" />
-                                </ToggleButton>
-                            </Tooltip>
-                            <Tooltip title="Table View">
-                                <ToggleButton value="table" data-testid="view-toggle-table" sx={{ px: 2 }}>
-                                    <TableChartIcon fontSize="small" />
-                                </ToggleButton>
-                            </Tooltip>
-                            <Tooltip title="Visualizer View">
-                                <ToggleButton value="visualizer" data-testid="view-toggle-visualizer" sx={{ px: 2 }}>
-                                    <BubbleChartIcon fontSize="small" />
-                                </ToggleButton>
-                            </Tooltip>
-                            <Tooltip title="Trends View">
-                                <ToggleButton value="trends" data-testid="view-toggle-trends" sx={{ px: 2 }}>
-                                    <TimelineIcon fontSize="small" />
-                                </ToggleButton>
-                            </Tooltip>
+                            {/* Mapped OUT of the same vocabulary `?view=` is validated
+                                against (`PipelineDetail.jsx`'s shape), so a fifth view
+                                cannot render, toggle and persist while being unlinkable
+                                — which is what hand-written `value=` literals allowed,
+                                silently, with nothing failing. Adding a view now means
+                                adding it to `SWARM_VIEWS`, and `SWARM_VIEW_CHROME`
+                                fails the render if it has no entry. */}
+                            {SWARM_VIEWS.map((value) => {
+                                const { label, Icon } = SWARM_VIEW_CHROME[value];
+                                return (
+                                    <Tooltip key={value} title={label}>
+                                        <ToggleButton value={value} data-testid={`view-toggle-${value}`} sx={{ px: 2 }}>
+                                            <Icon fontSize="small" />
+                                        </ToggleButton>
+                                    </Tooltip>
+                                );
+                            })}
                         </ToggleButtonGroup>
                         <RequirementJumpInput />
                         {view === 'cards' && (
@@ -418,7 +440,10 @@ const SwarmView = () => {
                         claims the full tab-panels grid area like table/visualizer. */}
                     {view === 'trends' && (
                         <Box className="app-content-tabpanel">
-                            <RequirementsTrendsView onDrillToTable={() => setView('table')} />
+                            {/* Transient, not persisted — clicking a chart bar to inspect
+                                its requirements is not a request to make Table the
+                                default in every tab. See `showViewTransiently`. */}
+                            <RequirementsTrendsView onDrillToTable={() => showViewTransiently('table')} />
                         </Box>
                     )}
             </Box>

--- a/src/SwarmView/__tests__/swarmViewLink.test.js
+++ b/src/SwarmView/__tests__/swarmViewLink.test.js
@@ -1,0 +1,95 @@
+// req #3302 — the `/swarm?view=` contract (req #3168 R9).
+//
+// The rules under test are the ones R9 states, and each is here because breaking
+// it is silent: an unvalidated param selects nothing in the ToggleButtonGroup, a
+// redundant `?view=cards` overrides a stored preference the link never meant to
+// touch, and a drifting key makes every existing link inert with nothing failing.
+
+import { describe, it, expect } from 'vitest';
+import {
+    SWARM_VIEWS,
+    DEFAULT_SWARM_VIEW,
+    SWARM_VIEW_STORAGE_KEY,
+    SWARM_VIEW_PARAM,
+    readViewParam,
+    swarmViewLinkTo,
+} from '../swarmViewLink';
+
+const params = (qs) => new URLSearchParams(qs);
+
+describe('the vocabulary', () => {
+    it('is the four panels SwarmView renders, in toggle order', () => {
+        expect(SWARM_VIEWS).toEqual(['cards', 'table', 'visualizer', 'trends']);
+    });
+
+    it('names cards as the first-time default', () => {
+        expect(DEFAULT_SWARM_VIEW).toBe('cards');
+        expect(SWARM_VIEWS[0]).toBe(DEFAULT_SWARM_VIEW);
+    });
+
+    // R1 — the storage key is `darwin-<feature>-view`, and `/agents` shows what a
+    // non-conforming one costs (a one-time reset for every reader).
+    it('persists under the R1-conforming key', () => {
+        expect(SWARM_VIEW_STORAGE_KEY).toBe('darwin-swarm-view');
+    });
+
+    // R9 — the parameter name is the page's own vocabulary. This toggle switches
+    // VIEWS, so it is `view`, not `mode`, and it takes no `darwin-` prefix.
+    it('reads the page\'s own vocabulary as the parameter name', () => {
+        expect(SWARM_VIEW_PARAM).toBe('view');
+        expect(SWARM_VIEW_PARAM.startsWith('darwin-')).toBe(false);
+    });
+});
+
+describe('readViewParam — validated, never trusted', () => {
+    it.each(SWARM_VIEWS)('accepts the known view %s', (v) => {
+        expect(readViewParam(params(`view=${v}`))).toBe(v);
+    });
+
+    // Falling through to null is what leaves the stored preference in charge. A
+    // pass-through would select nothing in the exclusive ToggleButtonGroup, which
+    // renders the toggle with no active state at all.
+    it.each([
+        ['an unknown value', 'view=xyz'],
+        ['an empty value', 'view='],
+        ['a case mismatch', 'view=Cards'],
+        ['a whitespace-padded value', 'view=%20cards'],
+        ['a different parameter', 'mode=table'],
+        ['no parameters at all', ''],
+    ])('returns null for %s', (_label, qs) => {
+        expect(readViewParam(params(qs))).toBeNull();
+    });
+
+    it('is safe against a missing searchParams object', () => {
+        expect(readViewParam(undefined)).toBeNull();
+        expect(readViewParam(null)).toBeNull();
+        expect(readViewParam({})).toBeNull();
+    });
+});
+
+describe('swarmViewLinkTo — the writing half', () => {
+    it.each(SWARM_VIEWS)('addresses the view %s', (v) => {
+        expect(swarmViewLinkTo(v)).toBe(`/swarm?view=${v}`);
+    });
+
+    // `?view=cards` is NOT redundant. `/swarm` alone lands a reader with a stored
+    // Table preference on Table — the exact gap R9 exists to close — so a link
+    // that means Cards has to say so. A link that means the PAGE writes `/swarm`
+    // and never calls this.
+    it('names the default view too', () => {
+        expect(swarmViewLinkTo(DEFAULT_SWARM_VIEW)).toBe('/swarm?view=cards');
+    });
+
+    it.each([undefined, null, '', 'xyz'])('falls back to the bare route for %s', (v) => {
+        expect(swarmViewLinkTo(v)).toBe('/swarm');
+    });
+
+    // The two halves are one contract: everything the writer emits, the reader
+    // must accept as the same view.
+    it('round-trips every view through the reader', () => {
+        for (const v of SWARM_VIEWS) {
+            const qs = swarmViewLinkTo(v).split('?')[1] || '';
+            expect(readViewParam(params(qs))).toBe(v);
+        }
+    });
+});

--- a/src/SwarmView/__tests__/useSwarmViewSelection.test.jsx
+++ b/src/SwarmView/__tests__/useSwarmViewSelection.test.jsx
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+//
+// req #3302 — the STATEFUL half of the `/swarm?view=` contract (R9, req #3168).
+//
+// `swarmViewLink.test.js` covers the pure vocabulary and the param reader. Every
+// rule R9 actually states is stateful, though — never written to storage, cleared
+// by a manual pick, re-seeded on a link change and not on anything else — and none
+// of it is reachable from a pure function. Hence the hook, and hence this file.
+//
+// A Router is the only provider needed: that is the whole reason the rules were
+// lifted out of `SwarmView.jsx`, which additionally needs both Contexts, a
+// QueryClient and a DnD provider.
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
+import { useSwarmViewSelection } from '../useSwarmViewSelection';
+import { SWARM_VIEW_STORAGE_KEY } from '../swarmViewLink';
+
+// A probe that renders the hook's answer, so every assertion reads the value the
+// page would actually render. It also captures `useNavigate` — an in-place
+// navigation has to go through the router the Probe is already inside;
+// re-rendering `MemoryRouter` with different `initialEntries` does NOT navigate
+// (that prop is read once, at mount), so a test written that way would assert
+// nothing while looking like it asserted the re-seed.
+let api;
+let navigate;
+let result;
+const Probe = () => {
+    api = useSwarmViewSelection();
+    navigate = useNavigate();
+    return <div data-testid="view">{api.view}</div>;
+};
+
+const mount = (entry) => {
+    result = render(
+        <MemoryRouter initialEntries={[entry]}><Probe /></MemoryRouter>
+    );
+    return result;
+};
+
+// Scoped to the current render, not `screen` — several cases re-render, and a
+// document-wide query would find every mount at once.
+const shown = () => result.getByTestId('view').textContent;
+const stored = () => ({
+    session: sessionStorage.getItem(SWARM_VIEW_STORAGE_KEY),
+    local: localStorage.getItem(SWARM_VIEW_STORAGE_KEY),
+});
+
+beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    api = undefined;
+    result = undefined;
+});
+
+afterEach(() => cleanup());
+
+describe('what the page renders on arrival', () => {
+    it('falls back to the default with no link and no stored value', () => {
+        mount('/swarm');
+        expect(shown()).toBe('cards');
+    });
+
+    it('honours the stored preference with no link', () => {
+        localStorage.setItem(SWARM_VIEW_STORAGE_KEY, 'trends');
+        mount('/swarm');
+        expect(shown()).toBe('trends');
+    });
+
+    it('lets the link WIN over a stored preference', () => {
+        localStorage.setItem(SWARM_VIEW_STORAGE_KEY, 'trends');
+        mount('/swarm?view=table');
+        expect(shown()).toBe('table');
+    });
+
+    // The whole point of R9: without this, the surface is unlinkable.
+    it('lands on the named view for a first-time visitor', () => {
+        mount('/swarm?view=visualizer');
+        expect(shown()).toBe('visualizer');
+    });
+
+    it('leaves the stored preference in charge for an unknown link value', () => {
+        localStorage.setItem(SWARM_VIEW_STORAGE_KEY, 'trends');
+        mount('/swarm?view=xyz');
+        expect(shown()).toBe('trends');
+    });
+});
+
+describe('the link is a TRANSIENT override and is never written', () => {
+    it('writes nothing to either store on arrival', () => {
+        localStorage.setItem(SWARM_VIEW_STORAGE_KEY, 'trends');
+        sessionStorage.setItem(SWARM_VIEW_STORAGE_KEY, 'trends');
+        mount('/swarm?view=table');
+        expect(shown()).toBe('table');
+        // The reader's default is untouched: they asked to see one thing once.
+        expect(stored()).toEqual({ session: 'trends', local: 'trends' });
+    });
+
+    it('leaves a first-time visitor\'s seeded default at the DEFAULT, not the link', () => {
+        mount('/swarm?view=table');
+        expect(shown()).toBe('table');
+        // useViewPreference seeds sessionStorage from the fallback on first mount;
+        // that seed must be the page default, never the link's value.
+        expect(stored().session).toBe('cards');
+        expect(stored().local).toBeNull();
+    });
+});
+
+describe('a MANUAL PICK clears the override and persists', () => {
+    it('makes the link inert from that moment', () => {
+        mount('/swarm?view=trends');
+        expect(shown()).toBe('trends');
+
+        act(() => api.setView('table'));
+        expect(shown()).toBe('table');
+        expect(stored()).toEqual({ session: 'table', local: 'table' });
+
+        // The query string is still `?view=trends` in the address bar. The
+        // override must NOT come back — that is what "inert" means.
+        act(() => api.setView('cards'));
+        expect(shown()).toBe('cards');
+    });
+
+    // MUI's exclusive ToggleButtonGroup fires onChange(_, null) when the
+    // already-selected button is clicked. Clearing the override there would drop
+    // the reader from the linked view back to their stored one, on a click that
+    // means "no change".
+    it('absorbs the null an already-active toggle click sends', () => {
+        localStorage.setItem(SWARM_VIEW_STORAGE_KEY, 'cards');
+        mount('/swarm?view=trends');
+        expect(shown()).toBe('trends');
+
+        act(() => api.setView(null));
+        expect(shown()).toBe('trends');
+        act(() => api.setView(undefined));
+        expect(shown()).toBe('trends');
+        expect(stored().local).toBe('cards');
+    });
+});
+
+describe('a CROSS-VIEW HANDSHAKE overrides without persisting', () => {
+    // Clicking a Trends chart bar to inspect its requirements is not a request to
+    // make Table the default in every tab forever.
+    it('shows the view and writes nothing', () => {
+        localStorage.setItem(SWARM_VIEW_STORAGE_KEY, 'trends');
+        sessionStorage.setItem(SWARM_VIEW_STORAGE_KEY, 'trends');
+        mount('/swarm');
+        expect(shown()).toBe('trends');
+
+        act(() => api.showTransiently('table'));
+        expect(shown()).toBe('table');
+        expect(stored()).toEqual({ session: 'trends', local: 'trends' });
+    });
+
+    it('refuses a value outside the vocabulary', () => {
+        mount('/swarm');
+        act(() => api.showTransiently('nope'));
+        expect(shown()).toBe('cards');
+    });
+
+    it('is undone by a later manual pick, which does persist', () => {
+        mount('/swarm');
+        act(() => api.showTransiently('table'));
+        expect(shown()).toBe('table');
+        act(() => api.setView('visualizer'));
+        expect(shown()).toBe('visualizer');
+        expect(stored().local).toBe('visualizer');
+    });
+});
+
+describe('the re-seed fires on a LINK change and nothing else', () => {
+    // The component stays mounted across an in-place navigation, so only the
+    // effect can answer the new link.
+    it('answers an in-place navigation to a new ?view=', () => {
+        mount('/swarm?view=table');
+        expect(shown()).toBe('table');
+
+        act(() => navigate('/swarm?view=trends'));
+        expect(shown()).toBe('trends');
+    });
+
+    it('releases the override when the param is dropped', () => {
+        localStorage.setItem(SWARM_VIEW_STORAGE_KEY, 'visualizer');
+        mount('/swarm?view=table');
+        expect(shown()).toBe('table');
+
+        act(() => navigate('/swarm'));
+        expect(shown()).toBe('visualizer');
+    });
+
+    // A manual pick changes no query param, so `linkView` is referentially
+    // identical and the effect must not re-fire against it. If it did, the pick
+    // would be undone one frame later and the control would look broken — which
+    // is why this asserts the picked view EXACTLY.
+    it('does not resurrect the override after a manual pick', () => {
+        mount('/swarm?view=trends');
+        act(() => api.setView('table'));
+        expect(shown()).toBe('table');
+
+        // A navigation that leaves the query string alone.
+        act(() => navigate('/swarm?view=trends'));
+        expect(shown()).toBe('table');
+    });
+
+    // Same rule from the other side: a re-navigation to the SAME link must not
+    // undo a transient drill either.
+    it('does not resurrect the override after a transient drill', () => {
+        mount('/swarm?view=trends');
+        act(() => api.showTransiently('table'));
+        expect(shown()).toBe('table');
+
+        act(() => navigate('/swarm?view=trends'));
+        expect(shown()).toBe('table');
+    });
+});
+
+describe('the STORED value is validated too', () => {
+    // An unmatched ToggleButtonGroup value selects nothing AND every
+    // `view === '…'` branch goes false — a header row over an empty body, with no
+    // error. localStorage is user- and E2E-writable, so this is reachable.
+    it.each(['', 'kanban', 'TABLE'])('normalizes the unrenderable stored value %o', (bad) => {
+        localStorage.setItem(SWARM_VIEW_STORAGE_KEY, bad);
+        mount('/swarm');
+        expect(shown()).toBe('cards');
+    });
+
+    it('never writes the normalization back', () => {
+        localStorage.setItem(SWARM_VIEW_STORAGE_KEY, 'kanban');
+        sessionStorage.setItem(SWARM_VIEW_STORAGE_KEY, 'kanban');
+        mount('/swarm');
+        expect(shown()).toBe('cards');
+        // A stored value the page cannot render is a temporary condition of the
+        // PAGE, not a preference change the reader made.
+        expect(stored()).toEqual({ session: 'kanban', local: 'kanban' });
+    });
+});

--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -3,12 +3,13 @@ import { useParams, useNavigate, useLocation, Link as RouterLink } from 'react-r
 import call_rest_api from '../../RestApi/RestApi';
 import { useSnackBarStore } from '../../stores/useSnackBarStore';
 import { useShowClosedStore, ALL_REQUIREMENT_STATUSES } from '../../stores/useShowClosedStore';
-import { useAllCategories, useMachines, useFeatureById, useEpicById } from '../../hooks/useDataQueries';
+import { useAllCategories, useMachines, useFeatureById, useEpicById, usePipelinedRequirementIds } from '../../hooks/useDataQueries';
 import { useEpicPipelineLocation } from './useEpicPipelineLocation';
 import { useRequirementStepLocation } from './useRequirementStepLocation';
 import { epicLinkTo } from '../pipelines/pipelineEpicLink';
 import { stepPlanLinkTo } from '../pipelines/pipelineStepLink';
-import { siblingActiveSort } from './requirementSort';
+import { siblingElevator, readElevatorIds } from './requirementSort';
+import { coerceSortMode, DEFAULT_SORT_MODE } from '../processSort';
 import { formatDateTime, formatDate } from '../../utils/dateFormat';
 import { requirementStatusTimestampFields, requirementStatusTimestampState } from '../../utils/requirementStatusTimestamps';
 import AuthContext from '../../Context/AuthContext';
@@ -194,7 +195,7 @@ const RequirementDetail = () => {
     } : null);
     const [sessions, setSessions] = useState([]);
     const [siblings, setSiblings] = useState([]);
-    const [sibSortMode, setSibSortMode] = useState('hand');
+    const [sibSortMode, setSibSortMode] = useState(DEFAULT_SORT_MODE);
     const [loading, setLoading] = useState(!isNew);
 
     // Req #2818: in the aggregator-template / category-unset flow the Category select is
@@ -356,6 +357,10 @@ const RequirementDetail = () => {
     // Filter chips now match DB status values directly
     const siblingStatuses = [...requirementStatusFilter];
 
+    // req #3302 — the card's OTHER filter. See `visibleSiblings` below.
+    const hidePipelined = useShowClosedStore(s => s.hidePipelinedRequirements);
+    const pipelinedIds = usePipelinedRequirementIds(profile?.userName, { enabled: hidePipelined });
+
     const queryClient = useQueryClient();
 
     const requirementDelete = useConfirmDialog({
@@ -446,7 +451,7 @@ const RequirementDetail = () => {
                     // so a dev-seeded session is visible here too (without this, dev showed the
                     // list from darwin_dev but linked sessions from production darwin).
                     call_rest_api(`${darwinUri}/swarm_sessions?source_ref=requirement:${p.id}`, 'GET', '', idToken).catch(() => null),
-                    call_rest_api(`${darwinUri}/requirements?category_fk=${p.category_fk}&fields=id,requirement_status,completed_at,deferred_at,started_at${siblingFilter}`, 'GET', '', idToken).catch(() => null),
+                    call_rest_api(`${darwinUri}/requirements?category_fk=${p.category_fk}&fields=id,requirement_status,completed_at,deferred_at,started_at,sort_order${siblingFilter}`, 'GET', '', idToken).catch(() => null),
                     call_rest_api(`${darwinUri}/categories?id=${p.category_fk}&fields=id,sort_mode`, 'GET', '', idToken).catch(() => null),
                 ]);
 
@@ -457,9 +462,7 @@ const RequirementDetail = () => {
                     setSiblings(siblingsResult.data);
                 }
                 if (categoryResult?.httpStatus?.httpStatus === 200 && categoryResult.data.length > 0) {
-                    // Mirror CategoryCard coercion: 'hand' / 'reverse' pass through, anything else → 'process'.
-                    const raw = categoryResult.data[0].sort_mode;
-                    setSibSortMode(raw === 'hand' ? 'hand' : raw === 'reverse' ? 'reverse' : 'process');
+                    setSibSortMode(coerceSortMode(categoryResult.data[0].sort_mode));
                 }
             } catch (error) {
                 showError(error, 'Unable to load requirement');
@@ -637,11 +640,11 @@ const RequirementDetail = () => {
             : `&requirement_status=(${siblingStatuses.join(',')})`;
         try {
             const [siblingsResult, categoryResult] = await Promise.all([
-                call_rest_api(`${darwinUri}/requirements?category_fk=${newCategoryFk}&fields=id,requirement_status,completed_at,deferred_at,started_at${siblingFilter}`, 'GET', '', idToken).catch(() => null),
+                call_rest_api(`${darwinUri}/requirements?category_fk=${newCategoryFk}&fields=id,requirement_status,completed_at,deferred_at,started_at,sort_order${siblingFilter}`, 'GET', '', idToken).catch(() => null),
                 call_rest_api(`${darwinUri}/categories?id=${newCategoryFk}&fields=id,sort_mode`, 'GET', '', idToken).catch(() => null),
             ]);
             if (siblingsResult?.httpStatus?.httpStatus === 200) setSiblings(siblingsResult.data || []);
-            if (categoryResult?.httpStatus?.httpStatus === 200) setSibSortMode(categoryResult.data[0]?.sort_mode || 'hand');
+            if (categoryResult?.httpStatus?.httpStatus === 200) setSibSortMode(coerceSortMode(categoryResult.data[0]?.sort_mode));
         } catch (e) {
             // siblings refresh is best-effort
         }
@@ -657,18 +660,41 @@ const RequirementDetail = () => {
         }
     }, [focusDescriptionPending, requirement]);
 
-    const sortedSiblings = useMemo(() => {
-        if (!siblings.length) return [];
-        return [...siblings].sort((a, b) => siblingActiveSort(sibSortMode, a, b));
-    }, [siblings, sibSortMode]);
+    // req #3302 — THE ELEVATOR'S POPULATION MUST BE THE CARD'S, not just its
+    // ORDER. `requirementSort.js`'s header states the invariant ("prev/next
+    // navigation matches the row order shown on the category card") and the two
+    // comparators have always agreed; what diverged is WHICH ROWS they sort.
+    // `CategoryCard` gained the pipelined filter in req #3258 and this list did
+    // not, so with `hidePipelinedRequirements` on — its DEFAULT since req #3242 —
+    // the siblings were a strict SUPERSET of the visible rows.
+    //
+    // Measured on `darwin_dev` category 1052 (Agents), default chips: the card's
+    // first row (#3100) sat at sibling index 1 behind pipelined #3074, so Up was
+    // enabled on the first row, and Down from it landed on pipelined #3136 —
+    // a requirement the card does not show at all.
+    //
+    // Same predicate, same source of truth (`utils/pipelineMembership.js`) and
+    // the same in-flight behaviour as the card: an unresolved junction read
+    // yields an empty set and drops nothing, so the elevator can only ever be
+    // too permissive for a moment, never hide a row the card is showing.
+    // req #3302 — the surface that opened this page hands over the ordered ids it
+    // rendered (`elevatorStateFrom`), and that wins. It is the ONLY thing that
+    // can be right for the SwarmStartCard aggregator, whose list is every
+    // category under ONE status with its own filter and sort — nothing derivable
+    // from this requirement's `category_fk`. A refresh or a pasted link carries
+    // no state, and the category query below is the fallback.
+    const linkOrderedIds = readElevatorIds(location.state);
 
-    const currentIndex = useMemo(() => {
-        const idNum = parseInt(id);
-        return sortedSiblings.findIndex(s => parseInt(s.id) === idNum);
-    }, [sortedSiblings, id]);
-
-    const prevId = currentIndex > 0 ? sortedSiblings[currentIndex - 1]?.id : null;
-    const nextId = currentIndex >= 0 && currentIndex < sortedSiblings.length - 1 ? sortedSiblings[currentIndex + 1]?.id : null;
+    const { prevId, nextId } = useMemo(
+        () => siblingElevator(siblings, {
+            sortMode: sibSortMode,
+            pipelinedIds,
+            hidePipelined,
+            currentId: id,
+            orderedIds: linkOrderedIds,
+        }),
+        [siblings, sibSortMode, pipelinedIds, hidePipelined, id, linkOrderedIds],
+    );
 
     const titleOverflow = Math.max(0, (requirement?.title || '').length - TITLE_SOFT_LIMIT);
 

--- a/src/SwarmView/detail/__tests__/elevatorMatchesCard.test.js
+++ b/src/SwarmView/detail/__tests__/elevatorMatchesCard.test.js
@@ -1,0 +1,322 @@
+// req #3302 — the prev/next elevator must agree with the category card.
+//
+// `requirementSort.js`'s own header states the invariant: *"Must stay in sync
+// with CategoryCard.activeSort so prev/next navigation in the single-requirement
+// editor matches the row order shown on the category card."* It had a guard for
+// exactly half of it. The two comparators agreed and always had; what diverged is
+// WHICH ROWS they sort — `CategoryCard` gained the pipelined filter in req #3258
+// (default ON since req #3242) and the sibling list did not, so the elevator
+// walked a strict SUPERSET of the visible rows.
+//
+// So this file pins BOTH halves: the ORDER (comparator parity) and the
+// POPULATION (filter parity). A file that pinned only the first is what let the
+// defect ship.
+
+import { describe, it, expect } from 'vitest';
+import { processSort, processSortReverse, requirementActiveSort, requirementHandSort,
+         coerceSortMode, DEFAULT_SORT_MODE } from '../../processSort';
+import { siblingProcessSort, siblingProcessSortReverse, siblingActiveSort, siblingElevator,
+         elevatorStateFrom, readElevatorIds } from '../requirementSort';
+import { excludePipelined, pipelinedRequirementIds } from '../../../utils/pipelineMembership';
+
+const CHIPS = ['authoring', 'approved', 'swarm_ready', 'development'];
+
+// The real rows from `darwin_dev` category 1052 (Agents), read 2026-08-07 — the
+// population the defect was measured on. Only the fields either sort reads.
+const AGENTS_CATEGORY = [
+    { id: 3074, requirement_status: 'authoring',  started_at: null, completed_at: null, deferred_at: null, pipelined: true },
+    { id: 3100, requirement_status: 'authoring',  started_at: null, completed_at: null, deferred_at: null, pipelined: false },
+    { id: 3136, requirement_status: 'authoring',  started_at: null, completed_at: null, deferred_at: null, pipelined: true },
+    { id: 3137, requirement_status: 'authoring',  started_at: null, completed_at: null, deferred_at: null, pipelined: true },
+    { id: 3152, requirement_status: 'authoring',  started_at: null, completed_at: null, deferred_at: null, pipelined: false },
+    { id: 3164, requirement_status: 'authoring',  started_at: null, completed_at: null, deferred_at: null, pipelined: true },
+    { id: 3101, requirement_status: 'approved',   started_at: null, completed_at: null, deferred_at: null, pipelined: false },
+    { id: 3154, requirement_status: 'approved',   started_at: null, completed_at: null, deferred_at: null, pipelined: false },
+    { id: 3170, requirement_status: 'approved',   started_at: null, completed_at: null, deferred_at: null, pipelined: false },
+];
+
+const junction = (rows) => rows.filter(r => r.pipelined).map(r => ({ requirement_fk: r.id }));
+
+// What the CARD renders: status chips, then the pipelined filter, then the sort.
+//
+// `CategoryCard.activeSort` is now a one-line delegation to `requirementActiveSort`
+// (req #3302), so this models the card with the card's OWN comparator. It used to
+// pick between `processSort`/`processSortReverse` by hand, which silently mapped
+// `hand` onto `processSort` — so parity was never actually asserted in hand mode,
+// which is the elevator's DEFAULT (`RequirementDetail`'s `sibSortMode` starts
+// there). A model that quietly answers a different question than the one asked is
+// the same vacuity this file already carries one scar from.
+const cardRows = (rows, { mode = 'process', hidePipelined = true, chips = CHIPS } = {}) => {
+    const byStatus = rows.filter(r => chips.includes(r.requirement_status));
+    const visible = excludePipelined(byStatus, pipelinedRequirementIds(junction(rows)), hidePipelined);
+    return [...visible].sort((a, b) => requirementActiveSort(mode, a, b)).map(r => r.id);
+};
+
+// What the ELEVATOR walks — through the REAL function `RequirementDetail` calls,
+// never a re-derivation of it. The first cut of this file rebuilt the filter and
+// the sort inline and stayed green when the component's own filter was deleted,
+// which is precisely the vacuity it exists to prevent.
+const elevator = (rows, { mode = 'process', hidePipelined = true, chips = CHIPS, currentId } = {}) =>
+    siblingElevator(
+        rows.filter(r => chips.includes(r.requirement_status)),
+        {
+            sortMode: mode,
+            pipelinedIds: pipelinedRequirementIds(junction(rows)),
+            hidePipelined,
+            currentId,
+        },
+    );
+
+const elevatorRows = (rows, opts = {}) => elevator(rows, opts).ordered.map(r => r.id);
+
+describe('the measured regression — darwin_dev category 1052, default chips', () => {
+    // Before the fix the elevator's population was `byStatus` with no pipelined
+    // filter, which is what these three assertions encode as the WRONG answer.
+    const brokenElevator = elevatorRows(AGENTS_CATEGORY, { hidePipelined: false });
+
+    it('reproduces the defect when the pipelined filter is skipped', () => {
+        // The card's first row sat at index 1, so Up was ENABLED on the first row.
+        expect(brokenElevator.indexOf(3100)).toBe(1);
+        // And Down from it landed on a pipelined row the card does not show.
+        expect(brokenElevator[2]).toBe(3136);
+    });
+
+    // The SYMPTOM, asserted through the arrow ids the buttons are actually
+    // wired to — `disabled={!prevId}` is what "dimmed" means on screen.
+    it('disables Up on the card\'s first row', () => {
+        const { currentIndex, prevId } = elevator(AGENTS_CATEGORY, { currentId: 3100 });
+        expect(currentIndex).toBe(0);
+        expect(prevId).toBeNull();
+    });
+
+    it('sends Down to the card\'s second row, not to a hidden one', () => {
+        const { nextId } = elevator(AGENTS_CATEGORY, { currentId: 3100 });
+        expect(nextId).toBe(3152);
+        expect(elevatorRows(AGENTS_CATEGORY)).not.toContain(3136);
+    });
+
+    it('disables Down on the last visible row', () => {
+        const ids = elevatorRows(AGENTS_CATEGORY);
+        const { nextId } = elevator(AGENTS_CATEGORY, { currentId: ids[ids.length - 1] });
+        expect(nextId).toBeNull();
+    });
+
+    // A requirement the filter itself removes has no place in the list, so
+    // neither arrow may guess a neighbour for it.
+    it('disables BOTH arrows on a requirement the filter hides', () => {
+        const { currentIndex, prevId, nextId } = elevator(AGENTS_CATEGORY, { currentId: 3136 });
+        expect(currentIndex).toBe(-1);
+        expect(prevId).toBeNull();
+        expect(nextId).toBeNull();
+    });
+});
+
+describe('population parity — the elevator walks exactly the card\'s rows', () => {
+    it.each(['process', 'reverse', 'hand'])('agrees in %s mode with the filter ON', (mode) => {
+        expect(elevatorRows(AGENTS_CATEGORY, { mode })).toEqual(cardRows(AGENTS_CATEGORY, { mode }));
+    });
+
+    // The toggle is a CONTROL, so the elevator has to follow it in both
+    // positions — pinning "always exclude" would break the other half.
+    it.each(['process', 'reverse', 'hand'])('agrees in %s mode with the filter OFF', (mode) => {
+        const opts = { mode, hidePipelined: false };
+        expect(elevatorRows(AGENTS_CATEGORY, opts)).toEqual(cardRows(AGENTS_CATEGORY, opts));
+        // ...and OFF really is a different answer, or this proves nothing.
+        expect(elevatorRows(AGENTS_CATEGORY, opts)).not.toEqual(elevatorRows(AGENTS_CATEGORY, { mode }));
+    });
+
+    it('agrees when the status chips are narrowed', () => {
+        const opts = { chips: ['authoring'] };
+        expect(elevatorRows(AGENTS_CATEGORY, opts)).toEqual(cardRows(AGENTS_CATEGORY, opts));
+    });
+
+    it('agrees when every row is pipelined — both go empty, not one', () => {
+        const allPipelined = AGENTS_CATEGORY.map(r => ({ ...r, pipelined: true }));
+        expect(elevatorRows(allPipelined)).toEqual([]);
+        expect(cardRows(allPipelined)).toEqual([]);
+    });
+});
+
+describe('comparator identity — there is ONE implementation (req #3302)', () => {
+    // This block used to compare two ORDERINGS, which passes for as long as two
+    // copies happen to agree and says nothing about whether they are one thing.
+    // The copies are gone: `requirementSort.js` re-exports `processSort.js`, so
+    // the guard is identity. A future re-transcription fails here immediately.
+    it('exports the SAME function objects, not equivalent ones', () => {
+        expect(siblingProcessSort).toBe(processSort);
+        expect(siblingProcessSortReverse).toBe(processSortReverse);
+        expect(siblingActiveSort).toBe(requirementActiveSort);
+    });
+
+    const corpus = [
+        { id: 5,  requirement_status: 'met',         completed_at: '2026-08-01T00:00:00', started_at: null, deferred_at: null },
+        { id: 3,  requirement_status: 'met',         completed_at: '2026-08-03T00:00:00', started_at: null, deferred_at: null },
+        { id: 9,  requirement_status: 'development', started_at: '2026-07-01T00:00:00', completed_at: null, deferred_at: null },
+        { id: 1,  requirement_status: 'development', started_at: '2026-07-09T00:00:00', completed_at: null, deferred_at: null },
+        { id: 12, requirement_status: 'authoring',   started_at: null, completed_at: null, deferred_at: null },
+        { id: 2,  requirement_status: 'approved',    started_at: null, completed_at: null, deferred_at: null },
+        { id: 7,  requirement_status: 'swarm_ready', started_at: null, completed_at: null, deferred_at: null },
+        { id: 4,  requirement_status: 'deferred',    deferred_at: '2026-06-01T00:00:00', started_at: null, completed_at: null },
+        { id: 8,  requirement_status: 'deferred',    deferred_at: '2026-06-30T00:00:00', started_at: null, completed_at: null },
+        { id: 11, requirement_status: 'wontfix',     completed_at: '2026-05-05T00:00:00', started_at: null, deferred_at: null },
+    ];
+
+    it('routes the elevator to the matching comparator', () => {
+        expect(siblingElevator(corpus, { sortMode: 'process' }).ordered.map(r => r.id))
+            .toEqual([...corpus].sort(processSort).map(r => r.id));
+        expect(siblingElevator(corpus, { sortMode: 'reverse' }).ordered.map(r => r.id))
+            .toEqual([...corpus].sort(processSortReverse).map(r => r.id));
+    });
+
+    // req #3302 — the defect the consolidation fixes. `changeSortMode` sorted hand
+    // mode with a BARE `requirementHandSort`, skipping the status band every other
+    // path applies, so the two disagreed the moment terminal work was on the card.
+    // Asserted as a DIFFERENCE, so it cannot pass vacuously on a fixture with no
+    // terminal rows.
+    it('bands terminal work below active work in hand mode', () => {
+        const handed = [...corpus].sort((a, b) => requirementActiveSort('hand', a, b)).map(r => r.id);
+        const bare = [...corpus].sort(requirementHandSort).map(r => r.id);
+        expect(handed).not.toEqual(bare);
+
+        const statusOf = id => corpus.find(r => r.id === id).requirement_status;
+        const terminal = new Set(['met', 'deferred', 'wontfix']);
+        const firstTerminal = handed.findIndex(id => terminal.has(statusOf(id)));
+        const lastActive = handed.map(id => terminal.has(statusOf(id))).lastIndexOf(false);
+        expect(firstTerminal).toBeGreaterThan(lastActive);
+    });
+
+    it('orders hand mode by sort_order within a band, NULL last', () => {
+        const rows = [
+            { id: 30, requirement_status: 'approved', sort_order: null },
+            { id: 10, requirement_status: 'approved', sort_order: 2 },
+            { id: 20, requirement_status: 'approved', sort_order: 1 },
+        ];
+        expect([...rows].sort((a, b) => requirementActiveSort('hand', a, b)).map(r => r.id))
+            .toEqual([20, 10, 30]);
+    });
+});
+
+describe('the handed-over order — the aggregator\'s fix', () => {
+    // The SwarmStartCard aggregator shows EVERY category under ONE status, with
+    // its own filter and sort. Nothing derivable from a requirement's
+    // `category_fk` can reproduce that list, which is why the surface hands it
+    // over instead. These ids are cross-category on purpose.
+    const AGGREGATOR_ROWS = [
+        { id: 3170, requirement_status: 'approved' },
+        { id: 3101, requirement_status: 'approved' },
+        { id: 2401, requirement_status: 'approved' },
+        { id: 3154, requirement_status: 'approved' },
+        { id: '',   requirement_status: 'authoring' },   // the template row
+    ];
+
+    const handed = elevatorStateFrom(AGGREGATOR_ROWS);
+
+    it('carries the rendered ids and drops the template row', () => {
+        expect(handed.siblingIds).toEqual([3170, 3101, 2401, 3154]);
+    });
+
+    it('round-trips through the reader', () => {
+        expect(readElevatorIds(handed)).toEqual([3170, 3101, 2401, 3154]);
+    });
+
+    it('returns null for a link that carried none', () => {
+        expect(readElevatorIds(undefined)).toBeNull();
+        expect(readElevatorIds({})).toBeNull();
+        expect(readElevatorIds({ siblingIds: [] })).toBeNull();
+        expect(readElevatorIds({ from: 'calendar' })).toBeNull();
+    });
+
+    const walk = (currentId) => siblingElevator([], {
+        sortMode: 'process', currentId, orderedIds: handed.siblingIds,
+    });
+
+    it('honours the TOP limit — Up is disabled on the first rendered row', () => {
+        const { currentIndex, prevId, nextId } = walk(3170);
+        expect(currentIndex).toBe(0);
+        expect(prevId).toBeNull();
+        expect(nextId).toBe(3101);
+    });
+
+    it('honours the BOTTOM limit — Down is disabled on the last rendered row', () => {
+        const { prevId, nextId } = walk(3154);
+        expect(prevId).toBe(2401);
+        expect(nextId).toBeNull();
+    });
+
+    it('walks the middle in the rendered order, not a re-sorted one', () => {
+        expect(walk(3101).prevId).toBe(3170);
+        expect(walk(3101).nextId).toBe(2401);
+    });
+
+    // The whole point: the handed-over order is used VERBATIM. Sorting it — by
+    // id, by status, by anything — is what produced the reported symptom.
+    it('does not re-sort the handed-over ids', () => {
+        const ids = siblingElevator([], { sortMode: 'process', orderedIds: handed.siblingIds })
+            .ordered.map(r => r.id);
+        expect(ids).toEqual([3170, 3101, 2401, 3154]);
+        expect(ids).not.toEqual([...ids].sort((a, b) => a - b));
+    });
+
+    // ...and it must not be filtered either. These rows never went through the
+    // pipelined predicate on the way in; applying it here would drop rows the
+    // aggregator deliberately showed.
+    it('does not filter the handed-over ids', () => {
+        const ids = siblingElevator([], {
+            sortMode: 'process',
+            orderedIds: handed.siblingIds,
+            pipelinedIds: new Set([3101, 2401]),
+            hidePipelined: true,
+        }).ordered.map(r => r.id);
+        expect(ids).toEqual([3170, 3101, 2401, 3154]);
+    });
+
+    it('falls back to the category query when the link carried no ids', () => {
+        const viaQuery = siblingElevator(
+            AGENTS_CATEGORY.filter(r => CHIPS.includes(r.requirement_status)),
+            { sortMode: 'process', pipelinedIds: pipelinedRequirementIds(junction(AGENTS_CATEGORY)),
+              hidePipelined: true, currentId: 3100, orderedIds: readElevatorIds(undefined) },
+        );
+        expect(viaQuery.prevId).toBeNull();
+        expect(viaQuery.nextId).toBe(3152);
+    });
+});
+
+describe('coerceSortMode — ONE reading of `categories.sort_mode` (req #3302)', () => {
+    it.each(['hand', 'process', 'reverse'])('passes the live value %s through', (v) => {
+        expect(coerceSortMode(v)).toBe(v);
+    });
+
+    // The two forms that disagreed. `RequirementDetail`'s category-CHANGE path read
+    // `sort_mode || 'hand'` raw while every other reader coerced, so a legacy
+    // `'created'` reached `requirementActiveSort`, which has no case for it and
+    // falls to the HAND branch — changing a requirement's category silently
+    // re-ordered the elevator by a mode the card never uses.
+    it.each([
+        ['the retired legacy value', 'created'],
+        ['an unrecognised value', 'kanban'],
+        ['null', null],
+        ['undefined', undefined],
+        ['empty', ''],
+    ])('resolves %s to the default', (_label, v) => {
+        expect(coerceSortMode(v)).toBe(DEFAULT_SORT_MODE);
+        expect(coerceSortMode(v)).toBe('process');
+    });
+
+    // The specific silent failure: an uncoerced legacy value is not inert, it
+    // selects a DIFFERENT order.
+    it('a raw legacy value would have ordered as hand, not as the default', () => {
+        // Both are ACTIVE, so hand puts them in one band and orders by id, while
+        // process ranks them by status. A met/authoring pair would NOT distinguish
+        // the branches — it sorts the same either way, which is how the first cut
+        // of this assertion passed vacuously.
+        const rows = [
+            { id: 1, requirement_status: 'development' },
+            { id: 3, requirement_status: 'authoring' },
+        ];
+        const asRaw = [...rows].sort((a, b) => requirementActiveSort('created', a, b)).map(r => r.id);
+        const asHand = [...rows].sort((a, b) => requirementActiveSort('hand', a, b)).map(r => r.id);
+        const asCoerced = [...rows].sort((a, b) => requirementActiveSort(coerceSortMode('created'), a, b)).map(r => r.id);
+        expect(asRaw).toEqual(asHand);          // unrecognised falls to the hand branch
+        expect(asCoerced).not.toEqual(asRaw);   // ...and coercing genuinely changes the answer
+    });
+});

--- a/src/SwarmView/detail/requirementSort.js
+++ b/src/SwarmView/detail/requirementSort.js
@@ -1,101 +1,131 @@
 // Sort helpers for the RequirementDetail sibling list.
 // Must stay in sync with CategoryCard.activeSort so prev/next navigation in the
 // single-requirement editor matches the row order shown on the category card.
+//
+// req #3302 — THAT INVARIANT IS ABOUT THE POPULATION AS WELL AS THE ORDER, and
+// only the order was ever honoured here. `CategoryCard` gained the pipelined
+// filter in req #3258 (default ON since req #3242) and this list did not, so the
+// elevator walked a strict SUPERSET of the visible rows: Up was enabled on the
+// card's first row, and Down landed on a requirement the card does not show.
+// `siblingElevator` below now owns BOTH halves plus the index arithmetic, so a
+// test can reach the answer the component actually renders rather than
+// re-deriving it — the failure mode that let this ship with a green suite.
 
-export const STATUS_SORT = {
-    authoring: 0,
-    approved: 0,
-    swarm_ready: 0,
-    development: 0,
-    deferred: 1,
-    met: 2,
-    wontfix: 3,
+import { excludePipelined } from '../../utils/pipelineMembership';
+
+// req #3302 — ONE IMPLEMENTATION. These were a second transcription of
+// `../processSort.js`'s comparators, kept in step by hand and by this file's own
+// header comment. They are now re-exports of the single implementation, under
+// the names this module's callers and tests already use. The `sibling*` aliases
+// survive because they read correctly at the call site (the detail page walks
+// SIBLINGS); they are the same functions, which
+// `__tests__/elevatorMatchesCard.test.js` asserts by identity rather than by
+// comparing two orderings — a comparison passes while two copies happen to agree
+// and says nothing about whether they are one thing.
+export {
+    STATUS_SORT_ACTIVE as STATUS_SORT,
+    STATUS_SORT_PROCESS,
+    STATUS_SORT_PROCESS_REVERSE,
+    processSort as siblingProcessSort,
+    processSortReverse as siblingProcessSortReverse,
+    requirementActiveSort as siblingActiveSort,
+} from '../processSort';
+
+import { requirementActiveSort } from '../processSort';
+
+const siblingActiveSortLocal = requirementActiveSort;
+
+/**
+ * THE elevator: which siblings the prev/next arrows walk, in what order, and
+ * where the current requirement sits in them.
+ *
+ * One function because the three answers are one fact. Splitting them is how the
+ * page came to sort the right rows and navigate the wrong ones.
+ *
+ * `hidePipelined` is passed through rather than assumed: the toggle is a user
+ * CONTROL on a browse surface (`useShowClosedStore.hidePipelinedRequirements`),
+ * so the elevator has to follow it in BOTH positions. When it is off — or while
+ * the junction read is still in flight, leaving `pipelinedIds` empty —
+ * `excludePipelined` returns the input untouched, so the elevator can only ever
+ * be momentarily too permissive, never hide a row the card is showing.
+ *
+ * @param {Array<{id: number|string, requirement_status: string}>} siblings
+ * @param {object}  opts
+ * @param {string}  opts.sortMode       'process' | 'reverse' | 'hand'
+ * @param {Set<number>} [opts.pipelinedIds]  from `pipelinedRequirementIds`
+ * @param {boolean} [opts.hidePipelined=false]
+ * @param {number|string} [opts.currentId]   the requirement being viewed
+ * @returns {{ordered: Array, currentIndex: number, prevId: (number|null), nextId: (number|null)}}
+ *   `currentIndex` is -1 when the current requirement is not in the visible set
+ *   (it is itself filtered out, or the read has not landed); both ids are then
+ *   null, which disables both arrows rather than guessing a neighbour.
+ */
+export const siblingElevator = (siblings, {
+    sortMode,
+    pipelinedIds,
+    hidePipelined = false,
+    currentId,
+    orderedIds = null,
+} = {}) => {
+    // HANDED-OVER ORDER WINS, and is used verbatim — no filter, no sort. It is
+    // the list the reader was looking at when they clicked, so re-deriving it
+    // could only make it agree less. This is the aggregator's whole fix, and it
+    // also makes the card exact in `hand` mode, where the sibling REST read does
+    // not even project the `sort_order` the card ordered by.
+    const ordered = orderedIds
+        ? orderedIds.map(id => ({ id }))
+        : (() => {
+            const rows = Array.isArray(siblings) ? siblings : [];
+            const visible = excludePipelined(rows, pipelinedIds, hidePipelined) || [];
+            return [...visible].sort((a, b) => siblingActiveSortLocal(sortMode, a, b));
+        })();
+
+    const idNum = parseInt(currentId, 10);
+    const currentIndex = Number.isNaN(idNum)
+        ? -1
+        : ordered.findIndex(s => parseInt(s.id, 10) === idNum);
+
+    return {
+        ordered,
+        currentIndex,
+        prevId: currentIndex > 0 ? (ordered[currentIndex - 1]?.id ?? null) : null,
+        nextId: currentIndex >= 0 && currentIndex < ordered.length - 1
+            ? (ordered[currentIndex + 1]?.id ?? null)
+            : null,
+    };
 };
 
-export const STATUS_SORT_PROCESS = {
-    authoring: 0,
-    approved: 1,
-    swarm_ready: 2,
-    development: 3,
-    deferred: 4,
-    met: 5,
-    wontfix: 6,
-};
+// ── The ELEVATOR LINK — one contract, both halves (req #3302) ────────────────
+//
+// A category card and the SwarmStartCard aggregator show DIFFERENT LISTS of the
+// same requirements: the card is one category under the status chips and the
+// pipelined toggle; the aggregator is EVERY category under ONE status, with
+// pipelined work excluded unconditionally and its own sort. Rebuilding either
+// from `category_fk` gets the aggregator wrong in all three dimensions at once
+// — scope, filter and order — which is what "the aggregator ignores top, bottom
+// and sort order" was.
+//
+// So the surface that opened the detail page HANDS OVER the ordered ids it
+// actually rendered, and the elevator walks those. There is no second
+// derivation to drift from the first — the failure this file already carries one
+// scar from. Both halves live here so the writer and the reader cannot disagree
+// about the key.
+//
+// It is carried in router state, so a REFRESH or a pasted link has none, and the
+// elevator falls back to the category query. That is the honest degradation:
+// with no list on screen there is nothing for the arrows to contradict.
 
-// Reverse-order rank (req #2406). Must match STATUS_SORT_PROCESS_REVERSE in ../processSort.js.
-export const STATUS_SORT_PROCESS_REVERSE = {
-    deferred: 0,
-    met: 1,
-    wontfix: 2,
-    development: 3,
-    swarm_ready: 4,
-    approved: 5,
-    authoring: 6,
-};
+/** Router state for a row opening the detail page. Spread into `navigate`'s `state`. */
+export const elevatorStateFrom = (requirementsArray) => ({
+    // The template row (`id === ''`) is an input affordance, not a requirement.
+    siblingIds: (Array.isArray(requirementsArray) ? requirementsArray : [])
+        .filter(r => r && r.id !== '' && r.id !== null && r.id !== undefined)
+        .map(r => Number(r.id))
+        .filter(n => !Number.isNaN(n)),
+});
 
-export const siblingCreatedSort = (a, b) => a.id - b.id;
-
-// Within-group secondary sort shared by forward and reverse process sorts.
-// Recency/id-tiebreaker carry the same meaning in either direction.
-const secondarySort = (a, b) => {
-    switch (a.requirement_status) {
-        case 'development': {
-            const aTime = a.started_at ? new Date(a.started_at).getTime() : 0;
-            const bTime = b.started_at ? new Date(b.started_at).getTime() : 0;
-            return aTime - bTime;  // oldest started first
-        }
-        case 'deferred': {
-            const aTime = a.deferred_at ? new Date(a.deferred_at).getTime() : 0;
-            const bTime = b.deferred_at ? new Date(b.deferred_at).getTime() : 0;
-            return bTime - aTime;  // most recently deferred first
-        }
-        case 'met':
-        case 'wontfix': {
-            // wontfix is terminal like met — both timestamp via completed_at (req #2783)
-            const aTime = a.completed_at ? new Date(a.completed_at).getTime() : 0;
-            const bTime = b.completed_at ? new Date(b.completed_at).getTime() : 0;
-            return bTime - aTime;  // most recently completed first
-        }
-        default:  // authoring, approved, swarm_ready — oldest (smallest id) first
-            return a.id - b.id;
-    }
-};
-
-export const siblingProcessSort = (a, b) => {
-    const aRank = STATUS_SORT_PROCESS[a.requirement_status] ?? 0;
-    const bRank = STATUS_SORT_PROCESS[b.requirement_status] ?? 0;
-    if (aRank !== bRank) return aRank - bRank;
-    return secondarySort(a, b);
-};
-
-export const siblingProcessSortReverse = (a, b) => {
-    const aRank = STATUS_SORT_PROCESS_REVERSE[a.requirement_status] ?? 0;
-    const bRank = STATUS_SORT_PROCESS_REVERSE[b.requirement_status] ?? 0;
-    if (aRank !== bRank) return aRank - bRank;
-    return secondarySort(a, b);
-};
-
-export const siblingActiveSort = (sortMode, a, b) => {
-    if (sortMode === 'process') return siblingProcessSort(a, b);
-    if (sortMode === 'reverse') return siblingProcessSortReverse(a, b);
-    const aState = STATUS_SORT[a.requirement_status] ?? 0;
-    const bState = STATUS_SORT[b.requirement_status] ?? 0;
-    if (aState !== bState) return aState - bState;
-    if (a.requirement_status === 'met' && b.requirement_status === 'met') {
-        const aTime = a.completed_at ? new Date(a.completed_at).getTime() : 0;
-        const bTime = b.completed_at ? new Date(b.completed_at).getTime() : 0;
-        if (aTime !== bTime) return bTime - aTime;
-    }
-    if (a.requirement_status === 'deferred' && b.requirement_status === 'deferred') {
-        const aTime = a.deferred_at ? new Date(a.deferred_at).getTime() : 0;
-        const bTime = b.deferred_at ? new Date(b.deferred_at).getTime() : 0;
-        if (aTime !== bTime) return bTime - aTime;
-    }
-    if (a.requirement_status === 'wontfix' && b.requirement_status === 'wontfix') {
-        // wontfix timestamps via completed_at (terminal, like met — req #2783)
-        const aTime = a.completed_at ? new Date(a.completed_at).getTime() : 0;
-        const bTime = b.completed_at ? new Date(b.completed_at).getTime() : 0;
-        if (aTime !== bTime) return bTime - aTime;
-    }
-    return siblingCreatedSort(a, b);
+/** The ordered ids a link carried, or `null` when it carried none. */
+export const readElevatorIds = (locationState) => {
+    const ids = locationState?.siblingIds;
+    return Array.isArray(ids) && ids.length > 0 ? ids : null;
 };

--- a/src/SwarmView/processSort.js
+++ b/src/SwarmView/processSort.js
@@ -74,3 +74,79 @@ export const requirementHandSort = (a, b) => {
     if (aSort !== bSort) return aSort - bSort;
     return a.id - b.id;
 };
+
+// ── THE requirement sort — one implementation, three modes (req #3302) ───────
+//
+// There were THREE copies of this rule and they disagreed:
+//
+//  1. `CategoryCard.activeSort` — status band, then `requirementHandSort`.
+//  2. `CategoryCard.changeSortMode` — bare `requirementHandSort`, NO status band.
+//     So picking Hand Sort ordered the rows one way and the very next refetch,
+//     status-chip toggle or cross-card drop re-ordered them another, with nothing
+//     on screen to explain it.
+//  3. `detail/requirementSort.js` — a second transcription of the comparators for
+//     the prev/next elevator, whose header already declared it must not drift.
+//
+// This is now the only one. (2) and (3) call it; `requirementSort.js` re-exports
+// the names its own callers and tests use.
+//
+// The status BAND is deliberate in hand mode and is not a bug being preserved:
+// terminal work sinks below active work in every mode, and `sort_order` positions
+// a row WITHIN its band. `changeSortMode` skipping it was the defect.
+const STATUS_SORT_ACTIVE = {
+    authoring: 0, approved: 0, swarm_ready: 0, development: 0,
+    deferred: 1, met: 2, wontfix: 3,
+};
+
+/**
+ * @param {string} sortMode  'process' | 'reverse' | anything else → hand
+ * @returns {number} comparator result; the template row (`id === ''`) sorts last.
+ */
+export const requirementActiveSort = (sortMode, a, b) => {
+    if (a.id === '') return 1;
+    if (b.id === '') return -1;
+    if (sortMode === 'process') return processSort(a, b);
+    if (sortMode === 'reverse') return processSortReverse(a, b);
+
+    const aState = STATUS_SORT_ACTIVE[a.requirement_status] ?? 0;
+    const bState = STATUS_SORT_ACTIVE[b.requirement_status] ?? 0;
+    if (aState !== bState) return aState - bState;
+
+    // Within a terminal band, most-recent first. `secondarySort` is not reused
+    // here: it keys off the status ranks of the PROCESS ladder, and hand mode's
+    // bands are coarser (all four active statuses share band 0).
+    if (a.requirement_status === b.requirement_status) {
+        const key = a.requirement_status === 'deferred' ? 'deferred_at'
+            : (a.requirement_status === 'met' || a.requirement_status === 'wontfix') ? 'completed_at'
+            : null;
+        if (key) {
+            const aTime = a[key] ? new Date(a[key]).getTime() : 0;
+            const bTime = b[key] ? new Date(b[key]).getTime() : 0;
+            if (aTime !== bTime) return bTime - aTime;
+        }
+    }
+    return requirementHandSort(a, b);
+};
+
+export { STATUS_SORT_ACTIVE };
+
+/** The card's default order when a category names nothing usable. */
+export const DEFAULT_SORT_MODE = 'process';
+
+/**
+ * `categories.sort_mode` -> one of the three live values (req #3302).
+ *
+ * FOUR copies of this coercion existed and TWO of them disagreed: `CategoryCard`
+ * (twice — the initial state and the rollback) and `RequirementDetail`'s initial
+ * load read `'hand' | 'reverse' | else process`, while its category-CHANGE path
+ * read `sort_mode || 'hand'` raw. That second form hands a legacy `'created'`
+ * straight through to `requirementActiveSort`, which has no case for it and falls
+ * to the HAND branch — so changing a requirement's category could silently
+ * re-order the prev/next elevator by a mode the card never uses. A NULL differed
+ * too: `'hand'` on one path, `'process'` on the other.
+ *
+ * Legacy `'created'` (retired) and anything unrecognised resolve to `process`,
+ * which is what every live category row carries.
+ */
+export const coerceSortMode = (raw) =>
+    raw === 'hand' ? 'hand' : raw === 'reverse' ? 'reverse' : DEFAULT_SORT_MODE;

--- a/src/SwarmView/swarmViewLink.js
+++ b/src/SwarmView/swarmViewLink.js
@@ -1,0 +1,60 @@
+// `/swarm?view=<panel>` — the URL contract for the requirements page's view
+// toggle (req #3168 R9, req #3302).
+//
+// ITS OWN MODULE, and it owns BOTH halves of the contract — the vocabulary and
+// the reader — for the reason `pipelineStepLink.js` gives: a writer and a reader
+// in two files drift on the key, and nothing fails when they do. It carries no
+// JSX and no MUI import so vitest can exercise it without a DOM, and so
+// `SwarmView.jsx` keeps its single component export and stays inside React Fast
+// Refresh (`memory/view-switchable-pages.md` § I, the `instructionSort.js`
+// lesson).
+
+/** The page's four panels, in toggle order. */
+export const SWARM_VIEWS = ['cards', 'table', 'visualizer', 'trends'];
+
+/** The view a first-time visitor lands on. */
+export const DEFAULT_SWARM_VIEW = 'cards';
+
+/** The `localStorage` / `sessionStorage` key `useViewPreference` persists under (R1). */
+export const SWARM_VIEW_STORAGE_KEY = 'darwin-swarm-view';
+
+/** The query parameter. `view`, because this page's toggle switches VIEWS (R9). */
+export const SWARM_VIEW_PARAM = 'view';
+
+/**
+ * The view a link is asking for, or `null` when it is not asking for one.
+ *
+ * VALIDATED, NEVER TRUSTED. An unknown `?view=xyz` is a typo; returning `null`
+ * leaves the reader's stored preference in charge rather than selecting nothing
+ * in the `ToggleButtonGroup`.
+ *
+ * The caller treats the result as a TRANSIENT OVERRIDE and never writes it back:
+ * a link asks to see one thing once, and must not redefine the reader's default
+ * (the `normalizeView` doctrine — an external condition never overwrites
+ * uncommitted user intent).
+ *
+ * @param {URLSearchParams} searchParams
+ * @returns {string|null}
+ */
+export const readViewParam = (searchParams) => {
+    const requested = searchParams?.get?.(SWARM_VIEW_PARAM);
+    return SWARM_VIEWS.includes(requested) ? requested : null;
+};
+
+/**
+ * The `to` for a link that should land on one view of `/swarm`.
+ *
+ * The writing half of the contract. It names EVERY view it is asked for, the
+ * default included — `?view=cards` is not redundant, because `/swarm` alone
+ * lands a reader with a stored Table preference on Table, which is the exact gap
+ * R9 exists to close. A link that means the PAGE rather than one view of it does
+ * not call this; it writes `/swarm`.
+ *
+ * An unknown view falls back to the bare route rather than emitting a parameter
+ * the reader would discard.
+ *
+ * @param {string} view
+ * @returns {string}
+ */
+export const swarmViewLinkTo = (view) =>
+    SWARM_VIEWS.includes(view) ? `/swarm?${SWARM_VIEW_PARAM}=${view}` : '/swarm';

--- a/src/SwarmView/useSwarmViewSelection.js
+++ b/src/SwarmView/useSwarmViewSelection.js
@@ -1,0 +1,73 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useViewPreference } from '../hooks/useViewPreference';
+import { normalizeView } from '../Components/ViewerHeader/normalizeView';
+import { SWARM_VIEWS, SWARM_VIEW_STORAGE_KEY, DEFAULT_SWARM_VIEW, readViewParam } from './swarmViewLink';
+
+// `normalizeView`'s shape. Every entry is enabled — `/swarm` has no not-yet-built
+// view, so V1's disabled-button case does not arise here.
+const VIEW_ENTRIES = SWARM_VIEWS.map(value => ({ value }));
+
+/**
+ * Which panel `/swarm` shows, and the three ways it can change (req #3302).
+ *
+ * ITS OWN MODULE because the rules below are STATEFUL, and a stateful rule that
+ * lives inside a 900-line page component is a rule no test can reach — the
+ * `instructionSort.js` lesson, and req #3246's "prose an LLM must interpret is
+ * not a mechanism" applied to a component. `SwarmView` needs a Router, both
+ * Contexts, a QueryClient and a DnD provider to mount; this hook needs a Router.
+ *
+ * The contract is R9's (`memory/view-switchable-pages.md`), whose reference
+ * instance is `PipelineDetail.jsx`'s `?mode=`:
+ *
+ *  - `?view=` is a TRANSIENT OVERRIDE and is NEVER written to the persisted
+ *    preference. A link asks to see one thing once; it must not redefine the
+ *    reader's default.
+ *  - A MANUAL PICK clears the override and persists, so the link goes inert from
+ *    that moment even though the query string is still in the address bar.
+ *  - A CROSS-VIEW HANDSHAKE (`showTransiently`) sets the override and persists
+ *    NOTHING. Drilling from a chart bar into the table is not a request to make
+ *    Table the default in every tab forever.
+ *  - The param is VALIDATED, never trusted, and so is the STORED value: both can
+ *    name a view this page does not have, and an unmatched ToggleButtonGroup
+ *    value selects nothing while every `view === '…'` branch goes false — a
+ *    header row over an empty body, with no error.
+ *
+ * @returns {{view: string, setView: (v: string|null) => void,
+ *            showTransiently: (v: string) => void, linkView: string|null}}
+ */
+export function useSwarmViewSelection() {
+    const [storedView, setStoredView] = useViewPreference(SWARM_VIEW_STORAGE_KEY, DEFAULT_SWARM_VIEW);
+    const [searchParams] = useSearchParams();
+    const linkView = readViewParam(searchParams);
+
+    // Re-seeded when the LINK changes, exactly as `PipelineDetail` re-seeds on a
+    // new link or record id: navigating in place from one `?view=` to another must
+    // not be answered by the previous link's already-cleared override. `linkView`
+    // is a primitive, so a manual pick — which changes no query param — leaves the
+    // dependency identical and the effect does not re-fire against it.
+    const [override, setOverride] = useState(linkView);
+    useEffect(() => { setOverride(linkView); }, [linkView]);
+
+    const view = normalizeView(override || storedView, VIEW_ENTRIES);
+
+    const setView = useCallback((newView) => {
+        // The hook's own null-guard would cover the stored write, but not the
+        // override: an exclusive ToggleButtonGroup sends `null` when the
+        // already-selected button is clicked, and clearing the override there
+        // would drop the reader from the linked view back to their stored one on
+        // a click that means "no change" (§ G pitfall 6, from the other side).
+        if (newView === null || newView === undefined) return;
+        setOverride(null);
+        setStoredView(newView);
+    }, [setStoredView]);
+
+    const showTransiently = useCallback((newView) => {
+        if (!SWARM_VIEWS.includes(newView)) return;
+        setOverride(newView);
+    }, []);
+
+    return { view, setView, showTransiently, linkView };
+}
+
+export default useSwarmViewSelection;

--- a/src/TaskPlanView/SwarmStartCard.jsx
+++ b/src/TaskPlanView/SwarmStartCard.jsx
@@ -37,6 +37,72 @@ import { requirementStatusTimestampFields, requirementStatusTimestampState } fro
 // 'wontfix' was never added, same reasoning). 'met' is special-cased: it shows only
 // the trailing-24h Met list — recent completions, not the full Met history.
 const SWARM_START_STATUSES = ['authoring', 'approved', 'swarm_ready', 'development', 'met'];
+
+// ── The card's order (req #3302) ────────────────────────────────────────────
+//
+// Two REAL positions. They were `hand` and `created`, and `changeSortMode`
+// discarded the value it was handed — both ran `isMet ? metSort : createdSort`,
+// so the menu had two entries and one behaviour and only the checkmark moved.
+//
+// Hand sort cannot work on this card at all: it aggregates ACROSS categories
+// while `requirements.sort_order` positions a row within ONE of them, and the
+// card is deliberately not a drop target (`memory/aggregator-card-pattern.md`),
+// so there is no way to set a position. The two orders that are meaningful for
+// "every requirement with status X" are the two comparators this file already
+// had, so this makes them selectable rather than inventing a third.
+export const SORT_OLDEST = 'oldest';
+export const SORT_NEWEST = 'newest';
+
+// The template row (id === '') is an input affordance, not a requirement, and
+// stays anchored at the bottom on every re-sort.
+const templateLast = (a, b) => (a.id === '' ? 1 : b.id === '' ? -1 : 0);
+
+// THE TWO MODES ARE INVERSES OVER ONE KEY, and that is not decoration. A first
+// cut made Oldest `id ASC` and Newest `completed_at DESC`, so on the met chip the
+// two answered different questions and the pair only looked like a direction
+// toggle — its own test caught it by asserting they must DIFFER on a fixture
+// where those two keys happened to agree.
+//
+// The key is "when did this happen": `completed_at` where there is one, id
+// otherwise. Rows with no completion sort LAST in both directions — they are
+// undated, not earliest, and flipping them to the front under Oldest would make
+// the met chip open on the rows it knows least about.
+const completedAtOf = (r) => (r.completed_at ? new Date(r.completed_at).getTime() : null);
+
+const byRecency = (a, b, dir) => {
+    const t = templateLast(a, b);
+    if (t) return t;
+    const aTime = completedAtOf(a);
+    const bTime = completedAtOf(b);
+    // Undated last, both directions.
+    if (aTime === null && bTime !== null) return 1;
+    if (bTime === null && aTime !== null) return -1;
+    if (aTime !== null && bTime !== null && aTime !== bTime) return (bTime - aTime) * dir;
+    // No completion anywhere — every row on the four queue chips — so the id is
+    // the only ordering fact there is.
+    return (b.id - a.id) * dir;
+};
+
+// Newest first: most-recently-completed first (req #2613's `metSort`), id DESC
+// where nothing is completed.
+const newestSort = (a, b) => byRecency(a, b, 1);
+
+// Oldest first: the exact inverse. id ASC where nothing is completed, which is
+// what the four queue chips have always shown.
+const oldestSort = (a, b) => byRecency(a, b, -1);
+
+export const aggregatorSort = (mode) => (mode === SORT_NEWEST ? newestSort : oldestSort);
+
+/**
+ * The order a chip shows before the reader has chosen one.
+ *
+ * Exported so a test can reach the rule rather than re-derive it. Newest for
+ * `met` — req #2613 made that list most-recently-completed first and it is what
+ * the list is read for — and Oldest for the four queue chips, which is what they
+ * have always shown. Keeping "unchosen" distinct from either value is what let
+ * the menu become real without changing what any chip shows on arrival.
+ */
+export const defaultSortMode = (isMet) => (isMet ? SORT_NEWEST : SORT_OLDEST);
 const MET_TRAILING_HOURS = 24;
 // Met window refresh cadence — also the quantum the window is rounded to so that
 // re-renders within a single quantum don't mint a new query key (req #2609).
@@ -57,8 +123,8 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import AccessTimeIcon from '@mui/icons-material/AccessTime';
-import SwapVertIcon from '@mui/icons-material/SwapVert';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { CircularProgress } from '@mui/material';
 
@@ -85,7 +151,15 @@ const SwarmStartCard = () => {
 
     const [requirementsArray, setRequirementsArray] = useState();
     const [sessionStatusMap, setSessionStatusMap] = useState({});
-    const [sortMode, setSortMode] = useState('hand');
+    // req #3302 — a REAL two-position order. This was `'hand' | 'created'`, and
+    // `changeSortMode` ignored the value entirely: both items ran
+    // `isMet ? metSort : createdSort`, so the two menu entries produced the same
+    // list and only the checkmark moved. Hand sort cannot work here at all — the
+    // aggregator is CROSS-CATEGORY and `requirements.sort_order` positions a row
+    // within ONE category, and the card is not a drop target, so there is no way
+    // to set it. The two orders that ARE meaningful for "every requirement with
+    // status X" are the two comparators this file already had.
+    const [sortMode, setSortMode] = useState(null);
     const [menuAnchorEl, setMenuAnchorEl] = useState(null);
     const menuOpen = Boolean(menuAnchorEl);
 
@@ -103,6 +177,14 @@ const SwarmStartCard = () => {
     }, [selectedStatus, effectiveStatus, setSelectedStatus]);
 
     const isMet = effectiveStatus === 'met';
+
+    // `null` means the reader has not chosen, so the chip's own default applies —
+    // Newest for `met` (req #2613: most-recently-completed first, which is what
+    // that list is read for) and Oldest for the four queue chips. Keeping the
+    // unchosen state distinct is what lets the menu become real without changing
+    // what either chip shows on arrival. A pick sticks for the visit and applies
+    // to every chip, which is why it is not persisted per status.
+    const effectiveSortMode = sortMode ?? defaultSortMode(isMet);
 
     // Trailing-24h Met window — quantized to MET_REFRESH_INTERVAL_MS boundaries and
     // bumped on a timer + tab-visibility return (req #2609). Quantization keeps the
@@ -232,42 +314,33 @@ const SwarmStartCard = () => {
         return counts;
     }, [allRequirementsForCounts, serverMetRequirements, eligibleMetRequirements, pipelinedIds, hidePipelined]);
 
-    // Template rows (id === '') always sort last so they stay anchored at the
-    // bottom of the card on every re-sort.
-    const createdSort = (a, b) => {
-        if (a.id === '') return 1;
-        if (b.id === '') return -1;
-        return a.id - b.id;
-    };
+    // Comparators are module-level — see `aggregatorSort` above.
 
-    // Met chip sort (req #2613): most-recently-completed first. Rows missing
-    // completed_at sink to the end; id DESC tiebreaker so same-instant completions
-    // surface the higher (typically newer) id first.
-    const metSort = (a, b) => {
-        if (a.id === '') return 1;
-        if (b.id === '') return -1;
-        const aTime = a.completed_at ? new Date(a.completed_at).getTime() : -Infinity;
-        const bTime = b.completed_at ? new Date(b.completed_at).getTime() : -Infinity;
-        if (aTime !== bTime) return bTime - aTime;
-        return b.id - a.id;
-    };
-
-    // Seed local state from server data (re-runs on every fetch — including chip switch).
-    // After req #2405 removed requirements.sort_order, 'hand' and 'created' sort modes
-    // both resolve to id-ascending order; the toggle is retained only for UI continuity
-    // and will be removed in a follow-up req.
+    // Seed local state from server data (re-runs on every fetch, chip switch, and
+    // sort-order pick). THE ONLY PLACE THIS CARD ORDERS ITS ROWS — `changeSortMode`
+    // deliberately re-sorts nothing, so there is one ordering path rather than two
+    // racing ones (req #3302).
     useEffect(() => {
         if (!currentRequirements) {
             setRequirementsArray(undefined);
             return;
         }
         const sorted = [...currentRequirements];
-        sorted.sort((a, b) => isMet ? metSort(a, b) : createdSort(a, b));
+        sorted.sort(aggregatorSort(effectiveSortMode));
         // Template row (req #2414) — title-only entry; saving is deferred to the
         // requirement editor where the user must pick a category before any POST.
-        sorted.push({ id: '', title: '', requirement_status: 'authoring', category_fk: null });
-        setRequirementsArray(sorted);
-    }, [currentRequirements, isMet]); // eslint-disable-line react-hooks/exhaustive-deps
+        //
+        // CARRY THE EXISTING TEMPLATE FORWARD (req #2747's fix, which `CategoryCard`
+        // has had since then and this card never did). A fresh `{ title: '' }`
+        // discards whatever the user has typed into the add-row but not yet saved,
+        // and since req #3302 this effect re-runs on a sort-order pick as well as
+        // on a refetch — so the loss went from occasional to routine.
+        setRequirementsArray(prev => {
+            const prevTemplate = prev && prev.find(r => r.id === '');
+            return [...sorted, prevTemplate
+                ?? { id: '', title: '', requirement_status: 'authoring', category_fk: null }];
+        });
+    }, [currentRequirements, effectiveSortMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // Build session status map (same logic as CategoryCard)
     useEffect(() => {
@@ -292,14 +365,18 @@ const SwarmStartCard = () => {
     const handleMenuOpen = (e) => setMenuAnchorEl(e.currentTarget);
     const handleMenuClose = () => setMenuAnchorEl(null);
 
+    // RECORD THE PICK, ALWAYS. The re-sort is the seeding effect's, which re-runs
+    // on `effectiveSortMode`.
+    //
+    // There is deliberately no `newMode === effectiveSortMode` early return: an
+    // unchosen `sortMode` is `null`, so on the met chip `effectiveSortMode` is
+    // already 'newest' and such a guard would swallow the click on "Newest first"
+    // — leaving the card looking correct while recording nothing, so switching
+    // chips silently flipped the order back. NOT CHANGING THE ORDER IS NOT THE
+    // SAME AS NOT CHANGING THE INTENTION.
     const changeSortMode = (newMode) => {
         handleMenuClose();
         setSortMode(newMode);
-        if (requirementsArray) {
-            const sorted = [...requirementsArray];
-            sorted.sort((a, b) => isMet ? metSort(a, b) : createdSort(a, b));
-            setRequirementsArray(sorted);
-        }
     };
 
     const handleChipClick = (status) => {
@@ -543,15 +620,15 @@ const SwarmStartCard = () => {
                         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
                     >
-                        <MenuItem onClick={() => changeSortMode('hand')} data-testid="swarm-start-sort-hand">
-                            <ListItemIcon><SwapVertIcon fontSize="small" /></ListItemIcon>
-                            <ListItemText>Hand Sort</ListItemText>
-                            {sortMode === 'hand' && <Check fontSize="small" sx={{ ml: 1 }} />}
+                        <MenuItem onClick={() => changeSortMode(SORT_OLDEST)} data-testid="swarm-start-sort-oldest">
+                            <ListItemIcon><ArrowUpwardIcon fontSize="small" /></ListItemIcon>
+                            <ListItemText>Oldest first</ListItemText>
+                            {effectiveSortMode === SORT_OLDEST && <Check fontSize="small" sx={{ ml: 1 }} />}
                         </MenuItem>
-                        <MenuItem onClick={() => changeSortMode('created')} data-testid="swarm-start-sort-created">
-                            <ListItemIcon><AccessTimeIcon fontSize="small" /></ListItemIcon>
-                            <ListItemText>Created Sort</ListItemText>
-                            {sortMode === 'created' && <Check fontSize="small" sx={{ ml: 1 }} />}
+                        <MenuItem onClick={() => changeSortMode(SORT_NEWEST)} data-testid="swarm-start-sort-newest">
+                            <ListItemIcon><ArrowDownwardIcon fontSize="small" /></ListItemIcon>
+                            <ListItemText>Newest first</ListItemText>
+                            {effectiveSortMode === SORT_NEWEST && <Check fontSize="small" sx={{ ml: 1 }} />}
                         </MenuItem>
                     </Menu>
                 </Box>
@@ -565,7 +642,11 @@ const SwarmStartCard = () => {
                         deleteClick,
                         requirementsArray,
                         setRequirementsArray,
-                        sortMode: 'created', // suppress insert indicators — no same-card reorder
+                        // A SENTINEL, not this card's sort mode (which is
+                        // SORT_OLDEST/SORT_NEWEST since req #3302). `RequirementRow`
+                        // reads it only to suppress the hand-sort insert indicators,
+                        // because the aggregator is not a drop target.
+                        sortMode: 'created',
                         setCrossCardInsertIndex,
                         sessionStatusMap,
                         categoryColorMap,

--- a/src/TaskPlanView/__tests__/SwarmStartCard.sortMenu.test.jsx
+++ b/src/TaskPlanView/__tests__/SwarmStartCard.sortMenu.test.jsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+//
+// req #3302 — the aggregator's sort menu, driven THROUGH THE MENU.
+//
+// `swarmStartCardSort.test.js` pins the comparators. That is not enough and this
+// file exists because it was not: the original defect was the WIRING —
+// `changeSortMode` discarded the mode it was handed — and a pure-comparator suite
+// stays green through it. The first fix then re-introduced a half-inert menu (an
+// early return that swallowed the click on whichever item matched the unchosen
+// default) and, again, every comparator test passed.
+//
+// So: mount the real card, click the real MenuItems, read the real row order.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DndProvider } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
+
+let activeRows;
+let metRows;
+const EMPTY = [];
+vi.mock('../../hooks/useDataQueries', () => ({
+    useRequirementsByStatus: () => ({ data: activeRows }),
+    useRequirementsDone: () => ({ data: metRows }),
+    useSessions: () => ({ data: EMPTY }),
+    useCategoryColors: () => ({ data: EMPTY }),
+    useAllRequirements: () => ({ data: EMPTY }),
+    usePipelinedRequirementIds: () => new Set(),
+}));
+
+vi.mock('../../RestApi/RestApi', () => ({
+    default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })),
+}));
+
+import SwarmStartCard from '../SwarmStartCard';
+import AuthContext from '../../Context/AuthContext';
+import AppContext from '../../Context/AppContext';
+import { useSwarmStartCardStore } from '../../stores/useSwarmStartCardStore';
+import { useShowClosedStore } from '../../stores/useShowClosedStore';
+
+const QUEUE = [
+    { id: 30, title: 'thirty', requirement_status: 'approved', category_fk: 1, completed_at: null },
+    { id: 10, title: 'ten',    requirement_status: 'approved', category_fk: 1, completed_at: null },
+    { id: 20, title: 'twenty', requirement_status: 'approved', category_fk: 1, completed_at: null },
+];
+
+const MET = [
+    { id: 30, title: 'thirty', requirement_status: 'met', category_fk: 1, completed_at: '2026-08-01T00:00:00' },
+    { id: 10, title: 'ten',    requirement_status: 'met', category_fk: 1, completed_at: '2026-08-05T00:00:00' },
+    { id: 20, title: 'twenty', requirement_status: 'met', category_fk: 1, completed_at: '2026-08-03T00:00:00' },
+];
+
+let roots = [];
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
+                            <SwarmStartCard />
+                        </DndProvider>
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    return { container };
+}
+
+async function flush() {
+    await act(async () => {
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+        await new Promise((r) => setTimeout(r, 0));
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+    });
+}
+
+const click = async (el) => {
+    expect(el, 'element must exist to be clicked').not.toBeNull();
+    await act(async () => { el.click(); });
+    await flush();
+};
+
+// The rendered order, read off the id chips the rows actually draw.
+const renderedIds = (container) => {
+    const card = container.querySelector('[data-testid="swarm-start-card"]');
+    return [...card.querySelectorAll('[data-testid^="req-id-chip-"]')]
+        .map(el => Number(el.getAttribute('data-testid').replace('req-id-chip-', '')));
+};
+
+// The menu is a portal on document.body, not inside the card.
+const openMenu = async (container) => {
+    await click(container.querySelector('[data-testid="swarm-start-card-menu"]'));
+};
+const menuItem = (testid) => document.body.querySelector(`[data-testid="${testid}"]`);
+
+const pick = async (container, testid) => {
+    await openMenu(container);
+    await click(menuItem(testid));
+};
+
+beforeEach(() => {
+    activeRows = undefined;
+    metRows = undefined;
+    useSwarmStartCardStore.setState({ selectedStatus: 'approved', show: true });
+    useShowClosedStore.setState({ hidePipelinedRequirements: false });
+});
+
+afterEach(() => {
+    act(() => { roots.forEach(r => r.unmount()); });
+    roots = [];
+    document.body.innerHTML = '';
+});
+
+describe('the menu changes the rendered order', () => {
+    it('opens a queue chip Oldest first', async () => {
+        activeRows = QUEUE;
+        const { container } = mount();
+        await flush();
+        expect(renderedIds(container)).toEqual([10, 20, 30]);
+    });
+
+    it('reverses the rows when Newest first is picked', async () => {
+        activeRows = QUEUE;
+        const { container } = mount();
+        await flush();
+        await pick(container, 'swarm-start-sort-newest');
+        expect(renderedIds(container)).toEqual([30, 20, 10]);
+    });
+
+    it('goes back when Oldest first is picked again', async () => {
+        activeRows = QUEUE;
+        const { container } = mount();
+        await flush();
+        await pick(container, 'swarm-start-sort-newest');
+        await pick(container, 'swarm-start-sort-oldest');
+        expect(renderedIds(container)).toEqual([10, 20, 30]);
+    });
+
+    // THE DEFECT THE FIRST FIX RE-INTRODUCED. `sortMode` starts null, so on the met
+    // chip `effectiveSortMode` is already 'newest'; an early return on
+    // `newMode === effectiveSortMode` swallowed this click and recorded nothing,
+    // leaving the card looking right while the intention was lost.
+    it('RECORDS a pick that matches the chip\'s current default', async () => {
+        metRows = MET;
+        useSwarmStartCardStore.setState({ selectedStatus: 'met' });
+        const { container } = mount();
+        await flush();
+        // Met opens Newest first — most-recently-completed leads.
+        expect(renderedIds(container)).toEqual([10, 20, 30]);
+
+        // Clicking the ALREADY-EFFECTIVE item must still stick...
+        await pick(container, 'swarm-start-sort-newest');
+        expect(renderedIds(container)).toEqual([10, 20, 30]);
+
+        // ...so switching to a queue chip keeps Newest rather than reverting to
+        // that chip's own default of Oldest.
+        metRows = undefined;
+        activeRows = QUEUE;
+        await click(container.querySelector('[data-testid="swarm-start-chip-approved"]'));
+        expect(renderedIds(container)).toEqual([30, 20, 10]);
+    });
+
+    it('applies the pick across a chip switch in the other direction too', async () => {
+        activeRows = QUEUE;
+        const { container } = mount();
+        await flush();
+        await pick(container, 'swarm-start-sort-newest');
+        expect(renderedIds(container)).toEqual([30, 20, 10]);
+
+        activeRows = undefined;
+        metRows = MET;
+        await click(container.querySelector('[data-testid="swarm-start-chip-met"]'));
+        expect(renderedIds(container)).toEqual([10, 20, 30]);
+    });
+});
+
+describe('the template row survives a sort pick (req #2747, extended by #3302)', () => {
+    it('keeps text typed into the add-row', async () => {
+        activeRows = QUEUE;
+        const { container } = mount();
+        await flush();
+
+        // MUI's multiline TextField renders TWO textareas per field: the real one
+        // and an `aria-hidden` shadow it measures with. Grabbing the shadow reads
+        // back its single sizing character instead of the value.
+        const visibleEditors = (root) => [...root.querySelectorAll('textarea')]
+            .filter(t => t.getAttribute('aria-hidden') !== 'true');
+
+        const card = container.querySelector('[data-testid="swarm-start-card"]');
+        const editors = visibleEditors(card);
+        const template = editors[editors.length - 1];
+        expect(template, 'the template row must render an editor').not.toBeUndefined();
+
+        await act(async () => {
+            const setter = Object.getOwnPropertyDescriptor(
+                window.HTMLTextAreaElement.prototype, 'value').set;
+            setter.call(template, 'half-typed requirement');
+            template.dispatchEvent(new Event('input', { bubbles: true }));
+        });
+        await flush();
+
+        await pick(container, 'swarm-start-sort-newest');
+
+        const after = visibleEditors(container.querySelector('[data-testid="swarm-start-card"]'));
+        const templateAfter = after[after.length - 1];
+        // The seeding effect re-runs on a sort pick; a fresh template would
+        // discard this silently.
+        expect(templateAfter.value).toBe('half-typed requirement');
+    });
+});

--- a/src/TaskPlanView/__tests__/swarmStartCardSort.test.js
+++ b/src/TaskPlanView/__tests__/swarmStartCardSort.test.js
@@ -1,0 +1,118 @@
+// req #3302 — the aggregator card's ORDER.
+//
+// The defect: `Hand Sort` / `Created Sort` were two menu entries with ONE
+// behaviour, because `changeSortMode` discarded the mode it was handed and both
+// ran `isMet ? metSort : createdSort`. Only the checkmark moved.
+//
+// So the assertions that matter here are DIFFERENCES — that the two modes are
+// genuinely two orders, and that each chip's arrival order is unchanged. A suite
+// that only checked "sorting produces a sorted list" would have passed against
+// the broken card.
+
+import { describe, it, expect } from 'vitest';
+import {
+    SORT_OLDEST,
+    SORT_NEWEST,
+    aggregatorSort,
+    defaultSortMode,
+} from '../SwarmStartCard';
+
+const TEMPLATE = { id: '', requirement_status: 'authoring', completed_at: null };
+
+// A queue chip (authoring/approved/swarm_ready/development): nothing is completed,
+// so `completed_at` is null on every row and only the id can order them.
+const QUEUE_ROWS = [
+    { id: 30, completed_at: null },
+    { id: 10, completed_at: null },
+    { id: 20, completed_at: null },
+    TEMPLATE,
+];
+
+// The met chip: completion times decide, ids only break ties.
+const MET_ROWS = [
+    { id: 30, completed_at: '2026-08-01T00:00:00' },
+    { id: 10, completed_at: '2026-08-05T00:00:00' },
+    { id: 20, completed_at: '2026-08-03T00:00:00' },
+    { id: 40, completed_at: null },
+    TEMPLATE,
+];
+
+const order = (rows, mode) => [...rows].sort(aggregatorSort(mode)).map(r => r.id);
+
+describe('the two modes are two ORDERS — the defect, stated as a difference', () => {
+    it('disagree on a queue chip', () => {
+        expect(order(QUEUE_ROWS, SORT_OLDEST)).not.toEqual(order(QUEUE_ROWS, SORT_NEWEST));
+    });
+
+    it('disagree on the met chip', () => {
+        expect(order(MET_ROWS, SORT_OLDEST)).not.toEqual(order(MET_ROWS, SORT_NEWEST));
+    });
+
+    it('are exhaustive — an unknown mode falls back to Oldest, never to nothing', () => {
+        expect(order(QUEUE_ROWS, 'hand')).toEqual(order(QUEUE_ROWS, SORT_OLDEST));
+        expect(order(QUEUE_ROWS, undefined)).toEqual(order(QUEUE_ROWS, SORT_OLDEST));
+    });
+});
+
+describe('Oldest first', () => {
+    it('is id ascending on a queue chip', () => {
+        expect(order(QUEUE_ROWS, SORT_OLDEST)).toEqual([10, 20, 30, '']);
+    });
+
+    it('is the exact inverse of Newest on the met chip', () => {
+        // Earliest completion first, undated last — NOT id order, which is the
+        // flaw the "two modes must differ" assertion above caught.
+        expect(order(MET_ROWS, SORT_OLDEST)).toEqual([30, 20, 10, 40, '']);
+    });
+});
+
+describe('Newest first', () => {
+    it('is id descending on a queue chip', () => {
+        expect(order(QUEUE_ROWS, SORT_NEWEST)).toEqual([30, 20, 10, '']);
+    });
+
+    it('is most-recently-completed first on the met chip (req #2613)', () => {
+        expect(order(MET_ROWS, SORT_NEWEST)).toEqual([10, 20, 30, 40, '']);
+    });
+
+    // Undated rows are not "earliest" — they are unknown. Putting them first
+    // under Oldest would open the met chip on the rows it knows least about.
+    it.each([SORT_OLDEST, SORT_NEWEST])('sinks rows with no completion to the end in %s', (mode) => {
+        const ids = order(MET_ROWS, mode);
+        expect(ids.indexOf(40)).toBe(ids.length - 2);   // ahead of the template only
+    });
+
+    it('is the exact reverse of Oldest, template aside', () => {
+        const dated = ids => ids.filter(id => id !== '');
+        expect(dated(order(MET_ROWS, SORT_NEWEST)).filter(id => id !== 40))
+            .toEqual(dated(order(MET_ROWS, SORT_OLDEST)).filter(id => id !== 40).reverse());
+    });
+});
+
+describe('the template row', () => {
+    it('stays anchored last in both modes', () => {
+        for (const mode of [SORT_OLDEST, SORT_NEWEST]) {
+            expect(order(QUEUE_ROWS, mode).at(-1)).toBe('');
+            expect(order(MET_ROWS, mode).at(-1)).toBe('');
+        }
+    });
+});
+
+describe('the per-chip default — arrival order is unchanged by req #3302', () => {
+    it('is Newest for the met chip', () => {
+        expect(defaultSortMode(true)).toBe(SORT_NEWEST);
+    });
+
+    it('is Oldest for the four queue chips', () => {
+        expect(defaultSortMode(false)).toBe(SORT_OLDEST);
+    });
+
+    // The whole point of keeping "unchosen" as a third state: making the menu
+    // real must not have changed what either chip shows before it is touched.
+    it('reproduces the pre-#3302 behaviour on both chips', () => {
+        // was `createdSort` — id ascending
+        expect(order(QUEUE_ROWS, defaultSortMode(false))).toEqual([10, 20, 30, '']);
+        // was `metSort` — most-recently-completed first
+        expect(order(MET_ROWS, defaultSortMode(true))).toEqual([10, 20, 30, 40, '']);
+    });
+});

--- a/src/__tests__/dataGridRowHeight.test.js
+++ b/src/__tests__/dataGridRowHeight.test.js
@@ -1,0 +1,167 @@
+// req #3302 — § D rule 2 of `memory/view-switchable-pages.md`, as a MECHANISM.
+//
+// The rule: *"Do NOT use `getRowHeight={() => 'auto'}` — it causes visual
+// corruption when sorting repeatedly (row virtualizer mis-measures on re-sort).
+// Use fixed `rowHeight`."* It was prose for a year and `RequirementsTableView`
+// broke it anyway, on the grid most able to trigger it (two `sortComparator`s and
+// a sortable header on every column). Prose an author has to remember is not a
+// mechanism (req #3246).
+//
+// Modelled on `iconButtonAccessibleName.test.js`: walk `src/`, fail on the
+// pattern, and carry the exemptions as data with a stated reason each.
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC = join(fileURLToPath(new URL('../', import.meta.url)));
+
+// Files allowed to keep auto height, each with the reason it is safe.
+//
+// `MapRunsView` PRE-DATES the discovery and is the Mapping Architect's, not this
+// agent's — listing it is the honest form of "known, not mine to change".
+// Converting it is its own requirement.
+const EXEMPT = new Map([
+    ['MapRuns/MapRunsView.jsx', 'pre-dates the rule; Mapping Architect owns it (see § D rule 2)'],
+]);
+
+// Strip comments AND string literals before matching, with a scanner rather than
+// a regex — the first cut used `/(^|[^:])\/\/[^\n]*/g`, which eats from any `//`
+// to end of line INCLUDING one inside a string (`title="a//b"`), silently taking
+// the rest of that line's code with it. Both directions matter: a comment must not
+// be flagged, and code must not be hidden.
+const strip = (src) => {
+    let out = '';
+    let i = 0;
+    const n = src.length;
+    while (i < n) {
+        const c = src[i];
+        const next = src[i + 1];
+        if (c === '/' && next === '/') { while (i < n && src[i] !== '\n') i++; continue; }
+        if (c === '/' && next === '*') { i += 2; while (i < n && !(src[i] === '*' && src[i + 1] === '/')) i++; i += 2; continue; }
+        if (c === '"' || c === "'" || c === '`') {
+            // Keep the quotes and the content: `getRowHeight={() => 'auto'}` IS the
+            // thing being detected, so string bodies cannot be discarded — only
+            // their power to start a comment.
+            const quote = c;
+            out += c; i++;
+            while (i < n) {
+                if (src[i] === '\\') { out += src[i] + (src[i + 1] ?? ''); i += 2; continue; }
+                out += src[i];
+                if (src[i] === quote) { i++; break; }
+                i++;
+            }
+            continue;
+        }
+        out += c; i++;
+    }
+    return out;
+};
+
+// `getRowHeight` anywhere near an `auto` string literal. Deliberately loose about
+// what sits between them, because the shapes that reach 'auto' are many and a
+// tight pattern is how the first cut MISSED five of them — a destructured param
+// (`({ id }) => 'auto'`, which MUI's own docs use) broke a `[^}]*` window, the
+// object-literal spread form (`{ getRowHeight: () => 'auto' }`) has no `={`, and
+// a template literal is not in `['"]`.
+//
+// KNOWN AND UNREACHABLE BY ANY REGEX: `getRowHeight={autoHeightFn}` with the
+// literal in another function. Named here rather than left as a silent hole; the
+// review gate is the backstop for that shape.
+const AUTO_HEIGHT = /getRowHeight\s*[:=]\s*[\s\S]{0,200}?['"`]auto['"`]/;
+
+const violates = (source) => AUTO_HEIGHT.test(strip(source));
+
+const walk = (dir, out = []) => {
+    for (const entry of readdirSync(dir)) {
+        if (entry === 'node_modules' || entry === '__tests__') continue;
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) walk(full, out);
+        else if (/\.(jsx?|tsx?)$/.test(entry)) out.push(full);
+    }
+    return out;
+};
+
+describe('DataGrid row height (§ D rule 2)', () => {
+    const offenders = walk(SRC)
+        .map(f => ({ path: relative(SRC, f), source: readFileSync(f, 'utf8') }))
+        .filter(f => violates(f.source))
+        .map(f => f.path)
+        .filter(p => !EXEMPT.has(p));
+
+    it('no grid outside the exemption list uses auto row height', () => {
+        expect(offenders, offenders.length
+            ? `auto row height re-introduced in:\n  ${offenders.join('\n  ')}\n`
+              + 'Use a fixed `rowHeight` and clamp prose cells; see § D rule 2 and '
+              + 'RequirementsTableView.jsx for the worked example.'
+            : undefined).toEqual([]);
+    });
+
+    // A detector that matches nothing proves nothing. The exempt file is the
+    // live positive control: if it stops matching, the regex has rotted and the
+    // guard has silently stopped guarding.
+    it('the detector still fires on the known instance', () => {
+        for (const [path] of EXEMPT) {
+            const source = readFileSync(join(SRC, path), 'utf8');
+            expect(violates(source), `${path} no longer matches — the pattern has rotted, `
+                + 'or the file was converted and should be removed from EXEMPT').toBe(true);
+        }
+    });
+
+    // The file that documents the prohibition must not be flagged for saying so.
+    it('does not flag a file that only MENTIONS the pattern in a comment', () => {
+        const documented = readFileSync(join(SRC, 'Agents/InstructionsTableView.jsx'), 'utf8');
+        expect(documented.includes("getRowHeight"), 'precondition: that file does mention it').toBe(true);
+        expect(violates(documented)).toBe(false);
+    });
+
+    it('the grid this rule was broken on now sets a fixed height', () => {
+        const source = readFileSync(join(SRC, 'SwarmView/RequirementsTableView.jsx'), 'utf8');
+        expect(violates(source)).toBe(false);
+        expect(/rowHeight=\{ROW_HEIGHT\}/.test(source)).toBe(true);
+    });
+
+    // ── The detector's own coverage ──────────────────────────────────────────
+    //
+    // A source-scanning guard is only as good as the shapes it recognises, and a
+    // review measured FIVE forms the first cut missed. Each one is a case here,
+    // so a future "tidy-up" of the pattern cannot quietly re-open them.
+    describe('the pattern catches every reachable shape', () => {
+        it.each([
+            ['canonical',            "<DataGrid getRowHeight={() => 'auto'} />"],
+            ['double quotes',        '<DataGrid getRowHeight={() => "auto"} />'],
+            ['template literal',     '<DataGrid getRowHeight={() => `auto`} />'],
+            ['destructured param',   "<DataGrid getRowHeight={({ id }) => 'auto'} />"],
+            ['MUI docs param',       "<DataGrid getRowHeight={({ densityFactor }) => 'auto'} />"],
+            ['object literal',       "const props = { getRowHeight: () => 'auto' };"],
+            ['block body',           "<DataGrid getRowHeight={() => { return 'auto'; }} />"],
+            ['conditional return',   "<DataGrid getRowHeight={(p) => p.id ? 'auto' : 52} />"],
+            ['extra spacing',        "<DataGrid  getRowHeight = { ()   =>   'auto' }  />"],
+            ['multi-line',           "<DataGrid\n  getRowHeight={() =>\n    'auto'\n  }\n/>"],
+        ])('flags the %s form', (_label, source) => {
+            expect(violates(source)).toBe(true);
+        });
+
+        it.each([
+            ['a line comment',       "// getRowHeight={() => 'auto'} stays forbidden"],
+            ['a block comment',      "/* getRowHeight={() => 'auto'} is banned */"],
+            ['a fixed height',       "<DataGrid rowHeight={72} />"],
+            ['an unrelated auto',    "<Box sx={{ overflowY: 'auto' }} />"],
+        ])('does not flag %s', (_label, source) => {
+            expect(violates(source)).toBe(false);
+        });
+
+        // The comment stripper must not take code with it. `//` inside a string
+        // is not a comment, and treating it as one hid the rest of that line.
+        it('does not let a URL or a string swallow the code after it', () => {
+            const src = `<Box title="https://x/y" /><DataGrid getRowHeight={() => 'auto'} />`;
+            expect(violates(src)).toBe(true);
+        });
+
+        it('still reads code that follows a real comment on the same line', () => {
+            const src = "const a = 1; // note\n<DataGrid getRowHeight={() => 'auto'} />";
+            expect(violates(src)).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3302-swarm-polish-orchestrated-1
- wip(Darwin): 2026-08-08T07:41:22Z
- chore: init swarm session feature/3302-swarm-polish-orchestrated-1

## Files changed
```
 src/SwarmView/CategoryCard.jsx                     |  72 ++---
 src/SwarmView/RequirementRow.jsx                   |   7 +-
 src/SwarmView/RequirementsTableView.jsx            |  98 ++++++-
 src/SwarmView/SwarmView.jsx                        |  73 +++--
 src/SwarmView/__tests__/swarmViewLink.test.js      |  95 ++++++
 .../__tests__/useSwarmViewSelection.test.jsx       | 238 +++++++++++++++
 src/SwarmView/detail/RequirementDetail.jsx         |  68 +++--
 .../detail/__tests__/elevatorMatchesCard.test.js   | 322 +++++++++++++++++++++
 src/SwarmView/detail/requirementSort.js            | 206 +++++++------
 src/SwarmView/processSort.js                       |  76 +++++
 src/SwarmView/swarmViewLink.js                     |  60 ++++
 src/SwarmView/useSwarmViewSelection.js             |  73 +++++
 src/TaskPlanView/SwarmStartCard.jsx                | 169 ++++++++---
 .../__tests__/SwarmStartCard.sortMenu.test.jsx     | 224 ++++++++++++++
 .../__tests__/swarmStartCardSort.test.js           | 118 ++++++++
 src/__tests__/dataGridRowHeight.test.js            | 167 +++++++++++
 16 files changed, 1831 insertions(+), 235 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)