### PR TITLE
req #3388

### DIFF
--- a/src/SwarmView/pipelines/__tests__/pipelineConformance.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineConformance.test.js
@@ -36,7 +36,7 @@ import { describe, it, expect } from 'vitest';
 
 import {
     buildPlanRows, displayOrder, verifyOrder, eligibility, launchBatches,
-    requirementCounts, pauseState,
+    requirementCounts, pauseState, serialState,
 } from '../pipelineModel';
 import { SUBSTRATE_REBUILD_MODEL } from './substrateRebuildFixture';
 
@@ -125,6 +125,11 @@ function observe(wireModel, now) {
     // because it writes `launchSuppressed`/`suppressedBy` onto `outRows` in
     // place, mirroring `observe.py`'s own call ordering.
     const pause = pauseState(model, outRows);
+
+    // req #3388 — AFTER `pauseState` and BEFORE the per-row loop, matching
+    // `observe.py` exactly: it APPENDS to the `suppressedBy` list pause wrote,
+    // so calling the two out of order would silently drop a pause reason.
+    const serial = serialState(model, outRows);
 
     const observedRows = {};
     for (const row of outRows) {
@@ -218,6 +223,18 @@ function observe(wireModel, now) {
             pipeline_paused: pause.pipelinePaused,
             paused_epic_ids: [...pause.pausedEpicIds],
             suppressed_step_ids: [...pause.suppressedStepIds],
+        },
+        // req #3388 — `execution_mode` is dropped for the same reason
+        // `pipeline_status` is: a verbatim wire field, not a derived answer.
+        // The epic ORDER, which epics are CLOSED, whose turn it is and which
+        // steps that holds are the four things two engines could disagree about.
+        serial: {
+            serial: serial.serial,
+            epic_order: [...serial.epicOrder],
+            closed_epic_ids: [...serial.closedEpicIds],
+            live_epic_id: serial.liveEpicId,
+            waiting_epic_ids: [...serial.waitingEpicIds],
+            held_step_ids: [...serial.heldStepIds],
         },
     };
 }

--- a/src/SwarmView/pipelines/pipelineModel.js
+++ b/src/SwarmView/pipelines/pipelineModel.js
@@ -134,6 +134,12 @@ export const PAUSED_STATUS = 'paused';
 // Requirement statuses that close a step (rule 1).
 export const TERMINAL_REQUIREMENT_STATUSES = ['met', 'deferred', 'wontfix'];
 
+// How a plan runs its epics (req #3388). `parallel` is every epic at once — the
+// behaviour that existed before this column, which is why it is the DEFAULT and
+// why an ABSENT value reads as parallel.
+export const MODE_PARALLEL = 'parallel';
+export const MODE_SERIAL = 'serial';
+
 const STATE_RANK = { [STEP_DONE]: 0, [STEP_RUNNING]: 1, [STEP_PENDING]: 2 };
 const RUN_RANK = { auto: 0, manual: 1 };
 
