### PR TITLE
Included in epic filter still busted

### DIFF
--- a/src/SwarmView/CategoryCard.jsx
+++ b/src/SwarmView/CategoryCard.jsx
@@ -6,7 +6,8 @@ import RequirementRow from './RequirementRow';
 import RequirementDeleteDialog from './RequirementDeleteDialog';
 import call_rest_api from '../RestApi/RestApi';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
-import { useRequirements, useSessions, usePipelinedRequirementIds } from '../hooks/useDataQueries';
+import { useRequirements, useSessions } from '../hooks/useDataQueries';
+import { useRequirementVisibility } from '../hooks/useRequirementVisibility';
 import { requirementKeys, categoryKeys } from '../hooks/useQueryKeys';
 import { useCrudCallbacks } from '../hooks/useCrudCallbacks';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
@@ -57,12 +58,6 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
     const sortModeMutationRef = useRef(0);
 
     const requirementStatusFilter = useShowClosedStore(s => s.requirementStatusFilter);
-    // req #3258 — same toggle as the requirements Table view (req #3180); Cards
-    // view was deliberately unfiltered by it until now (memory/architecture.md),
-    // but editing/hand-sorting an orchestrated requirement here doesn't make
-    // sense (its position is the plan's, not this card's), so hiding it is the
-    // fix for both the clutter and the broken edit affordance at once.
-    const hidePipelined = useShowClosedStore(s => s.hidePipelinedRequirements);
 
     const showError = useSnackBarStore(s => s.showError);
 
@@ -198,12 +193,16 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
         enabled: category.id !== '',
     });
 
-    // req #3258 — THE membership answer, shared with the Table view and the
-    // SwarmStartCard (req #3180). Read unconditionally (hooks are not
-    // conditional) but consulted only while the toggle is ON; the junction
-    // read is small and the plan pages already hold it, so the cache entry is
-    // normally warm either way.
-    const pipelinedIds = usePipelinedRequirementIds(profile?.userName);
+    // req #3419 — THE visibility answer, identical on every browse surface
+    // (Table view, the aggregator card, the detail page's up/down elevator).
+    // This card derives nothing of its own: `filterVisible` IS the rule, and it
+    // covers step-carried AND epic-filed work (req #3258 covered only the first,
+    // which is the defect req #3419 fixes).
+    // `orchestratedIds` is the SAME set `filterVisible` hides by — it is handed
+    // to the rows so an orchestrated requirement can be MARKED (gold title box,
+    // req #3419) when the toggle is showing them. Marking and hiding must never
+    // become two answers to one question.
+    const { filterVisible, orchestratedIds } = useRequirementVisibility(profile?.userName);
 
     // Seed local state from query data (hybrid pattern — local state owns template row).
     //
@@ -229,21 +228,20 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
                 requirementStatusFilter.includes(p.requirement_status)
             );
 
-            // req #3258 — same predicate as the Table view: hide requirements a
-            // pipeline step carries when the toggle is on. A no-op array when
-            // the toggle is off, same as `requirementStatusFilter` above.
-            if (hidePipelined) {
-                sortedRequirementsArray = sortedRequirementsArray.filter(p =>
-                    !pipelinedIds.has(Number(p.id))
-                );
-            }
+            // req #3419 — THE shared predicate, not a local copy. Returns the
+            // same array when nothing is dropped (toggle off, or reads still in
+            // flight), so this costs nothing on the off path.
+            // `sortedRequirementsArray` is already this effect's private copy,
+            // and `filterVisible` returns either it or a fresh `.filter` result —
+            // both private, so the in-place sort below is safe.
+            sortedRequirementsArray = filterVisible(sortedRequirementsArray);
 
             sortedRequirementsArray.sort((a, b) => activeSort(a, b));
             setRequirementsArray(prev => [...sortedRequirementsArray, buildTemplate(prev)]);
         } else if (serverRequirements && serverRequirements.length === 0) {
             setRequirementsArray(prev => [buildTemplate(prev)]);
         }
