### PR TITLE
No way to delete a swarm_starts row — add delete_swarm_start and a UI affordance

### DIFF
--- a/src/SwarmStarts/SwarmStartDeleteDialog.jsx
+++ b/src/SwarmStarts/SwarmStartDeleteDialog.jsx
@@ -1,0 +1,94 @@
+// Delete-confirm dialog for a swarm_start row (req #3265). Mirrors
+// RequirementDeleteDialog's shape/confirm pattern — no new confirm dialect.
+//
+// This guard is CLIENT-SIDE ONLY. The browser's delete goes through the
+// generic REST DELETE on `swarm_starts`, not the `delete_swarm_start` MCP
+// tool (MCP is agent-only) — and `swarm_start_sessions.swarm_start_fk` is
+// `ON DELETE CASCADE` in the schema, not RESTRICT, so nothing at the
+// database layer backstops this. The Delete button is disabled whenever
+// `linkedSessionIds` is non-empty OR still loading (`linkedLoading`) — the
+// loading gate matters because both call sites derive the id list from
+// queries that are NOT the one gating the page's render, so without it a
+// linked row briefly shows as deletable while sessions/junction are still
+// in flight (req #3265 code review, finding C2).
+
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+const SwarmStartDeleteDialog = ({ deleteDialogOpen, setDeleteDialogOpen, setDeleteId,
+                                   setDeleteConfirmed, swarmStart, linkedSessionIds = [],
+                                   linkedLoading = false }) => {
+
+    const dialogCleanUp = () => {
+        setDeleteDialogOpen(false);
+        setDeleteId({});
+        return;
+    };
+
+    const deleteSwarmStart = (event) => {
+        setDeleteConfirmed(true);
+        setDeleteDialogOpen(false);
+    };
+
+    const hasLinkedSessions = linkedSessionIds.length > 0;
+
+    return (
+
+        <Dialog open={deleteDialogOpen}
+                onClose={dialogCleanUp}
+                data-testid="swarm-start-delete-dialog" >
+
+            <DialogTitle id="confirm-delete-swarm-start-title">
+                {"Delete Swarm Start"}
+            </DialogTitle>
+            <DialogContent>
+                {linkedLoading ? (
+                    <DialogContentText id="confirm-delete-swarm-start-text">
+                        {`Cannot confirm there are no linked sessions yet — Delete stays disabled until that's known.`}
+                    </DialogContentText>
+                ) : hasLinkedSessions ? (
+                    <DialogContentText id="confirm-delete-swarm-start-text" color="error">
+                        {`This invocation is still linked to session${linkedSessionIds.length === 1 ? '' : 's'} `}
+                        {linkedSessionIds.join(', ')}
+                        {`. Unlink or address ${linkedSessionIds.length === 1 ? 'it' : 'them'} before deleting.`}
+                    </DialogContentText>
+                ) : (
+                    <DialogContentText id="confirm-delete-swarm-start-text">
+                        {`Do you want to permanently delete this swarm-start invocation record?`}
+                    </DialogContentText>
+                )}
+                {swarmStart?.id != null && (
+                    <Box sx={{
+                        mt: 2, mx: 2, p: 1,
+                        border: '1px solid',
+                        borderColor: 'divider',
+                        borderRadius: 1,
+                        bgcolor: 'background.paper',
+                    }}>
+                        <Typography variant="body2">
+                            {`#${swarmStart.id} — /swarm-start${swarmStart.arguments ? ` ${swarmStart.arguments}` : ''}`}
+                        </Typography>
+                    </Box>
+                )}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={deleteSwarmStart} variant="outlined"
+                        disabled={hasLinkedSessions || linkedLoading}
+                        data-testid="btn-confirm-delete-swarm-start">
+                    Delete
+                </Button>
+                <Button onClick={dialogCleanUp} variant="outlined" autoFocus>
+                    Cancel
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+export default SwarmStartDeleteDialog

--- a/src/SwarmStarts/SwarmStartDetail.jsx
+++ b/src/SwarmStarts/SwarmStartDetail.jsx
@@ -6,8 +6,14 @@
 
 import { useContext, useMemo, useRef } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 
 import AuthContext from '../Context/AuthContext';
+import AppContext from '../Context/AppContext';
+import call_rest_api from '../RestApi/RestApi';
+import { useSnackBarStore } from '../stores/useSnackBarStore';
+import { useConfirmDialog } from '../hooks/useConfirmDialog';
+import { swarmStartKeys, swarmStartSessionKeys } from '../hooks/useQueryKeys';
 import {
     useSwarmStartById,
     useSessions,
@@ -21,12 +27,15 @@ import { aiModelChipProps, aiModelLabel } from '../SwarmView/modelChipStyles';
 import { effortChipProps, effortLabel } from '../SwarmView/effortChipStyles';
 import { parseSummary } from './SwarmStartsPage';
 import { selectSessionsForSwarmStart } from './sessionFilter';
+import SwarmStartDeleteDialog from './SwarmStartDeleteDialog';
 
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
+import Tooltip from '@mui/material/Tooltip';
+import IconButton from '@mui/material/IconButton';
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
@@ -37,6 +46,7 @@ import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import DeleteIcon from '@mui/icons-material/Delete';
 import { DataGrid } from '@mui/x-data-grid';
 
 const SYNTHESIZED_HEADERS = ['Session', 'Branch', 'Autonomy', 'Terminal', 'PRs'];
@@ -113,17 +123,22 @@ export default function SwarmStartDetail() {
     const { id } = useParams();
     const navigate = useNavigate();
     const location = useLocation();
-    const { profile } = useContext(AuthContext);
+    const { idToken, profile } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
     const creatorFk = profile?.userName;
     const timezone = profile?.timezone;
+    const queryClient = useQueryClient();
+    const showError = useSnackBarStore(s => s.showError);
 
     const swarmStartId = parseInt(id);
     const { data: row, isLoading } = useSwarmStartById(creatorFk, swarmStartId);
 
     // Req #2494 — linked-sessions table. Junction is global; user-scope falls
     // out naturally when filtered against the user's own `useSessions` list.
-    const { data: sessionsArray, isLoading: sessionsLoading } = useSessions(creatorFk);
-    const { data: junction, isLoading: junctionLoading } = useAllSwarmStartSessions(creatorFk);
+    const { data: sessionsArray, isLoading: sessionsLoading, isError: sessionsError } =
+        useSessions(creatorFk);
+    const { data: junction, isLoading: junctionLoading, isError: junctionError } =
+        useAllSwarmStartSessions(creatorFk);
     // req #2943 — resolve this start's machine name from the machines cache.
     const { data: machinesData = [] } = useMachines(creatorFk);
     const machineName = useMemo(() => {
@@ -136,8 +151,33 @@ export default function SwarmStartDetail() {
         () => selectSessionsForSwarmStart(sessionsArray, junction, swarmStartId),
         [sessionsArray, junction, swarmStartId]
     );
-    const linkedLoading = sessionsLoading || junctionLoading;
+    // req #3265 code review (re-verify pass, finding 1) — a settled query
+    // error leaves isLoading false, so isError must gate the delete affordance
+    // too or a failed sessions/junction fetch reads as "confirmed unlinked".
+    const linkedLoading = sessionsLoading || junctionLoading || sessionsError || junctionError;
     const linkedSectionRef = useRef(null);
+
+    // req #3265 — delete affordance. This is a CLIENT-SIDE guard only: the
+    // dialog disables Delete and names linked sessions while `linkedLoading`
+    // gates it during the fetch, but there is no database-level backstop
+    // (swarm_start_sessions.swarm_start_fk is ON DELETE CASCADE, not
+    // RESTRICT — see SwarmStartDeleteDialog.jsx).
+    const swarmStartDelete = useConfirmDialog({
+        onConfirm: ({ swarmStartId: deleteId }) => {
+            const uri = `${darwinUri}/swarm_starts`;
+            call_rest_api(uri, 'DELETE', { id: deleteId }, idToken)
+                .then(result => {
+                    if (result.httpStatus.httpStatus === 200 || result.httpStatus.httpStatus === 204) {
+                        queryClient.invalidateQueries({ queryKey: swarmStartKeys.all(creatorFk) });
+                        queryClient.invalidateQueries({ queryKey: swarmStartSessionKeys.all(creatorFk) });
+                        navigate('/swarm/swarm-starts');
+                    } else {
+                        showError(result, 'Unable to delete swarm start');
+                    }
+                })
+                .catch(error => showError(error, 'Unable to delete swarm start'));
+        }
+    });
 
     const scrollToLinkedSessions = (e) => {
         if (e) e.preventDefault();
@@ -179,12 +219,20 @@ export default function SwarmStartDetail() {
     const NARROW = { maxWidth: 900 };
     return (
         <Box sx={{ p: 3, maxWidth: 1400 }} data-testid="swarm-start-detail">
-            <Box sx={{ mb: 2 }}>
+            <Box sx={{ mb: 2, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <Button variant="outlined" onClick={handleBack}
                         startIcon={<ArrowBackIcon />}
                         data-testid="btn-back">
                     Back
                 </Button>
+                <Tooltip title="Delete swarm start" enterDelay={400} enterNextDelay={200}>
+                    <IconButton
+                        onClick={() => swarmStartDelete.openDialog({ swarmStartId: row.id })}
+                        data-testid="btn-delete-swarm-start"
+                    >
+                        <DeleteIcon />
+                    </IconButton>
+                </Tooltip>
             </Box>
 
             <Typography variant="h5" gutterBottom>
@@ -320,6 +368,16 @@ export default function SwarmStartDetail() {
                     }
                 </AccordionDetails>
             </Accordion>
+
+            <SwarmStartDeleteDialog
+                deleteDialogOpen={swarmStartDelete.dialogOpen}
+                setDeleteDialogOpen={swarmStartDelete.setDialogOpen}
+                setDeleteId={swarmStartDelete.setInfoObject}
+                setDeleteConfirmed={swarmStartDelete.setConfirmed}
+                swarmStart={row}
+                linkedSessionIds={linkedSessions.map(s => s.id)}
+                linkedLoading={linkedLoading}
+            />
         </Box>
     );
 }

--- a/src/SwarmStarts/SwarmStartsPage.jsx
+++ b/src/SwarmStarts/SwarmStartsPage.jsx
@@ -7,10 +7,16 @@
 // `parseSummary` is exported so the SwarmStartDetail page (and the unit test)
 // can reuse it without duplicating the parser.
 
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useContext, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 
 import AuthContext from '../Context/AuthContext';
+import AppContext from '../Context/AppContext';
+import call_rest_api from '../RestApi/RestApi';
+import { useSnackBarStore } from '../stores/useSnackBarStore';
+import { useConfirmDialog } from '../hooks/useConfirmDialog';
+import { swarmStartKeys, swarmStartSessionKeys } from '../hooks/useQueryKeys';
 import {
     useAllSwarmStarts,
     useSessions,
@@ -22,12 +28,14 @@ import { formatDateTime } from '../utils/dateFormat';
 import { formatDuration } from '../utils/formatDuration';
 import { selectRequirementsForSwarmStart } from './requirementsList';
 import SwarmStartsStatsView from './SwarmStartsStatsView';
+import SwarmStartDeleteDialog from './SwarmStartDeleteDialog';
 
 import { aiModelChipProps, aiModelLabel } from '../SwarmView/modelChipStyles';
 import { effortChipProps, effortLabel } from '../SwarmView/effortChipStyles';
 
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -35,6 +43,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import BarChartIcon from '@mui/icons-material/BarChart';
+import DeleteIcon from '@mui/icons-material/Delete';
 import { DataGrid, GridToolbar } from '@mui/x-data-grid';
 
 const VIEW_STORAGE_KEY = 'darwin-swarm-starts-view';
@@ -50,8 +59,11 @@ const REQ_BASE_HEIGHT = 52;
 const formatNum = (v) => (v == null ? '—' : Number(v).toLocaleString());
 
 export default function SwarmStartsPage() {
-    const { profile } = useContext(AuthContext);
+    const { profile, idToken } = useContext(AuthContext);
+    const { darwinUri } = useContext(AppContext);
     const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const showError = useSnackBarStore(s => s.showError);
     const creatorFk = profile?.userName;
     const timezone = profile?.timezone;
 
@@ -59,9 +71,16 @@ export default function SwarmStartsPage() {
     // Req #2685 — junction + sessions feed the per-row "Requirements" cell.
     // Both lists are already paged into the cache by other views (SwarmStartDetail,
     // SessionsView); reusing them keeps this page free of extra round-trips.
-    const { data: sessionsArray = [] } = useSessions(creatorFk);
-    const { data: junction = [] } = useAllSwarmStartSessions(creatorFk);
+    const { data: sessionsArray = [], isLoading: sessionsLoading, isError: sessionsError } =
+        useSessions(creatorFk);
+    const { data: junction = [], isLoading: junctionLoading, isError: junctionError } =
+        useAllSwarmStartSessions(creatorFk);
     const { data: machinesData = [] } = useMachines(creatorFk);
+    // req #3265 code review (re-verify pass, finding 1) — a settled query
+    // error leaves isLoading false and data undefined (defaulted to []), which
+    // without isError here would read identically to "confirmed unlinked" and
+    // silently re-open the C2 fail-open on the error path.
+    const linkedLoading = sessionsLoading || junctionLoading || sessionsError || junctionError;
 
     // req #2943 — machine id → friendly name for the Machine column.
     const machineNameById = useMemo(() => {
@@ -73,6 +92,32 @@ export default function SwarmStartsPage() {
     // View toggle (Table | Stats) — req #2686.
     const [view, setView] = useViewPreference(VIEW_STORAGE_KEY, 'table');
     const handleViewChange = (_event, newView) => setView(newView);
+
+    // req #3265 — delete affordance. This is a CLIENT-SIDE guard only: the
+    // dialog disables Delete and names linked sessions, but there is no
+    // database-level backstop (swarm_start_sessions.swarm_start_fk is ON
+    // DELETE CASCADE, not RESTRICT — see SwarmStartDeleteDialog.jsx).
+    const swarmStartDelete = useConfirmDialog({
+        onConfirm: ({ swarmStartId }) => {
+            const uri = `${darwinUri}/swarm_starts`;
+            call_rest_api(uri, 'DELETE', { id: swarmStartId }, idToken)
+                .then(result => {
+                    if (result.httpStatus.httpStatus === 200 || result.httpStatus.httpStatus === 204) {
+                        queryClient.invalidateQueries({ queryKey: swarmStartKeys.all(creatorFk) });
+                        queryClient.invalidateQueries({ queryKey: swarmStartSessionKeys.all(creatorFk) });
+                    } else {
+                        showError(result, 'Unable to delete swarm start');
+                    }
+                })
+                .catch(error => showError(error, 'Unable to delete swarm start'));
+        }
+    });
+    // req #3265 W1 — a ref, not swarmStartDelete itself, in the columns memo's
+    // deps: useConfirmDialog returns a fresh object every render, which would
+    // otherwise re-identity `columns` (and reset DataGrid column state) on
+    // every render — see the identical reasoning on getRowHeight below.
+    const openDeleteRef = useRef(swarmStartDelete.openDialog);
+    openDeleteRef.current = swarmStartDelete.openDialog;
 
     // swarm_start.id → [{ reqId, title, sessionId, startedAt }], built once
     // per (sessions, junction) change. The DataGrid's `valueGetter` and
@@ -223,6 +268,31 @@ export default function SwarmStartsPage() {
             width: 200,
             valueFormatter: (value) => value ? formatDateTime(value, timezone) : '—',
         },
+        {
+            // req #3265 — delete affordance. stopPropagation keeps the click
+            // from triggering the row's navigate-to-detail handler.
+            field: 'actions',
+            headerName: '',
+            width: 50,
+            sortable: false,
+            filterable: false,
+            disableExport: true,
+            renderCell: (params) => (
+                <Tooltip title="Delete swarm start">
+                    <IconButton
+                        size="small"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            openDeleteRef.current({ swarmStartId: params.row.id });
+                        }}
+                        data-testid={`btn-delete-swarm-start-${params.row.id}`}
+                    >
+                        <DeleteIcon fontSize="small" />
+                    </IconButton>
+                </Tooltip>
+            ),
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     ], [timezone, requirementsByStart, machineNameById]);
 
     // Req #2685 — row height grows to fit one line per linked session.
@@ -307,6 +377,19 @@ export default function SwarmStartsPage() {
             {view === 'stats' && (
                 <SwarmStartsStatsView rows={swarmStarts} />
             )}
+
+            <SwarmStartDeleteDialog
+                deleteDialogOpen={swarmStartDelete.dialogOpen}
+                setDeleteDialogOpen={swarmStartDelete.setDialogOpen}
+                setDeleteId={swarmStartDelete.setInfoObject}
+                setDeleteConfirmed={swarmStartDelete.setConfirmed}
+                swarmStart={swarmStarts.find(s => s.id === swarmStartDelete.infoObject.swarmStartId)}
+                linkedSessionIds={
+                    (requirementsByStart.get(swarmStartDelete.infoObject.swarmStartId) || [])
+                        .map(r => r.sessionId)
+                }
+                linkedLoading={linkedLoading}
+            />
         </Box>
     );
 }

--- a/src/SwarmStarts/__tests__/SwarmStartDeleteDialog.test.jsx
+++ b/src/SwarmStarts/__tests__/SwarmStartDeleteDialog.test.jsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+//
+// Req #3265 — the delete guard on a swarm_start row is CLIENT-SIDE ONLY
+// (swarm_start_sessions.swarm_start_fk is ON DELETE CASCADE, not RESTRICT;
+// the browser's delete goes through the generic REST endpoint, never the
+// delete_swarm_start MCP tool's guard). The disabled Delete button is the
+// only thing standing between a linked row and a silent orphan of real
+// session history, so this file asserts that guard directly rather than
+// leaving it implicit in the parent pages' wiring.
+//
+// Mounted harness with raw react-dom + act — the house pattern (see
+// InstructionDeleteDialog.test.jsx). The dialog is a pure presentational
+// component: no contexts, no query client, no mocked modules.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import SwarmStartDeleteDialog from '../SwarmStartDeleteDialog';
+
+const SWARM_START = { id: 42, arguments: '3251' };
+
+let container;
+let root;
+let handlers;
+
+beforeEach(() => {
+    handlers = {
+        setDeleteDialogOpen: vi.fn(),
+        setDeleteId: vi.fn(),
+        setDeleteConfirmed: vi.fn(),
+    };
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.body.innerHTML = '';
+});
+
+const byTestId = (id) => document.querySelector(`[data-testid="${id}"]`);
+const text = (el) => (el?.textContent ?? '').replace(/\s+/g, ' ').trim();
+
+const render = (props = {}) => act(() => {
+    root.render(
+        <SwarmStartDeleteDialog
+            deleteDialogOpen
+            swarmStart={SWARM_START}
+            linkedSessionIds={[]}
+            {...handlers}
+            {...props}
+        />
+    );
+});
+
+const click = (el) => act(() => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+});
+
+describe('zero-session row', () => {
+    it('enables Delete and shows the plain confirmation copy', () => {
+        render({ linkedSessionIds: [] });
+
+        const btn = byTestId('btn-confirm-delete-swarm-start');
+        expect(btn.disabled).toBe(false);
+        expect(text(byTestId('swarm-start-delete-dialog'))).toContain(
+            'Do you want to permanently delete this swarm-start invocation record?');
+    });
+
+    it('confirming fires setDeleteConfirmed and closes the dialog', () => {
+        render({ linkedSessionIds: [] });
+        click(byTestId('btn-confirm-delete-swarm-start'));
+
+        expect(handlers.setDeleteConfirmed).toHaveBeenCalledWith(true);
+        expect(handlers.setDeleteDialogOpen).toHaveBeenCalledWith(false);
+    });
+});
+
+describe('linked row — the guard req #3265 exists to enforce', () => {
+    it('disables Delete and names every linked session id', () => {
+        render({ linkedSessionIds: [101, 102] });
+
+        const btn = byTestId('btn-confirm-delete-swarm-start');
+        expect(btn.disabled).toBe(true);
+        const body = text(byTestId('swarm-start-delete-dialog'));
+        expect(body).toContain('101');
+        expect(body).toContain('102');
+        expect(body).toContain('sessions');
+    });
+
+    it('singularises the copy at exactly one linked session', () => {
+        render({ linkedSessionIds: [307] });
+
+        const body = text(byTestId('swarm-start-delete-dialog'));
+        expect(body).toContain('session 307');
+        expect(body).not.toContain('sessions 307');
+    });
+
+    it('clicking a disabled Delete button never fires setDeleteConfirmed', () => {
+        render({ linkedSessionIds: [101] });
+        click(byTestId('btn-confirm-delete-swarm-start'));
+
+        expect(handlers.setDeleteConfirmed).not.toHaveBeenCalled();
+    });
+});
+
+describe('linkedLoading — fail CLOSED while the guard data is still in flight', () => {
+    it('disables Delete even with an empty linkedSessionIds list', () => {
+        // The exact race the code review (finding C2) flagged: both call sites
+        // derive linkedSessionIds from queries that are not the one gating the
+        // page's render, so an empty list during load must not read as "safe".
+        render({ linkedSessionIds: [], linkedLoading: true });
+
+        expect(byTestId('btn-confirm-delete-swarm-start').disabled).toBe(true);
+        expect(text(byTestId('swarm-start-delete-dialog'))).toContain(
+            'Cannot confirm there are no linked sessions yet');
+    });
+
+    it('re-enables once loading finishes with no linked sessions found', () => {
+        render({ linkedSessionIds: [], linkedLoading: true });
+        expect(byTestId('btn-confirm-delete-swarm-start').disabled).toBe(true);
+
+        render({ linkedSessionIds: [], linkedLoading: false });
+        expect(byTestId('btn-confirm-delete-swarm-start').disabled).toBe(false);
+    });
+});
+
+describe('cancel', () => {
+    it('closes the dialog and clears the selected row without confirming', () => {
+        render({ linkedSessionIds: [] });
+        const cancelBtn = Array.from(document.querySelectorAll('button'))
+            .find(b => text(b) === 'Cancel');
+        click(cancelBtn);
+
+        expect(handlers.setDeleteDialogOpen).toHaveBeenCalledWith(false);
+        expect(handlers.setDeleteId).toHaveBeenCalledWith({});
+        expect(handlers.setDeleteConfirmed).not.toHaveBeenCalled();
+    });
+});

--- a/src/SwarmStarts/__tests__/SwarmStartsPage.deleteGuard.test.jsx
+++ b/src/SwarmStarts/__tests__/SwarmStartsPage.deleteGuard.test.jsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+//
+// Req #3265 code review (re-verify pass, finding 2) — SwarmStartDeleteDialog.test.jsx
+// covers the dialog's own contract, but the C2 bug never lived in the dialog: it
+// lived in the WIRING that computes `linkedLoading` from `useSessions` /
+// `useAllSwarmStartSessions` and threads it down from SwarmStartsPage. Deleting
+// that prop from the page leaves every dialog-level test green, because the
+// prop defaults to `false`. This file mounts the real page (DataGrid stubbed,
+// same technique as SwarmStartsPage.tokens.test.jsx) so a regression in the
+// wiring itself — not just the dialog — fails a test.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-router-dom', async (importOriginal) => ({
+    ...(await importOriginal()),
+    useNavigate: () => () => {},
+}));
+
+vi.mock('@mui/x-data-grid', () => ({
+    GridToolbar: () => null,
+    DataGrid: ({ rows, columns }) => (
+        <div data-testid="grid">
+            {rows.map((row) => (
+                <div key={row.id} data-testid={`grid-row-${row.id}`}>
+                    {columns.map((col) => (
+                        <span key={col.field} data-testid={`cell-${col.field}-${row.id}`}>
+                            {col.renderCell
+                                ? col.renderCell({ row, id: row.id, field: col.field })
+                                : String(row[col.field] ?? '')}
+                        </span>
+                    ))}
+                </div>
+            ))}
+        </div>
+    ),
+}));
+
+const ROW = { id: 42, arguments: '3251', ai_model: 'opus', effort: 'high',
+               auto_start: 1, session_count: 1, wall_seconds: 10, turn_count: 1,
+               tokens_input: 1, tokens_output: 1, tokens_cache_read: 1, tokens_cache_write: 1 };
+// The linked session this row is tied to — the guard's whole reason to exist.
+const LINKED_SESSION = { id: 900 };
+const LINKED_JUNCTION_ROW = { swarm_start_fk: 42, session_fk: 900 };
+
+let dataQueriesMock;
+vi.mock('../../hooks/useDataQueries', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        useAllSwarmStarts: () => ({ data: [ROW], isLoading: false }),
+        useSessions: (...args) => dataQueriesMock.useSessions(...args),
+        useAllSwarmStartSessions: (...args) => dataQueriesMock.useAllSwarmStartSessions(...args),
+        useMachines: () => ({ data: [] }),
+    };
+});
+
+import SwarmStartsPage from '../SwarmStartsPage';
+import AuthContext from '../../Context/AuthContext';
+
+let roots = [];
+function mount() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AuthContext.Provider value={{ profile: { userName: 'tester', timezone: 'UTC' } }}>
+                    <SwarmStartsPage />
+                </AuthContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    return { container };
+}
+
+const click = (el) => act(() => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+});
+
+// Dialog renders via portal onto document.body, so lookups are document-wide.
+const openDeleteDialogFor = (container, rowId) => {
+    const btn = container.querySelector(
+        `[data-testid="cell-actions-${rowId}"] [data-testid="btn-delete-swarm-start-${rowId}"]`);
+    click(btn);
+};
+const confirmBtn = () => document.querySelector('[data-testid="btn-confirm-delete-swarm-start"]');
+
+describe('SwarmStartsPage delete-guard wiring (req #3265)', () => {
+    afterEach(() => {
+        act(() => { roots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+        vi.clearAllMocks();
+    });
+
+    it('disables Delete while the sessions/junction queries are still loading, even though the ' +
+       'row has no linked sessions in the not-yet-arrived data', () => {
+        dataQueriesMock = {
+            useSessions: () => ({ data: undefined, isLoading: true, isError: false }),
+            useAllSwarmStartSessions: () => ({ data: undefined, isLoading: true, isError: false }),
+        };
+        const { container } = mount();
+        openDeleteDialogFor(container, 42);
+
+        expect(confirmBtn().disabled).toBe(true);
+    });
+
+    it('disables Delete when the sessions query has settled into an error state (finding 1: ' +
+       'isLoading alone is false once a query errors, so isError must gate it too)', () => {
+        dataQueriesMock = {
+            useSessions: () => ({ data: undefined, isLoading: false, isError: true }),
+            useAllSwarmStartSessions: () => ({ data: [], isLoading: false, isError: false }),
+        };
+        const { container } = mount();
+        openDeleteDialogFor(container, 42);
+
+        expect(confirmBtn().disabled).toBe(true);
+    });
+
+    it('disables Delete when the junction query has settled into an error state', () => {
+        dataQueriesMock = {
+            useSessions: () => ({ data: [], isLoading: false, isError: false }),
+            useAllSwarmStartSessions: () => ({ data: undefined, isLoading: false, isError: true }),
+        };
+        const { container } = mount();
+        openDeleteDialogFor(container, 42);
+
+        expect(confirmBtn().disabled).toBe(true);
+    });
+
+    it('enables Delete once both queries have settled successfully with no link found', () => {
+        dataQueriesMock = {
+            useSessions: () => ({ data: [], isLoading: false, isError: false }),
+            useAllSwarmStartSessions: () => ({ data: [], isLoading: false, isError: false }),
+        };
+        const { container } = mount();
+        openDeleteDialogFor(container, 42);
+
+        expect(confirmBtn().disabled).toBe(false);
+    });
+
+    it('disables Delete once both queries have settled and a link IS found', () => {
+        dataQueriesMock = {
+            useSessions: () => ({ data: [LINKED_SESSION], isLoading: false, isError: false }),
+            useAllSwarmStartSessions: () => ({ data: [LINKED_JUNCTION_ROW], isLoading: false, isError: false }),
+        };
+        const { container } = mount();
+        openDeleteDialogFor(container, 42);
+
+        expect(confirmBtn().disabled).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3265-no-way-to-delete-a-swarm-starts-row-1
- wip(Darwin): 2026-08-07T11:17:10Z
- chore: init swarm session feature/3265-no-way-to-delete-a-swarm-starts-row-1

## Files changed
```
 src/SwarmStarts/SwarmStartDeleteDialog.jsx         |  94 ++++++++++++
 src/SwarmStarts/SwarmStartDetail.jsx               |  68 ++++++++-
 src/SwarmStarts/SwarmStartsPage.jsx                |  91 +++++++++++-
 .../__tests__/SwarmStartDeleteDialog.test.jsx      | 145 +++++++++++++++++++
 .../__tests__/SwarmStartsPage.deleteGuard.test.jsx | 160 +++++++++++++++++++++
 5 files changed, 549 insertions(+), 9 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)