### PR TITLE
Launch args must exclude non-swarm_ready requirements: the derivation emits met/deferred/wontfix, and /swarm-start answers with a prompt a run=auto orchestration cannot answer

### DIFF
--- a/src/SwarmView/pipelines/PipelinePlanTable.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanTable.jsx
@@ -223,6 +223,17 @@ function BatchBannerRow({ batch, colSpan, timezone }) {
                         <em>{batch.noLaunchReason
                             || 'no linked requirements — nothing to launch'}</em>
                     )}
+                    {/* req #3360. A PARTIAL exclusion is the common case and it
+                        is invisible without this: the command reads
+                        `/swarm-start 3329 3331 3333` on a step that links six
+                        requirements, which is indistinguishable from a dropped
+                        one. Rendered only ALONGSIDE a command — when there is
+                        none, `noLaunchReason` above already names every id. */}
+                    {batch.swarmStartCommand && (batch.launchExcluded || []).length > 0 && (
+                        <em data-testid={`pipeline-batch-skipped-${batch.letter}`}>
+                            skipped: {batch.launchExcluded.join(', ')}
+                        </em>
+                    )}
                 </Box>
             </TableCell>
         </TableRow>

--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -2881,6 +2881,12 @@ function PlanDataCard({ card, timezone, level, containerW, containerH }) {
                 {rowEl('Launch', b.swarmStartCommand
                     ? <code style={{ fontSize: '0.85em' }}>{b.swarmStartCommand}</code>
                     : (b.noLaunchReason || 'no linked requirements — nothing to launch'))}
+                {/* req #3360 — the ids the command DROPPED and why. Only
+                    alongside a command: with none, the reason above names them
+                    all already. Without this a six-requirement step showing a
+                    three-id command reads as a dropped requirement. */}
+                {b.swarmStartCommand && (b.launchExcluded || []).length > 0
+                    && rowEl('Skipped', b.launchExcluded.join(', '))}
             </div>
         );
     } else {

--- a/src/SwarmView/pipelines/__tests__/pipelineConformance.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineConformance.test.js
@@ -149,6 +149,12 @@ function observe(wireModel, now) {
             req_ids: [...(row.reqIds || [])],
             tracking_req_ids: [...(row.trackingReqIds || [])],
             unresolved_req_ids: [...(row.unresolvedReqIds || [])],
+            // req #3360 — the /swarm-start argument list and the reasons an id
+            // is missing from it. A plain rename, nothing derived: the split is
+            // `buildPlanRows`'s and this only projects it onto the wire shape.
+            launch_req_ids: [...(row.launchReqIds || [])],
+            launch_excluded: [...(row.launchExcluded || [])],
+            launch_block: row.launchBlock,
             dep_ids: [...(row.depIds || [])],
             time_deps: [...(row.timeDeps || [])],
             // COUNT, never the identities: this engine keys machines by TITLE and
@@ -175,6 +181,8 @@ function observe(wireModel, now) {
         time_deps: [...b.timeDeps],
         run: b.run,
         swarm_start_req_ids: [...b.swarmStartArgs],
+        launch_excluded: [...(b.launchExcluded || [])],
+        launch_block: b.launchBlock,
         no_launch_reason: b.noLaunchReason,
         machine_bucket_count: (b.machineLabels || []).length,
     }));

--- a/src/SwarmView/pipelines/__tests__/pipelineModel.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineModel.test.js
@@ -12,6 +12,7 @@ import {
     dominantLabels, machineLabels, fmtCost, aggregateStepCost,
     aggregateRowCost, sumReqCost, requirementCounts, isTrackingRequirement,
     pauseState, PAUSED_STATUS,
+    LAUNCHABLE_REQUIREMENT_STATUSES, EXCLUDED_CONTAINER, EXCLUDED_UNRESOLVED,
 } from '../pipelineModel';
 import { PLAN_JSON_ROWS, SUBSTRATE_REBUILD_MODEL } from './substrateRebuildFixture';
 