-    }, [serverRequirements, requirementStatusFilter, hidePipelined, pipelinedIds]);
+    }, [serverRequirements, requirementStatusFilter, filterVisible]);
 
     // Build session status map from query data
     useEffect(() => {
@@ -832,7 +830,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
                 { (requirementsArray) ?
                     <RequirementActionsContext.Provider value={{ statusClick, coordinationClick,
                         titleChange, titleKeyDown, titleOnBlur, deleteClick, requirementsArray, setRequirementsArray,
-                        sessionStatusMap, sortMode, setCrossCardInsertIndex }}>
+                        sessionStatusMap, sortMode, setCrossCardInsertIndex, orchestratedIds }}>
                         {requirementsArray.map((requirement, requirementIndex) => (
                             <RequirementRow {...{key: requirement.id, requirement, requirementIndex,
                                 categoryId: category.id, categoryName: category.category_name }}

--- a/src/SwarmView/RequirementRow.jsx
+++ b/src/SwarmView/RequirementRow.jsx
@@ -36,6 +36,7 @@ import DoneAllIcon from '@mui/icons-material/DoneAll';
 import ModelEffortIcon from './ModelEffortIcon';
 import { modelEffortGridTemplate } from './modelEffortLayout';
 import { useModelEffortDisplayStore } from '../stores/useModelEffortDisplayStore';
+import { orchestratedMarkSx } from './orchestratedMarkStyles';
 
 
 const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryName }) => {
@@ -46,7 +47,34 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
         titleOnBlur, deleteClick, sessionStatusMap,
         categoryColorMap, sortMode, setCrossCardInsertIndex,
         requirementsArray, setRequirementsArray,
+        orchestratedIds,
         strikethroughMet = true } = useRequirementActions();
+
+    // req #3419 — MARK the plan work. The toggle in the header hides it; when the
+    // reader turns the toggle OFF, orchestrated and unplanned rows sit side by
+    // side with nothing to tell them apart, and that is the state the reader is
+    // in precisely when the distinction matters.
+    //
+    // THE SAME SET, not a second answer. `orchestratedIds` comes from the host
+    // card's `useRequirementVisibility()` — the one hook that decides what the
+    // toggle hides — so a row can never be gold and visible-under-hiding, nor
+    // plain and hidden. Marking and hiding are one predicate (req #3419's whole
+    // point); computing "is this orchestrated" here would be the sixth copy.
+    //
+    // The template add-row is never marked: its id is '', and `Number('')` is 0,
+    // which is not a requirement id. Guarded explicitly anyway rather than relying
+    // on that — the same guard `pipelineMembership` makes.
+    // Absent context (a host that predates this) → undefined → no marking, which
+    // degrades to the previous appearance rather than throwing.
+    const isOrchestrated = requirement.id !== ''
+        && !!orchestratedIds?.has(Number(requirement.id));
+
+    // ONE fixed appearance — there is nothing to configure. Memoized anyway
+    // because `sx` identity drives MUI's style recomputation and this row
+    // re-renders on every keystroke in its own title field.
+    const markSx = React.useMemo(
+        () => orchestratedMarkSx({ isOrchestrated }),
+        [isOrchestrated]);
 
     // Model + Effort column preferences (req #3029). The columns always render in
     // the aggregator card; `showOnAllCards` promotes them onto CategoryCard rows
@@ -546,7 +574,20 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
                         multiline
                         disabled = {categoryId !== '' ? false : categoryName === '' ? true : false}
                         autoComplete ='off'
-                        sx = {{...(status === 'met' && strikethroughMet && {textDecoration: 'line-through'}), ...((status === 'deferred' || status === 'wontfix') && {opacity: 0.5}),}}
+                        data-testid={requirement.id === '' ? undefined
+                            : `requirement-title-${requirement.id}`}
+                        data-orchestrated={requirement.id === '' ? undefined
+                            : String(isOrchestrated)}
+                        sx = {{...(status === 'met' && strikethroughMet && {textDecoration: 'line-through'}), ...((status === 'deferred' || status === 'wontfix') && {opacity: 0.5}),
+                               // req #3419 — the gold ORCHESTRATED mark. The row
+                               // renders it; it does not DECIDE it. Both halves
+                               // live elsewhere on purpose: whether this row is
+                               // orchestrated comes from the one visibility hook,
+                               // and what the mark looks like from the one pure
+                               // `orchestratedMarkSx`. An empty object here means
+                               // an unmarked row is byte-identical to before.
+                               ...markSx,
+                        }}
                         size = 'small'
                         slotProps={{ htmlInput: { maxLength: 256 } }}
                         inputRef={isTemplate ? titleInputRef : undefined}

--- a/src/SwarmView/RequirementsTableView.jsx
+++ b/src/SwarmView/RequirementsTableView.jsx
@@ -24,7 +24,8 @@ import { DataGrid, GridToolbar, gridExpandedSortedRowIdsSelector } from '@mui/x-
 import AuthContext from '../Context/AuthContext';
 import AppContext from '../Context/AppContext';
 import call_rest_api from '../RestApi/RestApi';
-import { useAllRequirements, useAllCategories, useSessions, useMachines, usePipelinedRequirementIds } from '../hooks/useDataQueries';
+import { useAllRequirements, useAllCategories, useSessions, useMachines } from '../hooks/useDataQueries';
+import { useRequirementVisibility } from '../hooks/useRequirementVisibility';
 import { requirementKeys } from '../hooks/useQueryKeys';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
 import { requirementStatusChipProps, requirementStatusLabel } from './statusChipStyles';
@@ -125,8 +126,6 @@ const RequirementsTableView = () => {
     const creatorFk = profile?.userName;
 
     const requirementStatusFilter = useShowClosedStore(s => s.requirementStatusFilter);
-    // req #3180 — user-controlled, and it answers STEP association (see the store).
-    const hidePipelined = useShowClosedStore(s => s.hidePipelinedRequirements);
     const drill = useRequirementDrillStore(s => s.drill);
     const clearDrill = useRequirementDrillStore(s => s.clearDrill);
     const showError = useSnackBarStore(s => s.showError);
@@ -143,11 +142,10 @@ const RequirementsTableView = () => {
     // falling back to the raw id.
     const { data: machines = [] } = useMachines(creatorFk);
 
-    // req #3180 — THE membership answer, shared with the SwarmStartCard. Read
-    // unconditionally (hooks are not conditional) but consulted only while the
-    // toggle is ON; the junction read is small and the plan pages already hold
-    // it, so the cache entry is normally warm either way.
-    const pipelinedIds = usePipelinedRequirementIds(creatorFk);
+    // req #3419 — THE visibility answer, shared with the Cards view, the
+    // aggregator card and the detail page's up/down elevator. This view derives
+    // nothing of its own.
+    const { isVisible } = useRequirementVisibility(creatorFk);
 
     const categoryMap = useMemo(() => {
         const m = new Map();
@@ -183,10 +181,10 @@ const RequirementsTableView = () => {
     // Filter out:
     //  - Requirements whose status isn't in the chip filter
     //  - Requirements linked to closed categories (categoryMap only has open ones)
-    //  - req #3180 — when the pipeline toggle is ON, every requirement a pipeline
-    //    STEP carries, leaving the unscheduled residue.
+    //  - req #3180/#3419 — when the orchestrated toggle is ON, every requirement
+    //    a pipeline STEP carries or an EPIC seats, leaving the unplanned residue.
     //
-    // The pipeline toggle applies to the NORMAL branch only, exactly like the
+    // The orchestrated toggle applies to the NORMAL branch only, exactly like the
     // status chips: a Trends drill-down bypasses both. The drill's contract (see
     // req #2850 below) is that the row set EQUALS the bar that was clicked, and
     // RequirementsTrendsView charts from an unfiltered `useAllRequirements` — so
@@ -198,7 +196,6 @@ const RequirementsTableView = () => {
     // category, if a split segment was clicked). Matching reuses the chart's bucket
     // keying (`requirementBucketKey`) so the row set equals the bar that was clicked.
     const filteredRequirements = useMemo(() => {
-        const notPipelined = (r) => !hidePipelined || !pipelinedIds.has(Number(r.id));
         if (drill) {
             // categoryIds: explicit set the chart showed (a split segment → one id, or
             // a narrowed chip selection → that subset). Honored even for closed
@@ -220,9 +217,9 @@ const RequirementsTableView = () => {
         return requirements.filter(r =>
             requirementStatusFilter.includes(r.requirement_status) &&
             categoryMap.has(r.category_fk) &&
-            notPipelined(r)
+            isVisible(r)
         );
-    }, [requirements, requirementStatusFilter, categoryMap, drill, hidePipelined, pipelinedIds]);
+    }, [requirements, requirementStatusFilter, categoryMap, drill, isVisible]);
 
     // Multi-select state (v8 DataGrid shape: include=only these ids, exclude=all except these).
     // Both selectedCount and getSelectedIds are intersected with `filteredRequirements`

--- a/src/SwarmView/SwarmView.jsx
+++ b/src/SwarmView/SwarmView.jsx
@@ -228,6 +228,11 @@ const SwarmView = () => {
     ];
 
     // Model/Effort display preference (req #3029) — only meaningful in Cards view.
+    //
+    // req #3419 deliberately adds NOTHING here. The gold orchestrated mark had
+    // two toggles and a border-size ladder for one round and they were removed:
+    // the mark is one fixed appearance, so there is nothing to configure and
+    // nothing to keep in sync.
     const settingsToggleItems = view === 'cards' ? [
         {
             label: 'Show Model & Effort on all cards',
@@ -345,13 +350,20 @@ const SwarmView = () => {
                                 testId="requirement-status-filter"
                             />
                         )}
-                        {/* req #3180 — the label names the question it answers:
-                            PIPELINE STEP association ("is this scheduled"), not
-                            epic association ("does this belong to a body of
-                            work"). A requirement can carry a feature, and so an
-                            epic, while sitting in no plan at all; a label that
-                            didn't distinguish them would be read as answering
-                            whichever one the user had in mind. */}
+                        {/* req #3419 — ORCHESTRATED now means BOTH: a pipeline
+                            step carries it, OR an epic seats it (requirement ->
+                            feature -> epic). req #3180 answered step
+                            association alone and called the gap "what the
+                            filter exists to expose"; measured on production,
+                            what the reader saw was a control asked to hide
+                            orchestrated work still showing 4 epic-seated
+                            requirements in one card. Filed twice, so the
+                            control now answers the question its label makes.
+                            The tooltip names both halves for the same reason
+                            #3180's named one: a reader must not have to guess
+                            which membership the icon means. LAUNCH ELIGIBILITY
+                            is unaffected and stays step-only — see
+                            `swarmStartCardUtils.aggregatorRowVisible`. */}
                         {/* `!drill` for the same reason the status chips carry it:
                             a Trends drill-down bypasses both filters, so leaving
                             the control on screen would show an ON toggle that is
@@ -370,8 +382,8 @@ const SwarmView = () => {
                             is CURRENTLY VISIBLE, not which control is active. */}
                         {(view === 'cards' || (view === 'table' && !drill)) && (
                             <Tooltip title={hidePipelined
-                                ? 'Hiding orchestrated requirements'
-                                : 'Showing orchestrated requirements'}>
+                                ? 'Hiding orchestrated requirements (on a plan step or in an epic)'
+                                : 'Showing orchestrated requirements (on a plan step or in an epic)'}>
                                 <IconButton
                                     size="small"
                                     onClick={toggleHidePipelined}

--- a/src/SwarmView/__tests__/CategoryCard.pipelinedFilter.test.jsx
+++ b/src/SwarmView/__tests__/CategoryCard.pipelinedFilter.test.jsx
@@ -1,12 +1,24 @@
 // @vitest-environment jsdom
 //
-// Req #3258 — Cards view joins the Table view's `hidePipelinedRequirements`
-// toggle (req #3180). Mounts the REAL CategoryCard against a controllable
-// `usePipelinedRequirementIds` mock and the REAL useShowClosedStore, and
-// asserts the toggle actually removes/restores the row in this view too.
+// req #3258, rewritten for req #3419 — the card DELEGATES, it does not decide.
+//
+// The previous version of this file mounted the real CategoryCard against a
+// mocked `usePipelinedRequirementIds` and asserted that a pipelined row
+// disappeared. It passed throughout the defect req #3419 fixes, and it had to:
+// it handed the card a Set and then checked the card filtered by that Set. What
+// was wrong was WHICH ids the Set contained, one layer down, in the code the
+// mock replaced. `src/__tests__/requirementVisibility.harness.test.jsx` covers
+// that layer for real (only the HTTP transport is mocked).
+//
+// What is left for this file is the property the harness structurally cannot
+// assert, because it runs the real hook: that the card renders exactly what
+// `filterVisible` hands back and applies NO second rule of its own. With the
+// predicate stubbed to something no real membership rule would ever produce, a
+// card carrying a local copy of the rule shows a different list than a card that
+// delegates.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import React, { useState } from 'react';
+import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -18,47 +30,47 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
 
 const reqData = [
-    { id: 10, title: 'Not pipelined', requirement_status: 'authoring', category_fk: 5, sort_order: 0 },
-    { id: 11, title: 'Pipelined', requirement_status: 'authoring', category_fk: 5, sort_order: 1 },
+    { id: 10, title: 'Ten', requirement_status: 'authoring', category_fk: 5, sort_order: 0 },
+    { id: 11, title: 'Eleven', requirement_status: 'authoring', category_fk: 5, sort_order: 1 },
+    { id: 12, title: 'Twelve', requirement_status: 'authoring', category_fk: 5, sort_order: 2 },
 ];
 const EMPTY_SESSIONS = [];
-let pipelinedIds = new Set([11]);
 vi.mock('../../hooks/useDataQueries', () => ({
     useRequirements: () => ({ data: reqData }),
     useSessions: () => ({ data: EMPTY_SESSIONS }),
-    usePipelinedRequirementIds: () => pipelinedIds,
+}));
+
+// The stub predicate. `keep` is set per test; the card must reproduce it
+// exactly, whatever it says.
+let keep = new Set([10, 11, 12]);
+let visibilityCalls = 0;
+vi.mock('../../hooks/useRequirementVisibility', () => ({
+    useRequirementVisibility: () => {
+        visibilityCalls += 1;
+        // Referentially stable per `keep`, the way the real hook is — an
+        // unstable identity here would re-seed the card's local state every
+        // render rather than fail an assertion.
+        return React.useMemo(() => {
+            const isVisible = (r) => keep.has(Number(r?.id));
+            return {
+                hideOrchestrated: true,
+                pipelinedIds: new Set(),
+                orchestratedIds: new Set(),
+                isVisible,
+                filterVisible: (rows) => (Array.isArray(rows) ? rows.filter(isVisible) : rows),
+            };
+        }, [keep]);
+    },
 }));
 
 vi.mock('../../RestApi/RestApi', () => ({ default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })) }));
 
 import CategoryCard from '../CategoryCard';
-import { useShowClosedStore } from '../../stores/useShowClosedStore';
 import AuthContext from '../../Context/AuthContext';
 import AppContext from '../../Context/AppContext';
 
 const CATEGORY = { id: 5, category_name: 'Test Cat', project_fk: 1, sort_mode: 'process', color: null };
 const noop = () => {};
-
-function Harness() {
-    const [, setTick] = useState(0);
-    return (
-        <CategoryCard
-            category={CATEGORY}
-            categoryIndex={0}
-            projectId={1}
-            categoryChange={noop}
-            categoryKeyDown={noop}
-            categoryOnBlur={noop}
-            clickCardClosed={noop}
-            clickCardDelete={noop}
-            moveCard={noop}
-            persistCategoryOrder={noop}
-            removeCategory={noop}
-            isTemplate={false}
-            showClosed={false}
-        />
-    );
-}
 
 let roots = [];
 function mount() {
@@ -73,7 +85,21 @@ function mount() {
                 <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
                     <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
                         <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
-                            <Harness />
+                            <CategoryCard
+                                category={CATEGORY}
+                                categoryIndex={0}
+                                projectId={1}
+                                categoryChange={noop}
+                                categoryKeyDown={noop}
+                                categoryOnBlur={noop}
+                                clickCardClosed={noop}
+                                clickCardDelete={noop}
+                                moveCard={noop}
+                                persistCategoryOrder={noop}
+                                removeCategory={noop}
+                                isTemplate={false}
+                                showClosed={false}
+                            />
                         </DndProvider>
                     </AuthContext.Provider>
                 </AppContext.Provider>
@@ -83,50 +109,51 @@ function mount() {
     return { container };
 }
 
-// RequirementRow.jsx renders each real row's container as
-// `data-testid="requirement-<id>"` (the template row is `requirement-template`).
-const rowPresent = (container, id) => container.querySelector(`[data-testid="requirement-${id}"]`) !== null;
+const rowIds = (container) =>
+    [...container.querySelectorAll('[data-testid^="requirement-"]')]
+        .map(el => el.getAttribute('data-testid').slice('requirement-'.length))
+        .filter(v => /^\d+$/.test(v))
+        .map(Number);
 
-describe('CategoryCard hides/shows pipelined requirements with the shared toggle (req #3258)', () => {
+describe('CategoryCard delegates visibility to the shared hook (req #3419)', () => {
     beforeEach(() => {
-        pipelinedIds = new Set([11]);
         roots = [];
-        useShowClosedStore.setState({ hidePipelinedRequirements: false });
+        keep = new Set([10, 11, 12]);
+        visibilityCalls = 0;
     });
     afterEach(() => {
         act(() => { roots.forEach((r) => r.unmount()); });
         document.body.innerHTML = '';
-        useShowClosedStore.setState({ hidePipelinedRequirements: false });
     });
 
-    it('toggle OFF (no longer the default since req #3242 — set explicitly here): both rows render', () => {
+    // Generous timeouts throughout: this file mounts the real CategoryCard, and
+    // the first mount in a worker also pays the module-graph cost. A 5s default
+    // makes it flaky on a busy machine, which is noise rather than signal.
+    it('asks the shared hook at all', () => {
+        mount();
+        expect(visibilityCalls).toBeGreaterThan(0);
+    }, 30000);
+
+    it('renders exactly what the predicate keeps', () => {
+        keep = new Set([10, 12]);
         const { container } = mount();
-        expect(rowPresent(container, 10)).toBe(true);
-        expect(rowPresent(container, 11)).toBe(true);
-    });
+        expect(rowIds(container)).toEqual([10, 12]);
+    }, 30000);
 
-    it('toggle ON: the pipelined row is hidden, the other stays', async () => {
+    it('renders NOTHING when the predicate keeps nothing', () => {
+        keep = new Set();
         const { container } = mount();
+        expect(rowIds(container)).toEqual([]);
+        // ...and the add-row survives, because it is an affordance, not a row.
+        expect(container.querySelector('[data-testid="requirement-template"]')).not.toBeNull();
+    }, 30000);
 
-        await act(async () => {
-            useShowClosedStore.getState().toggleHidePipelinedRequirements();
-        });
-
-        expect(rowPresent(container, 10)).toBe(true);
-        expect(rowPresent(container, 11)).toBe(false);
-    });
-
-    it('toggle ON then OFF: the pipelined row returns', async () => {
+    it('reproduces a predicate no membership rule would produce', () => {
+        // The load-bearing case. A card that kept its own `pipelinedIds.has(...)`
+        // copy could still pass the two tests above by coincidence; it cannot
+        // reproduce an arbitrary predicate.
+        keep = new Set([11]);
         const { container } = mount();
-
-        await act(async () => {
-            useShowClosedStore.getState().toggleHidePipelinedRequirements();
-        });
-        expect(rowPresent(container, 11)).toBe(false);
-
-        await act(async () => {
-            useShowClosedStore.getState().toggleHidePipelinedRequirements();
-        });
-        expect(rowPresent(container, 11)).toBe(true);
-    });
+        expect(rowIds(container)).toEqual([11]);
+    }, 30000);
 });

--- a/src/SwarmView/__tests__/CategoryCard.statusTimestamps.test.jsx
+++ b/src/SwarmView/__tests__/CategoryCard.statusTimestamps.test.jsx
@@ -19,6 +19,16 @@ vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
 
 let reqData;
 const EMPTY_SESSIONS = [];
+// req #3419 — MODULE-LEVEL, never an inline `[]` literal. Each of these is a
+// query double called on every render; a fresh array each time churns the id
+// Sets in `useRequirementVisibility`, which churns every predicate and filtered
+// array downstream, which re-runs the seeding effect, which sets state — a
+// SYNCHRONOUS render loop that no per-test timeout can interrupt. Measured in
+// review: it wedged the worker rather than failing a test.
+const EMPTY_JUNCTION = [];
+const EMPTY_FEATURES = [];
+const EMPTY_ALL_REQS = [];
+
 vi.mock('../../hooks/useDataQueries', () => ({
     useRequirements: () => ({ data: reqData }),
     useSessions: () => ({ data: EMPTY_SESSIONS }),
@@ -27,7 +37,16 @@ vi.mock('../../hooks/useDataQueries', () => ({
     // pipelined — so an empty set is the neutral value. (Added by req #3298:
     // the export arrived with commit e2dfc8c and only the sibling
     // CategoryCard.pipelinedFilter suite was updated, leaving this one red.)
-    usePipelinedRequirementIds: () => new Set(),
+    useAllRequirements: () => ({ data: EMPTY_ALL_REQS }),
+
+    // req #3419 — the three bounded reads `useRequirementVisibility` joins.
+    // The REAL hook runs here rather than a double: it owns the memoization the
+    // aggregator's `useMemo` chain depends on, and a stand-in that got that
+    // wrong would loop rather than fail. `ALL_ROWS` is re-exported because the
+    // hook passes it (a closed feature still seats its requirements).
+    useAllPipelineStepRequirements: () => ({ data: EMPTY_JUNCTION }),
+    useAllFeatures: () => ({ data: EMPTY_FEATURES }),
+    ALL_ROWS: 'all',
 }));
 
 const putBodies = [];
@@ -107,6 +126,12 @@ describe('CategoryCard status writes carry all three timestamp columns (req #324
         document.body.innerHTML = '';
     });
 
+    // req #3419 — explicit timeout. This file mounts the REAL CategoryCard,
+    // which since this requirement resolves visibility through three live
+    // queries before it can seed a row. Measured at 4.2s on a loaded machine
+    // against vitest's 5s default — passing, but close enough that the suite
+    // flakes. The work is slow, not hung; the same allowance its sibling
+    // CategoryCard specs already carry.
     it('sends all three NULL-sentinel timestamp columns alongside requirement_status', async () => {
         const { container } = mount();
         await flush();
@@ -126,5 +151,5 @@ describe('CategoryCard status writes carry all three timestamp columns (req #324
             completed_at: 'NULL',
             deferred_at: 'NULL',
         });
-    });
+    }, 30000);
 });

--- a/src/SwarmView/__tests__/CategoryCard.templatefocus.test.jsx
+++ b/src/SwarmView/__tests__/CategoryCard.templatefocus.test.jsx
@@ -22,10 +22,29 @@ vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
 // (a new reference per re-seed); useSessions stays a stable empty list.
 let reqData = [{ id: 10, title: 'Existing req', requirement_status: 'authoring', category_fk: 5, sort_order: 0 }];
 const EMPTY_SESSIONS = [];
+// req #3419 — MODULE-LEVEL, never an inline `[]` literal. Each of these is a
+// query double called on every render; a fresh array each time churns the id
+// Sets in `useRequirementVisibility`, which churns every predicate and filtered
+// array downstream, which re-runs the seeding effect, which sets state — a
+// SYNCHRONOUS render loop that no per-test timeout can interrupt. Measured in
+// review: it wedged the worker rather than failing a test.
+const EMPTY_JUNCTION = [];
+const EMPTY_FEATURES = [];
+const EMPTY_ALL_REQS = [];
+
 vi.mock('../../hooks/useDataQueries', () => ({
     useRequirements: () => ({ data: reqData }),
     useSessions: () => ({ data: EMPTY_SESSIONS }),
-    usePipelinedRequirementIds: () => new Set(),
+    useAllRequirements: () => ({ data: EMPTY_ALL_REQS }),
+
+    // req #3419 — the three bounded reads `useRequirementVisibility` joins.
+    // The REAL hook runs here rather than a double: it owns the memoization the
+    // aggregator's `useMemo` chain depends on, and a stand-in that got that
+    // wrong would loop rather than fail. `ALL_ROWS` is re-exported because the
+    // hook passes it (a closed feature still seats its requirements).
+    useAllPipelineStepRequirements: () => ({ data: EMPTY_JUNCTION }),
+    useAllFeatures: () => ({ data: EMPTY_FEATURES }),
+    ALL_ROWS: 'all',
 }));
 
 vi.mock('../../RestApi/RestApi', () => ({ default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })) }));
@@ -97,6 +116,12 @@ describe('CategoryCard template title keeps focus across a background re-seed (r
         document.body.innerHTML = '';
     });
 
+    // req #3419 — explicit timeout. This file mounts the REAL CategoryCard,
+    // which since this requirement resolves visibility through three live
+    // queries before it can seed a row. Measured at 4.2s on a loaded machine
+    // against vitest's 5s default — passing, but close enough that the suite
+    // flakes. The work is slow, not hung; the same allowance its sibling
+    // CategoryCard specs already carry.
     it('keeps focus on the template title when serverRequirements refetches', async () => {
         const { container } = mount();
 
@@ -122,5 +147,5 @@ describe('CategoryCard template title keeps focus across a background re-seed (r
         const taAfter = templateTextarea(container);
         expect(taAfter).not.toBeNull();
         expect(document.activeElement).toBe(taAfter);
-    });
+    }, 30000);
 });

--- a/src/SwarmView/__tests__/orchestratedMarkStyles.test.js
+++ b/src/SwarmView/__tests__/orchestratedMarkStyles.test.js
@@ -1,0 +1,105 @@
+// req #3419 — what a marked title box looks like.
+//
+// `orchestratedMarkSx` is pure precisely so this file can pin the rule without
+// mounting anything. The component-level proof that the MARK tracks the same set
+// as the FILTER lives in `src/__tests__/requirementVisibility.harness.test.jsx`;
+// this file is about appearance once that question is answered.
+//
+// THE MARK IS A GOLD BACKGROUND (user direction, 2026-08-10), plus a gold FOCUS
+// RING at the theme's own focus width — the theme's blue ring was tried first
+// and was overshadowed by the gold field, reading as no focus indicator at all.
+// An earlier cut carried two gear-menu toggles and a four-rung border-size
+// ladder; all of it was removed along with the store and the `SettingsMenu`
+// prop that hosted it. These tests are written against the ABSENCE of an
+// outline at rest and on hover, so a border creeping back into either state
+// fails here rather than only on screen.
+
+import { describe, it, expect } from 'vitest';
+import {
+    orchestratedMarkSx,
+    ORCHESTRATED_GOLD,
+    ORCHESTRATED_GOLD_FILL,
+    FOCUS_BORDER_WIDTH,
+} from '../orchestratedMarkStyles';
+
+const inner = (sx) => sx['& .MuiOutlinedInput-root'];
+
+describe('orchestratedMarkSx', () => {
+    it('marks nothing on a requirement no plan carries', () => {
+        // The load-bearing case: an unmarked row must render EXACTLY as it did
+        // before this feature existed, which an empty object guarantees.
+        expect(orchestratedMarkSx({ isOrchestrated: false })).toEqual({});
+        expect(orchestratedMarkSx({})).toEqual({});
+        expect(orchestratedMarkSx()).toEqual({});
+    });
+
+    it('is a gold background on a rounded rectangle', () => {
+        const sx = orchestratedMarkSx({ isOrchestrated: true });
+        expect(inner(sx).backgroundColor).toBe(ORCHESTRATED_GOLD_FILL);
+        expect(inner(sx).borderRadius).toBe('8px');
+    });
+
+    it('draws NO outline at rest and NO outline on hover', () => {
+        // The whole shape of the final design. A width of 0 rather than a
+        // colour change, so nothing is drawn at all — a transparent border
+        // would still occupy its box and shift the text.
+        const sx = orchestratedMarkSx({ isOrchestrated: true });
+        expect(inner(sx)['& .MuiOutlinedInput-notchedOutline']).toEqual({ borderWidth: 0 });
+        expect(inner(sx)['&:hover .MuiOutlinedInput-notchedOutline']).toEqual({ borderWidth: 0 });
+    });
+
+    it('sets a border colour ONLY on focus', () => {
+        // Guards the regression the removed border would creep back through:
+        // rest and hover must carry no colour at all, so the gold cannot
+        // reappear one interaction state at a time.
+        const sx = orchestratedMarkSx({ isOrchestrated: true });
+        expect(inner(sx)['& .MuiOutlinedInput-notchedOutline'].borderColor).toBeUndefined();
+        expect(inner(sx)['&:hover .MuiOutlinedInput-notchedOutline'].borderColor).toBeUndefined();
+    });
+
+    it('draws a GOLD focus ring at the theme\'s own focus width', () => {
+        // Leaving focus to the theme did not work: its ring is `primary.main`,
+        // and blue on the gold field is overshadowed by it — on screen the
+        // field read as having no focus indicator at all. Gold, and the SAME
+        // width an unmarked field focuses at, so only the hue differs.
+        const sx = orchestratedMarkSx({ isOrchestrated: true });
+        expect(inner(sx)['&.Mui-focused .MuiOutlinedInput-notchedOutline']).toEqual({
+            borderWidth: FOCUS_BORDER_WIDTH,
+            borderColor: ORCHESTRATED_GOLD,
+        });
+    });
+
+    it('focuses at the same weight as an unmarked field — 2px, MUI\'s default', () => {
+        // The value is stated in this module rather than read from the theme,
+        // so pin it: a marked field focusing at a different weight than a plain
+        // one is the drift this asserts against.
+        expect(FOCUS_BORDER_WIDTH).toBe('2px');
+    });
+
+    it('touches only the input root — no width, height or spacing', () => {
+        // A marked row must line up with an unmarked one in the same card, so
+        // the mark may not change the box model. `borderRadius` and
+        // `backgroundColor` are paint; a stray margin/padding would not be.
+        const sx = orchestratedMarkSx({ isOrchestrated: true });
+        expect(Object.keys(sx)).toEqual(['& .MuiOutlinedInput-root']);
+        for (const key of ['margin', 'padding', 'width', 'height', 'fontSize']) {
+            expect(inner(sx)[key]).toBeUndefined();
+        }
+    });
+
+    it('tints rather than fills — the title stays editable text', () => {
+        // A solid gold would black out in dark mode. Assert the alpha is real
+        // and below half, the property that keeps the theme's text readable on
+        // top of it. With the border gone this value is the ENTIRE mark.
+        const alpha = Number(ORCHESTRATED_GOLD_FILL.match(/,\s*([\d.]+)\)$/)[1]);
+        expect(alpha).toBeGreaterThan(0);
+        expect(alpha).toBeLessThan(0.5);
+    });
+
+    it('builds the fill from the named gold, not a second hex', () => {
+        // One hue, one definition. `rgba(184,134,11,…)` IS `#B8860B`.
+        const [r, g, b] = ORCHESTRATED_GOLD_FILL.match(/\d+/g).map(Number);
+        const hex = `#${[r, g, b].map(n => n.toString(16).padStart(2, '0')).join('')}`;
+        expect(hex.toUpperCase()).toBe(ORCHESTRATED_GOLD.toUpperCase());
+    });
+});