@@ -1322,5 +1328,81 @@ export function pauseState(model, rows) {
         pipelinePaused,
         pausedEpicIds: [...pausedEpicIds].sort((a, b) => a - b),
         suppressedStepIds,
+    };
+}
+
+/**
+ * Which epic's turn it is, and therefore which steps must WAIT for it (req #3388).
+ *
+ * The browser half of `pipeline_derive.py::serial_state`. That module's
+ * docstring carries the full rationale — the order is FIRST APPEARANCE IN
+ * DISPLAY ORDER (topological, not `epics.sort_order`, which is global to the
+ * epic and measured backwards on pipeline 79), an epic is CLOSED when every
+ * step it owns is `done`, and the live epic is the first one not closed.
+ *
+ * Called AFTER `pauseState`, whose `suppressedBy` list this APPENDS to rather
+ * than replacing: a step held by both a pause and a turn must name both, or
+ * unpausing it looks like it should start and does not. `turn` stays a distinct
+ * reason from `epic`/`pipeline` because they clear differently — a pause needs a
+ * person, a turn passes by itself when the epic ahead closes.
+ *
+ * An epic is BEHIND, LIVE or AHEAD, and only the ones AHEAD are held — a CLOSED
+ * epic is never suppressed, because `turn` means "has not had its turn yet",
+ * which is false of an epic that has finished. That is the one place serial does
+ * NOT copy `pauseState`, whose `epic` reason means "this scope is paused" and is
+ * true of its done steps too. Within an epic that IS ahead, suppression is by
+ * MEMBERSHIP and not eligibility, exactly as `pauseState` does it.
+ *
+ * A step with no epic label is never suppressed by turn: it has no turn to wait
+ * for, and holding it would deadlock a plan no unpause could rescue.
+ */
+export function serialState(model, rows) {
+    const pipeline = (model && model.pipeline) || {};
+    const mode = pipeline.execution_mode || MODE_PARALLEL;
+    const serial = mode === MODE_SERIAL;
+
+    // `rows` arrive in DISPLAY order — the caller's contract, and the whole
+    // basis of the sequence.
+    const epicOrder = [];
+    for (const row of rows || []) {
+        if (row.epicId != null && !epicOrder.includes(row.epicId)) {
+            epicOrder.push(row.epicId);
+        }
+    }
+
+    const closedEpicIds = epicOrder.filter((epicId) => (rows || [])
+        .filter((row) => row.epicId === epicId)
+        .every((row) => row.state === STEP_DONE));
+    const closed = new Set(closedEpicIds);
+
+    let liveEpicId = null;
+    for (const epicId of epicOrder) {
+        if (!closed.has(epicId)) { liveEpicId = epicId; break; }
+    }
+
+    // AHEAD of the live epic: not closed (behind) and not live.
+    const waitingEpicIds = epicOrder.filter(
+        (epicId) => !closed.has(epicId) && epicId !== liveEpicId);
+    const waiting = new Set(waitingEpicIds);
+
+    const heldStepIds = [];
+    if (serial && liveEpicId != null) {
+        for (const row of rows || []) {
+            if (row.epicId == null || !waiting.has(row.epicId)) continue;
+            row.suppressedBy = [...(row.suppressedBy || []), 'turn'];
+            row.launchSuppressed = true;
+            heldStepIds.push(row.id);
+        }
+    }
+
+    return {
+        executionMode: mode,
+        serial,
+        // In display order, which IS the running order. Not sorted by id.
+        epicOrder,
+        closedEpicIds,
+        liveEpicId,
+        waitingEpicIds,
+        heldStepIds,
     };
 }

--- a/src/SwarmView/pipelines/pipelineViewModel.js
+++ b/src/SwarmView/pipelines/pipelineViewModel.js
@@ -23,6 +23,7 @@ import {
     eligibility,
     requirementCounts,
     pauseState,
+    serialState,
     STEP_DONE,
     STEP_RUNNING,
     STEP_PENDING,
@@ -294,6 +295,15 @@ export function orderedPlan(model, { now, costIndex = null } = {}) {
     // every mutation these rows carry.
     const pause = pauseState(model || {}, rows);
 
+    // req #3388 — serial turn-taking, IMMEDIATELY AFTER pause and before
+    // anything reads `suppressedBy`. It appends `turn` to the same list pause
+    // just wrote, so calling it later (or not at all) leaves the browser
+    // showing a step as launchable while the engine is holding it — the two
+    // surfaces disagreeing about the live plan, which is the exact failure the
+    // shared conformance corpus exists to prevent. The corpus pins
+    // `serialState` itself; THIS line is what puts it on the browser's path.
+    const serial = serialState(model || {}, rows);
+
     // MUTATED IN PLACE deliberately: `rows` are the freshly built PlanRows this
     // call owns (buildPlanRows returns new objects every time), never the caller's
     // input, so there is nothing outside this function to surprise.
@@ -326,6 +336,11 @@ export function orderedPlan(model, { now, costIndex = null } = {}) {
         // that only has `plan` (not the rows) can still read the plan-wide
         // and epic-wide pause facts.
         pause,
+        // req #3388 — the mode, the epic order, which epics are closed, whose
+        // turn it is and what that holds. Carried beside `pause` for the same
+        // reason: a consumer with only `plan` and not the rows still needs the
+        // plan-wide answer.
+        serial,
     };
 }
 


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3388-pipeline-execution-mode-serial-one-1
- Pipeline execution mode: SERIAL (one epic at a time) vs PARALLEL, as a plan property rather than a hand-maintained wall of pauses (req #3388)
- chore: init swarm session feature/3388-pipeline-execution-mode-serial-one-1

## Files changed
```
 .../__tests__/pipelineConformance.test.js          | 19 ++++-
 src/SwarmView/pipelines/pipelineModel.js           | 82 ++++++++++++++++++++++
 src/SwarmView/pipelines/pipelineViewModel.js       | 15 ++++
 3 files changed, 115 insertions(+), 1 deletion(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)