@@ -69,6 +70,23 @@ function row(id, state, deps = [], opts = {}) {
         epic: opts.epic !== undefined ? opts.epic : null,
         feature: opts.feature !== undefined ? opts.feature : null,
         reqIds: opts.reqIds || [],
+        trackingReqIds: opts.trackingReqIds || [],
+        // req #3360 — `launchableReqIds` READS this field rather than
+        // recomputing it, because `buildPlanRows` is the one place with the
+        // requirement rows in hand. A hand-built row must therefore carry it,
+        // exactly as it already carries `state` and `epicId` rather than
+        // deriving them. DEFAULTS TO `reqIds` minus the containers, which is
+        // what `buildPlanRows` produces for the all-`swarm_ready` step every
+        // batching test here means to describe; a case that means to exercise
+        // the STATUS filter sets the two apart explicitly.
+        launchReqIds: opts.launchReqIds !== undefined
+            ? opts.launchReqIds
+            : (opts.reqIds || []).filter(
+                (rid) => !(opts.trackingReqIds || []).includes(rid)),
+        launchExcluded: opts.launchExcluded !== undefined
+            ? opts.launchExcluded
+            : (opts.trackingReqIds || []).map(
+                (rid) => `${rid} ${EXCLUDED_CONTAINER}`),
         depIds: deps,
         timeDeps: opts.timeDeps || [],
         machineLabels: opts.machines || [],
@@ -242,7 +260,7 @@ describe('the tracking exemption — a container is not work (req #3123)', () =>
             ],
             stepDeps: [],
             requirements: [
-                { id: 500, requirement_status: 'approved', machine_fk: null },
+                { id: 500, requirement_status: 'swarm_ready', machine_fk: null },
                 { id: 600, requirement_status: 'development', machine_fk: 3, tracking: 1 },
             ],
             features: [], epics: [], machines: [{ id: 3, title: 'WSL' }],
@@ -274,8 +292,8 @@ describe('the tracking exemption — a container is not work (req #3123)', () =>
                 { step_fk: 3, dep_step_fk: 1, time_at: null },
             ],
             requirements: [
-                { id: 500, requirement_status: 'approved', machine_fk: null },
-                { id: 501, requirement_status: 'approved', machine_fk: null },
+                { id: 500, requirement_status: 'swarm_ready', machine_fk: null },
+                { id: 501, requirement_status: 'swarm_ready', machine_fk: null },
                 { id: 600, requirement_status: 'development', machine_fk: 3, tracking: 1 },
             ],
             features: [], epics: [], machines: [{ id: 3, title: 'WSL' }],
@@ -326,8 +344,8 @@ describe('the tracking exemption — a container is not work (req #3123)', () =>
         // Two pending steps sharing a gate, one of which links a container.
         const rows = [
             row(1, STEP_DONE),
-            { ...row(2, STEP_PENDING, [1], { reqIds: [100, 200] }), trackingReqIds: [200] },
-            { ...row(3, STEP_PENDING, [1], { reqIds: [300] }), trackingReqIds: [] },
+            row(2, STEP_PENDING, [1], { reqIds: [100, 200], trackingReqIds: [200] }),
+            row(3, STEP_PENDING, [1], { reqIds: [300], trackingReqIds: [] }),
         ];
         const [batch] = launchBatches(displayOrder(rows).rows);
         expect(batch.swarmStartArgs).toEqual([100, 300]);
@@ -338,8 +356,8 @@ describe('the tracking exemption — a container is not work (req #3123)', () =>
         + 'never an argument-less one', () => {
         const rows = [
             row(1, STEP_DONE),
-            { ...row(2, STEP_PENDING, [1], { reqIds: [200] }), trackingReqIds: [200] },
-            { ...row(3, STEP_PENDING, [1], { reqIds: [201] }), trackingReqIds: [201] },
+            row(2, STEP_PENDING, [1], { reqIds: [200], trackingReqIds: [200] }),
+            row(3, STEP_PENDING, [1], { reqIds: [201], trackingReqIds: [201] }),
         ];
         const [batch] = launchBatches(displayOrder(rows).rows);
         expect(batch.swarmStartArgs).toEqual([]);
@@ -652,11 +670,11 @@ describe('launchBatches — rules 2 + 8, the launch unit is explicit', () => {
             ],
             stepDeps: [],
             requirements: [
-                { id: 70, requirement_status: 'approved', feature_fk: 1, machine_fk: null },
-                { id: 71, requirement_status: 'approved', feature_fk: 1, machine_fk: null },
-                { id: 72, requirement_status: 'approved', feature_fk: 1, machine_fk: null },
-                { id: 73, requirement_status: 'approved', feature_fk: 1, machine_fk: null },
-                { id: 74, requirement_status: 'approved', feature_fk: 2, machine_fk: null },
+                { id: 70, requirement_status: 'swarm_ready', feature_fk: 1, machine_fk: null },
+                { id: 71, requirement_status: 'swarm_ready', feature_fk: 1, machine_fk: null },
+                { id: 72, requirement_status: 'swarm_ready', feature_fk: 1, machine_fk: null },
+                { id: 73, requirement_status: 'swarm_ready', feature_fk: 1, machine_fk: null },
+                { id: 74, requirement_status: 'swarm_ready', feature_fk: 2, machine_fk: null },
             ],
             features: [{ id: 1, title: 'F1', epic_fk: 1 }, { id: 2, title: 'F2', epic_fk: 2 }],
             epics: [{ id: 1, title: 'E1' }, { id: 2, title: 'E2' }],
@@ -1004,11 +1022,34 @@ describe('code-review hardenings (2026-07-26)', () => {
             gateStepIds: [40],
             run: 'auto',
             machineLabels: ['Mac mini'],
-            swarmStartArgs: [3118, 3108],
-            swarmStartCommand: '/swarm-start 3118 3108',
         });
         const posn = new Map(ids(result.rows).map((id, i) => [id, i]));
         expect(Math.abs(posn.get(41) - posn.get(43))).toBe(1);
+
+        // req #3360, ON THE REAL FIXTURE AND WITHOUT EDITING IT. #3118 and
+        // #3108 are both `approved` here — the fixture header says pending rows
+        // were given `approved/swarm_ready` interchangeably, because before this
+        // requirement the two behaved identically. They no longer do, and the
+        // batch forms exactly as before while carrying NO command.
+        expect(batches[0].swarmStartArgs).toEqual([]);
+        expect(batches[0].swarmStartCommand).toBeNull();
+        expect(batches[0].noLaunchReason)
+            .toBe('nothing launchable — only swarm_ready launches: '
+                + '3118 approved, 3108 approved');
+        expect(batches[0].launchExcluded).toEqual(['3118 approved', '3108 approved']);
+
+        // And the SAME plan with those two moved to `swarm_ready` derives the
+        // exact command this test was written for — which is what keeps the
+        // lettering/gate/machine assertions above tied to a real launch.
+        const ready = SUBSTRATE_REBUILD_MODEL.requirements.map(
+            (r) => ([3118, 3108].includes(r.id)
+                ? { ...r, requirement_status: 'swarm_ready' } : r));
+        const readyBatches = launchBatches(displayOrder(buildPlanRows(
+            { ...SUBSTRATE_REBUILD_MODEL, steps, requirements: ready })).rows);
+        expect(readyBatches[0].swarmStartArgs).toEqual([3118, 3108]);
+        expect(readyBatches[0].swarmStartCommand).toBe('/swarm-start 3118 3108');
+        expect(readyBatches[0].noLaunchReason).toBeNull();
+        expect(readyBatches[0].launchExcluded).toEqual([]);
     });
 });
 

--- a/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
@@ -243,9 +243,12 @@ const BATCH_READS = {
         { id: 3, step_fk: 4, dep_step_fk: 1, time_at: null },
     ],
     requirements: [
-        { id: 900, requirement_status: 'approved', machine_fk: 2, feature_fk: 101 },
-        { id: 901, requirement_status: 'approved', machine_fk: 2, feature_fk: 101 },
-        { id: 902, requirement_status: 'approved', machine_fk: 2, feature_fk: 101 },
+        // `swarm_ready`, not `approved` — req #3360 makes it the ONLY launchable
+        // status, and this fixture's subject is BATCHING, so its requirements
+        // have to be launchable for the batch to carry a command at all.
+        { id: 900, requirement_status: 'swarm_ready', machine_fk: 2, feature_fk: 101 },
+        { id: 901, requirement_status: 'swarm_ready', machine_fk: 2, feature_fk: 101 },
+        { id: 902, requirement_status: 'swarm_ready', machine_fk: 2, feature_fk: 101 },
     ],
     features: [{ id: 101, title: 'Wave', epic_fk: 11 }],
     epics: [{ id: 11, title: 'Epic' }],

--- a/src/SwarmView/pipelines/pipelineModel.js
+++ b/src/SwarmView/pipelines/pipelineModel.js
@@ -66,6 +66,19 @@
 //                                       from model.requirements (truncated read /
 //                                       data loss) — render LOUDLY; these rows'
 //                                       state may be under-derived
+// @property {number[]} launchReqIds     req #3360 — the EXACT /swarm-start argument
+//                                       list for this step: junction order,
+//                                       `swarm_ready` only, containers removed
+// @property {string[]} launchExcluded   one entry per linked id NOT in
+//                                       launchReqIds, pre-rendered as
+//                                       `"<reqId> <reason>"` — flat, because the
+//                                       server twin's derived block may carry no
+//                                       nested row (req #3078 payload budget)
+// @property {?string} launchBlock       req #3360 — WHY there is no command, as
+//                                       an enum to branch on: 'no-links' |
+//                                       'containers' | 'not-ready' | null. The
+//                                       first two mean CLOSE the step, the third
+//                                       means the work is not ready
 // @property {number[]} depIds           step dependencies
 // @property {string[]} timeDeps         time gates (ISO-8601)
 // @property {?number} epicId            dominant epic (rule 10)
@@ -111,12 +124,19 @@
 // @property {('auto'|'manual')} run
 // @property {string[]} machineLabels
 // @property {number[]} swarmStartArgs   the EXACT requirement-id argument list (rule 8),
-//                                       tracking containers excluded
+//                                       tracking containers and non-`swarm_ready`
+//                                       requirements excluded
 // @property {?string} swarmStartCommand '/swarm-start <req ids>', null when the
 //                                       batch has nothing launchable
+// @property {string[]} launchExcluded   req #3360 — every member's exclusions,
+//                                       flattened in member order. Present even
+//                                       when there IS a command: a PARTIAL
+//                                       exclusion is the common case
+// @property {?string} launchBlock       req #3360 — the enum behind noLaunchReason
 // @property {?string} noLaunchReason    why there is no command — null when there is
 //                                       one. Distinguishes "no links at all" from
 //                                       "every link is a container" (req #3123)
+//                                       from "nothing is launchable" (req #3360)
 //
 // @typedef {Object} StepCost  shape-compatible with the cost-rollup req (#3117)
 // @property {number} wallSecs
@@ -133,6 +153,50 @@ export const PAUSED_STATUS = 'paused';
 
 // Requirement statuses that close a step (rule 1).
 export const TERMINAL_REQUIREMENT_STATUSES = ['met', 'deferred', 'wontfix'];
+
+// The ONLY status a /swarm-start argument may carry (req #3360). Decided by the
+// user 2026-08-07 and NOT open for re-derivation: `authoring`, `approved`,
+// `met`, `deferred`, `wontfix` and `development` are ALL excluded from a step's
+// launch argument list.
+//
+// A named set rather than a boolean test, so `tests/swarm/test-pipeline-skill-contract.sh`
+// can read the rule BY NAME and pin the /swarm-start skill's prose against it —
+// widening the rule is then one edit and the binding test fails until the prose
+// follows. The two statuses worth justifying, because they are the ones a later
+// session will be tempted to re-admit: `approved` was in every previous copy of
+// this list and the user was asked about it specifically and said skip it;
+// `development` means a session already took the requirement past readiness, so
+// excluding it STRENGTHENS req #3191 (whose whole mechanism is `session-init.sh`
+// writing `development` to suppress a relaunch, defeated until now by an
+// argument list that never read the column).
+export const LAUNCHABLE_REQUIREMENT_STATUSES = ['swarm_ready'];
+
+// Why an id is NOT in a step's launch argument list — published per excluded id
+// so no consumer re-derives one.
+//
+// EACH ENTRY IS ONE FLAT STRING, `"<reqId> <reason>"`, and the shape is forced
+// rather than chosen: the server twin's derived block may carry no nested row
+// anywhere (req #3078's payload budget, pinned by
+// `test_the_derived_block_is_compact_ids_and_enums_only`), and these two must
+// stay identical. It is also the form every consumer wants — all of them RENDER
+// the exclusion and none reads the status programmatically, and for a status
+// exclusion the reason IS the status.
+export const EXCLUDED_CONTAINER = 'tracking container';
+export const EXCLUDED_UNRESOLVED = 'unresolved — not in the composed read';
+export const EXCLUDED_NO_STATUS = 'no status';
+
+// WHY a step or batch has no command, as an ENUM a consumer can BRANCH on —
+// `noLaunchReason` is the same decision rendered as a sentence for a human.
+// Both come from `launchBlock`, so they cannot disagree.
+//
+// THE THREE CASES NEED DIFFERENT READER ACTIONS, and the two that predate req
+// #3360 need the SAME one. `no-links` and `containers` mean *close the step* —
+// there is no work and there never will be. `not-ready` means *the work exists
+// and is not ready*, and closing the step there destroys the plan record for
+// work nobody has done.
+export const BLOCK_NO_LINKS = 'no-links';
+export const BLOCK_CONTAINERS = 'containers';
+export const BLOCK_NOT_READY = 'not-ready';
 
 // How a plan runs its epics (req #3388). `parallel` is every epic at once — the
 // behaviour that existed before this column, which is why it is the DEFAULT and
@@ -174,6 +238,57 @@ export function isTrackingRequirement(req) {
     if (typeof value === 'boolean') return value;
     const n = Number(value);
     return Number.isFinite(n) ? n !== 0 : false;
+}
+
+// Rule 8, with the status finally read (req #3360). Splits a step's linked ids
+// into the ones a /swarm-start may carry and one record per id it may NOT, each
+// carrying the REASON.
+//
+// Before this requirement the split subtracted containers and stopped, so an
+// orchestrated launch attempted work that was already finished — measured
+// 2026-08-07 on pipeline 79 step 230, `/swarm-start 3329 3330 3331 3332 3333
+// 3334` with three of them `met`, while the sync report printed "met —
+// /swarm-start has nothing to do with it" for each of the three on the same
+// read. The plan layer already knew and emitted the ids anyway.
+//
+// ORDER IS THE PLAN'S OWN. Both lists come out in junction order — rule 8's
+// "the requirement ids ARE the argument list" means the command must be stable
+// across cycles, and re-sorting here would make it depend on which ids happened
+// to be excluded.
+//
+// UNRESOLVED IS EXCLUDED, deliberately. A junction row whose requirement is
+// missing from the read has no readable status, and "only swarm_ready launches"
+// cannot be satisfied by a row nobody read. Fail closed.
+//
+// @param {number[]} reqIds
+// @param {number[]} trackingReqIds
+// @param {Map<number, PipelineRequirement>} reqsById
+// @returns {{launchReqIds: number[], launchExcluded: string[]}}
+function splitLaunchable(reqIds, trackingReqIds, reqsById) {
+    const tracking = new Set(trackingReqIds || []);
+    const launchReqIds = [];
+    const launchExcluded = [];
+    const note = (rid, reason) => launchExcluded.push(`${rid} ${reason}`);
+    for (const rid of reqIds || []) {
+        if (tracking.has(rid)) {
+            note(rid, EXCLUDED_CONTAINER);
+            continue;
+        }
+        const req = reqsById.get(rid);
+        if (!req) {
+            note(rid, EXCLUDED_UNRESOLVED);
+            continue;
+        }
+        const status = req.requirement_status != null ? req.requirement_status : null;
+        if (LAUNCHABLE_REQUIREMENT_STATUSES.includes(status)) {
+            launchReqIds.push(rid);
+        } else {
+            // The STATUS IS THE REASON, so it is the phrase rather than a label
+            // wrapped around one: a reader seeing `3330 met` needs no glossary.
+            note(rid, status || EXCLUDED_NO_STATUS);
+        }
+    }
+    return { launchReqIds, launchExcluded };
 }
 
 // Rule 1: STEP STATE IS DERIVED, NEVER STORED-BY-HAND. Any GATING requirement in
@@ -392,6 +507,12 @@ export function buildPlanRows(model) {
         // nothing was read that said so.
         const trackingReqIds = reqIds.filter(
             (rid) => isTrackingRequirement(reqsById.get(rid)));
+        // req #3360. Computed HERE, where reqsById is already in hand, and
+        // published on the row rather than recomputed at each call site: the
+        // launch argument list and the reasons an id is missing from it are two
+        // halves of one answer, and deriving them apart is how they disagree.
+        const { launchReqIds, launchExcluded } = splitLaunchable(
+            reqIds, trackingReqIds, reqsById);
         const labels = inheritedLabels(step.id, new Set()) || dominantLabels(step, model);
         const machines = machineLabels(step, model);
         const deps = depsByStep.get(step.id) || { depIds: [], timeDeps: [] };
@@ -405,6 +526,11 @@ export function buildPlanRows(model) {
             reqIds,
             trackingReqIds,
             unresolvedReqIds,
+            launchReqIds,
+            launchExcluded,
+            // req #3360. Per ROW as well as per batch: a solo step never forms
+            // a batch, and the plan table renders rows.
+            launchBlock: launchBlock([{ reqIds, trackingReqIds, launchReqIds }]),
             depIds: deps.depIds,
             timeDeps: deps.timeDeps,
             epicId: labels.epicId,
@@ -1008,15 +1134,63 @@ function batchLetter(i) {
     return s;
 }
 
-// The requirement ids a step actually LAUNCHES: its links minus its tracking
-// containers (req #3123). Rule 8 says a step's requirement ids ARE the
-// /swarm-start argument list, so before the flag existed a step linking its
-// plan's tracker would have launched a session against the plan itself —
-// a container has no work to do and no acceptance criteria to satisfy.
-// Now that the signal is durable, the defect is fixable, so it is fixed here.
+// The requirement ids a step actually LAUNCHES: rule 8's argument list, minus
+// its tracking containers (req #3123) and minus everything that is not
+// `swarm_ready` (req #3360).
+//
+// THE ANSWER IS READ, NOT RECOMPUTED. buildPlanRows owns the split, where the
+// requirement rows are in hand; this is the accessor both launchBatches and
+// every render surface go through, so the batch command and the per-row list
+// cannot disagree about the same step.
+//
+// IT FAILS CLOSED. A row without the field launches NOTHING rather than falling
+// back to the wider set — a silent fallback here would restore exactly the
+// defect req #3360 removed, on the one input class (a row built by something
+// other than buildPlanRows) nobody would think to test.
 function launchableReqIds(row) {
-    const tracking = new Set(row.trackingReqIds || []);
-    return (row.reqIds || []).filter((id) => !tracking.has(id));
+    return [...(row.launchReqIds || [])];
+}
+
+// Why each of this step's linked requirements is missing from its command.
+function launchExclusionsOf(row) {
+    return [...(row.launchExcluded || [])];
+}
+
+// The noLaunchReason for a batch whose launchable set is empty. ONE vocabulary,
+// EXTENDED (req #3360), never a parallel one: the caller that has to ask "is
+// this the container field or the status field?" is the caller that reads the
+// wrong one. The first two values predate req #3360 and are unchanged — a
+// corpus asserts them, and "every link is a container" and "some links are
+// finished work" want different reader actions.
+// WHICH of the three no-command cases this is — the enum, not the sentence.
+// ASKED OF THE IDS, never by parsing a rendered reason back apart. Null when
+// something IS launchable.
+function launchBlock(members) {
+    if (members.some((m) => launchableReqIds(m).length)) return null;
+    if (!members.some((m) => (m.reqIds || []).length)) return BLOCK_NO_LINKS;
+    const allContainers = members.every((m) => {
+        const tracking = new Set(m.trackingReqIds || []);
+        return (m.reqIds || []).every((rid) => tracking.has(rid));
+    });
+    return allContainers ? BLOCK_CONTAINERS : BLOCK_NOT_READY;
+}
+
+// The human sentence for each enum value — chosen BY the enum rather than
+// re-decided, so the value a consumer branches on and the sentence it prints
+// can never describe different situations.
+function noLaunchReasonFor(members) {
+    switch (launchBlock(members)) {
+    case BLOCK_NO_LINKS:
+        return 'no linked requirements — nothing to launch';
+    case BLOCK_CONTAINERS:
+        return 'every linked requirement is a tracking container — nothing to launch';
+    default:
+        // NAMED, WITH THE STATUS. A shrinking argument list with no explanation
+        // is indistinguishable from a bug (rule 7), and this is the shape where
+        // it shrank all the way to nothing.
+        return `nothing launchable — only ${LAUNCHABLE_REQUIREMENT_STATUSES.join(', ')} `
+            + `launches: ${members.flatMap(launchExclusionsOf).join(', ')}`;
+    }
 }
 
 // Rules 2 + 8: pending steps sharing an identical (dominant epic, remaining step
@@ -1063,17 +1237,24 @@ export function launchBatches(orderedRows) {
             machineLabels: labels,
             swarmStartArgs: reqIds,
             swarmStartCommand: reqIds.length ? `/swarm-start ${reqIds.join(' ')}` : null,
+            // req #3360. Flattened across members in the same member order the
+            // command is built in, so a reader can line the two up: these are
+            // the ids that WOULD have been in the command and why each is not.
+            // Carried even when the command is non-empty — a PARTIAL exclusion
+            // is the common case and the one most easily mistaken for a bug.
+            launchExcluded: members.flatMap(launchExclusionsOf),
+            // req #3360. The enum beside the sentence: noLaunchReason is for a
+            // person, this is what a consumer BRANCHES on to choose a remedy.
+            launchBlock: launchBlock(members),
             // Why there is no command, in the batch rather than at each render
             // surface — "no linked requirements" acquired a SECOND meaning with
             // req #3123 and was flatly false for the new one: a batch can now
             // carry requirement links and still have nothing to launch, because
-            // every one of them is a container. Both the table and the
-            // visualizer print this field, so they cannot drift apart.
-            noLaunchReason: reqIds.length
-                ? null
-                : (members.some((m) => (m.reqIds || []).length)
-                    ? 'every linked requirement is a tracking container — nothing to launch'
-                    : 'no linked requirements — nothing to launch'),
+            // every one of them is a container. Req #3360 added a THIRD, for the
+            // same reason: every link can be real work that is simply not
+            // launchable. Both the table and the visualizer print this field, so
+            // they cannot drift apart.
+            noLaunchReason: reqIds.length ? null : noLaunchReasonFor(members),
         });
     }
     return batches;


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-08T14:30:13Z
- chore: init swarm session feature/3360-launch-args-must-exclude-non-swarm-1

## Files changed
```
 src/SwarmView/pipelines/PipelinePlanTable.jsx      |  11 ++
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx |   6 +
 .../__tests__/pipelineConformance.test.js          |   8 +
 .../pipelines/__tests__/pipelineModel.test.js      |  69 +++++--
 .../pipelines/__tests__/pipelineViewModel.test.js  |   9 +-
 src/SwarmView/pipelines/pipelineModel.js           | 213 +++++++++++++++++++--
 6 files changed, 283 insertions(+), 33 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)