### PR TITLE
dateFormat.js parses the naive 'T'-separated datetime as LOCAL time while the space-separated form is normalized to UTC

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test:e2e": "bash ../scripts/run-e2e.sh",
-    "test:unit": "vitest run src/"
+    "test:unit": "TZ=America/Los_Angeles vitest run src/"
   },
   "overrides": {
     "react-is": "$react"

--- a/src/Agents/instructionSort.js
+++ b/src/Agents/instructionSort.js
@@ -45,13 +45,12 @@ export const SORT_MODES = [
 // 00:00 and 08:00 UTC rendered tomorrow's date to a US Pacific viewer, and disagreed
 // with the `Created` column beside it, which parsed correctly.
 // The condition is "carries NO timezone information", not "contains a space".
-// `utils/dateFormat.js` normalizes only the space form, which is sufficient there
-// because it is only ever handed Lambda-Rest output — but this is an EXPORTED helper
-// with a generic name, and the next caller to pass it an ISO-without-offset string
-// (`2026-07-26T02:00:00`) would silently re-acquire the exact off-by-one-day defect
-// it exists to remove. Widened deliberately: on every input either function actually
-// sees this is a superset of dateFormat's behaviour, so the two cannot disagree on
-// real data — they only differ on a shape Lambda-Rest never emits.
+// `utils/dateFormat.js` now normalizes BOTH the space and 'T' forms to UTC
+// (req #3120 fixed the asymmetry that used to leave it handling only the
+// space form) — this module keeps its own copy anyway so a single call site
+// cannot get it wrong, and REQUIRES seconds where dateFormat's makes them
+// optional, so this regex is the narrower of the two rather than a superset.
+// Both still agree on every input Lambda-Rest actually emits.
 const NO_TIMEZONE = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?$/;
 
 export const dbTimestamp = (value) => {

--- a/src/CalendarFC/timeSeriesSizes.js
+++ b/src/CalendarFC/timeSeriesSizes.js
@@ -192,15 +192,18 @@ export function computePhaseSegments(session, startPct, endPct) {
 export const SWARM_CLUSTER_WINDOW_MS = 3 * 60 * 1000;   // 3 minutes
 
 // Parse a started_at/completed_at value the same way the rest of the
-// visualizer does (utils/dateFormat.toDate): MySQL-format "YYYY-MM-DD HH:MM:SS"
-// is UTC-stored and must be given an explicit `Z`, otherwise `new Date(...)`
-// parses it in the browser's local tz — which silently disagrees with
-// positionFor/toLocaleDateString and skews relative deltas across DST
-// boundaries. Kept local to this module so timeSeriesSizes stays standalone
-// (no circular dep with the dateFormat utility).
+// visualizer does (utils/dateFormat.toDate): a naive datetime — space OR 'T'
+// separated, no Z/offset designator — is UTC-stored and must be given an
+// explicit `Z`, otherwise `new Date(...)` parses it in the browser's local tz
+// — which silently disagrees with positionFor/toLocaleDateString and skews
+// relative deltas across DST boundaries. Kept local to this module so
+// timeSeriesSizes stays standalone (no circular dep with the dateFormat
+// utility); the regex is a duplicate of dateFormat's `NAIVE_DATETIME` (req
+// #3120) and must be kept in step with it.
+const NAIVE_DATETIME = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/;
 function parseStartedAtMs(value) {
     if (!value) return NaN;
-    if (typeof value === 'string' && value.includes(' ') && !value.includes('T')) {
+    if (typeof value === 'string' && NAIVE_DATETIME.test(value)) {
         return new Date(value.replace(' ', 'T') + 'Z').getTime();
     }
     return new Date(value).getTime();

--- a/src/SwarmView/KonvaSwarmCanvas.jsx
+++ b/src/SwarmView/KonvaSwarmCanvas.jsx
@@ -123,10 +123,14 @@ const dateAtWorldY = (rows, y) => {
 
 // Popup datetime — "Mon Day @ h:mma" with NO year and NO weekday (req feedback).
 // Parses MySQL UTC ("YYYY-MM-DD HH:MM:SS") and ISO strings the same way as
-// utils/dateFormat's toDate.
+// utils/dateFormat's toDate: a naive datetime (space OR 'T' separated, no
+// Z/offset) is UTC-stored. Duplicated rather than imported because toDate
+// itself isn't exported; kept in step with dateFormat's `NAIVE_DATETIME`
+// (req #3120).
+const NAIVE_DATETIME = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/;
 const parseTs = (s) => {
     if (!s) return null;
-    if (typeof s === 'string' && s.includes(' ') && !s.includes('T')) return new Date(s.replace(' ', 'T') + 'Z');
+    if (typeof s === 'string' && NAIVE_DATETIME.test(s)) return new Date(s.replace(' ', 'T') + 'Z');
     return new Date(s);
 };
 const fmtDT = (s, tz) => {

--- a/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
@@ -526,13 +526,23 @@ describe('formatTimeGate — one formatter for both surfaces', () => {
         expect(formatTimeGate(WIRE, 'UTC')).toBe('Jul 24, 2026, 6:31 AM');
     });
 
-    it('reads the naive T form as the SAME instant as the space form', () => {
-        // dateFormat.formatDateTime alone does NOT: it parses a `T`-separated
-        // datetime with no designator as LOCAL time, which would put the label an
-        // offset out of step with the engine's own toEpochMs — eligibility and the
-        // gate it is computed from disagreeing about what the value means.
-        expect(formatTimeGate('2026-07-24T06:31:38', 'UTC'))
-            .toBe(formatTimeGate('2026-07-24 06:31:38', 'UTC'));
+    it('reads the naive T form as the SAME absolute instant as the space form', () => {
+        // Regression guard for req #3120: dateFormat.formatDateTime used to parse
+        // a `T`-separated datetime with no designator as LOCAL time, which put the
+        // label an offset out of step with the engine's own toEpochMs —
+        // eligibility and the gate it is computed from disagreeing about what the
+        // value means. formatTimeGate's own normalization workaround was retired
+        // once dateFormat.js was fixed to handle both forms; this test now pins
+        // that fix rather than the workaround.
+        //
+        // Pinned to an ABSOLUTE value, not just T-vs-space parity: the pre-fix bug
+        // parsed the T form using the process's local timezone, so on a host whose
+        // local zone happens to be UTC the buggy and fixed parses are identical and
+        // a parity-only assertion would pass against either. `test:unit` pins
+        // `TZ=America/Los_Angeles` (Darwin/package.json) so this is meaningful
+        // wherever the suite runs.
+        expect(formatTimeGate('2026-07-24T06:31:38', 'UTC')).toBe('Jul 24, 2026, 6:31 AM');
+        expect(formatTimeGate('2026-07-24 06:31:38', 'UTC')).toBe('Jul 24, 2026, 6:31 AM');
     });
 
     it('leaves an explicit offset alone', () => {

--- a/src/SwarmView/pipelines/pipelineViewModel.js
+++ b/src/SwarmView/pipelines/pipelineViewModel.js
@@ -562,18 +562,9 @@ export function batchMachineLabel(batch) {
 // apart — the banner shipped the raw wire value (`2026-07-24 06:31:38.000000`,
 // UTC, microseconds and all) while the cell showed a localized one.
 //
-// `dateFormat.formatDateTime` normalizes MySQL's space-separated naive form
-// ("2026-07-24 06:31:38") to UTC but reads the ISO-ish `T` form
-// ("2026-07-24T06:31:38") as LOCAL — a silent offset-sized error on the same
-// stored value. Lambda-Rest emits the space form today (MySQL JSON_OBJECT), so
-// nothing hits it; the engine's own toEpochMs handles BOTH, and eligibility
-// disagreeing with the label about what a gate means is exactly the class of bug
-// this feature cannot afford. Normalize here so the two halves agree regardless
-// of which form arrives. (The `dateFormat` asymmetry is a real pre-existing bug
-// in a util with many callers and no live symptom — flagged, not silently
-// widened from inside this requirement.)
-const NAIVE_T_FORM = /^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)$/;
-
+// `dateFormat.formatDateTime` now normalizes BOTH the MySQL space-separated
+// naive form and the ISO-ish `T` form to UTC (req #3120 fixed the asymmetry
+// that used to live here), so no local normalization is needed.
 /**
  * A wall-clock dependency, rendered the way every other timestamp in the app is.
  *
@@ -583,8 +574,7 @@ const NAIVE_T_FORM = /^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)$/;
  */
 export function formatTimeGate(timeAt, timezone) {
     if (!timeAt) return '';
-    const m = NAIVE_T_FORM.exec(String(timeAt));
-    return formatDateTime(m ? `${m[1]} ${m[2]}` : timeAt, timezone);
+    return formatDateTime(timeAt, timezone);
 }
 
 /**

--- a/src/utils/__tests__/dateFormat.test.js
+++ b/src/utils/__tests__/dateFormat.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatCardDateTime, periodDateRange, shiftPeriod, currentPeriodStart, formatPeriodLabel, toDateTimeLocalValue, fromDateTimeLocalValue, trimMicroseconds } from '../dateFormat';
+import { formatCardDateTime, formatDateTime, formatDate, formatHM12, formatHHMM, getTimeOfDayFraction, periodDateRange, shiftPeriod, currentPeriodStart, formatPeriodLabel, toDateTimeLocalValue, fromDateTimeLocalValue, trimMicroseconds } from '../dateFormat';
 
 describe('trimMicroseconds', () => {
     it('strips the microsecond tail from a MySQL DATETIME(6) string', () => {
@@ -21,6 +21,54 @@ describe('trimMicroseconds', () => {
     it('returns the em-dash placeholder for null/empty', () => {
         expect(trimMicroseconds(null)).toBe('—');
         expect(trimMicroseconds('')).toBe('—');
+    });
+});
+
+// ── naive datetime parsing (req #3120) ──────────────────────────────────────
+// A naive datetime with no Z/offset designator is stored/produced as UTC
+// everywhere in Darwin, regardless of whether the separator is a space (MySQL
+// JSON_OBJECT) or a 'T' (ISO-ish). Every formatter below shares the same
+// `toDate` parse helper, so one regression here would silently affect all of
+// them — the guard is tested once at each formatter's front door.
+//
+// Every case below pins an ABSOLUTE expected value, not just T-form/space-form
+// equality: the pre-fix bug parsed the T form as the *process's local*
+// timezone, so on a host whose local zone happens to be UTC (a bare parity
+// check, or a CI/container image defaulting to UTC) the buggy and fixed
+// parses are byte-identical and a parity-only assertion would pass against
+// either. `test:unit` pins `TZ=America/Los_Angeles` (package.json) so these
+// absolute values are meaningful wherever the suite runs; keep both a fixed
+// TZ and an absolute expectation if this block is ever extended.
+describe('naive datetime parsing — space and T forms agree', () => {
+    it('formatDateTime reads the T form as the same absolute UTC instant as the space form', () => {
+        expect(formatDateTime('2026-07-24T06:31:38', 'UTC')).toBe('Jul 24, 2026, 6:31 AM');
+        expect(formatDateTime('2026-07-24 06:31:38', 'UTC')).toBe('Jul 24, 2026, 6:31 AM');
+    });
+
+    it('formatDateTime still respects an explicit offset', () => {
+        // 06:31:38+05:00 is 01:31:38 UTC — must NOT be treated as naive UTC.
+        expect(formatDateTime('2026-07-24T06:31:38+05:00', 'UTC')).toBe('Jul 24, 2026, 1:31 AM');
+        expect(formatDateTime('2026-07-24T06:31:38Z', 'UTC')).toBe('Jul 24, 2026, 6:31 AM');
+    });
+
+    it('formatDate reads the T form as the same absolute UTC instant as the space form', () => {
+        expect(formatDate('2026-07-24T23:31:38', 'UTC')).toBe('Jul 24, 2026');
+        expect(formatDate('2026-07-24 23:31:38', 'UTC')).toBe('Jul 24, 2026');
+    });
+
+    it('formatHM12 reads the T form as the same absolute UTC instant as the space form', () => {
+        expect(formatHM12('2026-07-24T06:31:38', 'UTC')).toBe('6:31a');
+        expect(formatHM12('2026-07-24 06:31:38', 'UTC')).toBe('6:31a');
+    });
+
+    it('formatHHMM reads the T form as the same absolute UTC instant as the space form', () => {
+        expect(formatHHMM('2026-07-24T06:31:38', 'UTC')).toBe('06:31');
+        expect(formatHHMM('2026-07-24 06:31:38', 'UTC')).toBe('06:31');
+    });
+
+    it('getTimeOfDayFraction reads the T form as the same absolute UTC instant as the space form', () => {
+        expect(getTimeOfDayFraction('2026-07-24T06:31:38', 'UTC')).toBeCloseTo(0.2719675925925926, 12);
+        expect(getTimeOfDayFraction('2026-07-24 06:31:38', 'UTC')).toBeCloseTo(0.2719675925925926, 12);
     });
 });
 

--- a/src/utils/dateFormat.js
+++ b/src/utils/dateFormat.js
@@ -2,11 +2,20 @@
 // All functions accept an IANA timezone string (e.g. 'America/Los_Angeles').
 // If timezone is null/undefined, falls back to browser default.
 
+// A naive datetime — space- or 'T'-separated, no trailing Z/offset designator —
+// is stored/produced as UTC everywhere in Darwin (MySQL JSON_OBJECT emits the
+// space form; other sources emit the 'T' form for the same instant). Mirrors
+// the naive-vs-designator distinction in pipelineModel.js's TIMESTAMP_RE so
+// both engines agree on what a bare timestamp means (req #3120).
+const NAIVE_DATETIME = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/;
+
 function toDate(dateStr) {
     if (!dateStr) return null;
-    // MySQL format: "YYYY-MM-DD HH:MM:SS" — stored as UTC, append Z
-    if (typeof dateStr === 'string' && dateStr.includes(' ') && !dateStr.includes('T')) {
-        return new Date(dateStr.replace(' ', 'T') + 'Z');
+    if (typeof dateStr === 'string') {
+        const trimmed = dateStr.trim();
+        if (NAIVE_DATETIME.test(trimmed)) {
+            return new Date(trimmed.replace(' ', 'T') + 'Z');
+        }
     }
     return new Date(dateStr);
 }


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3120-dateformat-parses-naive-t-separated-1
- wip(Darwin): 2026-08-07T13:53:18Z
- chore: init swarm session feature/3120-dateformat-parses-naive-t-separated-1

## Files changed
```
 package.json                                       |  2 +-
 src/Agents/instructionSort.js                      | 13 +++---
 src/CalendarFC/timeSeriesSizes.js                  | 17 +++++---
 src/SwarmView/KonvaSwarmCanvas.jsx                 |  8 +++-
 .../pipelines/__tests__/pipelineViewModel.test.js  | 24 ++++++++---
 src/SwarmView/pipelines/pipelineViewModel.js       | 18 ++------
 src/utils/__tests__/dateFormat.test.js             | 50 +++++++++++++++++++++-
 src/utils/dateFormat.js                            | 15 +++++--
 8 files changed, 105 insertions(+), 42 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)