--- a/src/SwarmView/detail/RequirementDetail.jsx
+++ b/src/SwarmView/detail/RequirementDetail.jsx
@@ -3,7 +3,8 @@ import { useParams, useNavigate, useLocation, Link as RouterLink } from 'react-r
 import call_rest_api from '../../RestApi/RestApi';
 import { useSnackBarStore } from '../../stores/useSnackBarStore';
 import { useShowClosedStore, ALL_REQUIREMENT_STATUSES } from '../../stores/useShowClosedStore';
-import { useAllCategories, useMachines, useFeatureById, useEpicById, usePipelinedRequirementIds } from '../../hooks/useDataQueries';
+import { useAllCategories, useMachines, useFeatureById, useEpicById } from '../../hooks/useDataQueries';
+import { useRequirementVisibility } from '../../hooks/useRequirementVisibility';
 import { useEpicPipelineLocation } from './useEpicPipelineLocation';
 import { useRequirementStepLocation } from './useRequirementStepLocation';
 import { epicLinkTo } from '../pipelines/pipelineEpicLink';
@@ -357,9 +358,9 @@ const RequirementDetail = () => {
     // Filter chips now match DB status values directly
     const siblingStatuses = [...requirementStatusFilter];
 
-    // req #3302 — the card's OTHER filter. See `visibleSiblings` below.
-    const hidePipelined = useShowClosedStore(s => s.hidePipelinedRequirements);
-    const pipelinedIds = usePipelinedRequirementIds(profile?.userName, { enabled: hidePipelined });
+    // req #3302 / #3419 — the card's OTHER filter, as the card's OWN predicate.
+    // See the elevator memo below.
+    const { isVisible } = useRequirementVisibility(profile?.userName);
 
     const queryClient = useQueryClient();
 
@@ -673,10 +674,11 @@ const RequirementDetail = () => {
     // enabled on the first row, and Down from it landed on pipelined #3136 —
     // a requirement the card does not show at all.
     //
-    // Same predicate, same source of truth (`utils/pipelineMembership.js`) and
-    // the same in-flight behaviour as the card: an unresolved junction read
-    // yields an empty set and drops nothing, so the elevator can only ever be
-    // too permissive for a moment, never hide a row the card is showing.
+    // req #3419 — no longer "the same predicate": it IS the predicate. The card,
+    // the table, the aggregator and this elevator all read
+    // `useRequirementVisibility().isVisible`, so there is no second derivation
+    // left to drift. That also fixed the narrower half of the same defect —
+    // requirements filed under an EPIC were never hidden anywhere.
     // req #3302 — the surface that opened this page hands over the ordered ids it
     // rendered (`elevatorStateFrom`), and that wins. It is the ONLY thing that
     // can be right for the SwarmStartCard aggregator, whose list is every
@@ -688,12 +690,11 @@ const RequirementDetail = () => {
     const { prevId, nextId } = useMemo(
         () => siblingElevator(siblings, {
             sortMode: sibSortMode,
-            pipelinedIds,
-            hidePipelined,
+            isVisible,
             currentId: id,
             orderedIds: linkOrderedIds,
         }),
-        [siblings, sibSortMode, pipelinedIds, hidePipelined, id, linkOrderedIds],
+        [siblings, sibSortMode, isVisible, id, linkOrderedIds],
     );
 
     const titleOverflow = Math.max(0, (requirement?.title || '').length - TITLE_SOFT_LIMIT);

--- a/src/SwarmView/detail/__tests__/elevatorMatchesCard.test.js
+++ b/src/SwarmView/detail/__tests__/elevatorMatchesCard.test.js
@@ -17,7 +17,7 @@ import { processSort, processSortReverse, requirementActiveSort, requirementHand
          coerceSortMode, DEFAULT_SORT_MODE } from '../../processSort';
 import { siblingProcessSort, siblingProcessSortReverse, siblingActiveSort, siblingElevator,
          elevatorStateFrom, readElevatorIds } from '../requirementSort';
-import { excludePipelined, pipelinedRequirementIds } from '../../../utils/pipelineMembership';
+import { orchestratedRequirementIds } from '../../../utils/pipelineMembership';
 
 const CHIPS = ['authoring', 'approved', 'swarm_ready', 'development'];
 
@@ -37,6 +37,20 @@ const AGENTS_CATEGORY = [
 
 const junction = (rows) => rows.filter(r => r.pipelined).map(r => ({ requirement_fk: r.id }));
 
+// req #3419 — features, so the fixture can express EPIC association as well as
+// step association. `epicSeated` rows carry `feature_fk: 900`, whose feature
+// names an epic; `feature_fk: 901` names none and must NOT count.
+const FEATURES = [{ id: 900, epic_fk: 4 }, { id: 901, epic_fk: null }];
+
+// THE predicate, built exactly the way `useRequirementVisibility` builds it, and
+// then handed to BOTH models below. One predicate is the whole point of req
+// #3419: while the card and the elevator each derived their own, the two could
+// (and did) answer different questions.
+const visibilityFor = (rows, hideOrchestrated) => {
+    const ids = orchestratedRequirementIds(junction(rows), rows, FEATURES);
+    return (r) => !hideOrchestrated || !ids.has(Number(r?.id));
+};
+
 // What the CARD renders: status chips, then the pipelined filter, then the sort.
 //
 // `CategoryCard.activeSort` is now a one-line delegation to `requirementActiveSort`
@@ -48,7 +62,7 @@ const junction = (rows) => rows.filter(r => r.pipelined).map(r => ({ requirement
 // the same vacuity this file already carries one scar from.
 const cardRows = (rows, { mode = 'process', hidePipelined = true, chips = CHIPS } = {}) => {
     const byStatus = rows.filter(r => chips.includes(r.requirement_status));
-    const visible = excludePipelined(byStatus, pipelinedRequirementIds(junction(rows)), hidePipelined);
+    const visible = byStatus.filter(visibilityFor(rows, hidePipelined));
     return [...visible].sort((a, b) => requirementActiveSort(mode, a, b)).map(r => r.id);
 };
 
@@ -61,8 +75,7 @@ const elevator = (rows, { mode = 'process', hidePipelined = true, chips = CHIPS,
         rows.filter(r => chips.includes(r.requirement_status)),
         {
             sortMode: mode,
-            pipelinedIds: pipelinedRequirementIds(junction(rows)),
-            hidePipelined,
+            isVisible: visibilityFor(rows, hidePipelined),
             currentId,
         },
     );
@@ -134,6 +147,53 @@ describe('population parity — the elevator walks exactly the card\'s rows', ()
         const allPipelined = AGENTS_CATEGORY.map(r => ({ ...r, pipelined: true }));
         expect(elevatorRows(allPipelined)).toEqual([]);
         expect(cardRows(allPipelined)).toEqual([]);
+    });
+});
+
+// ── req #3419 — the OTHER half of "orchestrated" ─────────────────────────────
+//
+// Measured on production 2026-08-09: with the toggle ON, category 1 still showed
+// #3304/#3314 (feature 35 -> epic 4), #3385 (feature 31 -> epic 7) and #3433
+// (feature 41 -> epic 9). No pipeline step carried them, so the step-only
+// predicate kept them, on every surface — the card, the table, the aggregator
+// AND these arrows. One predicate now, so one fix covers all four.
+describe('epic-seated work is orchestrated too (req #3419)', () => {
+    // 3100 and 3152 are unplanned; 3074 is step-carried; 3160 is epic-seated
+    // with NO step; 3161 carries a feature that names no epic, so it is NOT.
+    const MIXED = [
+        { id: 3074, requirement_status: 'authoring', started_at: null, completed_at: null, deferred_at: null, pipelined: true,  feature_fk: null },
+        { id: 3100, requirement_status: 'authoring', started_at: null, completed_at: null, deferred_at: null, pipelined: false, feature_fk: null },
+        { id: 3160, requirement_status: 'authoring', started_at: null, completed_at: null, deferred_at: null, pipelined: false, feature_fk: 900 },
+        { id: 3161, requirement_status: 'authoring', started_at: null, completed_at: null, deferred_at: null, pipelined: false, feature_fk: 901 },
+        { id: 3152, requirement_status: 'authoring', started_at: null, completed_at: null, deferred_at: null, pipelined: false, feature_fk: null },
+    ];
+
+    // Every row is `authoring`, so `process` mode falls to its id-ascending
+    // secondary sort — the expected orders below are id order, not fixture order.
+    it('hides the epic-seated requirement with the toggle ON', () => {
+        expect(cardRows(MIXED)).toEqual([3100, 3152, 3161]);
+        expect(elevatorRows(MIXED)).toEqual([3100, 3152, 3161]);
+    });
+
+    it('keeps a requirement whose feature names no epic', () => {
+        // Categorized is not planned. Hiding this would remove work nobody has
+        // scheduled — the exact residue the toggle exists to leave behind.
+        expect(cardRows(MIXED)).toContain(3161);
+    });
+
+    it('shows it again with the toggle OFF — it is a control, not a rule', () => {
+        const opts = { hidePipelined: false };
+        expect(cardRows(MIXED, opts)).toEqual([3074, 3100, 3152, 3160, 3161]);
+        expect(elevatorRows(MIXED, opts)).toEqual(cardRows(MIXED, opts));
+    });
+
+    it('never lets Down land on an epic-seated row the card hides', () => {
+        // The reported symptom, on the arrows: before req #3419 the elevator
+        // and the card BOTH kept 3160, so this passed vacuously; the assertion
+        // that matters is that the arrow ids equal the rendered list.
+        const { nextId } = elevator(MIXED, { currentId: 3100 });
+        expect(nextId).toBe(3152);
+        expect(elevatorRows(MIXED)).not.toContain(3160);
     });
 });
 
@@ -264,8 +324,7 @@ describe('the handed-over order — the aggregator\'s fix', () => {
         const ids = siblingElevator([], {
             sortMode: 'process',
             orderedIds: handed.siblingIds,
-            pipelinedIds: new Set([3101, 2401]),
-            hidePipelined: true,
+            isVisible: (r) => ![3101, 2401].includes(Number(r?.id)),
         }).ordered.map(r => r.id);
         expect(ids).toEqual([3170, 3101, 2401, 3154]);
     });
@@ -273,8 +332,8 @@ describe('the handed-over order — the aggregator\'s fix', () => {
     it('falls back to the category query when the link carried no ids', () => {
         const viaQuery = siblingElevator(
             AGENTS_CATEGORY.filter(r => CHIPS.includes(r.requirement_status)),
-            { sortMode: 'process', pipelinedIds: pipelinedRequirementIds(junction(AGENTS_CATEGORY)),
-              hidePipelined: true, currentId: 3100, orderedIds: readElevatorIds(undefined) },
+            { sortMode: 'process', isVisible: visibilityFor(AGENTS_CATEGORY, true),
+              currentId: 3100, orderedIds: readElevatorIds(undefined) },
         );
         expect(viaQuery.prevId).toBeNull();
         expect(viaQuery.nextId).toBe(3152);

--- a/src/SwarmView/detail/requirementSort.js
+++ b/src/SwarmView/detail/requirementSort.js
@@ -11,8 +11,6 @@
 // test can reach the answer the component actually renders rather than
 // re-deriving it — the failure mode that let this ship with a green suite.
 
-import { excludePipelined } from '../../utils/pipelineMembership';
-
 // req #3302 — ONE IMPLEMENTATION. These were a second transcription of
 // `../processSort.js`'s comparators, kept in step by hand and by this file's own
 // header comment. They are now re-exports of the single implementation, under
@@ -42,18 +40,23 @@ const siblingActiveSortLocal = requirementActiveSort;
  * One function because the three answers are one fact. Splitting them is how the
  * page came to sort the right rows and navigate the wrong ones.
  *
- * `hidePipelined` is passed through rather than assumed: the toggle is a user
- * CONTROL on a browse surface (`useShowClosedStore.hidePipelinedRequirements`),
- * so the elevator has to follow it in BOTH positions. When it is off — or while
- * the junction read is still in flight, leaving `pipelinedIds` empty —
- * `excludePipelined` returns the input untouched, so the elevator can only ever
- * be momentarily too permissive, never hide a row the card is showing.
+ * req #3419 — the population filter arrives as the CARD'S OWN PREDICATE
+ * (`useRequirementVisibility().isVisible`) rather than as the ingredients to
+ * re-derive it here. This file previously re-applied `excludePipelined` from a
+ * `(pipelinedIds, hidePipelined)` pair — a second transcription of the rule, and
+ * the very drift its own header warns about, one layer down. Handing the
+ * predicate over means the elevator walks the rows the card renders BY
+ * CONSTRUCTION; there is nothing left that could disagree.
+ *
+ * Omitting `isVisible` shows everything, which keeps the honest degradation the
+ * previous shape had: while the visibility reads are in flight the predicate is
+ * momentarily too permissive, never hiding a row the card is showing.
  *
  * @param {Array<{id: number|string, requirement_status: string}>} siblings
  * @param {object}  opts
  * @param {string}  opts.sortMode       'process' | 'reverse' | 'hand'
- * @param {Set<number>} [opts.pipelinedIds]  from `pipelinedRequirementIds`
- * @param {boolean} [opts.hidePipelined=false]
+ * @param {(row: {id: number|string}) => boolean} [opts.isVisible]
+ *        `useRequirementVisibility().isVisible`; omitted = every sibling walks.
  * @param {number|string} [opts.currentId]   the requirement being viewed
  * @returns {{ordered: Array, currentIndex: number, prevId: (number|null), nextId: (number|null)}}
  *   `currentIndex` is -1 when the current requirement is not in the visible set
@@ -62,8 +65,7 @@ const siblingActiveSortLocal = requirementActiveSort;
  */
 export const siblingElevator = (siblings, {
     sortMode,
-    pipelinedIds,
-    hidePipelined = false,
+    isVisible,
     currentId,
     orderedIds = null,
 } = {}) => {
@@ -76,7 +78,7 @@ export const siblingElevator = (siblings, {
         ? orderedIds.map(id => ({ id }))
         : (() => {
             const rows = Array.isArray(siblings) ? siblings : [];
-            const visible = excludePipelined(rows, pipelinedIds, hidePipelined) || [];
+            const visible = typeof isVisible === 'function' ? rows.filter(isVisible) : rows;
             return [...visible].sort((a, b) => siblingActiveSortLocal(sortMode, a, b));
         })();
 

--- a/src/SwarmView/orchestratedMarkStyles.js
+++ b/src/SwarmView/orchestratedMarkStyles.js
@@ -1,0 +1,87 @@
+// The gold mark an ORCHESTRATED requirement's title box wears — req #3419.
+//
+// THE MARK IS A GOLD BACKGROUND. No outline at rest, no outline on hover; the
+// rounded gold field IS the signal. The ONE border it draws is the focus ring,
+// in gold at the theme's own focus width — see the `Mui-focused` rule below for
+// why that is a requirement rather than a decoration.
+//
+// This settled after two rounds of toning down and one round of user-facing
+// controls, all of which are GONE (user direction, 2026-08-10: "Remove all UI
+// options added. Choose to have the gold background and no border whatsoever").
+// What that removed, deliberately and in full: a persisted preference store, two
+// toggles and a four-rung border-size ladder in the gear menu, and a generic
+// `choiceItems` prop on `SettingsMenu` that existed only to host the ladder. One
+// appearance, no settings, nothing to keep in sync — which is this requirement's
+// own YONO principle applied to its own UI.
+//
+// A pure function rather than `sx` inlined in the row, because it answers ONE
+// question — what does a marked title box look like — and a test can reach it
+// without a DOM. Whether a row IS orchestrated is a different question, answered
+// once in `hooks/useRequirementVisibility.js` from the same set the visibility
+// toggle hides by.
+
+// `#B8860B` (dark goldenrod) at low alpha. A TINT, not a fill: the title is
+// editable text, so the gold has to carry over whatever surface the theme
+// provides while leaving the theme's own text colour readable on top of it. A
+// solid gold would black out in dark mode.
+//
+// With no resting outline, this value is the whole mark in every state but
+// focus — so it is the one dial worth turning if the signal reads too strong or
+// too weak.
+export const ORCHESTRATED_GOLD = '#B8860B';
+export const ORCHESTRATED_GOLD_FILL = 'rgba(184, 134, 11, 0.14)';
+
+// MUI's OutlinedInput thickens its notched outline to 2px on focus. The gold
+// focus ring MATCHES that width exactly, so a marked field and a plain one
+// focus identically and only the hue differs — the same rule the rest of this
+// mark follows.
+//
+// It is stated here rather than read from the theme because this module is pure
+// (no hook, no `useTheme`), which is what lets every case be tested without a
+// DOM. If MUI's default ever moves, a marked field would focus at the old width
+// while a plain one moved — visible immediately on screen, and the one-line fix
+// is here.
+export const FOCUS_BORDER_WIDTH = '2px';
+
+/**
+ * The `sx` fragment for a requirement title box.
+ *
+ * @param {object} opts
+ * @param {boolean} opts.isOrchestrated  from `useRequirementVisibility`
+ * @returns {object} an `sx` object — EMPTY for an unorchestrated row, so it
+ *   renders byte-identically to how it did before this feature existed.
+ */
+export const orchestratedMarkSx = ({ isOrchestrated } = {}) => {
+    if (!isOrchestrated) return {};
+
+    // `borderWidth: 0` rather than `border: 'none'`: MUI's notched outline is a
+    // fieldset whose border it also animates, and zeroing the width leaves that
+    // machinery intact instead of fighting it.
+    const noOutline = { borderWidth: 0 };
+
+    return {
+        '& .MuiOutlinedInput-root': {
+            backgroundColor: ORCHESTRATED_GOLD_FILL,
+            // A rounded RECTANGLE — the shape was the original ask, and with no
+            // outline the radius is the only thing giving the field its form.
+            borderRadius: '8px',
+            '& .MuiOutlinedInput-notchedOutline': noOutline,
+            '&:hover .MuiOutlinedInput-notchedOutline': noOutline,
+            // FOCUS IS THE ONE EXCEPTION, and it is now GOLD rather than the
+            // theme's own colour. Leaving it to the theme did not work: the
+            // default ring is `primary.main`, and blue drawn on the gold field
+            // is overshadowed by it — measured on screen, the field read as
+            // having no focus indicator at all. Same WIDTH as an unmarked
+            // field's ring, so the two focus identically and only the hue
+            // differs.
+            //
+            // This is the one place the mark draws a border, and it is not a
+            // decoration: a text input the reader can click into with no sign
+            // of where the caret went is an accessibility defect.
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                borderWidth: FOCUS_BORDER_WIDTH,
+                borderColor: ORCHESTRATED_GOLD,
+            },
+        },
+    };
+};

--- a/src/TaskPlanView/SwarmStartCard.jsx
+++ b/src/TaskPlanView/SwarmStartCard.jsx
@@ -19,15 +19,15 @@ import RequirementRow from '../SwarmView/RequirementRow';
 import RequirementDeleteDialog from '../SwarmView/RequirementDeleteDialog';
 import call_rest_api from '../RestApi/RestApi';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
-import { useRequirementsByStatus, useRequirementsDone, useSessions, useCategoryColors, useAllRequirements, usePipelinedRequirementIds } from '../hooks/useDataQueries';
-import { excludePipelined } from '../utils/pipelineMembership';
-import { PIPELINE_FILTERED_STATUSES, tallyRequirementStatuses } from './swarmStartCardUtils';
+import { useRequirementsByStatus, useRequirementsDone, useSessions, useCategoryColors, useAllRequirements } from '../hooks/useDataQueries';
+import { useRequirementVisibility } from '../hooks/useRequirementVisibility';
+import { filterKeepingIdentity } from '../utils/pipelineMembership';
+import { aggregatorRowVisible, tallyRequirementStatuses } from './swarmStartCardUtils';
 import { requirementKeys } from '../hooks/useQueryKeys';
 import { useCrudCallbacks } from '../hooks/useCrudCallbacks';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { RequirementActionsContext } from '../hooks/useRequirementActions';
 import { useSwarmStartCardStore } from '../stores/useSwarmStartCardStore';
-import { useShowClosedStore } from '../stores/useShowClosedStore';
 import { requirementStatusChipProps, requirementStatusLabel } from '../SwarmView/statusChipStyles';
 import { requirementStatusTimestampFields, requirementStatusTimestampState } from '../utils/requirementStatusTimestamps';
 
@@ -232,37 +232,38 @@ const SwarmStartCard = () => {
         { fields: 'id,title,requirement_status,coordination_type,ai_model,effort,category_fk,completed_at' },
     );
 
-    // req #3180 — this card OFFERS requirements for a direct swarm-start, so the
-    // ones a pipeline step already carries do not belong on its launch chips:
-    // their launch is the coordinator's to make, at the point the plan says so.
-    //
-    // The launch exclusion (PIPELINE_FILTERED_STATUSES) is UNCONDITIONAL — not a
-    // user preference. Offering an ineligible launch is a defect, not a viewing
-    // choice, so nothing gates it here.
-    //
-    // The DEVELOPMENT/MET chips are different: both populations are legitimate
-    // to browse, same reasoning as the requirements table — so THOSE respect
-    // the same global toggle the table and Cards view do (req #3242), on top of
-    // (never instead of) the unconditional launch exclusion above.
-    const pipelinedIds = usePipelinedRequirementIds(profile?.userName);
-    const hidePipelined = useShowClosedStore(s => s.hidePipelinedRequirements);
-    const chipOffersLaunch = PIPELINE_FILTERED_STATUSES.includes(effectiveStatus);
-    const excludeFromThisChip = chipOffersLaunch || hidePipelined;
+    // req #3180 / #3419 — this card OFFERS requirements for a direct
+    // swarm-start, and it is also a browse surface. Both rules live in ONE place
+    // (`aggregatorRowVisible`), and the chip badges below apply the very same
+    // predicate, so a count can never disagree with the rows under it.
+    const visibility = useRequirementVisibility(profile?.userName);
 
-    // Memoized because this feeds a useEffect dependency and a useMemo below —
-    // `excludePipelined` mints a new array whenever it actually drops something,
-    // so an unmemoized call would re-seed local state on every render.
+    // Memoized AND identity-preserving, and both halves are load-bearing.
+    // `eligibleRequirements` is a dependency of the seeding `useEffect` below,
+    // which calls `setRequirementsArray` — so an array that changes identity on
+    // every render is not wasted work, it is a synchronous render loop. A bare
+    // `.filter` does exactly that whenever anything upstream churns (a query
+    // hook handing back a fresh `[]`, say). `filterKeepingIdentity` returns the
+    // INPUT when it drops nothing, which is what absorbed that churn before req
+    // #3419 — see its docstring.
+    const rowVisible = React.useMemo(
+        () => aggregatorRowVisible(effectiveStatus, visibility),
+        [effectiveStatus, visibility]);
+
     const eligibleRequirements = React.useMemo(
-        () => excludePipelined(serverRequirements, pipelinedIds, excludeFromThisChip),
-        [serverRequirements, pipelinedIds, excludeFromThisChip]);
+        () => filterKeepingIdentity(serverRequirements, rowVisible),
+        [serverRequirements, rowVisible]);
 
-    // The Met chip's own population never went through `eligibleRequirements`
-    // (its query is `serverMetRequirements`, not `serverRequirements`) — so the
-    // toggle needs its own pass here. `chipOffersLaunch` never applies to Met
-    // (it is not in PIPELINE_FILTERED_STATUSES), hence `hidePipelined` alone.
+    // The Met chip's own population never goes through `eligibleRequirements`
+    // (its query is `serverMetRequirements`, not `serverRequirements`) — so it
+    // needs its own pass, under the Met chip's own rule.
+    const metRowVisible = React.useMemo(
+        () => aggregatorRowVisible('met', visibility),
+        [visibility]);
+
     const eligibleMetRequirements = React.useMemo(
-        () => excludePipelined(serverMetRequirements, pipelinedIds, hidePipelined),
-        [serverMetRequirements, pipelinedIds, hidePipelined]);
+        () => filterKeepingIdentity(serverMetRequirements, metRowVisible),
+        [serverMetRequirements, metRowVisible]);
 
     // The array that drives the card body for the currently selected chip.
     const currentRequirements = isMet ? eligibleMetRequirements : eligibleRequirements;
@@ -290,8 +291,9 @@ const SwarmStartCard = () => {
     // useAllRequirements doesn't carry completed_at and can't be filtered to the
     // 24-hour window here. Returns { authoring, approved, swarm_ready, development, met }.
     //
-    // req #3180 — a launch chip's count applies the SAME rule as its list, from
-    // the same Set, so the header can never disagree with the rows beneath it.
+    // req #3180 / #3419 — a chip's count applies the SAME rule as its list, from
+    // the SAME function (`aggregatorRowVisible`), so the header can never
+    // disagree with the rows beneath it.
     //
     // LOAD-BEARING: a chip's badge matches the rows beneath it only because both
     // sources are the same population — `useAllRequirements` here and
@@ -307,12 +309,12 @@ const SwarmStartCard = () => {
     // again here means a message is being reintroduced.
     const statusCountMap = React.useMemo(() => {
         const { counts } = tallyRequirementStatuses(
-            allRequirementsForCounts, SWARM_START_STATUSES, pipelinedIds, hidePipelined);
+            allRequirementsForCounts, SWARM_START_STATUSES, visibility);
         if (Array.isArray(serverMetRequirements)) {
             counts.met = eligibleMetRequirements?.length ?? serverMetRequirements.length;
         }
         return counts;
-    }, [allRequirementsForCounts, serverMetRequirements, eligibleMetRequirements, pipelinedIds, hidePipelined]);
+    }, [allRequirementsForCounts, serverMetRequirements, eligibleMetRequirements, visibility]);
 
     // Comparators are module-level — see `aggregatorSort` above.
 
@@ -651,6 +653,10 @@ const SwarmStartCard = () => {
                         sessionStatusMap,
                         categoryColorMap,
                         strikethroughMet: false, // req #2584 — recent-Met list, not crossed-off
+                        // req #3419 — the SAME set the toggle hides by, so a row
+                        // that survives this card's own launch exclusion is still
+                        // marked when it is plan work.
+                        orchestratedIds: visibility.orchestratedIds,
                     }}>
                         {/* req #3286 — THE CARD RENDERS NO MESSAGES. Two used to sit here:
                             the "No <status> requirements" empty state and the req #3180

--- a/src/TaskPlanView/__tests__/SwarmStartCard.noMessages.test.jsx
+++ b/src/TaskPlanView/__tests__/SwarmStartCard.noMessages.test.jsx
@@ -49,6 +49,13 @@ let activeRows;
 let metRows;
 let allRows;
 let pipelinedIds;
+// req #3419 — the junction rows the REAL `useRequirementVisibility` reads. The
+// tests still express intent as a Set of ids; this is the wire shape.
+let junctionRows = [];
+const setPipelined = (ids) => {
+    pipelinedIds = ids;
+    junctionRows = [...ids].map((id) => ({ step_fk: 1, requirement_fk: id }));
+};
 const EMPTY = [];
 vi.mock('../../hooks/useDataQueries', () => ({
     useRequirementsByStatus: () => ({ data: activeRows }),
@@ -56,7 +63,15 @@ vi.mock('../../hooks/useDataQueries', () => ({
     useSessions: () => ({ data: EMPTY }),
     useCategoryColors: () => ({ data: EMPTY }),
     useAllRequirements: () => ({ data: allRows }),
-    usePipelinedRequirementIds: () => pipelinedIds,
+
+    // req #3419 — the three bounded reads `useRequirementVisibility` joins.
+    // The REAL hook runs here rather than a double: it owns the memoization the
+    // aggregator's `useMemo` chain depends on, and a stand-in that got that
+    // wrong would loop rather than fail. `ALL_ROWS` is re-exported because the
+    // hook passes it (a closed feature still seats its requirements).
+    useAllPipelineStepRequirements: () => ({ data: junctionRows }),
+    useAllFeatures: () => ({ data: [] }),
+    ALL_ROWS: 'all',
 }));
 
 vi.mock('../../RestApi/RestApi', () => ({
@@ -218,7 +233,7 @@ describe('SwarmStartCard renders no messages (req #3286)', () => {
         activeRows = EMPTY;
         metRows = EMPTY;
         allRows = EMPTY;
-        pipelinedIds = new Set();
+        setPipelined(new Set());
         useShowClosedStore.setState({ hidePipelinedRequirements: false });
     });
     afterEach(() => {
@@ -279,7 +294,7 @@ describe('SwarmStartCard renders no messages (req #3286)', () => {
         const rows = [req(10, 'swarm_ready'), req(11, 'swarm_ready')];
         activeRows = rows;
         allRows = rows;
-        pipelinedIds = new Set([10, 11]);
+        setPipelined(new Set([10, 11]));
         useSwarmStartCardStore.setState({ selectedStatus: 'swarm_ready' });
         const { container } = mount();
         await flush();
@@ -299,7 +314,7 @@ describe('SwarmStartCard renders no messages (req #3286)', () => {
         const rows = [req(10, 'swarm_ready'), req(11, 'swarm_ready'), req(12, 'swarm_ready')];
         activeRows = rows;
         allRows = rows;
-        pipelinedIds = new Set([11]);
+        setPipelined(new Set([11]));
         useSwarmStartCardStore.setState({ selectedStatus: 'swarm_ready' });
         const { container } = mount();
         await flush();
@@ -339,7 +354,7 @@ describe('SwarmStartCard renders no messages (req #3286)', () => {
         const rows = [req(10, 'development'), req(11, 'development')];
         activeRows = rows;
         allRows = rows;
-        pipelinedIds = new Set([10, 11]);
+        setPipelined(new Set([10, 11]));
         useShowClosedStore.setState({ hidePipelinedRequirements: true });
         useSwarmStartCardStore.setState({ selectedStatus: 'development' });
         const { container } = mount();

--- a/src/TaskPlanView/__tests__/SwarmStartCard.sortMenu.test.jsx
+++ b/src/TaskPlanView/__tests__/SwarmStartCard.sortMenu.test.jsx
@@ -26,13 +26,31 @@ vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
 let activeRows;
 let metRows;
 const EMPTY = [];
+// req #3419 — MODULE-LEVEL, never an inline `[]` literal. Each of these is a
+// query double called on every render; a fresh array each time churns the id
+// Sets in `useRequirementVisibility`, which churns every predicate and filtered
+// array downstream, which re-runs the seeding effect, which sets state — a
+// SYNCHRONOUS render loop that no per-test timeout can interrupt. Measured in
+// review: it wedged the worker rather than failing a test.
+const EMPTY_JUNCTION = [];
+const EMPTY_FEATURES = [];
+const EMPTY_ALL_REQS = [];
+
 vi.mock('../../hooks/useDataQueries', () => ({
     useRequirementsByStatus: () => ({ data: activeRows }),
     useRequirementsDone: () => ({ data: metRows }),
     useSessions: () => ({ data: EMPTY }),
     useCategoryColors: () => ({ data: EMPTY }),
     useAllRequirements: () => ({ data: EMPTY }),
-    usePipelinedRequirementIds: () => new Set(),
+
+    // req #3419 — the three bounded reads `useRequirementVisibility` joins.
+    // The REAL hook runs here rather than a double: it owns the memoization the
+    // aggregator's `useMemo` chain depends on, and a stand-in that got that
+    // wrong would loop rather than fail. `ALL_ROWS` is re-exported because the
+    // hook passes it (a closed feature still seats its requirements).
+    useAllPipelineStepRequirements: () => ({ data: EMPTY_JUNCTION }),
+    useAllFeatures: () => ({ data: EMPTY_FEATURES }),
+    ALL_ROWS: 'all',
 }));
 
 vi.mock('../../RestApi/RestApi', () => ({

--- a/src/TaskPlanView/__tests__/SwarmStartCard.statusTimestamps.test.jsx
+++ b/src/TaskPlanView/__tests__/SwarmStartCard.statusTimestamps.test.jsx
@@ -21,13 +21,31 @@ vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
 
 let reqData;
 const EMPTY = [];
+// req #3419 — MODULE-LEVEL, never an inline `[]` literal. Each of these is a
+// query double called on every render; a fresh array each time churns the id
+// Sets in `useRequirementVisibility`, which churns every predicate and filtered
+// array downstream, which re-runs the seeding effect, which sets state — a
+// SYNCHRONOUS render loop that no per-test timeout can interrupt. Measured in
+// review: it wedged the worker rather than failing a test.
+const EMPTY_JUNCTION = [];
+const EMPTY_FEATURES = [];
+const EMPTY_ALL_REQS = [];
+
 vi.mock('../../hooks/useDataQueries', () => ({
     useRequirementsByStatus: () => ({ data: reqData }),
     useRequirementsDone: () => ({ data: EMPTY }),
     useSessions: () => ({ data: EMPTY }),
     useCategoryColors: () => ({ data: EMPTY }),
     useAllRequirements: () => ({ data: reqData }),
-    usePipelinedRequirementIds: () => new Set(),
+
+    // req #3419 — the three bounded reads `useRequirementVisibility` joins.
+    // The REAL hook runs here rather than a double: it owns the memoization the
+    // aggregator's `useMemo` chain depends on, and a stand-in that got that
+    // wrong would loop rather than fail. `ALL_ROWS` is re-exported because the
+    // hook passes it (a closed feature still seats its requirements).
+    useAllPipelineStepRequirements: () => ({ data: EMPTY_JUNCTION }),
+    useAllFeatures: () => ({ data: EMPTY_FEATURES }),
+    ALL_ROWS: 'all',
 }));
 
 const putBodies = [];

--- a/src/TaskPlanView/__tests__/swarmStartCardUtils.test.js
+++ b/src/TaskPlanView/__tests__/swarmStartCardUtils.test.js
@@ -3,8 +3,24 @@ import {
     sortSwarmReadyItems,
     getCoordLabel,
     PIPELINE_FILTERED_STATUSES,
+    aggregatorRowVisible,
     tallyRequirementStatuses,
 } from '../swarmStartCardUtils';
+
+// req #3419 — the tally takes the `useRequirementVisibility` context object now,
+// and applies it through `aggregatorRowVisible`, the SAME function the card
+// filters its rows with. Before, the list and its own badge were two
+// transcriptions of one rule.
+//
+// These tests were written against the pre-#3419 `(pipelinedIds, hidePipelined)`
+// pair, where BOTH exclusions read one Set. `ctx` reproduces exactly that, so
+// every assertion below still means what it meant — the widening (an
+// `orchestratedIds` that is a strict superset) is asserted separately.
+const ctx = (ids, hide = false) => ({
+    pipelinedIds: ids,
+    orchestratedIds: ids,
+    hideOrchestrated: hide,
+});
 
 const req = (id, overrides = {}) => ({
     id,
@@ -108,14 +124,14 @@ describe('tallyRequirementStatuses', () => {
     ];
 
     it('counts every chip when no requirement is pipelined', () => {
-        const { counts } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set());
+        const { counts } = tallyRequirementStatuses(rows, ALL_CHIPS, ctx(new Set()));
         expect(counts).toEqual({
             authoring: 2, approved: 1, swarm_ready: 1, development: 1, met: 1,
         });
     });
 
     it('drops a pipelined launch-chip requirement from counts', () => {
-        const { counts } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([2, 3, 4]));
+        const { counts } = tallyRequirementStatuses(rows, ALL_CHIPS, ctx(new Set([2, 3, 4])));
         expect(counts.authoring).toBe(1);
         expect(counts.approved).toBe(0);
         expect(counts.swarm_ready).toBe(0);
@@ -124,7 +140,7 @@ describe('tallyRequirementStatuses', () => {
     it('leaves development and met counted even when pipelined', () => {
         // THE decision. If this test starts failing because someone made the
         // exclusion uniform, the Development chip has just gone blank.
-        const { counts } = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([5, 6]));
+        const { counts } = tallyRequirementStatuses(rows, ALL_CHIPS, ctx(new Set([5, 6])));
         expect(counts.development).toBe(1);
         expect(counts.met).toBe(1);
     });
@@ -133,19 +149,17 @@ describe('tallyRequirementStatuses', () => {
         // id === '' is the "type a title here" row, not a requirement — and
         // Number('') is 0, which must never reach the Set lookup.
         const withTemplate = [...rows, { id: '', requirement_status: 'authoring' }];
-        const { counts } = tallyRequirementStatuses(withTemplate, ALL_CHIPS, new Set([0]));
+        const { counts } = tallyRequirementStatuses(withTemplate, ALL_CHIPS, ctx(new Set([0])));
         expect(counts.authoring).toBe(2);
     });
 
     it('matches a numeric Set against string row ids', () => {
-        const { counts } = tallyRequirementStatuses(
-            [{ id: '4', requirement_status: 'swarm_ready' }], ALL_CHIPS, new Set([4]));
+        const { counts } = tallyRequirementStatuses([{ id: '4', requirement_status: 'swarm_ready' }], ALL_CHIPS, ctx(new Set([4])));
         expect(counts.swarm_ready).toBe(0);
     });
 
     it('ignores statuses outside the chip vocabulary', () => {
-        const { counts } = tallyRequirementStatuses(
-            [...rows, req(9, { requirement_status: 'wontfix' })], ALL_CHIPS, new Set());
+        const { counts } = tallyRequirementStatuses([...rows, req(9, { requirement_status: 'wontfix' })], ALL_CHIPS, ctx(new Set()));
         expect(counts.wontfix).toBeUndefined();
         expect(Object.keys(counts)).toEqual(ALL_CHIPS);
     });
@@ -153,14 +167,14 @@ describe('tallyRequirementStatuses', () => {
     it('returns a zeroed map for a missing read', () => {
         // The in-flight state. Showing MORE than we eventually will is the
         // deliberate direction — never hide eligible work behind a pending fetch.
-        const { counts } = tallyRequirementStatuses(undefined, ALL_CHIPS, new Set([1]));
+        const { counts } = tallyRequirementStatuses(undefined, ALL_CHIPS, ctx(new Set([1])));
         expect(counts).toEqual({
             authoring: 0, approved: 0, swarm_ready: 0, development: 0, met: 0,
         });
     });
 
     it('tolerates a missing pipelined Set', () => {
-        const { counts } = tallyRequirementStatuses(rows, ALL_CHIPS, undefined);
+        const { counts } = tallyRequirementStatuses(rows, ALL_CHIPS, ctx(undefined));
         expect(counts.swarm_ready).toBe(1);
     });
 
@@ -170,14 +184,13 @@ describe('tallyRequirementStatuses', () => {
     // to hide orchestrated requirements everywhere.
     describe('hidePipelined (req #3242)', () => {
         it('defaults to false — identical to omitting the argument', () => {
-            const withDefault = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([5, 6]));
-            const explicitFalse = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([5, 6]), false);
+            const withDefault = tallyRequirementStatuses(rows, ALL_CHIPS, ctx(new Set([5, 6])));
+            const explicitFalse = tallyRequirementStatuses(rows, ALL_CHIPS, ctx(new Set([5, 6]), false));
             expect(explicitFalse).toEqual(withDefault);
         });
 
         it('hides development and met when true', () => {
-            const { counts, hidden } = tallyRequirementStatuses(
-                rows, ALL_CHIPS, new Set([5, 6]), true);
+            const { counts, hidden } = tallyRequirementStatuses(rows, ALL_CHIPS, ctx(new Set([5, 6]), true));
             expect(counts.development).toBe(0);
             expect(counts.met).toBe(0);
             expect(hidden.development).toBe(1);
@@ -185,8 +198,8 @@ describe('tallyRequirementStatuses', () => {
         });
 
         it('leaves launch chips exclusion identical whether true or false — never doubled, never skipped', () => {
-            const off = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([1, 2, 4]), false);
-            const on = tallyRequirementStatuses(rows, ALL_CHIPS, new Set([1, 2, 4]), true);
+            const off = tallyRequirementStatuses(rows, ALL_CHIPS, ctx(new Set([1, 2, 4]), false));
+            const on = tallyRequirementStatuses(rows, ALL_CHIPS, ctx(new Set([1, 2, 4]), true));
             expect(on.counts.authoring).toBe(off.counts.authoring);
             expect(on.counts.swarm_ready).toBe(off.counts.swarm_ready);
             expect(on.hidden.authoring).toBe(off.hidden.authoring);
@@ -194,12 +207,87 @@ describe('tallyRequirementStatuses', () => {
         });
 
         it('count + hidden still sums to the population with the flag on', () => {
-            const { counts, hidden } = tallyRequirementStatuses(
-                rows, ALL_CHIPS, new Set([1, 2, 3, 4, 5, 6]), true);
+            const { counts, hidden } = tallyRequirementStatuses(rows, ALL_CHIPS, ctx(new Set([1, 2, 3, 4, 5, 6]), true));
             for (const s of ALL_CHIPS) {
                 const total = rows.filter(r => r.requirement_status === s).length;
                 expect(counts[s] + hidden[s]).toBe(total);
             }
         });
+    });
+});
+
+// ── req #3419 — ONE rule for the rows and the badge, and TWO memberships ─────
+describe('aggregatorRowVisible (req #3419)', () => {
+    // 10 is step-carried (and therefore also orchestrated); 20 is epic-seated
+    // with no step; 30 is neither.
+    const V = {
+        pipelinedIds: new Set([10]),
+        orchestratedIds: new Set([10, 20]),
+        hideOrchestrated: false,
+    };
+    const ids = (status, v, rows) => rows.filter(aggregatorRowVisible(status, v)).map(r => r.id);
+    const ROWS = [{ id: 10 }, { id: 20 }, { id: 30 }];
+
+    it('withholds step-carried work from a LAUNCH chip unconditionally', () => {
+        // req #3180: its launch is the coordinator's to make. No toggle gates it.
+        for (const status of PIPELINE_FILTERED_STATUSES) {
+            expect(ids(status, V, ROWS)).toEqual([20, 30]);
+        }
+    });
+
+    it('KEEPS epic-seated work on a launch chip while the toggle is off', () => {
+        // The decision this pins: a requirement seated under an epic that no
+        // step carries IS launchable. Widening launch eligibility to epic
+        // membership would withhold real work — which is why the two Sets stay
+        // separate rather than collapsing into one.
+        expect(ids('swarm_ready', V, ROWS)).toContain(20);
+    });
+
+    it('keeps everything on an observation chip while the toggle is off', () => {
+        expect(ids('development', V, ROWS)).toEqual([10, 20, 30]);
+        expect(ids('met', V, ROWS)).toEqual([10, 20, 30]);
+    });
+
+    it('drops BOTH memberships on every chip once the toggle is on', () => {
+        const on = { ...V, hideOrchestrated: true };
+        expect(ids('development', on, ROWS)).toEqual([30]);
+        expect(ids('met', on, ROWS)).toEqual([30]);
+        expect(ids('swarm_ready', on, ROWS)).toEqual([30]);
+    });
+
+    it('tolerates a missing context entirely — shows everything', () => {
+        // The in-flight state, and the deliberate failure direction: never hide
+        // eligible work behind a read that has not landed.
+        expect(ROWS.filter(aggregatorRowVisible('swarm_ready'))).toEqual(ROWS);
+        expect(ROWS.filter(aggregatorRowVisible('swarm_ready', {}))).toEqual(ROWS);
+    });
+});
+
+describe('the badge cannot disagree with the rows (req #3419)', () => {
+    // This is the property the shared function buys. Asserting it by OUTCOME —
+    // count the rows the card would render, compare to the badge — is the only
+    // form that stays true if someone re-inlines one of the two.
+    const ROWS = [
+        req(10, { requirement_status: 'swarm_ready' }),
+        req(20, { requirement_status: 'swarm_ready' }),
+        req(30, { requirement_status: 'swarm_ready' }),
+        req(40, { requirement_status: 'development' }),
+        req(50, { requirement_status: 'development' }),
+    ];
+    const CHIPS = ['authoring', 'approved', 'swarm_ready', 'development', 'met'];
+    const V = {
+        pipelinedIds: new Set([10]),
+        orchestratedIds: new Set([10, 20, 40]),
+    };
+
+    it.each([false, true])('agrees per chip with hideOrchestrated=%s', (hide) => {
+        const v = { ...V, hideOrchestrated: hide };
+        const { counts } = tallyRequirementStatuses(ROWS, CHIPS, v);
+        for (const status of CHIPS) {
+            const rendered = ROWS
+                .filter(r => r.requirement_status === status)
+                .filter(aggregatorRowVisible(status, v));
+            expect(counts[status]).toBe(rendered.length);
+        }
     });
 });

--- a/src/TaskPlanView/swarmStartCardUtils.js
+++ b/src/TaskPlanView/swarmStartCardUtils.js
@@ -25,7 +25,45 @@ export const sortSwarmReadyItems = (items) => {
 export const PIPELINE_FILTERED_STATUSES = ['authoring', 'approved', 'swarm_ready'];
 
 /**
- * Per-status counts for the chip badges, applying the pipeline exclusion.
+ * THE aggregator's row rule for ONE chip — req #3419.
+ *
+ * Both things this card does with the rule (build the chip's ROW LIST, and count
+ * the chip's BADGE) call this. They used to be two transcriptions of one
+ * sentence, which is a list and its own count able to disagree.
+ *
+ * TWO EXCLUSIONS, and they answer different questions:
+ *
+ *   LAUNCH LEGALITY — `PIPELINE_FILTERED_STATUSES` chips offer a direct
+ *     swarm-start, and a requirement a pipeline STEP carries is not eligible for
+ *     one (req #3180). UNCONDITIONAL: offering an ineligible launch is a defect,
+ *     not a viewing preference, so no toggle gates it. STEP association ONLY —
+ *     widening it to epic membership would withhold work that IS launchable.
+ *
+ *   BROWSE PREFERENCE — the reader's global "hide orchestrated requirements"
+ *     toggle, which since req #3419 means step-carried OR epic-filed. Applies to
+ *     every chip, on top of (never instead of) the launch exclusion.
+ *
+ * @param {string} status  the chip's requirement_status
+ * @param {object} ctx  from `useRequirementVisibility`
+ * @param {Set<number>} [ctx.pipelinedIds]      STEP association
+ * @param {Set<number>} [ctx.orchestratedIds]   step OR epic
+ * @param {boolean} [ctx.hideOrchestrated]
+ * @returns {(row: {id: number|string}) => boolean} true = the row belongs here
+ */
+export const aggregatorRowVisible = (status, {
+    pipelinedIds, orchestratedIds, hideOrchestrated = false,
+} = {}) => {
+    const offersLaunch = PIPELINE_FILTERED_STATUSES.includes(status);
+    return (row) => {
+        const id = Number(row?.id);
+        if (offersLaunch && pipelinedIds && pipelinedIds.has(id)) return false;
+        if (hideOrchestrated && orchestratedIds && orchestratedIds.has(id)) return false;
+        return true;
+    };
+};
+
+/**
+ * Per-status counts for the chip badges, applying the same rule as the rows.
  *
  * Pure so the "which chips filter" decision is pinned by tests rather than only
  * by a rendered card.
@@ -39,22 +77,21 @@ export const PIPELINE_FILTERED_STATUSES = ['authoring', 'approved', 'swarm_ready
  * population is 0.
  *
  * @param {Array<{id: number, requirement_status: string}>} requirements
- * @param {string[]} statuses      the chip vocabulary; every key is initialized to 0
- * @param {Set<number>} pipelinedIds  from `pipelinedRequirementIds`
- * @param {boolean} [hidePipelined=false]  req #3242 — the same global
- *        `useShowClosedStore.hidePipelinedRequirements` toggle the requirements
- *        pages read. `PIPELINE_FILTERED_STATUSES` stays UNCONDITIONAL regardless
- *        of this flag (offering an ineligible launch is a defect, not a viewing
- *        preference — see the module comment); this only widens exclusion to
- *        the observation statuses (development/met) when the reader has asked
- *        to hide orchestrated requirements everywhere, matching the toggle's
- *        behaviour on the requirements table and Cards view.
+ * @param {string[]} statuses  the chip vocabulary; every key is initialized to 0
+ * @param {object} ctx  the `useRequirementVisibility` context handed to
+ *        `aggregatorRowVisible` — ONE rule, so the badge cannot disagree with
+ *        the rows it sits above.
  * @returns {{counts: Object, hidden: Object}}
  */
-export const tallyRequirementStatuses = (requirements, statuses, pipelinedIds, hidePipelined = false) => {
+export const tallyRequirementStatuses = (requirements, statuses, ctx = {}) => {
     const counts = {};
     const hidden = {};
-    statuses.forEach(s => { counts[s] = 0; hidden[s] = 0; });
+    const visibleFor = {};
+    statuses.forEach(s => {
+        counts[s] = 0;
+        hidden[s] = 0;
+        visibleFor[s] = aggregatorRowVisible(s, ctx);
+    });
     if (!Array.isArray(requirements)) return { counts, hidden };
 
     for (const r of requirements) {
@@ -63,8 +100,7 @@ export const tallyRequirementStatuses = (requirements, statuses, pipelinedIds, h
         if (!r || r.id === '' || r.id === undefined || r.id === null) continue;
         const status = r.requirement_status;
         if (counts[status] === undefined) continue;
-        if ((PIPELINE_FILTERED_STATUSES.includes(status) || hidePipelined)
-                && pipelinedIds && pipelinedIds.has(Number(r.id))) {
+        if (!visibleFor[status](r)) {
             hidden[status] += 1;
             continue;
         }

--- a/src/__tests__/requirementVisibility.harness.test.jsx
+++ b/src/__tests__/requirementVisibility.harness.test.jsx
@@ -1,0 +1,517 @@
+// @vitest-environment jsdom
+//
+// ── THE requirement-visibility harness — req #3419 ───────────────────────────
+//
+// The requirement that produced this file asked for one thing above all: *"if
+// there is only one place to calculate the query for this button then it will
+// always work... otherwise you have a single test harness that can test all
+// implementations with excellent test coverage."*
+//
+// WHY IT EXISTS. The orchestrated toggle was busted twice. The second time, the
+// suite was GREEN — because every test that touched the rule MOCKED THE HOOK
+// THAT ANSWERS IT (`usePipelinedRequirementIds: () => pipelinedIds`). Those
+// tests proved that a component filters by whatever Set it is handed. They could
+// not, and did not, prove that the Set is the right Set. The defect lived in the
+// half nobody mounted.
+//
+// So this file mocks EXACTLY ONE THING: `call_rest_api`, the HTTP transport.
+// Everything above it is real — `createEntityQueries`, `useDataQueries`,
+// `useRequirementVisibility`, `pipelineMembership`, `processSort`, and the four
+// surfaces themselves. One fixture goes in at the wire; four independently
+// written renderers come out; they are asserted to AGREE. A rule that is
+// computed in one place cannot fail that assertion, and a rule that quietly
+// grows a sixth copy will.
+//
+// THE FIXTURE ENCODES THE MEASURED DEFECT. Production, 2026-08-09: category 1
+// under the default chips held 27 requirements, 9 survived the toggle, and 4 of
+// those 9 were seated under an epic (#3304/#3314 -> feature 35 -> epic 4, #3385
+// -> feature 31 -> epic 7, #3433 -> feature 41 -> epic 9) with no pipeline step
+// carrying them. Row 102 below is that row.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DndProvider } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-router-dom', () => ({
+    useNavigate: () => () => {},
+    useLocation: () => ({ state: null, pathname: '/swarm', search: '' }),
+    Link: ({ children }) => <span>{children}</span>,
+}));
+
+// ── THE FIXTURE ──────────────────────────────────────────────────────────────
+//
+// 100  unplanned                                    -> always visible
+// 101  carried by pipeline step 1                   -> STEP association
+// 102  seated under feature 900 -> epic 4, NO step  -> EPIC association (#3419)
+// 103  under feature 901, which names NO epic       -> NOT orchestrated
+// 104  seated under feature 900, status development -> EPIC, observation chip
+const CATEGORY_ID = 5;
+const ROWS = [
+    { id: 100, title: 'Unplanned', requirement_status: 'authoring', category_fk: CATEGORY_ID, feature_fk: null, sort_order: 0, coordination_type: 'implemented', ai_model: 'opus', effort: 'high', machine_fk: null, started_at: null, completed_at: null, deferred_at: null },
+    { id: 101, title: 'On a plan step', requirement_status: 'authoring', category_fk: CATEGORY_ID, feature_fk: null, sort_order: 1, coordination_type: 'implemented', ai_model: 'opus', effort: 'high', machine_fk: null, started_at: null, completed_at: null, deferred_at: null },
+    { id: 102, title: 'In an epic, no step', requirement_status: 'authoring', category_fk: CATEGORY_ID, feature_fk: 900, sort_order: 2, coordination_type: 'implemented', ai_model: 'opus', effort: 'high', machine_fk: null, started_at: null, completed_at: null, deferred_at: null },
+    { id: 103, title: 'Feature with no epic', requirement_status: 'authoring', category_fk: CATEGORY_ID, feature_fk: 901, sort_order: 3, coordination_type: 'implemented', ai_model: 'opus', effort: 'high', machine_fk: null, started_at: null, completed_at: null, deferred_at: null },
+    { id: 104, title: 'In an epic, in flight', requirement_status: 'development', category_fk: CATEGORY_ID, feature_fk: 900, sort_order: 4, coordination_type: 'implemented', ai_model: 'opus', effort: 'high', machine_fk: null, started_at: '2026-08-01T00:00:00', completed_at: null, deferred_at: null },
+];
+const FEATURES = [{ id: 900, epic_fk: 4 }, { id: 901, epic_fk: null }];
+const JUNCTION = [{ step_fk: 1, requirement_fk: 101 }];
+const CATEGORIES = [{ id: CATEGORY_ID, category_name: 'Harness', project_fk: 1, color: null, sort_mode: 'process' }];
+
+// The answer, stated once, independently of any component.
+const ORCHESTRATED = [101, 102, 104];
+const VISIBLE_WHEN_HIDING = [100, 103];
+
+// ── the ONE mock: the wire ───────────────────────────────────────────────────
+//
+// Routed on the real URLs the real hooks build, so a hook that changes its
+// query string fails here loudly instead of silently receiving `[]` — which is
+// what `fetchEntity` turns a 404 into, and is exactly the shape of "nothing is
+// orchestrated, hide nothing".
+const restCalls = [];
+const serve = (uri) => {
+    const [path, query = ''] = uri.split('?');
+    const table = path.split('/').pop();
+    const params = new URLSearchParams(query);
+
+    if (table === 'requirements') {
+        if (params.has('category_fk')) {
+            return ROWS.filter(r => String(r.category_fk) === params.get('category_fk'));
+        }
+        if (params.get('requirement_status') === 'met') return [];
+        if (params.has('requirement_status')) {
+            return ROWS.filter(r => r.requirement_status === params.get('requirement_status'));
+        }
+        return ROWS;   // whole-table projections, incl. `fields=id,feature_fk`
+    }
+    if (table === 'features') return FEATURES;
+    if (table === 'pipeline_step_requirements') return JUNCTION;
+    if (table === 'categories') return CATEGORIES;
+    return [];
+};
+
+vi.mock('../RestApi/RestApi', () => ({
+    default: vi.fn((uri, method) => {
+        if (method !== 'GET') {
+            return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] });
+        }
+        restCalls.push(uri);
+        return Promise.resolve({ httpStatus: { httpStatus: 200 }, data: serve(uri) });
+    }),
+}));
+
+import CategoryCard from '../SwarmView/CategoryCard';
+import RequirementsTableView from '../SwarmView/RequirementsTableView';
+import SwarmStartCard from '../TaskPlanView/SwarmStartCard';
+import { useRequirementVisibility } from '../hooks/useRequirementVisibility';
+import { siblingElevator } from '../SwarmView/detail/requirementSort';
+import { orchestratedRequirementIds } from '../utils/pipelineMembership';
+import { useShowClosedStore } from '../stores/useShowClosedStore';
+import { useSwarmStartCardStore } from '../stores/useSwarmStartCardStore';
+import AuthContext from '../Context/AuthContext';
+import AppContext from '../Context/AppContext';
+
+const noop = () => {};
+
+let roots = [];
+let containers = [];
+
+const mount = (ui) => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    containers.push(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local/darwin', darwinOpsUri: 'http://test.local/darwin' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
+                            {ui}
+                        </DndProvider>
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    return container;
+};
+
+// Let every query in the tree resolve. The visibility hook fans out to three
+// reads and each surface to several more, and TanStack schedules its state
+// updates across real task boundaries — so a fixed number of microtask ticks is
+// a race, not a wait. Poll until the tree says it is done.
+// The inner budget MATCHES the per-test timeout on purpose. A smaller budget
+// always fires first, so a genuine failure would surface as "settle() gave up"
+// with no assertion diff — and this is the one test that would have caught the
+// original defect, so it is the one that must not become a mystery under load.
+const TIMEOUT = 60000;
+const settle = async (predicate = () => true, budgetMs = 55000) => {
+    const start = Date.now();
+    let last = null;
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        await act(async () => { await new Promise(r => setTimeout(r, 25)); });
+        try {
+            if (predicate()) return;
+        } catch (e) { last = e; }
+        if (Date.now() - start > budgetMs) {
+            throw new Error(`settle() gave up after ${budgetMs}ms${last ? `: ${last.message}` : ''}`);
+        }
+    }
+};
+
+// The card renders a spinner until its requirements query lands, so "no rows"
+// and "not loaded" look the same in the DOM. The add-row template is the
+// difference: it exists only once `requirementsArray` is seeded.
+const cardLoaded = (container) => () =>
+    container.querySelector('[data-testid="requirement-template"]') !== null;
+
+// The aggregator always renders its chips; the badge text is the signal that the
+// counts query has landed.
+const aggregatorLoaded = (container) => () =>
+    container.querySelector('[data-testid="swarm-start-chip-badge-authoring"] .MuiBadge-badge') !== null;
+
+const Card = () => (
+    <CategoryCard
+        category={CATEGORIES[0]}
+        categoryIndex={0}
+        projectId={1}
+        categoryChange={noop}
+        categoryKeyDown={noop}
+        categoryOnBlur={noop}
+        clickCardClosed={noop}
+        clickCardDelete={noop}
+        moveCard={noop}
+        persistCategoryOrder={noop}
+        removeCategory={noop}
+        isTemplate={false}
+        showClosed={false}
+    />
+);
+
+// The ids a surface actually put on screen, in render order. `requirement-<id>`
+// is RequirementRow's own testid; the template add-row is `requirement-template`.
+const renderedIds = (container) =>
+    [...container.querySelectorAll('[data-testid^="requirement-"]')]
+        .map(el => el.getAttribute('data-testid').slice('requirement-'.length))
+        .filter(v => v !== 'template' && /^\d+$/.test(v))
+        .map(Number);
+
+// A probe that hands the REAL hook's output back to the test, so the elevator
+// and the pure predicate can be driven by exactly what the components consume.
+let probed = null;
+const Probe = () => {
+    probed = useRequirementVisibility('tester');
+    return null;
+};
+
+describe('req #3419 — one visibility rule, every surface (the single harness)', () => {
+    beforeEach(() => {
+        roots = [];
+        containers = [];
+        restCalls.length = 0;
+        probed = null;
+        useShowClosedStore.setState({
+            hidePipelinedRequirements: true,
+            requirementStatusFilter: ['authoring', 'approved', 'swarm_ready', 'development'],
+        });
+        useSwarmStartCardStore.setState({ selectedStatus: 'authoring' });
+    });
+    afterEach(() => {
+        act(() => { roots.forEach(r => r.unmount()); });
+        containers.forEach(c => c.remove());
+        document.body.innerHTML = '';
+        useShowClosedStore.setState({ hidePipelinedRequirements: true });
+    });
+
+    // ── the answer itself ────────────────────────────────────────────────────
+    describe('the shared hook', () => {
+        it('reads the three lists and answers step OR epic', async () => {
+            mount(<Probe />);
+            await settle(() => probed.orchestratedIds.size === ORCHESTRATED.length);
+            expect([...probed.orchestratedIds].sort((a, b) => a - b)).toEqual(ORCHESTRATED);
+        }, TIMEOUT);
+
+        it('keeps the STEP set narrow — launch eligibility is not widened', async () => {
+            // req #3180 stays intact: a requirement seated under an epic that no
+            // step carries IS launchable, and the aggregator must keep offering
+            // it. Collapsing these two Sets into one is the tempting
+            // simplification that would withhold real work.
+            mount(<Probe />);
+            await settle(() => probed.pipelinedIds.size === 1);
+            expect([...probed.pipelinedIds]).toEqual([101]);
+        }, TIMEOUT);
+
+        it('agrees with the pure function it is a memoized form of', async () => {
+            mount(<Probe />);
+            await settle(() => probed.orchestratedIds.size === ORCHESTRATED.length);
+            expect(probed.orchestratedIds)
+                .toEqual(orchestratedRequirementIds(JUNCTION, ROWS, FEATURES));
+        }, TIMEOUT);
+
+        it('actually issued the reads — an empty answer must not be silent', async () => {
+            // `fetchEntity` turns a 404 into `[]`, so a hook pointed at the wrong
+            // URL produces "nothing is orchestrated" rather than an error. Assert
+            // the three reads happened at all.
+            mount(<Probe />);
+            await settle(() => probed.orchestratedIds.size === ORCHESTRATED.length);
+            expect(restCalls.some(u => u.includes('/pipeline_step_requirements'))).toBe(true);
+            expect(restCalls.some(u => u.includes('/features'))).toBe(true);
+            expect(restCalls.some(u => u.includes('fields=id,feature_fk'))).toBe(true);
+        }, TIMEOUT);
+
+        it('hides nothing while the reads are in flight', () => {
+            // Deliberate failure direction: show MORE, never hide eligible work
+            // behind a pending or failed fetch.
+            mount(<Probe />);
+            expect(probed.orchestratedIds.size).toBe(0);
+            expect(probed.isVisible({ id: 101 })).toBe(true);
+        });
+    });
+
+    // ── surface by surface, through the REAL chain ───────────────────────────
+    describe('the Cards view', () => {
+        it('hides step-carried AND epic-seated work with the toggle ON', async () => {
+            const c = mount(<Card />);
+            await settle(cardLoaded(c));
+            await settle(() => renderedIds(c).length === VISIBLE_WHEN_HIDING.length);
+            expect(renderedIds(c)).toEqual(VISIBLE_WHEN_HIDING);
+        }, TIMEOUT);
+
+        it('shows every row with the toggle OFF', async () => {
+            useShowClosedStore.setState({ hidePipelinedRequirements: false });
+            const c = mount(<Card />);
+            await settle(cardLoaded(c));
+            await settle(() => renderedIds(c).length === 5);
+            expect(renderedIds(c).sort((a, b) => a - b)).toEqual([100, 101, 102, 103, 104]);
+        }, TIMEOUT);
+
+        it('responds to the toggle live, without a remount', async () => {
+            const c = mount(<Card />);
+            await settle(cardLoaded(c));
+            await settle(() => renderedIds(c).length === VISIBLE_WHEN_HIDING.length);
+            expect(renderedIds(c)).toEqual(VISIBLE_WHEN_HIDING);
+            await act(async () => {
+                useShowClosedStore.getState().toggleHidePipelinedRequirements();
+            });
+            await settle(() => renderedIds(c).length === 5);
+            expect(renderedIds(c)).toContain(102);
+        }, TIMEOUT);
+
+        it('keeps the add-row template regardless of the toggle', async () => {
+            // `Number('')` is 0; a predicate that let the template through the
+            // Set lookup would be one id collision away from eating the add-row.
+            const c = mount(<Card />);
+            await settle(cardLoaded(c));
+            expect(c.querySelector('[data-testid="requirement-template"]')).not.toBeNull();
+        }, TIMEOUT);
+    });
+
+    describe('the aggregator card', () => {
+        it('withholds step-carried work from a launch chip even with the toggle OFF', async () => {
+            useShowClosedStore.setState({ hidePipelinedRequirements: false });
+            const c = mount(<SwarmStartCard />);
+            await settle(aggregatorLoaded(c));
+            await settle(() => renderedIds(c).length === 3);
+            const ids = renderedIds(c);
+            expect(ids).not.toContain(101);   // req #3180 — unconditional
+            expect(ids).toContain(102);       // ...but epic-seated work IS launchable
+        }, TIMEOUT);
+
+        it('withholds epic-seated work too once the toggle is ON', async () => {
+            const c = mount(<SwarmStartCard />);
+            await settle(aggregatorLoaded(c));
+            await settle(() => renderedIds(c).length === 2);
+            expect(renderedIds(c)).toEqual([100, 103]);
+        }, TIMEOUT);
+
+        it('badges the chip with the number of rows it renders', async () => {
+            // The list and its own count are one function since req #3419. This
+            // asserts it by OUTCOME, so re-inlining either half fails here.
+            const c = mount(<SwarmStartCard />);
+            await settle(aggregatorLoaded(c));
+            await settle(() => renderedIds(c).length === 2);
+            const badge = c.querySelector('[data-testid="swarm-start-chip-badge-authoring"] .MuiBadge-badge');
+            expect(badge?.textContent).toBe(String(renderedIds(c).length));
+        }, TIMEOUT);
+    });
+
+    // ── req #3419 — the gold title box ───────────────────────────────────────
+    //
+    // The mark and the filter are ONE predicate. That is the property worth
+    // testing: not "is it gold" (a style assertion pins a hex value, not a
+    // rule), but "is the marked set EXACTLY the set the toggle hides". A second
+    // derivation would show up here as a row that is gold and still visible
+    // under hiding, or plain and hidden.
+    describe('orchestrated rows are MARKED, from the same set that hides them', () => {
+        const marked = (container) =>
+            [...container.querySelectorAll('[data-orchestrated="true"]')]
+                .map(el => Number(el.getAttribute('data-testid').replace('requirement-title-', '')))
+                .sort((a, b) => a - b);
+        const plain = (container) =>
+            [...container.querySelectorAll('[data-orchestrated="false"]')]
+                .map(el => Number(el.getAttribute('data-testid').replace('requirement-title-', '')))
+                .sort((a, b) => a - b);
+
+        it('marks exactly the orchestrated rows when the toggle is OFF', async () => {
+            // Toggle OFF is the state where the mark earns its keep: both
+            // populations are on screen together.
+            useShowClosedStore.setState({ hidePipelinedRequirements: false });
+            const c = mount(<Card />);
+            await settle(cardLoaded(c));
+            await settle(() => renderedIds(c).length === 5);
+            expect(marked(c)).toEqual(ORCHESTRATED);
+            expect(plain(c)).toEqual(VISIBLE_WHEN_HIDING);
+        }, TIMEOUT);
+
+        it('marks step-carried AND epic-seated work, not just step-carried', async () => {
+            // 102 is epic-seated with no step. A mark built on the old step-only
+            // predicate would leave it plain.
+            useShowClosedStore.setState({ hidePipelinedRequirements: false });
+            const c = mount(<Card />);
+            await settle(cardLoaded(c));
+            await settle(() => renderedIds(c).length === 5);
+            expect(marked(c)).toContain(101);   // step-carried
+            expect(marked(c)).toContain(102);   // epic-seated only
+        }, TIMEOUT);
+
+        it('marks NOTHING that survives the toggle — mark and filter are one set', async () => {
+            // The invariant. Whatever is on screen while hiding is, by
+            // definition, not orchestrated; so nothing there may be gold.
+            const c = mount(<Card />);
+            await settle(cardLoaded(c));
+            await settle(() => renderedIds(c).length === VISIBLE_WHEN_HIDING.length);
+            expect(marked(c)).toEqual([]);
+            expect(plain(c)).toEqual(VISIBLE_WHEN_HIDING);
+        }, TIMEOUT);
+
+        it('never marks the add-row template', async () => {
+            // `Number('')` is 0. A predicate that let the template reach the Set
+            // lookup would gild the add-row the first time id 0 appeared.
+            useShowClosedStore.setState({ hidePipelinedRequirements: false });
+            const c = mount(<Card />);
+            await settle(cardLoaded(c));
+            const template = c.querySelector('[data-testid="requirement-template"]');
+            expect(template).not.toBeNull();
+            expect(template.querySelector('[data-orchestrated]')).toBeNull();
+        }, TIMEOUT);
+
+        it('marks in the aggregator card too, from its own copy of the same set', async () => {
+            useShowClosedStore.setState({ hidePipelinedRequirements: false });
+            const c = mount(<SwarmStartCard />);
+            await settle(aggregatorLoaded(c));
+            await settle(() => renderedIds(c).length === 3);
+            // 101 is withheld by the launch exclusion; 102 is offered AND marked.
+            expect(marked(c)).toEqual([102]);
+        }, TIMEOUT);
+    });
+
+    describe('the Table view', () => {
+        // The fourth surface the hook's docstring names. Without it, the table's
+        // only proof was that it happens to call the same callback — which is
+        // precisely the standard of evidence req #3419 exists to reject.
+        const tableIds = (container) =>
+            [...container.querySelectorAll('.MuiDataGrid-row')]
+                .map(el => Number(el.getAttribute('data-id')))
+                .filter(n => !Number.isNaN(n))
+                .sort((a, b) => a - b);
+
+        it('hides step-carried AND epic-seated work with the toggle ON', async () => {
+            const c = mount(<RequirementsTableView />);
+            await settle(() => tableIds(c).length === VISIBLE_WHEN_HIDING.length);
+            expect(tableIds(c)).toEqual(VISIBLE_WHEN_HIDING);
+        }, TIMEOUT);
+
+        it('shows every row with the toggle OFF', async () => {
+            useShowClosedStore.setState({ hidePipelinedRequirements: false });
+            const c = mount(<RequirementsTableView />);
+            await settle(() => tableIds(c).length === 5);
+            expect(tableIds(c)).toEqual([100, 101, 102, 103, 104]);
+        }, TIMEOUT);
+
+        it('renders the same rows the Cards view does', async () => {
+            const card = mount(<Card />);
+            const table = mount(<RequirementsTableView />);
+            await settle(cardLoaded(card));
+            await settle(() => renderedIds(card).length === VISIBLE_WHEN_HIDING.length
+                && tableIds(table).length === VISIBLE_WHEN_HIDING.length);
+            expect(tableIds(table)).toEqual([...renderedIds(card)].sort((a, b) => a - b));
+        }, TIMEOUT);
+    });
+
+    describe('the up/down elevator', () => {
+        const elevatorIds = (visibility) => siblingElevator(
+            ROWS.filter(r => ['authoring', 'approved', 'swarm_ready', 'development']
+                .includes(r.requirement_status)),
+            { sortMode: 'process', isVisible: visibility.isVisible, currentId: 100 },
+        );
+
+        it('walks exactly the rows the card rendered', async () => {
+            const c = mount(<Card />);
+            mount(<Probe />);
+            await settle(cardLoaded(c));
+            await settle(() => renderedIds(c).length === VISIBLE_WHEN_HIDING.length
+                && probed.orchestratedIds.size === ORCHESTRATED.length);
+            expect(elevatorIds(probed).ordered.map(r => r.id)).toEqual(renderedIds(c));
+        }, TIMEOUT);
+
+        it('never sends Down to an epic-seated row the card hides', async () => {
+            mount(<Probe />);
+            await settle(() => probed.orchestratedIds.size === ORCHESTRATED.length);
+            const { nextId } = elevatorIds(probed);
+            expect(nextId).toBe(103);
+            expect(elevatorIds(probed).ordered.map(r => r.id)).not.toContain(102);
+        }, TIMEOUT);
+
+        it('disables both arrows on a requirement the filter itself hides', async () => {
+            mount(<Probe />);
+            await settle(() => probed.orchestratedIds.size === ORCHESTRATED.length);
+            const at102 = siblingElevator(ROWS, {
+                sortMode: 'process', isVisible: probed.isVisible, currentId: 102,
+            });
+            expect(at102.currentIndex).toBe(-1);
+            expect(at102.prevId).toBeNull();
+            expect(at102.nextId).toBeNull();
+        }, TIMEOUT);
+    });
+
+    // ── the property the whole refactor buys ─────────────────────────────────
+    describe('cross-surface agreement', () => {
+        // The aggregator shows ONE status and applies its own unconditional
+        // launch exclusion on top, so the fair comparison is: among the rows
+        // both surfaces could show (authoring, minus the step-carried one the
+        // launch rule removes), do they render the same set?
+        const COMPARABLE = ROWS
+            .filter(r => r.requirement_status === 'authoring' && r.id !== 101)
+            .map(r => r.id);
+
+        it.each([true, false])('card, aggregator and hook agree (hiding=%s)', async (hiding) => {
+            useShowClosedStore.setState({ hidePipelinedRequirements: hiding });
+            const expected = hiding ? [100, 103] : [100, 102, 103];
+
+            const card = mount(<Card />);
+            const agg = mount(<SwarmStartCard />);
+            mount(<Probe />);
+            await settle(cardLoaded(card));
+            await settle(aggregatorLoaded(agg));
+            await settle(() => probed.orchestratedIds.size === ORCHESTRATED.length
+                && renderedIds(card).length === (hiding ? 2 : 5));
+
+            const fromCard = renderedIds(card).filter(id => COMPARABLE.includes(id));
+            const fromAggregator = renderedIds(agg).filter(id => COMPARABLE.includes(id));
+            const fromHook = COMPARABLE.filter(id => probed.isVisible({ id }));
+
+            expect(fromCard.sort()).toEqual(expected);
+            expect(fromAggregator.sort()).toEqual(expected);
+            expect(fromHook.sort()).toEqual(expected);
+        }, TIMEOUT);
+    });
+});

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
 import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
 import { domainKeys, areaKeys, taskKeys, projectKeys, categoryKeys, requirementKeys, priorityCardOrderKeys, recurringTaskKeys, mapRunKeys, mapRouteKeys, mapCoordinateKeys, mapViewKeys, mapPartnerKeys, mapRunPartnerKeys, epicKeys, featureKeys, testCaseKeys, featureTestCaseKeys, testPlanKeys, testPlanCaseKeys, testRunKeys, testResultKeys, customerKeys, buildProjectKeys, branchKeys, buildKeys, customerReleaseKeys } from './useQueryKeys';
@@ -9,8 +9,6 @@ import { devServers, sessions, swarmStarts, swarmStartSessions, swarmUndos, swar
 import { fetchEntity } from './factory/createEntityQueries';
 // req #3166 — THE batched GET /map_coordinates, shared with the export paths.
 import { fetchCoordinatesForRuns, buildRunTrackUri, COORD_TRACK_FIELDS } from '../services/mapCoordinatesBatch';
-// req #3180 — THE browser's one derivation of pipeline-step membership.
-import { pipelinedRequirementIds } from '../utils/pipelineMembership';
 
 export function useDomains(creatorFk, { closed, fields = 'id,domain_name,sort_order', enabled = true } = {}) {
     const { darwinUri } = useContext(AppContext);
@@ -989,19 +987,13 @@ export const useOrchestrationClaims         = orchestrationClaims.useAll;
 export const useAllPipelineStepRequirements = pipelineStepRequirements.useAll;
 export const useAllPipelineStepDeps         = pipelineStepDeps.useAll;
 
-// Req #3180 — the requirement ids a pipeline STEP carries, as a Set.
-//
-// One shared hook over the junction read above, so the two surfaces that need
-// this (the SwarmStartCard aggregator, the requirements-page filter) consult ONE
-// query cache entry and ONE derivation. It costs no extra fetch on the plan
-// pages, which already hold this exact read.
-//
-// The Set is memoized on the query data, so it is referentially stable between
-// refetches that change nothing — consumers use it as a useMemo dependency.
-export function usePipelinedRequirementIds(creatorFk, { enabled = true } = {}) {
-    const { data } = useAllPipelineStepRequirements(creatorFk, { enabled });
-    return useMemo(() => pipelinedRequirementIds(data), [data]);
-}
+// req #3419 — `usePipelinedRequirementIds` lived here (req #3180) and is GONE.
+// Four surfaces called it and each then wrote its own "is this row on screen"
+// expression around the Set, which is how one defect took two requirements to
+// find. The single answer — and the step-only Set, for the aggregator's
+// unconditional launch exclusion — is `hooks/useRequirementVisibility.js`.
+// Nothing else may derive it; the junction read itself stays public above
+// because the plan pages consume the ROWS, not the membership question.
 
 // Req #3117 — the plan page's Cost column. TWO more bounded list reads, never a
 // per-requirement fetch: the junction maps requirements to their sessions, the

--- a/src/hooks/useRequirementVisibility.js
+++ b/src/hooks/useRequirementVisibility.js
@@ -1,0 +1,148 @@
+// THE requirement-visibility answer for every browse surface — req #3419.
+//
+// ── WHY THIS HOOK EXISTS (You Only Need One) ────────────────────────────────
+//
+// "Should this requirement be on screen given the orchestrated toggle?" was
+// written FIVE times, once per surface, each re-reading the store and
+// re-deriving the id set:
+//
+//   1. SwarmView/CategoryCard.jsx        `if (hidePipelined) rows.filter(...)`
+//   2. SwarmView/RequirementsTableView   `notPipelined = r => !hide || !ids.has(...)`
+//   3. TaskPlanView/SwarmStartCard.jsx   `excludePipelined(rows, ids, offers || hide)` x2
+//   4. TaskPlanView/swarmStartCardUtils  inline `ids.has(Number(r.id))` in the tally
+//   5. SwarmView/detail/requirementSort  `excludePipelined(rows, ids, hide)`
+//
+// Five copies means a fix is five edits and a miss is invisible, which is
+// exactly how req #3419 became the SECOND requirement filed for one defect.
+// There is now one hook: every surface asks it, nobody re-derives it, and a
+// change to the rule is one edit that every surface inherits.
+//
+// ── WHY THE SETS ARE BUILT FROM WHOLE-TABLE READS, NOT FROM THE LIST'S ROWS ──
+//
+// Epic association needs `feature_fk` on the requirement. The per-surface
+// projections DISAGREE about carrying it — `useRequirements` does,
+// `useRequirementsByStatus`, `useRequirementsDone` and the detail page's sibling
+// fetch do not — so a predicate reading `r.feature_fk` would answer correctly on
+// one card and silently answer "not orchestrated" on the others. Deriving the id
+// SET from its own bounded reads makes the predicate `ids.has(r.id)`, which every
+// projection can satisfy, and removes the whole class of drift.
+//
+// COST, MEASURED — and these reads are COLD, not warm. An earlier version of
+// this comment claimed they were already on the page; they are not:
+//
+//   * `useAllRequirements` keys on `{fields}` (useDataQueries.js), and this
+//     hook's `id,feature_fk` matches no existing caller — the table asks for
+//     `id,title,requirement_status,…`, the aggregator for `id,requirement_status`.
+//     Three distinct cache entries, three distinct whole-table reads.
+//   * the junction is read only by the PLAN pages (PipelineDetail, PipelinesPage,
+//     StepsPage), not by `/swarm` or `/taskcards`.
+//   * `useAllFeatures` with `{fields:'id,epic_fk', closed:'all'}` is a fourth
+//     distinct key.
+//
+// Net: +2 whole-table reads on the `/swarm` cards, the `/swarm` table and
+// `/taskcards`; +3 on `/swarm/requirement/:id`, which previously gated its one
+// junction read on the toggle. All three are 2-column bounded lists and
+// TanStack dedupes them across the N mounted `CategoryCard`s, so this is a
+// handful of small requests and NOT a fan-out — req #3080 design rule 5 holds
+// (no per-requirement fetch, and the request count does not grow with the
+// number of requirements or cards). Stated plainly here so nobody has to
+// re-measure it to know what the hook costs.
+
+import { useCallback, useMemo } from 'react';
+
+import {
+    useAllPipelineStepRequirements,
+    useAllRequirements,
+    useAllFeatures,
+    ALL_ROWS,
+} from './useDataQueries';
+import { useShowClosedStore } from '../stores/useShowClosedStore';
+import {
+    pipelinedRequirementIds,
+    epicRequirementIds,
+    excludeByIds,
+} from '../utils/pipelineMembership';
+
+// Whole-table projections, narrow on purpose. `fields` is in every one of these
+// cache keys, so these slices never collide with a caller asking for more.
+const REQUIREMENT_FIELDS = 'id,feature_fk';
+const FEATURE_FIELDS = 'id,epic_fk';
+
+/**
+ * @param {string} creatorFk  the profile userName; falsy disables every read.
+ * @returns {{
+ *   hideOrchestrated: boolean,
+ *   pipelinedIds: Set<number>,
+ *   orchestratedIds: Set<number>,
+ *   isVisible: (row: {id: number|string}) => boolean,
+ *   filterVisible: (rows: Array) => Array,
+ * }}
+ *
+ * `hideOrchestrated` is the persisted user control
+ * (`useShowClosedStore.hidePipelinedRequirements` — the store key keeps its
+ * req #3180 name so no persistence migration is needed; its MEANING is this
+ * hook's, and every reader goes through here).
+ *
+ * `pipelinedIds` is STEP association only. It is exported for the one caller
+ * that needs the narrow fact — the aggregator card's UNCONDITIONAL launch
+ * exclusion (req #3180) — and must not be used to answer "is this on screen".
+ *
+ * `isVisible` / `filterVisible` are the browse answer. `filterVisible` returns
+ * the SAME ARRAY REFERENCE when nothing is dropped, so it is safe in a
+ * `useMemo`/`useEffect` dependency.
+ */
+export function useRequirementVisibility(creatorFk) {
+    const hideOrchestrated = useShowClosedStore(s => s.hidePipelinedRequirements);
+
+    // Read unconditionally — hooks are not conditional, and gating these on the
+    // toggle would mean the FIRST flip renders stale-empty for a round trip,
+    // showing rows the user just asked to hide. All three are cached lists.
+    const { data: stepRequirements } = useAllPipelineStepRequirements(creatorFk);
+    const { data: requirementFeatureRows } = useAllRequirements(creatorFk, {
+        fields: REQUIREMENT_FIELDS,
+    });
+    const { data: features } = useAllFeatures(creatorFk, {
+        fields: FEATURE_FIELDS,
+        // A CLOSED feature still seats its requirements under its epic — see
+        // `epicRequirementIds`. `closed: 0` (the hook default) would
+        // un-orchestrate everything under a finished feature.
+        closed: ALL_ROWS,
+    });
+
+    const pipelinedIds = useMemo(
+        () => pipelinedRequirementIds(stepRequirements),
+        [stepRequirements]);
+
+    const epicIds = useMemo(
+        () => epicRequirementIds(requirementFeatureRows, features),
+        [requirementFeatureRows, features]);
+
+    // The union, built here rather than by `orchestratedRequirementIds` so the
+    // two halves keep their own memo and a junction refetch does not re-walk the
+    // requirement/feature join (and vice versa). Same rule, same result — the
+    // harness asserts it against the pure function.
+    const orchestratedIds = useMemo(() => {
+        if (epicIds.size === 0) return pipelinedIds;
+        const ids = new Set(pipelinedIds);
+        for (const id of epicIds) ids.add(id);
+        return ids;
+    }, [pipelinedIds, epicIds]);
+
+    const isVisible = useCallback(
+        (row) => !hideOrchestrated || !orchestratedIds.has(Number(row?.id)),
+        [hideOrchestrated, orchestratedIds]);
+
+    const filterVisible = useCallback(
+        (rows) => excludeByIds(rows, orchestratedIds, hideOrchestrated),
+        [orchestratedIds, hideOrchestrated]);
+
+    // REFERENTIALLY STABLE. Callers pass the whole object to memoized predicate
+    // factories (`aggregatorRowVisible`); a fresh object literal each render
+    // would make every one of those recompute, mint a new array, and re-seed the
+    // local state a `useEffect` holds — a render loop, not merely waste.
+    return useMemo(
+        () => ({ hideOrchestrated, pipelinedIds, orchestratedIds, isVisible, filterVisible }),
+        [hideOrchestrated, pipelinedIds, orchestratedIds, isVisible, filterVisible]);
+}
+
+export default useRequirementVisibility;

--- a/src/stores/useShowClosedStore.js
+++ b/src/stores/useShowClosedStore.js
@@ -24,13 +24,24 @@ export const useShowClosedStore = create(
             sessionMachineFilter: DEFAULT_SESSION_MACHINES,
 
             // req #3180 — the requirements pages' pipeline filter (now Cards
-            // view too, req #3258). ON hides every requirement a pipeline STEP
-            // carries, leaving the residue: work nobody has scheduled. Note
-            // which question it answers — STEP association (a
-            // `pipeline_step_requirements` row, "is this scheduled"), NOT epic
-            // association ("does this belong to a body of work"), which a
-            // requirement can carry while sitting in no plan at all. Exposing
-            // that gap is the point of the ON state.
+            // view too, req #3258). ON hides every ORCHESTRATED requirement,
+            // leaving the residue: work that is part of no plan at all.
+            //
+            // req #3419 WIDENED WHAT THAT MEANS, and reversed this comment.
+            // It used to answer STEP association only (a
+            // `pipeline_step_requirements` row, "is this scheduled") and NOT
+            // epic association ("does this belong to a body of work"), and it
+            // said exposing the gap between them was the point of the ON state.
+            // Measured on production, that gap is what the reader reports as a
+            // bug — asked to hide orchestrated work, the page kept showing
+            // requirements plainly seated under an epic. Filed twice. ON now
+            // means STEP **or** EPIC.
+            //
+            // THE KEY NAME IS HISTORY, NOT THE RULE. It keeps its req #3180
+            // spelling so no persistence migration is needed; the rule itself
+            // lives in `hooks/useRequirementVisibility.js`, which is the ONLY
+            // thing that should read this key besides the control in
+            // `SwarmView.jsx`. Do not re-derive it from here.
             //
             // A CONTROL, not an automatic exclusion, because on a BROWSE page
             // both populations are legitimate to look at and only the user knows

--- a/src/utils/__tests__/pipelineMembership.test.js
+++ b/src/utils/__tests__/pipelineMembership.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pipelinedRequirementIds, excludePipelined } from '../pipelineMembership';
+import { pipelinedRequirementIds, epicRequirementIds, orchestratedRequirementIds, excludeByIds } from '../pipelineMembership';
 
 // req #3180. This module is the browser's ONE answer to "does a pipeline step
 // carry this requirement" — both the SwarmStartCard aggregator and the
@@ -55,38 +55,138 @@ describe('pipelinedRequirementIds', () => {
     });
 });
 
-describe('excludePipelined', () => {
+describe('excludeByIds', () => {
     const rows = [{ id: 3074 }, { id: 3180 }, { id: 3172 }];
 
     it('drops exactly the requirements a step carries', () => {
-        const kept = excludePipelined(rows, new Set([3074, 3172]));
+        const kept = excludeByIds(rows, new Set([3074, 3172]));
         expect(kept.map(r => r.id)).toEqual([3180]);
     });
 
     it('returns the input unchanged when disabled', () => {
         // Same reference, so an opted-out caller cannot trip a referential
         // -equality dependency into re-running.
-        expect(excludePipelined(rows, new Set([3074]), false)).toBe(rows);
+        expect(excludeByIds(rows, new Set([3074]), false)).toBe(rows);
     });
 
     it('returns the input unchanged when nothing is pipelined', () => {
-        expect(excludePipelined(rows, new Set())).toBe(rows);
-        expect(excludePipelined(rows, undefined)).toBe(rows);
+        expect(excludeByIds(rows, new Set())).toBe(rows);
+        expect(excludeByIds(rows, undefined)).toBe(rows);
     });
 
     it('shows MORE, never less, while the junction read is in flight', () => {
         // The deliberate failure direction: an unresolved (or failed) membership
         // read must not blank a launch surface, and must never hide eligible
         // work behind a fetch error.
-        expect(excludePipelined(rows, pipelinedRequirementIds(undefined))).toBe(rows);
+        expect(excludeByIds(rows, pipelinedRequirementIds(undefined))).toBe(rows);
     });
 
     it('matches a numeric set against string row ids', () => {
-        const kept = excludePipelined([{ id: '3074' }, { id: '3180' }], new Set([3074]));
+        const kept = excludeByIds([{ id: '3074' }, { id: '3180' }], new Set([3074]));
         expect(kept.map(r => r.id)).toEqual(['3180']);
     });
 
     it('passes a non-array through untouched', () => {
-        expect(excludePipelined(undefined, new Set([3074]))).toBe(undefined);
+        expect(excludeByIds(undefined, new Set([3074]))).toBe(undefined);
+    });
+});
+
+// ── req #3419 — EPIC association, and the union the browse toggle asks ────────
+//
+// The measured defect: with the toggle ON, category 1 kept showing 4
+// requirements that are plainly part of a plan — #3304 and #3314 (feature 35 ->
+// epic 4), #3385 (feature 31 -> epic 7), #3433 (feature 41 -> epic 9) — because
+// no pipeline STEP carried them yet. These pin the wider question.
+
+describe('epicRequirementIds (req #3419)', () => {
+    const FEATURES = [
+        { id: 35, epic_fk: 4 },
+        { id: 31, epic_fk: 7 },
+        { id: 41, epic_fk: 9 },
+        { id: 99, epic_fk: null },   // a feature that names no epic
+    ];
+
+    it('collects requirements whose feature names an epic', () => {
+        const ids = epicRequirementIds([
+            { id: 3304, feature_fk: 35 },
+            { id: 3385, feature_fk: 31 },
+            { id: 3433, feature_fk: 41 },
+        ], FEATURES);
+        expect(ids).toEqual(new Set([3304, 3385, 3433]));
+    });
+
+    it('does NOT count a requirement whose feature names no epic', () => {
+        // "Filed under a feature" is not "part of a body of work". A feature
+        // with a null epic_fk is categorization, not a plan.
+        const ids = epicRequirementIds([{ id: 3400, feature_fk: 99 }], FEATURES);
+        expect(ids.size).toBe(0);
+    });
+
+    it('does NOT count a requirement with no feature at all', () => {
+        const ids = epicRequirementIds([
+            { id: 3418, feature_fk: null },
+            { id: 3420 },
+        ], FEATURES);
+        expect(ids.size).toBe(0);
+    });
+
+    it('ignores a feature_fk that resolves to nothing', () => {
+        // A dangling fk must not be read as epic membership — the feature read
+        // may simply not have landed, and guessing "orchestrated" would hide
+        // work behind a fetch gap. Fail toward showing more.
+        const ids = epicRequirementIds([{ id: 3304, feature_fk: 35 }], []);
+        expect(ids.size).toBe(0);
+    });
+
+    it('normalizes string ids the way the step answer does', () => {
+        const ids = epicRequirementIds([{ id: '3304', feature_fk: '35' }], FEATURES);
+        expect(ids.has(3304)).toBe(true);
+    });
+
+    it('never counts the template row', () => {
+        // CategoryCard's add-row carries id '' and no feature; Number('') is 0,
+        // which must not become a member of anything.
+        const ids = epicRequirementIds([{ id: '', feature_fk: 35 }], FEATURES);
+        expect(ids.size).toBe(0);
+    });
+
+    it('returns an empty set while either read is in flight', () => {
+        expect(epicRequirementIds(undefined, FEATURES).size).toBe(0);
+        expect(epicRequirementIds([{ id: 3304, feature_fk: 35 }], undefined).size).toBe(0);
+    });
+});
+
+describe('orchestratedRequirementIds (req #3419)', () => {
+    const FEATURES = [{ id: 35, epic_fk: 4 }];
+    const JUNCTION = [{ step_fk: 1, requirement_fk: 3419 }];
+    const REQS = [
+        { id: 3419, feature_fk: 46 },   // step-carried, feature unknown here
+        { id: 3304, feature_fk: 35 },   // epic-seated, no step
+        { id: 3418, feature_fk: null }, // neither
+    ];
+
+    it('is the UNION of step association and epic association', () => {
+        const ids = orchestratedRequirementIds(JUNCTION, REQS, FEATURES);
+        expect(ids).toEqual(new Set([3419, 3304]));
+    });
+
+    it('leaves unplanned work alone — that residue is the point of the toggle', () => {
+        const ids = orchestratedRequirementIds(JUNCTION, REQS, FEATURES);
+        expect(ids.has(3418)).toBe(false);
+    });
+
+    it('is a strict superset of the step answer', () => {
+        // Launch eligibility (req #3180) reads the STEP set and must stay
+        // narrow; the browse toggle reads this one. Widening the first would
+        // withhold launchable work.
+        const step = pipelinedRequirementIds(JUNCTION);
+        const all = orchestratedRequirementIds(JUNCTION, REQS, FEATURES);
+        for (const id of step) expect(all.has(id)).toBe(true);
+        expect(all.size).toBeGreaterThan(step.size);
+    });
+
+    it('degrades to the step answer when the epic reads have not landed', () => {
+        const ids = orchestratedRequirementIds(JUNCTION, undefined, undefined);
+        expect(ids).toEqual(new Set([3419]));
     });
 });

--- a/src/utils/pipelineMembership.js
+++ b/src/utils/pipelineMembership.js
@@ -1,30 +1,73 @@
-// Pipeline membership — req #3180.
+// Requirement ORCHESTRATION membership — req #3180, widened by req #3419.
 //
-// THE browser's one answer to "does a pipeline step carry this requirement".
-// Both consumers (the SwarmStartCard aggregator and the requirements page
-// filter) read it from here; computing it a second way is how the two surfaces
-// start disagreeing, which is the same defect class this requirement removes at
-// the data layer.
+// THE browser's one answer to "is this requirement part of a plan". Two
+// different questions live here and they must not be collapsed:
 //
-// WHICH QUESTION THIS ANSWERS: STEP association — a direct
-// `pipeline_step_requirements` junction row, i.e. "is this scheduled". It is NOT
-// epic association (requirement -> feature -> epic), which answers "does this
-// belong to a body of work" and is true of plenty of requirements no step will
-// ever run. Those two populations differ, and the gap between them — work
-// correctly filed under an epic that no step will run — is exactly what the
-// requirements-page filter exists to expose. Every label built on this says
-// "pipeline step" so it cannot be read as answering the other question.
+//   STEP association (`pipelinedRequirementIds`)
+//     A `pipeline_step_requirements` junction row exists — "is this SCHEDULED".
+//     This is LAUNCH ELIGIBILITY (req #3180): a step-carried requirement is not
+//     eligible for a direct swarm-start, because its launch is the coordinator's
+//     to make at the point the plan says so. It is therefore applied
+//     UNCONDITIONALLY on the surfaces that OFFER a launch, never as a
+//     preference, and it must stay NARROW. The daemon derives the same fact
+//     server-side as `requirement.pipelined`
+//     (darwin-mcp/services/requirements.py); the two cannot share code — the
+//     browser reaches Lambda-Rest, the daemon reaches it from a localhost
+//     process — so they are deliberate duplicates of one rule, exactly like
+//     pipelineModel.js and pipeline_derive.py.
 //
-// The daemon derives the same fact server-side as `requirement.pipelined`
-// (darwin-mcp/services/requirements.py). The two cannot share code — the browser
-// reaches Lambda-Rest, the daemon reaches it from a localhost process — so they
-// are deliberate duplicates of one rule, exactly like pipelineModel.js and
-// pipeline_derive.py.
+//   EPIC association (`epicRequirementIds`)
+//     `requirements.feature_fk` -> `features.epic_fk` — "does this belong to a
+//     BODY OF WORK". True of plenty of requirements no step carries yet.
+//
+//   ORCHESTRATED (`orchestratedRequirementIds`) — the UNION, and THE answer the
+//     user-facing browse toggle asks for.
+//
+// req #3419 — WHY THE UNION EXISTS. req #3180 pointed the browse toggle at STEP
+// association alone and wrote that the gap between the two populations "is
+// exactly what the filter exists to expose". Measured against production on
+// 2026-08-09, that gap is what the control's reader sees as a bug: category 1
+// under the default status chips holds 27 requirements, 9 survive the toggle,
+// and 4 of those 9 are filed under an epic (#3304 and #3314 -> feature 35 ->
+// epic 4, #3385 -> feature 31 -> epic 7, #3433 -> feature 41 -> epic 9). Asked
+// to hide orchestrated work, the page kept showing work that is plainly part of
+// a plan. That was filed twice (req #3419 is the second), so the control now
+// answers the question its label makes.
+//
+// The two answers stay SEPARATE functions rather than one widened set, because
+// they are asked by different rules and only one of them is unconditional:
+// LEGALITY reads the step set (`aggregatorRowVisible`'s `offersLaunch` branch),
+// VISIBILITY reads the union.
+//
+// WHAT THE BROWSE TOGGLE COSTS ON THE LAUNCH CHIPS, measured 2026-08-09 against
+// production with the toggle at its shipped default (ON, req #3242):
+//
+//     approved     2 offered -> 0   (#3172, #3176)
+//     authoring   42 offered -> 33  (#3178 #3304 #3314 #3315 #3385 #3424 #3425 #3426 #3433)
+//     swarm_ready  UNAFFECTED — no swarm_ready requirement was epic-seated
+//
+// swarm_ready being untouched is the load-bearing part of that table: it is the
+// chip the launch workflow actually runs on, so the practical cost is the
+// two-row `approved` chip going empty.
+//
+// Every id there is LEGAL to launch — no step carries it. So the approved chip
+// is empty in the default configuration, and that is a real consequence, not an
+// oversight. It is kept because the two rules answer opposite questions:
+// req #3180's is "offering a launch the coordinator owns is a DEFECT", which is
+// about showing something the reader must NOT act on; the toggle's is "I do not
+// want plan work on screen", which is a PREFERENCE, and a filter reducing what
+// you can act on is what a filter does. The reader reverses it with one click,
+// and the aggregator sits inside the same Cards view the requirement asked to
+// clean up — exempting it would put the hidden rows straight back on screen a
+// card away. If that trade turns out wrong, the change is one condition in
+// `aggregatorRowVisible`, not here.
 
 /**
+ * Requirement ids at least one pipeline STEP carries.
+ *
  * @param {Array<{requirement_fk: number}>} stepRequirements  rows from
  *        `useAllPipelineStepRequirements` (the junction, whole-table read).
- * @returns {Set<number>} requirement ids at least one pipeline step carries.
+ * @returns {Set<number>}
  */
 export const pipelinedRequirementIds = (stepRequirements) => {
     const ids = new Set();
@@ -40,24 +83,106 @@ export const pipelinedRequirementIds = (stepRequirements) => {
 };
 
 /**
- * Drop every requirement a pipeline step carries.
+ * Requirement ids whose `feature_fk` resolves to a feature that names an EPIC.
+ *
+ * A feature with a NULL `epic_fk` is NOT epic association — the requirement is
+ * filed, but under nothing a plan is organized around. Requiring the epic is
+ * what makes this answerable as "part of a body of work" rather than merely
+ * "categorized".
+ *
+ * CLOSED features count. `features.closed` says the feature is finished, not
+ * that its requirements left the epic, and a caller that reads only open
+ * features would silently un-orchestrate everything under a completed feature.
+ * The hook therefore reads features with `closed: ALL_ROWS`.
+ *
+ * @param {Array<{id: number|string, feature_fk: number|null}>} requirements
+ *        rows carrying `feature_fk` — a WHOLE-TABLE projection, never the
+ *        per-surface list. See `useRequirementVisibility` for why.
+ * @param {Array<{id: number, epic_fk: number|null}>} features
+ * @returns {Set<number>}
+ */
+export const epicRequirementIds = (requirements, features) => {
+    const ids = new Set();
+    if (!Array.isArray(requirements) || !Array.isArray(features)) return ids;
+
+    const featureHasEpic = new Set();
+    for (const f of features) {
+        if (!f || f.id === null || f.id === undefined) continue;
+        if (f.epic_fk === null || f.epic_fk === undefined) continue;
+        featureHasEpic.add(Number(f.id));
+    }
+    if (featureHasEpic.size === 0) return ids;
+
+    for (const r of requirements) {
+        if (!r || r.id === null || r.id === undefined || r.id === '') continue;
+        if (r.feature_fk === null || r.feature_fk === undefined) continue;
+        if (!featureHasEpic.has(Number(r.feature_fk))) continue;
+        ids.add(Number(r.id));
+    }
+    return ids;
+};
+
+/**
+ * THE browse answer: a requirement is ORCHESTRATED when a pipeline step carries
+ * it OR it is filed under an epic.
+ *
+ * @param {Array} stepRequirements  the junction rows
+ * @param {Array} requirements      whole-table `id,feature_fk` projection
+ * @param {Array} features          whole-table `id,epic_fk` projection
+ * @returns {Set<number>}
+ */
+export const orchestratedRequirementIds = (stepRequirements, requirements, features) => {
+    const ids = pipelinedRequirementIds(stepRequirements);
+    for (const id of epicRequirementIds(requirements, features)) ids.add(id);
+    return ids;
+};
+
+/**
+ * Drop every row whose id is in `ids`. The ONE filter primitive — both facts
+ * above are applied through it, so "which rows survive" has a single reading.
  *
  * `enabled === false` returns the input array UNCHANGED (same reference), so a
- * caller that has not opted in — or whose junction read has not resolved — pays
- * nothing and cannot trip a referential-equality dependency.
+ * caller that has not opted in — or whose reads have not resolved — pays nothing
+ * and cannot trip a referential-equality dependency.
  *
- * WHILE THE JUNCTION READ IS IN FLIGHT the set is empty, so nothing is dropped
- * and the surface shows MORE than it eventually will. That direction is the
- * deliberate one: the alternative (treat unknown as pipelined) would blank a
- * launch surface on every page load and, worse, would hide eligible work behind
- * a fetch failure.
+ * WHILE THE READS ARE IN FLIGHT the set is empty, so nothing is dropped and the
+ * surface shows MORE than it eventually will. That direction is the deliberate
+ * one: the alternative (treat unknown as orchestrated) would blank a launch
+ * surface on every page load and, worse, would hide eligible work behind a fetch
+ * failure.
  *
- * @param {Array<{id: number}>} requirements
- * @param {Set<number>} pipelinedIds  from `pipelinedRequirementIds`
+ * @param {Array<{id: number}>} rows
+ * @param {Set<number>} ids
  * @param {boolean} [enabled=true]
  */
-export const excludePipelined = (requirements, pipelinedIds, enabled = true) => {
-    if (!enabled || !Array.isArray(requirements)) return requirements;
-    if (!pipelinedIds || pipelinedIds.size === 0) return requirements;
-    return requirements.filter(r => !pipelinedIds.has(Number(r?.id)));
+export const excludeByIds = (rows, ids, enabled = true) => {
+    if (!enabled || !Array.isArray(rows)) return rows;
+    if (!ids || ids.size === 0) return rows;
+    return filterKeepingIdentity(rows, r => !ids.has(Number(r?.id)));
+};
+
+/**
+ * `Array.prototype.filter` that returns the INPUT ARRAY when it drops nothing.
+ *
+ * THIS IS LOAD-BEARING, not a micro-optimization. Every consumer of these
+ * predicates feeds the result into a `useMemo`/`useEffect` dependency, and
+ * several of those effects call `setState` with a new array. A bare `.filter`
+ * mints a fresh identity on every render, so the effect re-runs, sets state,
+ * re-renders, and filters again — a SYNCHRONOUS render loop that pins the event
+ * loop, which means it does not merely fail a test, it wedges the process (no
+ * per-test timeout can interrupt it).
+ *
+ * `excludeByIds` had this property from req #3180 via its `ids.size === 0` fast
+ * path, which absorbed identity churn coming from ABOVE it. Req #3419's first
+ * cut replaced two of its call sites with a raw `.filter` and reintroduced the
+ * loop; this is the primitive that puts it back, in one place, for predicates
+ * that are not id-set membership.
+ *
+ * @param {Array} rows
+ * @param {(row: any) => boolean} predicate
+ */
+export const filterKeepingIdentity = (rows, predicate) => {
+    if (!Array.isArray(rows)) return rows;
+    const kept = rows.filter(predicate);
+    return kept.length === rows.length ? rows : kept;
 };


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-10T07:59:29Z
- wip(Darwin): 2026-08-10T07:53:37Z
- chore: init swarm session feature/3419-included-in-epic-filter-still-1

## Files changed
```
 src/SwarmView/CategoryCard.jsx                     |  63 +--
 src/SwarmView/RequirementRow.jsx                   |  52 ++-
 src/SwarmView/RequirementsTableView.jsx            |  25 +-
 src/SwarmView/SwarmView.jsx                        |  30 +-
 .../__tests__/CategoryCard.epicFilter.test.jsx     |  17 +-
 .../CategoryCard.pipelinedFilter.test.jsx          | 157 ++++---
 .../CategoryCard.statusTimestamps.test.jsx         |  29 +-
 .../__tests__/CategoryCard.templatefocus.test.jsx  |  29 +-
 .../__tests__/orchestratedMarkStyles.test.js       | 105 +++++
 src/SwarmView/detail/RequirementDetail.jsx         |  23 +-
 .../detail/__tests__/elevatorMatchesCard.test.js   |  75 ++-
 src/SwarmView/detail/requirementSort.js            |  28 +-
 src/SwarmView/orchestratedMarkStyles.js            |  87 ++++
 src/TaskPlanView/SwarmStartCard.jsx                |  90 ++--
 .../__tests__/SwarmStartCard.epicFilter.test.jsx   |  15 +-
 .../__tests__/SwarmStartCard.noMessages.test.jsx   |  25 +-
 .../__tests__/SwarmStartCard.sortMenu.test.jsx     |  20 +-
 .../SwarmStartCard.statusTimestamps.test.jsx       |  20 +-
 .../__tests__/swarmStartCardUtils.test.js          | 124 ++++-
 src/TaskPlanView/swarmStartCardUtils.js            |  66 ++-
 .../requirementVisibility.harness.test.jsx         | 517 +++++++++++++++++++++
 src/hooks/useDataQueries.js                        |  26 +-
 src/hooks/useRequirementVisibility.js              | 161 +++++++
 src/stores/useShowClosedStore.js                   |  25 +-
 src/utils/__tests__/pipelineMembership.test.js     | 118 ++++-
 src/utils/pipelineMembership.js                    | 208 +++++++--
 26 files changed, 1828 insertions(+), 307 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)