### PR TITLE
One telemetry record + one run harness shared by swarm sessions and agent runs

### DIFF
--- a/src/Agents/ContextPage.jsx
+++ b/src/Agents/ContextPage.jsx
@@ -93,6 +93,10 @@ import { deleteAgentTelemetryRun, updateAgentTelemetryRun } from './actions/cont
 import { aiModelChipProps, aiModelLabel } from '../SwarmView/modelChipStyles';
 import { effortChipProps, effortLabel } from '../SwarmView/effortChipStyles';
 import {
+    NOT_MEASURED, TOKEN_FIELDS, TOKEN_LABELS, envelopeCost, envelopePrompt,
+    formatTokenCount, formatWallMs, hasEnvelope,
+} from '../utils/telemetryEnvelope';
+import {
     NA as NA_TEXT, fmt, sortByColumn, naturalSortDir, DEFAULT_SORT_FIELD, DEFAULT_SORT_DIR,
     assignMarkers, computeCells, runDateLabel,
 } from './contextRenderUtils';
@@ -634,6 +638,85 @@ const ContextPage = () => {
                                   data-testid="agent-context-effort" />
                         </Box>
                     </Box>
+
+                    {/* WHAT THIS CAPTURE RUN ITSELF COST — the shared telemetry
+                        envelope (req #3202). Everything in the table below
+                        measures ONE AGENT's context; this measures the run that
+                        produced the table, in the same terms a swarm session
+                        records, which is what makes the two comparable at all.
+                        Before #3202 this page showed no run cost whatsoever.
+
+                        The whole block is hidden for a capture with no envelope
+                        (every pre-#3202 row, and any run whose transcript could
+                        not be resolved) rather than rendered as a panel of
+                        em-dashes — but a run that measured SOME of it shows the
+                        rest as NOT_MEASURED, never as zero. That distinction is
+                        the point: ~1,900 rows carry NULL here with no backfill
+                        possible, and printing 0 for them would be a false claim
+                        about a real run. */}
+                    {hasEnvelope(activeRun) && (() => {
+                        const cost = envelopeCost(activeRun);
+                        const prompt = envelopePrompt(activeRun);
+                        return (
+                            <Box data-testid="agent-context-envelope"
+                                 sx={{ display: 'flex', gap: 4, flexWrap: 'wrap',
+                                       alignItems: 'flex-start' }}>
+                                <Box>
+                                    <Typography variant="subtitle2" color="text.secondary"
+                                                sx={{ fontWeight: 'bold', fontSize: '1.25rem' }}>
+                                        Run Wall Clock
+                                    </Typography>
+                                    <Typography variant="body2"
+                                                data-testid="agent-context-wall-ms">
+                                        {formatWallMs(activeRun.wall_ms)}
+                                    </Typography>
+                                </Box>
+                                <Box>
+                                    <Typography variant="subtitle2" color="text.secondary"
+                                                sx={{ fontWeight: 'bold', fontSize: '1.25rem' }}>
+                                        Run Tokens
+                                    </Typography>
+                                    <Typography variant="body2"
+                                                data-testid="agent-context-tokens-total">
+                                        {cost.measured ? formatTokenCount(cost.total) : NOT_MEASURED}
+                                    </Typography>
+                                    <Typography variant="caption" color="text.secondary"
+                                                data-testid="agent-context-tokens-breakdown">
+                                        {TOKEN_FIELDS.map((field) => (
+                                            `${TOKEN_LABELS[field]} ${formatTokenCount(cost.parts[field])}`
+                                        )).join(' · ')}
+                                    </Typography>
+                                </Box>
+                                {prompt && (
+                                    <Box sx={{ maxWidth: 520 }}>
+                                        <Typography variant="subtitle2" color="text.secondary"
+                                                    sx={{ fontWeight: 'bold', fontSize: '1.25rem' }}>
+                                            Prompt
+                                        </Typography>
+                                        <Typography variant="body2"
+                                                    sx={{ whiteSpace: 'pre-wrap',
+                                                          wordBreak: 'break-word' }}
+                                                    data-testid="agent-context-prompt">
+                                            {prompt.text}
+                                        </Typography>
+                                        {/* The stored text is a bounded prefix. Say so
+                                            explicitly rather than letting a reader take a
+                                            clipped prompt for the whole one. */}
+                                        <Typography variant="caption" color="text.secondary"
+                                                    data-testid="agent-context-prompt-meta">
+                                            {prompt.truncated
+                                                ? `first ${prompt.text.length.toLocaleString('en-US')} of `
+                                                : ''}
+                                            {prompt.chars == null
+                                                ? ''
+                                                : `${prompt.chars.toLocaleString('en-US')} chars`}
+                                            {prompt.shaShort ? ` · sha256 ${prompt.shaShort}` : ''}
+                                        </Typography>
+                                    </Box>
+                                )}
+                            </Box>
+                        );
+                    })()}
 
                     {/* House edit-in-place field (GhostTextField's "outlined" mode —
                         same commit contract as InstructionsPage's fields): saves

--- a/src/Agents/__tests__/ContextPage.test.jsx
+++ b/src/Agents/__tests__/ContextPage.test.jsx
@@ -176,3 +176,85 @@ describe('ContextPage — CC BASE BREAKDOWN columns (req #3095)', () => {
         }
     });
 });
+
+// ---------------------------------------------------------------------------
+// req #3202 — the SHARED TELEMETRY ENVELOPE on the run header
+// ---------------------------------------------------------------------------
+// Everything above measures ONE AGENT's context. The envelope measures what the
+// CAPTURE RUN itself cost, in the same terms a swarm session records — and this
+// page showed NO run cost at all before #3202.
+//
+// These tests exist because storing the record is not delivering it: a column
+// written and never rendered is invisible, and the acceptance for #3202 is that
+// both domains USE the record. They also pin the NULL rule at the render layer,
+// which is where a fabricated zero would actually mislead somebody.
+
+describe('ContextPage — shared telemetry envelope (req #3202)', () => {
+    const ENVELOPE_RUN = {
+        ...RUN,
+        wall_ms: 252431,
+        tokens_input: 1200, tokens_cache_write: 45600,
+        tokens_cache_read: 12300000, tokens_output: 8400,
+        prompt_text: '/agent-telemetry-run 2026-08-08 capture',
+        prompt_sha256: 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+        prompt_chars: 39,
+    };
+
+    it('renders the run wall clock in a human unit, from milliseconds', () => {
+        runsData = [ENVELOPE_RUN];
+        mount();
+        expect(container.querySelector('[data-testid="agent-context-wall-ms"]').textContent)
+            .toBe('4m 12s');
+    });
+
+    it('renders the four-way token usage the table below cannot show', () => {
+        runsData = [ENVELOPE_RUN];
+        mount();
+        expect(container.querySelector('[data-testid="agent-context-tokens-total"]').textContent)
+            .toBe('12.4M');
+        const breakdown = container
+            .querySelector('[data-testid="agent-context-tokens-breakdown"]').textContent;
+        expect(breakdown).toContain('Input 1.2k');
+        expect(breakdown).toContain('Cache write 45.6k');
+        expect(breakdown).toContain('Cache read 12.3M');
+        expect(breakdown).toContain('Output 8.4k');
+    });
+
+    it('renders what the run was asked — the thing nothing captured before', () => {
+        runsData = [ENVELOPE_RUN];
+        mount();
+        expect(container.querySelector('[data-testid="agent-context-prompt"]').textContent)
+            .toBe('/agent-telemetry-run 2026-08-08 capture');
+        expect(container.querySelector('[data-testid="agent-context-prompt-meta"]').textContent)
+            .toContain('abcdef012345');
+    });
+
+    it('says so when the stored prompt is only a prefix of what was asked', () => {
+        runsData = [{ ...ENVELOPE_RUN, prompt_text: 'x'.repeat(2000), prompt_chars: 5400 }];
+        mount();
+        const meta = container
+            .querySelector('[data-testid="agent-context-prompt-meta"]').textContent;
+        expect(meta).toContain('first 2,000 of');
+        expect(meta).toContain('5,400 chars');
+    });
+
+    it('hides the whole block for a pre-#3202 capture rather than showing em-dashes', () => {
+        runsData = [RUN];
+        mount();
+        expect(container.querySelector('[data-testid="agent-context-envelope"]')).toBeNull();
+    });
+
+    it('NEVER prints 0 for a token type nobody measured', () => {
+        // THE rule. A partially-measured capture must show the part it knows and
+        // an em-dash for the rest — a 0 here would be a false claim about a real
+        // run, and would understate every aggregate it fed.
+        runsData = [{ ...RUN, wall_ms: 5000, tokens_output: 8400 }];
+        mount();
+        const breakdown = container
+            .querySelector('[data-testid="agent-context-tokens-breakdown"]').textContent;
+        expect(breakdown).toContain('Output 8.4k');
+        expect(breakdown).toContain('Input —');
+        expect(breakdown).toContain('Cache read —');
+        expect(breakdown).not.toContain('Input 0');
+    });
+});

--- a/src/hooks/factory/devopsQueries.js
+++ b/src/hooks/factory/devopsQueries.js
@@ -301,6 +301,23 @@ export const agentTelemetryRuns = createEntityQueries({
     defaultFields:
         'id,captured_at,label,agent_count,harness_version,source_note,' +
         'ai_model,effort,machine_fk,' +
+        // req #3202 — the shared telemetry envelope: what the CAPTURE RUN itself
+        // cost, which this page had no form of before.
+        //
+        // `prompt_text` is carried on the LIST read, deliberately, and against
+        // the general rule that a list never carries a blob (req #3078). Two
+        // reasons, both specific to this table: the page has no by-id header
+        // fetch — the picker's list IS where `activeRun` comes from, so omitting
+        // it would mean the prompt could never render at all — and a capture is
+        // a deliberate manual act that spends real billed API turns per agent,
+        // so this table grows by a handful of rows a MONTH (5 rows in production
+        // at time of writing), against a 2000-char cap. That is ~2 KB a row on a
+        // set that would need thousands of captures to approach any ceiling.
+        // darwin-mcp's own list read of this table DOES drop it (HEAVY_COLUMNS),
+        // because that surface has `darwin://agent-telemetry-runs/{id}` to fall
+        // back on and this one does not.
+        'wall_ms,tokens_input,tokens_cache_write,tokens_cache_read,tokens_output,' +
+        'prompt_text,prompt_sha256,prompt_chars,' +
         'creator_fk,create_ts,update_ts',
     fieldsInKey: true,
     defaultSort: 'captured_at:desc',

--- a/src/utils/__tests__/telemetryEnvelope.test.js
+++ b/src/utils/__tests__/telemetryEnvelope.test.js
@@ -1,0 +1,133 @@
+// Render rules for the SHARED TELEMETRY ENVELOPE (req #3202).
+//
+// The tests that matter here are all one rule: **NULL means NOT MEASURED and
+// must never render as 0.** Roughly 1,900 pre-#3202 rows carry NULL in every
+// envelope column, with no backfill possible — their transcripts are rotated or
+// deleted, so any number written now would be fabricated. A page that prints
+// "0 tokens" for one of those is making a false claim about a real run, and a
+// total that sums NULLs as zeros silently understates every aggregate.
+
+import { describe, it, expect } from 'vitest';
+import {
+    NOT_MEASURED,
+    TOKEN_FIELDS,
+    envelopeCost,
+    envelopePrompt,
+    formatTokenCount,
+    formatWallMs,
+    hasEnvelope,
+} from '../telemetryEnvelope';
+
+describe('formatWallMs — the ONE wall-clock unit', () => {
+    it('renders not-measured as an em-dash, never as 0s', () => {
+        expect(formatWallMs(null)).toBe(NOT_MEASURED);
+        expect(formatWallMs(undefined)).toBe(NOT_MEASURED);
+    });
+
+    it('keeps sub-second precision instead of collapsing it to 0s', () => {
+        // An agent's boot latency is a real sub-second measurement — it is why
+        // the envelope chose milliseconds over the seconds Domain A used.
+        expect(formatWallMs(412)).toBe('412ms');
+        expect(formatWallMs(0)).toBe('0ms');
+    });
+
+    it('reads as a duration once past a second', () => {
+        expect(formatWallMs(1000)).toBe('1s');
+        expect(formatWallMs(252431)).toBe('4m 12s');
+        expect(formatWallMs(3_600_000)).toBe('1h');
+    });
+
+    it('refuses junk rather than printing it', () => {
+        expect(formatWallMs('abc')).toBe(NOT_MEASURED);
+        expect(formatWallMs(-5)).toBe(NOT_MEASURED);
+    });
+});
+
+describe('formatTokenCount', () => {
+    it('renders not-measured as an em-dash', () => {
+        expect(formatTokenCount(null)).toBe(NOT_MEASURED);
+    });
+
+    it('renders a measured zero as zero — it is a real measurement', () => {
+        expect(formatTokenCount(0)).toBe('0');
+    });
+
+    it('compacts large counts', () => {
+        expect(formatTokenCount(789)).toBe('789');
+        expect(formatTokenCount(45_600)).toBe('45.6k');
+        expect(formatTokenCount(12_300_000)).toBe('12.3M');
+    });
+});
+
+describe('envelopeCost — measured is reported separately from the total', () => {
+    it('reports an unmeasured run as measured:false with a null total', () => {
+        const cost = envelopeCost({ id: 1 });
+        expect(cost.measured).toBe(false);
+        expect(cost.total).toBeNull();
+        for (const field of TOKEN_FIELDS) expect(cost.parts[field]).toBeNull();
+    });
+
+    it('distinguishes a genuinely zero-cost run from an unmeasured one', () => {
+        const zero = envelopeCost({
+            tokens_input: 0, tokens_cache_write: 0,
+            tokens_cache_read: 0, tokens_output: 0,
+        });
+        expect(zero.measured).toBe(true);
+        expect(zero.total).toBe(0);
+    });
+
+    it('totals only the types that were measured', () => {
+        const cost = envelopeCost({ tokens_output: 40, tokens_input: 2 });
+        expect(cost.total).toBe(42);
+        expect(cost.parts.tokens_cache_read).toBeNull();
+        expect(cost.measured).toBe(true);
+    });
+
+    it('treats an unreadable value as unmeasured, not as zero', () => {
+        const cost = envelopeCost({ tokens_output: 'lots' });
+        expect(cost.parts.tokens_output).toBeNull();
+        expect(cost.measured).toBe(false);
+    });
+});
+
+describe('envelopePrompt — the stored text is a bounded prefix', () => {
+    it('is null when no prompt was captured', () => {
+        expect(envelopePrompt({})).toBeNull();
+        expect(envelopePrompt({ prompt_text: '' })).toBeNull();
+    });
+
+    it('marks a clipped prompt as clipped, by comparing against the FULL length', () => {
+        const prompt = envelopePrompt({
+            prompt_text: 'x'.repeat(2000),
+            prompt_chars: 5400,
+            prompt_sha256: 'abcdef0123456789',
+        });
+        expect(prompt.truncated).toBe(true);
+        expect(prompt.chars).toBe(5400);
+        expect(prompt.shaShort).toBe('abcdef012345');
+    });
+
+    it('does not claim truncation for a prompt that fit', () => {
+        const prompt = envelopePrompt({ prompt_text: 'short', prompt_chars: 5 });
+        expect(prompt.truncated).toBe(false);
+    });
+
+    it('does not guess truncation when the full length is unknown', () => {
+        const prompt = envelopePrompt({ prompt_text: 'x'.repeat(2000) });
+        expect(prompt.truncated).toBe(false);
+        expect(prompt.chars).toBeNull();
+    });
+});
+
+describe('hasEnvelope — a pre-#3202 row shows no panel of em-dashes', () => {
+    it('is false for a row that measured nothing', () => {
+        expect(hasEnvelope({ id: 1, label: 'old capture' })).toBe(false);
+        expect(hasEnvelope(null)).toBe(false);
+    });
+
+    it('is true on any single measured field, including a genuine zero', () => {
+        expect(hasEnvelope({ wall_ms: 0 })).toBe(true);
+        expect(hasEnvelope({ tokens_output: 0 })).toBe(true);
+        expect(hasEnvelope({ prompt_sha256: 'abc' })).toBe(true);
+    });
+});

--- a/src/utils/telemetryEnvelope.js
+++ b/src/utils/telemetryEnvelope.js
@@ -1,0 +1,135 @@
+// Render helpers for the SHARED TELEMETRY ENVELOPE (req #3202).
+//
+// The envelope is the one measurement record every container of "a Claude run
+// happened" carries — `swarm_sessions`, `swarm_starts`, `swarm_completes` and
+// `agent_telemetry_runs`, identical column names on all four. Its definition
+// lives in `scripts/telemetry/envelope.py`; this file is only how it is DISPLAYED.
+//
+// THE ONE RULE THESE HELPERS EXIST TO ENFORCE
+// -------------------------------------------
+// **NULL means NOT MEASURED. It must never render as 0.** Every envelope column
+// is nullable and roughly 1,900 pre-#3202 rows carry NULL in all of them, with no
+// backfill possible (their transcripts are rotated or deleted, so any number
+// written now would be fabricated). A page that prints "0 tokens" for one of
+// those rows is making a false claim about a real run, and — worse — a total that
+// sums NULLs as zeros silently understates every aggregate it appears in.
+//
+// So: a helper returns `null` when nothing was measured, the caller renders the
+// em-dash, and `envelopeCost()` reports `measured` separately from `total` so a
+// genuine zero stays distinguishable from an absent measurement.
+
+import { formatDuration } from './formatDuration';
+
+// The four priced token types, in the order the envelope declares them.
+export const TOKEN_FIELDS = [
+    'tokens_input',
+    'tokens_cache_write',
+    'tokens_cache_read',
+    'tokens_output',
+];
+
+export const TOKEN_LABELS = {
+    tokens_input: 'Input',
+    tokens_cache_write: 'Cache write',
+    tokens_cache_read: 'Cache read',
+    tokens_output: 'Output',
+};
+
+// What a not-measured value looks like. One constant so every surface agrees.
+export const NOT_MEASURED = '—';
+
+/**
+ * Milliseconds → a human duration. The envelope's wall clock is in ms — the ONE
+ * unit across both telemetry domains — but a reader wants "4m 12s", not 252431.
+ *
+ * Sub-second runs keep their milliseconds rather than collapsing to "0s": an
+ * agent's boot latency is a real sub-second measurement (it was `boot_time_ms`
+ * precisely because seconds would destroy it), and rounding it away here would
+ * undo the reason the envelope chose the finer unit.
+ */
+export function formatWallMs(ms) {
+    if (ms == null) return NOT_MEASURED;
+    const n = Number(ms);
+    if (!Number.isFinite(n) || n < 0) return NOT_MEASURED;
+    if (n < 1000) return `${Math.round(n)}ms`;
+    return formatDuration(Math.round(n / 1000));
+}
+
+/** Compact token count (12.3M / 45.6k / 789). Null stays null-shaped. */
+export function formatTokenCount(v) {
+    if (v == null) return NOT_MEASURED;
+    const n = Number(v);
+    if (!Number.isFinite(n)) return NOT_MEASURED;
+    if (Math.abs(n) >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+    if (Math.abs(n) >= 1e3) return `${(n / 1e3).toFixed(1)}k`;
+    return n.toLocaleString('en-US');
+}
+
+/**
+ * The four-way token usage on a row, plus whether ANY of it was measured.
+ *
+ * `measured: false` (with `total: null`) is the important case and the reason
+ * this returns an object rather than a number: a caller must be able to tell
+ * "this run cost nothing measurable" apart from "nobody measured this run", and
+ * a bare 0 collapses the two.
+ *
+ * `total` sums only the types that ARE present, so a partial capture — say a
+ * transcript that yielded output but no cache figures — reports the part it
+ * knows instead of nothing at all.
+ */
+export function envelopeCost(row) {
+    const parts = {};
+    let total = null;
+    for (const field of TOKEN_FIELDS) {
+        const raw = row?.[field];
+        if (raw == null) {
+            parts[field] = null;
+            continue;
+        }
+        const n = Number(raw);
+        if (!Number.isFinite(n)) {
+            parts[field] = null;
+            continue;
+        }
+        parts[field] = n;
+        total = (total ?? 0) + n;
+    }
+    return { parts, total, measured: total !== null };
+}
+
+/**
+ * The prompt as it should be shown: the stored text is a bounded 2000-char
+ * PREFIX, so a reader must be able to see that it is a prefix.
+ *
+ * `truncated` is derived by comparing the stored text's length against
+ * `prompt_chars` (the FULL length) rather than against the cap — the cap is a
+ * writer-side constant and a row written under a different one must still
+ * describe itself honestly.
+ */
+export function envelopePrompt(row) {
+    const text = row?.prompt_text;
+    if (!text) return null;
+    const chars = row?.prompt_chars == null ? null : Number(row.prompt_chars);
+    const truncated = chars != null && Number.isFinite(chars) && chars > text.length;
+    return {
+        text,
+        chars: Number.isFinite(chars) ? chars : null,
+        truncated,
+        sha256: row?.prompt_sha256 || null,
+        // The first 12 hex chars are plenty to eyeball "same prompt?" between two
+        // runs; the full digest stays available for an exact comparison.
+        shaShort: row?.prompt_sha256 ? String(row.prompt_sha256).slice(0, 12) : null,
+    };
+}
+
+/**
+ * True when a row carries no envelope measurement at all — every token type
+ * NULL, no wall clock, no prompt. Lets a surface omit the whole block for a
+ * pre-#3202 row rather than render a panel of em-dashes.
+ */
+export function hasEnvelope(row) {
+    if (!row) return false;
+    if (row.wall_ms != null) return true;
+    if (row.prompt_text || row.prompt_sha256 || row.prompt_chars != null) return true;
+    return TOKEN_FIELDS.some((field) => row[field] != null);
+}


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-09T01:18:16Z
- chore: init swarm session feature/3202-one-telemetry-record-one-run-1

## Files changed
```
 src/Agents/ContextPage.jsx                    |  83 ++++++++++++++++
 src/Agents/__tests__/ContextPage.test.jsx     |  82 ++++++++++++++++
 src/hooks/factory/devopsQueries.js            |  17 ++++
 src/utils/__tests__/telemetryEnvelope.test.js | 133 +++++++++++++++++++++++++
 src/utils/telemetryEnvelope.js                | 135 ++++++++++++++++++++++++++
 5 files changed, 450 insertions(+)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)