### PR TITLE
Epic name click -> Taskcards

### DIFF
--- a/src/SwarmView/CategoryCard.jsx
+++ b/src/SwarmView/CategoryCard.jsx
@@ -14,6 +14,7 @@ import { useSwarmTabStore } from '../stores/useSwarmTabStore';
 import { useShowClosedStore } from '../stores/useShowClosedStore';
 import { RequirementActionsContext } from '../hooks/useRequirementActions';
 import { requirementStatusTimestampFields, requirementStatusTimestampState } from '../utils/requirementStatusTimestamps';
+import { filterToEpic, effectiveHidePipelined } from '../utils/epicMembership';
 
 import AuthContext from '../Context/AuthContext'
 import AppContext from '../Context/AppContext';
@@ -39,7 +40,7 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import { CircularProgress } from '@mui/material';
 
-const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categoryKeyDown, categoryOnBlur, clickCardClosed, clickCardDelete, moveCard, persistCategoryOrder, removeCategory, isTemplate, showClosed }) => {
+const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categoryKeyDown, categoryOnBlur, clickCardClosed, clickCardDelete, moveCard, persistCategoryOrder, removeCategory, isTemplate, showClosed, epicReqIds = null }) => {
 
     const revertDragTabSwitch = useSwarmTabStore(s => s.revertDragTabSwitch);
 
@@ -62,7 +63,15 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
     // but editing/hand-sorting an orchestrated requirement here doesn't make
     // sense (its position is the plan's, not this card's), so hiding it is the
     // fix for both the clutter and the broken edit affordance at once.
-    const hidePipelined = useShowClosedStore(s => s.hidePipelinedRequirements);
+    const storedHidePipelined = useShowClosedStore(s => s.hidePipelinedRequirements);
+    // req #3428 — an epic filter FORCES the pipeline toggle off, through the one
+    // shared predicate `SwarmView` states the rule with. `hidePipelinedRequirements`
+    // defaults to ON (req #3242) while an epic's requirements are seated in
+    // pipeline steps by construction, so without this the epic page would arrive
+    // empty. The store is never written: dismissing the pill restores exactly the
+    // toggle state the reader had.
+    const epicFilterActive = epicReqIds != null;
+    const hidePipelined = effectiveHidePipelined(storedHidePipelined, epicFilterActive);
 
     const showError = useSnackBarStore(s => s.showError);
 
@@ -238,12 +247,23 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
                 );
             }
 
+            // req #3428 — the epic filter, applied exactly where the status chips
+            // and the pipeline toggle are. A no-op (same array reference) when
+            // `epicReqIds` is null, same as the two above when they are off.
+            sortedRequirementsArray = filterToEpic(sortedRequirementsArray, epicReqIds);
+
             sortedRequirementsArray.sort((a, b) => activeSort(a, b));
-            setRequirementsArray(prev => [...sortedRequirementsArray, buildTemplate(prev)]);
+            // THE ADD-A-REQUIREMENT ROW IS SUPPRESSED WHILE FILTERED. A row saved
+            // there carries no `feature_fk`, so it belongs to no epic and would
+            // vanish from this card the instant it saved — a control whose result
+            // the reader cannot see. It comes back with the filter's dismissal.
+            setRequirementsArray(prev => epicFilterActive
+                ? sortedRequirementsArray
+                : [...sortedRequirementsArray, buildTemplate(prev)]);
         } else if (serverRequirements && serverRequirements.length === 0) {
-            setRequirementsArray(prev => [buildTemplate(prev)]);
+            setRequirementsArray(prev => epicFilterActive ? [] : [buildTemplate(prev)]);
         }
-    }, [serverRequirements, requirementStatusFilter, hidePipelined, pipelinedIds]);
+    }, [serverRequirements, requirementStatusFilter, hidePipelined, pipelinedIds, epicReqIds, epicFilterActive]);
 
     // Build session status map from query data
     useEffect(() => {
@@ -492,7 +512,13 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
     const [{ isDragging }, drag] = useDrag(() => ({
         type: "categoryCard",
         item: () => ({ areaId: category.id, areaIndex: categoryIndex, domainId: projectId, areaData: { ...category } }),
-        canDrag: () => !isTemplate,
+        // req #3428 — NO REORDERING UNDER A FILTER. `moveCard` and
+        // `persistCategoryOrder` index into the FULL `categoriesArray` and write
+        // `sort_order` from those indices, while the reader is looking at a
+        // subset of the cards — so a drag here writes positions computed against
+        // neighbours they cannot see. Same reasoning req #3258 gave for hiding
+        // orchestrated rows: the ordering is not this view's to set right now.
+        canDrag: () => !isTemplate && !epicFilterActive,
         collect: (monitor) => ({
             isDragging: monitor.isDragging(),
         }),
@@ -507,7 +533,7 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
                 revertDragTabSwitch();
             }
         },
-    }), [category, categoryIndex, projectId, isTemplate, persistCategoryOrder, removeCategory, revertDragTabSwitch]);
+    }), [category, categoryIndex, projectId, isTemplate, persistCategoryOrder, removeCategory, revertDragTabSwitch, epicFilterActive]);
 
     const cardRef = useRef(null);
     const mergedRef = useCallback((node) => {
@@ -721,6 +747,21 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
     // One implementation now, called by every path that orders this card.
     const activeSort = (a, b) => requirementActiveSort(sortMode, a, b);
 
+    // req #3428 — "only the categories that have requirements from the epic".
+    // The card that has none renders NOTHING, decided here because this component
+    // already owns that category's requirement list; asking the panel above would
+    // mean a per-category fan-out or a new aggregate read to learn something one
+    // card already knows.
+    //
+    // `undefined` (the read has not landed) counts as empty ON PURPOSE: showing
+    // the loading spinner would flash a full grid of cards that then collapses to
+    // two. The card appears when it has something to show.
+    //
+    // The "add new category" template card needs no rule of its own — it holds no
+    // requirements at all, so this removes it, which is the tell that the rule is
+    // the right one.
+    if (epicFilterActive && (!requirementsArray || requirementsArray.length === 0)) return null;
+
     return (
         <Card key={categoryIndex} raised={true} ref={mergedRef}
               data-testid={category.id === '' ? 'category-card-template' : `category-card-${category.id}`}
@@ -832,7 +873,8 @@ const CategoryCard = ({category, categoryIndex, projectId, categoryChange, categ
                 { (requirementsArray) ?
                     <RequirementActionsContext.Provider value={{ statusClick, coordinationClick,
                         titleChange, titleKeyDown, titleOnBlur, deleteClick, requirementsArray, setRequirementsArray,
-                        sessionStatusMap, sortMode, setCrossCardInsertIndex }}>
+                        sessionStatusMap, sortMode, setCrossCardInsertIndex,
+                        dragDisabled: epicFilterActive }}>
                         {requirementsArray.map((requirement, requirementIndex) => (
                             <RequirementRow {...{key: requirement.id, requirement, requirementIndex,
                                 categoryId: category.id, categoryName: category.category_name }}

--- a/src/SwarmView/CategoryTabPanel.jsx
+++ b/src/SwarmView/CategoryTabPanel.jsx
@@ -19,7 +19,12 @@ import AppContext from '../Context/AppContext';
 
 import Box from '@mui/material/Box';
 
-const CategoryTabPanel = ( { project, projectIndex, activeTab, showClosed, showSwarmStartCard } ) => {
+// req #3428 — `epicReqIds` is the epic filter's SCOPE, passed straight through
+// from the page to both card kinds. A Set of requirement ids, or `null` when no
+// filter is active. This panel neither reads the URL nor derives membership: the
+// host owns the filter, and one derivation upstairs is what stops the aggregator
+// and the category cards from disagreeing about what the epic contains.
+const CategoryTabPanel = ( { project, projectIndex, activeTab, showClosed, showSwarmStartCard, epicReqIds = null } ) => {
 
     const clearDragTabSwitch = useSwarmTabStore(s => s.clearDragTabSwitch);
 
@@ -396,7 +401,7 @@ const CategoryTabPanel = ( { project, projectIndex, activeTab, showClosed, showS
             >
                 { categoriesArray &&
                     <Box className="card swarm-card" ref={panelDrop}>
-                        {showSwarmStartCard && <SwarmStartCard />}
+                        {showSwarmStartCard && <SwarmStartCard epicReqIds={epicReqIds} />}
                         { categoriesArray.map((category, categoryIndex) => (
                             <CategoryCard {...{key: category.id,
                                            category,
@@ -411,7 +416,8 @@ const CategoryTabPanel = ( { project, projectIndex, activeTab, showClosed, showS
                                            persistCategoryOrder: persistCategoryOrder,
                                            removeCategory,
                                            isTemplate: category.id === '',
-                                           showClosed,}}/>
+                                           showClosed,
+                                           epicReqIds,}}/>
                         ))}
                     </Box>
                 }

--- a/src/SwarmView/RequirementRow.jsx
+++ b/src/SwarmView/RequirementRow.jsx
@@ -46,6 +46,13 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
         titleOnBlur, deleteClick, sessionStatusMap,
         categoryColorMap, sortMode, setCrossCardInsertIndex,
         requirementsArray, setRequirementsArray,
+        // req #3428 — the host card says whether a row may be dragged at all.
+        // Under an epic filter the reader sees a SUBSET of the rows, and both
+        // drop paths (`addRequirementToCategory`'s same-card splice and its
+        // cross-card insert) rebuild `sort_order` from positions in that subset,
+        // i.e. against neighbours the reader cannot see. Defaults false, so every
+        // existing host behaves exactly as before.
+        dragDisabled = false,
         strikethroughMet = true } = useRequirementActions();
 
     // Model + Effort column preferences (req #3029). The columns always render in
@@ -98,7 +105,7 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
                 sourceHeight: rect?.height || 40,
             };
         },
-        canDrag: () => !isTemplate,
+        canDrag: () => !isTemplate && !dragDisabled,
         end: (item, monitor) => {
             // Always release the cross-card insert index — same-card splice
             // already cleared it in addRequirementToCategory; this covers the
@@ -127,8 +134,9 @@ const RequirementRow = ({ requirement, requirementIndex, categoryId, categoryNam
         // Volatile requirement fields + requirementIndex are intentionally NOT
         // deps — the `item` factory reads them live from refs at drag-start, so
         // the spec/connector only needs to be rebuilt when behaviour-affecting
-        // inputs change (canDrag → isTemplate; end → sortMode + the setters).
-    }), [isTemplate, sortMode, setCrossCardInsertIndex, setRequirementsArray]);
+        // inputs change (canDrag → isTemplate + dragDisabled; end → sortMode +
+        // the setters).
+    }), [isTemplate, dragDisabled, sortMode, setCrossCardInsertIndex, setRequirementsArray]);
 
     // Hover-only drop target — sets the insert indicator above/below this row
     // and writes the splice target into the parent CategoryCard via

--- a/src/SwarmView/SwarmView.jsx
+++ b/src/SwarmView/SwarmView.jsx
@@ -9,8 +9,9 @@ import { useShowClosedStore, ALL_REQUIREMENT_STATUSES } from '../stores/useShowC
 import { useSwarmStartCardStore } from '../stores/useSwarmStartCardStore';
 import { useModelEffortDisplayStore } from '../stores/useModelEffortDisplayStore';
 import { useRequirementDrillStore } from '../stores/useRequirementDrillStore';
-import { useProjects } from '../hooks/useDataQueries';
+import { useProjects, useAllEpics, useAllCategories, useEpicRequirementIds } from '../hooks/useDataQueries';
 import { projectKeys } from '../hooks/useQueryKeys';
+import { firstProjectIndexWithEpicWork } from '../utils/epicMembership';
 
 import ProjectCloseDialog from './ProjectCloseDialog';
 import ProjectAddDialog from './ProjectAddDialog';
@@ -21,7 +22,8 @@ import SwarmVisualizerView from './SwarmVisualizerView';
 import RequirementsTrendsView from './RequirementsTrendsView';
 import VisualizerToolbar from './VisualizerToolbar';
 
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 
@@ -45,8 +47,9 @@ import RequirementJumpInput from '../NavBar/RequirementJumpInput';
 import FolderIcon from '@mui/icons-material/Folder';
 import CategoryIcon from '@mui/icons-material/Category';
 import { requirementStatusChipProps, requirementStatusLabel } from './statusChipStyles';
+import Chip from '@mui/material/Chip';
 import ChipFilter from '../Components/ChipFilter';
-import { SWARM_VIEWS } from './swarmViewLink';
+import { SWARM_VIEWS, readEpicParam, withoutEpicParam } from './swarmViewLink';
 import { useSwarmViewSelection } from './useSwarmViewSelection';
 
 // req #2992 — fixed vocabulary, so options are module-level. Colors come from
@@ -117,6 +120,84 @@ const SwarmView = () => {
     // chips are replaced by the drill pill (the chips don't apply while drilled).
     const drill = useRequirementDrillStore(s => s.drill);
     const showClosed = false;
+
+    // ── `?epic=` — the plan visualizer's epic chip lands here (req #3428) ────
+    // A URL param, not a store: the LINK IS THE FILTER, so it is deep-linkable,
+    // survives a reload, and dismissing the pill clears it without touching a
+    // single saved preference. That is the doctrine `FeaturesPage.jsx` already
+    // states for the sibling target of the same chip, and the reason this is not
+    // shaped like `useRequirementDrillStore` — a drill is computed INSIDE its
+    // page and never crosses a route; this arrives from a different one.
+    const navigate = useNavigate();
+    const [searchParams, setSearchParams] = useSearchParams();
+    const epicId = readEpicParam(searchParams);
+    const epicFilterActive = epicId !== null;
+    // THE FILTER IS THE CARDS VIEW'S — one expression, so the pill, the two
+    // suppressed controls and the row predicate can only ever turn on together.
+    // In the other panels the parameter sleeps: it is still in the address bar,
+    // nothing is filtered, and nothing claims to be.
+    const epicFilterApplies = epicFilterActive && view === 'cards';
+    // ONE derivation of "which requirements does this epic contain", shared with
+    // every card and the aggregator — see the hook for why it is an id Set and
+    // not a wider projection.
+    //
+    // KEYED ON `epicFilterApplies`, NOT `epicFilterActive`: with `?epic=` in the
+    // address bar and the reader on Table/Visualizer/Trends the filter is asleep,
+    // and three reads whose results nothing consumes are pure cost.
+    const scopedEpicId = epicFilterApplies ? epicId : null;
+    const { epicReqIds, isError: epicScopeError, requirements: epicScopeRequirements } =
+        useEpicRequirementIds(profile?.userName, scopedEpicId);
+    const { data: epicRows = [] } = useAllEpics(profile?.userName, { enabled: epicFilterApplies });
+    const { data: allCategories = [] } = useAllCategories(profile?.userName, {
+        fields: 'id,project_fk', closed: 0, enabled: epicFilterApplies,
+    });
+    const epicTitle = epicFilterActive
+        ? (epicRows.find(e => Number(e.id) === epicId)?.title ?? String(epicId))
+        : null;
+    // A FAILED MEMBERSHIP READ SHOWS EVERYTHING AND SAYS SO. `epicReqIds` is null
+    // on error, so nothing is filtered; the pill goes red and names the state
+    // instead of the epic. The alternative — an empty Set — renders every card
+    // gone and every badge zero, which reads as "this epic has no work" and never
+    // corrects itself. Filtering is a claim, and a claim that cannot be checked
+    // must not be made silently.
+    const epicFilterFailed = epicFilterApplies && epicScopeError;
+    // IS A SCOPE ACTUALLY IN FORCE? Everything the filter OVERRIDES hangs off
+    // this rather than off `epicFilterApplies`, so a failed read restores the two
+    // suppressed controls and the aggregator's own preference along with the
+    // rows — the same rule from the other side: a control is off screen only
+    // while something else is deciding for it.
+    const epicFilterEngaged = epicFilterApplies && epicReqIds != null;
+    const clearEpicFilter = () => setSearchParams(withoutEpicParam(searchParams), { replace: true });
+
+    // WHERE THE EPIC'S WORK ACTUALLY LIVES, so the link does not land on an
+    // empty tab. An epic's requirements sit in categories and categories sit in
+    // projects, so a bare landing opens whichever project this reader last
+    // worked in — routinely one with none of that epic in it, i.e. the feature
+    // invisible on arrival.
+    //
+    // SEEDED ONCE PER `epicId`, the same re-seed discipline `useSwarmViewSelection`
+    // uses for `linkView`: a manual tab click wins from that moment on, and
+    // clearing the filter re-arms it for the next link.
+    //
+    // IT DOES NOT REDEFINE THE READER'S WORKING PROJECT — see the effect below,
+    // which stands down while the filter is engaged. Letting it through would
+    // have made following this link write `darwin_working_project` to
+    // localStorage for 90 days, so a reader who glanced at one epic would find
+    // bare `/swarm` opening on a different project ever after. That is the one
+    // thing this whole feature promises not to do.
+    const epicTabSeededFor = useRef(null);
+    useEffect(() => {
+        if (!epicFilterEngaged) { epicTabSeededFor.current = null; return; }
+        if (epicTabSeededFor.current === epicId) return;
+        const index = firstProjectIndexWithEpicWork(
+            projectsArray, allCategories, epicScopeRequirements, epicReqIds);
+        // null means either "not resolved yet" (try again next render) or
+        // "nowhere" — and leaving the reader on the tab they chose is the right
+        // answer to the second, so neither case seeds.
+        if (index === null) return;
+        epicTabSeededFor.current = epicId;
+        setActiveTab(index);
+    }, [epicFilterEngaged, epicId, projectsArray, allCategories, epicScopeRequirements, epicReqIds]);
 
     // TanStack Query — fetch projects (open only or with closed based on chip filter)
     const { data: serverProjects } = useProjects(profile?.userName, {
@@ -196,15 +277,24 @@ const SwarmView = () => {
         defaultInfo: ''
     });
 
-    // Persist working project whenever active tab changes
+    // Persist working project whenever active tab changes.
+    //
+    // req #3428 — NOT WHILE AN EPIC FILTER IS ENGAGED. `darwin_working_project`
+    // is persisted to localStorage with a 90-day life, and the tab under a filter
+    // is not a choice the reader made about where they work — it is either this
+    // page's own seed or a click inside a transient, dismissable view. Writing it
+    // would mean glancing at one epic silently re-homed bare `/swarm`, which is
+    // the same class of defect as the filter writing the view preference or the
+    // aggregator toggle, and this is where it would have leaked in.
     useEffect(() => {
+        if (epicFilterEngaged) return;
         if (projectsArray && projectsArray.length > 0) {
             const tabIndex = parseInt(activeTab);
             if (tabIndex >= 0 && tabIndex < projectsArray.length) {
                 setWorkingProject(projectsArray[tabIndex].id);
             }
         }
-    }, [activeTab, projectsArray]);
+    }, [activeTab, projectsArray, epicFilterEngaged]);
 
     const changeActiveTab = (event, newValue) => {
         if (newValue === 9999)
@@ -337,6 +427,40 @@ const SwarmView = () => {
                         )}
                         {view === 'visualizer' && <VisualizerToolbar />}
                         <Box sx={{ flexGrow: 1 }} />
+                        {/* req #3428 — the epic filter's dismissable pill, first
+                            item of the right-hand cluster because that is where
+                            this page's filters live. Deliberately NOT on the
+                            left: the project `<Tabs>` there carry
+                            `flexShrink: 1, minWidth: 0`, so a variable-width
+                            chip beside them steals width from the tabs.
+
+                            RENDERED EXACTLY WHEN IT IS APPLYING — `view ===
+                            'cards'` is the same condition the row filter turns
+                            on, because this filter is the CARDS view's. In the
+                            other three panels the parameter sleeps and re-applies
+                            on return; only the ✕ clears it. A control on screen
+                            that is not applying is the defect the `!drill`
+                            guards below already exist to avoid.
+
+                            The body opens the Epics editor and the ✕ clears the
+                            filter — `FeaturesPage.jsx`'s chip, which is the other
+                            end of the same epic chip's two links. MUI routes the
+                            delete icon's click to `onDelete` alone, so the two
+                            never fire together. */}
+                        {epicFilterApplies && (
+                            <Chip size="small"
+                                  color={epicFilterFailed ? 'error' : 'secondary'}
+                                  label={epicFilterFailed
+                                      ? `Epic filter unavailable — showing everything`
+                                      : `Epic: ${epicTitle}`}
+                                  onClick={() => navigate('/swarm/epics')}
+                                  title={epicFilterFailed
+                                      ? 'The epic membership read failed, so nothing is being filtered'
+                                      : 'Open the Epics editor'}
+                                  onDelete={clearEpicFilter}
+                                  sx={{ flexShrink: 0, cursor: 'pointer' }}
+                                  data-testid="swarm-epic-filter-chip" />
+                        )}
                         {(view === 'cards' || (view === 'table' && !drill)) && (
                             <ChipFilter
                                 options={requirementStatusOptions}
@@ -368,7 +492,13 @@ const SwarmView = () => {
                             `hidePipelined` used to light up blue to announce
                             the filter it applies; now the icon announces what
                             is CURRENTLY VISIBLE, not which control is active. */}
-                        {(view === 'cards' || (view === 'table' && !drill)) && (
+                        {/* req #3428 — `!epicFilterApplies` joins `!drill` for
+                            the reason stated three comments up: an epic filter
+                            forces this toggle OFF (`effectiveHidePipelined`), so
+                            leaving it on screen would show a control that is not
+                            applying — and, worse, an ON toggle whose stored value
+                            says the exact opposite of what the reader sees. */}
+                        {(view === 'cards' || (view === 'table' && !drill)) && !epicFilterEngaged && (
                             <Tooltip title={hidePipelined
                                 ? 'Hiding orchestrated requirements'
                                 : 'Showing orchestrated requirements'}>
@@ -387,7 +517,12 @@ const SwarmView = () => {
                                 </IconButton>
                             </Tooltip>
                         )}
-                        {view === 'cards' && (
+                        {/* Hidden under an epic filter for the same reason: the
+                            aggregator is forced visible there (the requirement's
+                            "you get the aggregator on"), so this toggle would
+                            flip a stored preference and change nothing on
+                            screen. */}
+                        {view === 'cards' && !epicFilterEngaged && (
                             <Tooltip title={showSwarmStartCard ? 'Hide Swarm-Start Card' : 'Show Swarm-Start Card'}>
                                 <IconButton
                                     size="small"
@@ -415,13 +550,29 @@ const SwarmView = () => {
                     )}
 
                     {/* Content — cards view */}
+                    {/* req #3428 — TWO derived overrides, neither of which
+                        writes a store.
+
+                        The aggregator is FORCED VISIBLE under an epic filter
+                        (the requirement's "you get the aggregator on") by OR-ing
+                        the host's own boolean, never by calling `toggle()`: an
+                        external condition must not overwrite uncommitted user
+                        intent, so dismissing the pill restores exactly the
+                        aggregator state the reader had.
+
+                        `epicReqIds` is the SCOPE, threaded down as a prop
+                        because the HOST owns the filter — an aggregator never
+                        invents one. `null` (not an empty Set) is what says "no
+                        filter": an empty Set means the filter is on and matches
+                        nothing, which is a different page. */}
                     {view === 'cards' && projectsArray.map( (project, projectIndex) =>
                         <CategoryTabPanel key={project.id}
                                           project = {project}
                                           projectIndex = {projectIndex}
                                           activeTab = {activeTab}
                                           showClosed = {showClosed}
-                                          showSwarmStartCard = {showSwarmStartCard}>
+                                          epicReqIds = {epicFilterEngaged ? epicReqIds : null}
+                                          showSwarmStartCard = {showSwarmStartCard || epicFilterEngaged}>
                         </CategoryTabPanel>
                     )}
 

--- a/src/SwarmView/__tests__/CategoryCard.epicFilter.test.jsx
+++ b/src/SwarmView/__tests__/CategoryCard.epicFilter.test.jsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+//
+// Req #3428 — the epic filter as the CategoryCard actually applies it.
+//
+// The pure rules are pinned in `utils/__tests__/epicMembership.test.js`; this
+// suite exists for the three things only a mounted card can show, and all three
+// are places where the feature silently fails rather than errors:
+//   1. the forced pipeline override — without it this page renders EMPTY, because
+//      `hidePipelinedRequirements` defaults to ON and an epic's requirements are
+//      seated in pipeline steps by construction;
+//   2. a card with none of the epic's work renders NOTHING, which is the
+//      requirement's "only those categories that have requirements from the epic";
+//   3. the add-a-requirement row stands down, because a row saved there would
+//      belong to no epic and vanish on save.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DndProvider } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// The first mounted `it()` in a file absorbs the cold module-compile cost of the
+// component tree (react-dnd + MUI + this page), which on a loaded machine is
+// measured at 5-8s against vitest's 5000ms default — red in CI about half the
+// time, for nothing. File-scoped rather than a global config change, so no other
+// suite's timeout moves.
+vi.setConfig({ testTimeout: 30000 });
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
+
+// 10 is in the epic, 11 is not — and BOTH are pipelined, which is the ordinary
+// state of an epic's work and the state that makes rule 1 above load-bearing.
+const reqData = [
+    { id: 10, title: 'In the epic', requirement_status: 'authoring', category_fk: 5, feature_fk: 46, sort_order: 0 },
+    { id: 11, title: 'Another epic', requirement_status: 'authoring', category_fk: 5, feature_fk: 50, sort_order: 1 },
+];
+const EMPTY_SESSIONS = [];
+let pipelinedIds = new Set([10, 11]);
+vi.mock('../../hooks/useDataQueries', () => ({
+    useRequirements: () => ({ data: reqData }),
+    useSessions: () => ({ data: EMPTY_SESSIONS }),
+    usePipelinedRequirementIds: () => pipelinedIds,
+}));
+
+vi.mock('../../RestApi/RestApi', () => ({ default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })) }));
+
+import CategoryCard from '../CategoryCard';
+import { useShowClosedStore } from '../../stores/useShowClosedStore';
+import AuthContext from '../../Context/AuthContext';
+import AppContext from '../../Context/AppContext';
+
+const CATEGORY = { id: 5, category_name: 'Test Cat', project_fk: 1, sort_mode: 'process', color: null };
+const noop = () => {};
+
+let roots = [];
+function mount(epicReqIds) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
+                            <CategoryCard
+                                category={CATEGORY}
+                                categoryIndex={0}
+                                projectId={1}
+                                categoryChange={noop}
+                                categoryKeyDown={noop}
+                                categoryOnBlur={noop}
+                                clickCardClosed={noop}
+                                clickCardDelete={noop}
+                                moveCard={noop}
+                                persistCategoryOrder={noop}
+                                removeCategory={noop}
+                                isTemplate={false}
+                                showClosed={false}
+                                epicReqIds={epicReqIds}
+                            />
+                        </DndProvider>
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    return { container };
+}
+
+const rowPresent = (container, id) => container.querySelector(`[data-testid="requirement-${id}"]`) !== null;
+const cardPresent = (container) => container.querySelector('[data-testid="category-card-5"]') !== null;
+
+describe('CategoryCard under an epic filter (req #3428)', () => {
+    beforeEach(() => {
+        pipelinedIds = new Set([10, 11]);
+        roots = [];
+        // THE SHIPPED DEFAULT (req #3242), stated explicitly because it is the
+        // whole point of the first test below.
+        useShowClosedStore.setState({ hidePipelinedRequirements: true });
+    });
+    afterEach(() => {
+        act(() => { roots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+        useShowClosedStore.setState({ hidePipelinedRequirements: false });
+    });
+
+    it('shows the epic\'s row even though it is pipelined and the toggle is ON', () => {
+        // The defect this closes: with `hidePipelined` left in charge, the page
+        // the epic link opens is blank, and nothing anywhere reports an error.
+        const { container } = mount(new Set([10]));
+        expect(rowPresent(container, 10)).toBe(true);
+    });
+
+    it('shows ONLY the epic\'s rows', () => {
+        const { container } = mount(new Set([10]));
+        expect(rowPresent(container, 11)).toBe(false);
+    });
+
+    it('renders no card at all when this category holds none of the epic', () => {
+        const { container } = mount(new Set([9999]));
+        expect(cardPresent(container)).toBe(false);
+    });
+
+    it('suppresses the add-a-requirement row while filtered', () => {
+        const { container } = mount(new Set([10]));
+        expect(container.querySelector('[data-testid="requirement-template"]')).toBeNull();
+    });
+
+    it('with NO filter (null), behaves exactly as before — both the toggle and '
+        + 'the template row are back in charge', () => {
+        const { container } = mount(null);
+        // The stored toggle is ON and both rows are pipelined, so the unfiltered
+        // card is empty of rows but still RENDERS, template and all.
+        expect(cardPresent(container)).toBe(true);
+        expect(rowPresent(container, 10)).toBe(false);
+        expect(rowPresent(container, 11)).toBe(false);
+        expect(container.querySelector('[data-testid="requirement-template"]')).not.toBeNull();
+    });
+
+    it('never writes the store — dismissing the filter restores what the reader had', () => {
+        mount(new Set([10]));
+        expect(useShowClosedStore.getState().hidePipelinedRequirements).toBe(true);
+    });
+});

--- a/src/SwarmView/__tests__/SwarmView.epicFilter.test.jsx
+++ b/src/SwarmView/__tests__/SwarmView.epicFilter.test.jsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+//
+// Req #3428 — the WIRING, which is where this feature's real risk sits.
+//
+// Everything else about the epic filter is pure and pinned elsewhere. What no
+// pure suite can catch is the page assembling it wrongly: a pill that renders in
+// a view the filter is not applying to, an aggregator that was supposed to be
+// forced visible and is not, a toggle left on screen that no longer does
+// anything, or a scope that never reaches the cards. Each of those renders a
+// plausible page and reports nothing.
+//
+// The heavy children are stubs — this asserts what `SwarmView` DECIDES, not what
+// a CategoryCard draws (that has its own suite).
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// The first mounted `it()` in a file absorbs the cold module-compile cost of the
+// component tree (react-dnd + MUI + this page), which on a loaded machine is
+// measured at 5-8s against vitest's 5000ms default — red in CI about half the
+// time, for nothing. File-scoped rather than a global config change, so no other
+// suite's timeout moves.
+vi.setConfig({ testTimeout: 30000 });
+
+// TWO projects, and the epic's work is in the SECOND — so the tab seed has a
+// real decision to make and the working-project assertions below are not
+// trivially satisfied by there being nowhere else to go.
+const PROJECTS = [
+    { id: 7, project_name: 'Personal', sort_order: 0 },
+    { id: 1, project_name: 'Darwin', sort_order: 1 },
+];
+const EPICS = [{ id: 11, title: "Bill's Polish #1" }];
+const CATEGORIES = [{ id: 5, project_fk: 1 }];
+const SCOPE_REQUIREMENTS = [{ id: 10, feature_fk: 46, category_fk: 5 }];
+let epicReqIdsFromHook = new Set([10]);
+let scopeReadFails = false;
+
+vi.mock('../../hooks/useDataQueries', () => ({
+    useProjects: () => ({ data: PROJECTS }),
+    useAllEpics: () => ({ data: EPICS }),
+    useAllCategories: () => ({ data: CATEGORIES }),
+    useEpicRequirementIds: (_creator, epicId) => {
+        if (epicId == null) return { epicReqIds: null, isError: false, requirements: undefined };
+        if (scopeReadFails) return { epicReqIds: null, isError: true, requirements: undefined };
+        return { epicReqIds: epicReqIdsFromHook, isError: false, requirements: SCOPE_REQUIREMENTS };
+    },
+}));
+
+// Records the props the page hands the tab panel — the aggregator's forced
+// visibility and the filter scope are decisions made HERE, so this is where they
+// are observable.
+let panelProps = [];
+vi.mock('../CategoryTabPanel', () => ({
+    default: (props) => { panelProps.push(props); return <div data-testid="tab-panel" />; },
+}));
+vi.mock('../RequirementDragLayer', () => ({ default: () => null }));
+vi.mock('../SwarmVisualizerView', () => ({ default: () => null }));
+vi.mock('../RequirementsTrendsView', () => ({ default: () => null }));
+vi.mock('../VisualizerToolbar', () => ({ default: () => null }));
+vi.mock('../RequirementsTableView', () => ({
+    default: () => <div data-testid="table-view" />, SWARM_TABLE_WIDTH: 1200,
+}));
+vi.mock('../../Components/SettingsMenu/SettingsMenu', () => ({ default: () => null }));
+vi.mock('../../NavBar/RequirementJumpInput', () => ({ default: () => null }));
+vi.mock('../../RestApi/RestApi', () => ({ default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })) }));
+
+import SwarmView from '../SwarmView';
+import AuthContext from '../../Context/AuthContext';
+import AppContext from '../../Context/AppContext';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useSwarmStartCardStore } from '../../stores/useSwarmStartCardStore';
+import { useWorkingProjectStore } from '../../stores/useWorkingProjectStore';
+import { SWARM_VIEW_STORAGE_KEY } from '../swarmViewLink';
+
+const mount = (entry) => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+        <MemoryRouter initialEntries={[entry]}>
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <SwarmView />
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        </MemoryRouter>
+    );
+};
+
+const lastPanelProps = () => panelProps[panelProps.length - 1];
+
+describe('SwarmView under ?epic= (req #3428)', () => {
+    beforeEach(() => {
+        panelProps = [];
+        epicReqIdsFromHook = new Set([10]);
+        scopeReadFails = false;
+        localStorage.clear();
+        useWorkingProjectStore.setState({ projectId: null, timestamp: null });
+        // The aggregator's own persisted preference is OFF — so anything visible
+        // below is the filter forcing it, not the store agreeing by accident.
+        useSwarmStartCardStore.setState({ show: false });
+    });
+    afterEach(() => { cleanup(); localStorage.clear(); });
+
+    it('renders the dismissable pill, named after the epic', () => {
+        const { getByTestId } = mount('/swarm?view=cards&epic=11');
+        expect(getByTestId('swarm-epic-filter-chip').textContent).toContain("Bill's Polish #1");
+    });
+
+    it('falls back to the raw id for an epic with no row — not an error state', () => {
+        const { getByTestId } = mount('/swarm?view=cards&epic=99999');
+        expect(getByTestId('swarm-epic-filter-chip').textContent).toContain('99999');
+    });
+
+    it('forces the aggregator visible without touching its stored preference', () => {
+        mount('/swarm?view=cards&epic=11');
+        expect(lastPanelProps().showSwarmStartCard).toBe(true);
+        // THE STORE IS UNTOUCHED — an external condition never overwrites
+        // uncommitted user intent, so dismissing the pill restores what was there.
+        expect(useSwarmStartCardStore.getState().show).toBe(false);
+    });
+
+    it('hands the scope down to the cards', () => {
+        mount('/swarm?view=cards&epic=11');
+        expect(lastPanelProps().epicReqIds).toBe(epicReqIdsFromHook);
+    });
+
+    it('removes the pipeline toggle and the aggregator toggle, because neither '
+        + 'would be applying', () => {
+        const { queryByTestId } = mount('/swarm?view=cards&epic=11');
+        expect(queryByTestId('hide-pipelined-toggle')).toBeNull();
+        expect(queryByTestId('swarm-start-card-toggle')).toBeNull();
+    });
+
+    it('keeps the status chips, which are orthogonal to epic membership', () => {
+        const { queryByTestId } = mount('/swarm?view=cards&epic=11');
+        expect(queryByTestId('requirement-status-filter')).not.toBeNull();
+    });
+
+    it('dismissing the pill clears the filter and restores every control', () => {
+        const { getByTestId, queryByTestId } = mount('/swarm?view=cards&epic=11');
+        // MUI puts the ✕ in its own button; clicking it fires `onDelete` alone.
+        fireEvent.click(getByTestId('swarm-epic-filter-chip').querySelector('.MuiChip-deleteIcon'));
+        expect(queryByTestId('swarm-epic-filter-chip')).toBeNull();
+        expect(queryByTestId('hide-pipelined-toggle')).not.toBeNull();
+        expect(queryByTestId('swarm-start-card-toggle')).not.toBeNull();
+        expect(lastPanelProps().epicReqIds).toBeNull();
+        expect(lastPanelProps().showSwarmStartCard).toBe(false);
+    });
+
+    it('THE PARAMETER SLEEPS OUTSIDE THE CARDS VIEW: no pill, no scope, controls '
+        + 'back — a filter control is on screen exactly when it is applying', () => {
+        const { queryByTestId } = mount('/swarm?view=table&epic=11');
+        expect(queryByTestId('table-view')).not.toBeNull();
+        expect(queryByTestId('swarm-epic-filter-chip')).toBeNull();
+        expect(queryByTestId('hide-pipelined-toggle')).not.toBeNull();
+    });
+
+    it('with no ?epic= at all, nothing about the page changes', () => {
+        const { queryByTestId } = mount('/swarm?view=cards');
+        expect(queryByTestId('swarm-epic-filter-chip')).toBeNull();
+        expect(queryByTestId('hide-pipelined-toggle')).not.toBeNull();
+        expect(queryByTestId('swarm-start-card-toggle')).not.toBeNull();
+        expect(lastPanelProps().epicReqIds).toBeNull();
+        expect(lastPanelProps().showSwarmStartCard).toBe(false);
+    });
+
+    it('an epic link never rewrites the reader\'s stored view preference', () => {
+        mount('/swarm?view=cards&epic=11');
+        expect(localStorage.getItem(SWARM_VIEW_STORAGE_KEY)).toBeNull();
+    });
+
+    it('NEVER RE-HOMES THE READER: the seeded tab is not written to the persisted '
+        + 'working project', () => {
+        // `darwin_working_project` lives 90 days. Letting the seed through would
+        // mean glancing at one epic silently changed where bare `/swarm` opens,
+        // for months — the same class of defect as the filter writing the view
+        // preference, arrived at through a second effect.
+        mount('/swarm?view=cards&epic=11');
+        expect(useWorkingProjectStore.getState().projectId).toBeNull();
+        // Read the PERSISTED value, not the key's existence: zustand's `persist`
+        // writes the whole state on any change, so the reset in `beforeEach`
+        // creates the key by itself.
+        expect(JSON.parse(localStorage.getItem('darwin_working_project')).state.projectId)
+            .toBeNull();
+    });
+
+    it('with no filter, the working project is persisted exactly as before', () => {
+        mount('/swarm?view=cards');
+        expect(useWorkingProjectStore.getState().projectId).not.toBeNull();
+    });
+
+    it('A FAILED MEMBERSHIP READ SHOWS EVERYTHING AND SAYS SO — it must never '
+        + 'render as "this epic has no work"', () => {
+        scopeReadFails = true;
+        const { getByTestId, queryByTestId } = mount('/swarm?view=cards&epic=11');
+        const chip = getByTestId('swarm-epic-filter-chip');
+        expect(chip.textContent).toContain('unavailable');
+        // Nothing is filtered, so every control the filter overrides comes back.
+        expect(lastPanelProps().epicReqIds).toBeNull();
+        expect(lastPanelProps().showSwarmStartCard).toBe(false);
+        expect(queryByTestId('hide-pipelined-toggle')).not.toBeNull();
+        expect(queryByTestId('swarm-start-card-toggle')).not.toBeNull();
+    });
+});

--- a/src/SwarmView/__tests__/swarmViewLink.epicParam.test.js
+++ b/src/SwarmView/__tests__/swarmViewLink.epicParam.test.js
@@ -1,0 +1,83 @@
+// Req #3428 — `?epic=` on `/swarm`, both halves of the contract.
+//
+// Its own file rather than more cases in `swarmViewLink.test.js`: that suite
+// pins the VIEW vocabulary, and the two contracts are read for different reasons.
+
+import { describe, it, expect } from 'vitest';
+import {
+    SWARM_EPIC_PARAM, SWARM_EPIC_VIEW,
+    swarmEpicLinkTo, readEpicParam, withoutEpicParam,
+} from '../swarmViewLink';
+
+describe('swarmEpicLinkTo — the writer', () => {
+    it('names the view explicitly, not just the page', () => {
+        // `/swarm` alone opens whichever panel the reader last chose, so a link
+        // without `view=` lands a Table-preferring reader on the Table — and this
+        // link's whole promise is the cards.
+        expect(swarmEpicLinkTo(11)).toBe('/swarm?view=cards&epic=11');
+        expect(SWARM_EPIC_VIEW).toBe('cards');
+        expect(SWARM_EPIC_PARAM).toBe('epic');
+    });
+
+    it('accepts a numeric string, as an id read off a row would arrive', () => {
+        expect(swarmEpicLinkTo('11')).toBe('/swarm?view=cards&epic=11');
+    });
+
+    it('returns null on an unusable id so the caller renders NO control', () => {
+        // A plan's "No epic" band has no id. A link built anyway would navigate
+        // to `/swarm?epic=undefined` and filter every requirement away under a
+        // pill reading "Epic: undefined".
+        for (const bad of [null, undefined, '', '   ', 'abc', 1.5, 0, -3, NaN]) {
+            expect(swarmEpicLinkTo(bad)).toBeNull();
+        }
+    });
+});
+
+describe('readEpicParam — the reader', () => {
+    const params = (qs) => new URLSearchParams(qs);
+
+    it('reads an integer id', () => {
+        expect(readEpicParam(params('view=cards&epic=11'))).toBe(11);
+    });
+
+    it('is null when the parameter is absent', () => {
+        expect(readEpicParam(params('view=cards'))).toBeNull();
+        expect(readEpicParam(undefined)).toBeNull();
+        expect(readEpicParam({})).toBeNull();
+    });
+
+    it('refuses address-bar text that is not an id', () => {
+        // `Number('')` is 0 and `Number('1.5')` is 1.5 — either would filter
+        // every row away under a pill naming an epic that does not exist.
+        for (const bad of ['', '   ', 'abc', '1.5', '0', '-3', '11abc']) {
+            expect(readEpicParam(params(`epic=${encodeURIComponent(bad)}`))).toBeNull();
+        }
+    });
+
+    it('accepts an id that names no epic row — that is not an error', () => {
+        expect(readEpicParam(params('epic=99999'))).toBe(99999);
+    });
+});
+
+describe('withoutEpicParam — dismissing the pill', () => {
+    it('drops only the epic, leaving the rest of the query string alone', () => {
+        const next = withoutEpicParam(params0('view=cards&epic=11&other=x'));
+        expect(next.get('epic')).toBeNull();
+        expect(next.get('view')).toBe('cards');
+        expect(next.get('other')).toBe('x');
+    });
+
+    it('returns a NEW object — React Router hands back a live one, and mutating '
+        + 'it in place changes the location while re-rendering nothing', () => {
+        const original = params0('view=cards&epic=11');
+        const next = withoutEpicParam(original);
+        expect(next).not.toBe(original);
+        expect(original.get('epic')).toBe('11');
+    });
+
+    it('is a no-op on params that carry no epic', () => {
+        expect(withoutEpicParam(params0('view=table')).toString()).toBe('view=table');
+    });
+});
+
+function params0(qs) { return new URLSearchParams(qs); }

--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -92,6 +92,10 @@ import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+// req #3428 — the icon `/swarm`'s own view toggle uses for Cards. Reusing the
+// page's mark rather than inventing one is what makes the chip's second control
+// legible as a destination.
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
 
 import {
     formatTimeGates, rowMachineLabel, batchMachineLabel, STEP_RUNNING,
@@ -125,6 +129,9 @@ import {
     epicZoomHint, epicZoomHintSuffix, gestureMovedCamera, EPIC_ZOOM_CLICK_SLOP,
     EPIC_ZOOM_BAND, EPIC_ZOOM_BATCH,
 } from './pipelineEpicZoom';
+// req #3428 — the epic chip's second destination. The URL contract lives with
+// the rest of `/swarm`'s query string, so this file names no query key itself.
+import { swarmEpicLinkTo } from '../swarmViewLink';
 import { useSavedViewport } from '../../hooks/useSavedViewport';
 import { viewportStorageKey, writeViewport } from '../../utils/viewportMemory';
 import '../../CalendarFC/swarmVisualizer.css';
@@ -2545,6 +2552,66 @@ export default function PipelinePlanVisualizer({
                                     }}
                                 >
                                     ↗
+                                </Box>
+                            )}
+                            {/* req #3428 — the SECOND destination this chip
+                                offers: the epic's own requirements, as task
+                                cards, on the ordinary requirements page under a
+                                dismissable filter.
+
+                                THE MARK IS THE PAGE'S OWN VOCABULARY, not a new
+                                glyph: `ViewModuleIcon` is literally what
+                                `SwarmView`'s Cards toggle draws
+                                (`SWARM_VIEW_CHROME.cards`), so a reader who has
+                                seen that toggle recognises where this goes. A
+                                second arrow would have been wrong — ↗ already
+                                means "leave the page", and two arrows read as
+                                one control drawn twice.
+
+                                Its width is RESERVED in `placeEpicChips`
+                                (`EPIC_CHIP_CARDS_LINK_W`) under the same
+                                `epicId != null` condition that renders it — see
+                                the keep-out note above this whole flex row.
+
+                                `stopPropagation` on BOTH handlers for the reason
+                                the ↗'s own comment gives: without it the chip's
+                                handler also fires and focuses the band the user
+                                is navigating away from. */}
+                            {/* The render condition is `epicId != null` and NOTHING
+                                ELSE, because that is exactly the condition
+                                `placeEpicChips` reserves the width under. An extra
+                                truthiness term here (e.g. on the built href) would
+                                let a band reserve 24px it never draws — a small
+                                lie, but the whole point of the reservation is that
+                                the two cannot drift. The href is checked inside the
+                                handlers instead, where a null simply does nothing. */}
+                            {e.epicId != null && (
+                                <Box
+                                    component="span"
+                                    role="link"
+                                    tabIndex={0}
+                                    aria-label={`Open ${e.text} requirements in the task cards view`}
+                                    title={`Open “${e.text}” requirements in the Task Cards view`}
+                                    data-testid={`pipeline-viz-epic-cards-${e.key}`}
+                                    onClick={(ev) => {
+                                        ev.stopPropagation();
+                                        const to = swarmEpicLinkTo(e.epicId);
+                                        if (to) navigate(to);
+                                    }}
+                                    onKeyDown={(ev) => {
+                                        if (ev.key !== 'Enter') return;
+                                        ev.stopPropagation();
+                                        ev.preventDefault();
+                                        const to = swarmEpicLinkTo(e.epicId);
+                                        if (to) navigate(to);
+                                    }}
+                                    sx={{
+                                        display: 'inline-flex', alignItems: 'center',
+                                        lineHeight: 1, px: '2px', opacity: 0.7,
+                                        '&:hover': { opacity: 1 },
+                                    }}
+                                >
+                                    <ViewModuleIcon sx={{ fontSize: 14 }} />
                                 </Box>
                             )}
                         </Box>

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -16,7 +16,7 @@ import { buildPipelineModel, orderedPlan } from '../pipelineViewModel';
 import { semanticLevel, SEMANTIC_OUT_MAX } from '../../konvaSwarmModel';
 import {
     computePlanLayout, beadStyle, stepLabelText, BEAD_RADIUS, BEAD_HIT_RADIUS,
-    PLAN_VIZ_PALETTE, placeEpicChips, EPIC_CHIP_OPEN_LINK_W,
+    PLAN_VIZ_PALETTE, placeEpicChips, EPIC_CHIP_OPEN_LINK_W, EPIC_CHIP_CARDS_LINK_W,
     STEP_WIDTH_FACTORS, isStepWidth, K_READABLE, PLAN_VIZ_FONT, READABLE_MIN_PX,
     NEXT_HALO_RADIUS, NEXT_HALO_STROKE, NEXT_HALO_DASH, EPIC_CHIP_CHAR_W,
     NEXT_HALO_SCREEN_RADIUS, NEXT_HALO_MAX_OUTER, NEXT_HALO_MAX_MAGNIFY,
@@ -1405,7 +1405,7 @@ describe('epic name pinned to its band, clamped to the viewport (req #3257)', ()
         const scale = h / EPIC_CHIP_H;
         const text = band.epicLabel || band.epic;
         const w = text.length * EPIC_CHIP_CHAR_W * scale + EPIC_CHIP_PAD_W * scale
-            + (band.epicId != null ? EPIC_CHIP_OPEN_LINK_W : 0)
+            + (band.epicId != null ? EPIC_CHIP_OPEN_LINK_W + EPIC_CHIP_CARDS_LINK_W : 0)
             + EPIC_PAUSE_BUBBLE_W;
         return { w, h };
     };
@@ -2081,7 +2081,7 @@ describe('epic name pinned to its band, clamped to the viewport (req #3257)', ()
         // so 24 unmeasured px is 24 px that hangs past the edge it was clamped to.
         expect(chip.w).toBeCloseTo(
             20 * EPIC_CHIP_CHAR_W + EPIC_CHIP_PAD_W
-            + EPIC_CHIP_OPEN_LINK_W + EPIC_PAUSE_BUBBLE_W, 6);
+            + EPIC_CHIP_OPEN_LINK_W + EPIC_CHIP_CARDS_LINK_W + EPIC_PAUSE_BUBBLE_W, 6);
         expect(chip.clipped).toBe(false);
     });
 
@@ -2418,7 +2418,7 @@ describe('the epic name holds a legible minimum font (req #3272)', () => {
             const text = band.epicLabel || band.epic;
             const w = text.length * EPIC_CHIP_CHAR_W * scale
                 + EPIC_CHIP_PAD_W * scale
-                + (band.epicId != null ? EPIC_CHIP_OPEN_LINK_W : 0)
+                + (band.epicId != null ? EPIC_CHIP_OPEN_LINK_W + EPIC_CHIP_CARDS_LINK_W : 0)
                 + EPIC_PAUSE_BUBBLE_W;
             const x = Math.min(ix0 + MX, right - MX - w);
             const y = Math.min(iy0 + MY, bottom - MY - h);
@@ -2825,7 +2825,7 @@ describe('epic band label counts, behind a toggle (req #3225)', () => {
         // footprint is reserved on every chip now that the measured box is what
         // keeps the name inside its own rectangle.
         expect(chip.w).toBeCloseTo(20 * EPIC_CHIP_CHAR_W + 18
-            + EPIC_CHIP_OPEN_LINK_W + EPIC_PAUSE_BUBBLE_W, 6);
+            + EPIC_CHIP_OPEN_LINK_W + EPIC_CHIP_CARDS_LINK_W + EPIC_PAUSE_BUBBLE_W, 6);
     });
 
     it('the toggle is a pure display transform: the ONLY thing that changes '
@@ -3817,7 +3817,7 @@ describe('the pause status bubble (req #3226)', () => {
         });
         // + EPIC_CHIP_OPEN_LINK_W since req #3257 (see the fallback test above).
         expect(withBubble[0].w).toBeCloseTo(20 * EPIC_CHIP_CHAR_W + 18
-            + EPIC_CHIP_OPEN_LINK_W + EPIC_PAUSE_BUBBLE_W, 6);
+            + EPIC_CHIP_OPEN_LINK_W + EPIC_CHIP_CARDS_LINK_W + EPIC_PAUSE_BUBBLE_W, 6);
     });
 
     // "its rectangle belongs in the same label set the zero-overlap invariant

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -2897,6 +2897,19 @@ export const EPIC_CHIP_FONT = PLAN_VIZ_FONT.epic;
 // can hang past the band's right edge or under the key, which is the exact
 // under-measurement bug this module's own header comment warns about.
 export const EPIC_CHIP_OPEN_LINK_W = 24;
+// The "open this epic's requirements as task cards" control (req #3428) — a
+// SECOND link control riding beside the ↗, and the SAME kind of flat, unscaled
+// screen-px reservation for the identical reason: a fixed `fontSize: 14` MUI
+// glyph plus the chip's own flex `gap`, neither of which shrinks when the chip
+// does. It renders under exactly the same condition as the ↗ (`epicId != null`)
+// and is measured under the same condition, so the two can never drift apart.
+//
+// UNMEASURED CONTENT IS CONTENT THAT HANGS PAST THE EDGE IT WAS CLAMPED TO —
+// this file's own header warning, and since req #3257 the measured box is what
+// keeps the name inside its own rectangle and clear of the key, not merely clear
+// of another floating chip. 24 px of unreserved glyph is 24 px of name over the
+// band's right edge.
+export const EPIC_CHIP_CARDS_LINK_W = 24;
 // The pause status bubble (req #3226) — a small filled circle immediately left
 // of the epic name, the SAME kind of flat, unscaled reservation as the ↗
 // control above and for the identical reason: it is a fixed-diameter dot plus
@@ -3093,12 +3106,14 @@ export function placeEpicChips({
         // name, so this stays the identity transform for callers that never set
         // it.
         const bandText = band.epicLabel || band.epic;
-        // The two FLAT, unscaled reservations: the ↗ control (only rendered when
-        // there is an epic to open) and the pause bubble (rendered on every
-        // band, "No epic" included). Neither shrinks with the chip, and both are
-        // in the measured box before anything is clamped or clipped against it.
+        // The FLAT, unscaled reservations: the two link controls — the ↗ to the
+        // features view and the cards control to the epic's requirements (req
+        // #3428) — which render only when there is an epic to open, and the
+        // pause bubble, which renders on every band, "No epic" included. None of
+        // them shrinks with the chip, and all are in the measured box before
+        // anything is clamped or clipped against it.
         const wFull = bandText.length * charW * scale + EPIC_CHIP_PAD_W * scale
-            + (band.epicId != null ? EPIC_CHIP_OPEN_LINK_W : 0)
+            + (band.epicId != null ? EPIC_CHIP_OPEN_LINK_W + EPIC_CHIP_CARDS_LINK_W : 0)
             + EPIC_PAUSE_BUBBLE_W;
 
         // ── THE RULE ────────────────────────────────────────────────────────

--- a/src/SwarmView/swarmViewLink.js
+++ b/src/SwarmView/swarmViewLink.js
@@ -58,3 +58,95 @@ export const readViewParam = (searchParams) => {
  */
 export const swarmViewLinkTo = (view) =>
     SWARM_VIEWS.includes(view) ? `/swarm?${SWARM_VIEW_PARAM}=${view}` : '/swarm';
+
+// ── `?epic=` — ONE epic's work, seen as task cards (req #3428) ──────────────
+//
+// `/swarm?view=cards&epic=<eid>`. The writer is the plan visualizer's epic chip
+// (`PipelinePlanVisualizer.jsx`) and the readers are this page plus three
+// components under it — five files that must agree on one query-string key
+// exactly, which is this module's whole reason for existing. It lives HERE
+// rather than in a module of its own because this module already owns `/swarm`'s
+// query string: a second one would have to import `SWARM_VIEW_PARAM` back out of
+// this one to compose a single URL, which is two owners of one contract.
+//
+// `view=cards` IS CARRIED EXPLICITLY, for the reason `swarmViewLinkTo` gives
+// above: `/swarm` alone opens whichever panel this reader last chose, so a link
+// that omitted the view would land a Table-preferring reader on the Table — and
+// this link's whole promise is the CARDS. It seeds the same TRANSIENT override,
+// so the reader's stored default is never rewritten.
+//
+// THE THIRD `?epic=` IN THIS CODEBASE, AND THAT IS FINE. `pipelineEpicLink.js`
+// owns `?epic=` on `/swarm/pipeline/<pid>`, where it means FOCUS THIS BAND;
+// `FeaturesPage.jsx` owns it on `/swarm/features`, where it means FILTER TO THIS
+// EPIC; this owns it on `/swarm` and means what the second one means. Three
+// ROUTES, one meaning each, so no reader ever has to work out which sense is in
+// play — and the key is the same word because the noun is the same, which is
+// what makes the address bar legible. The three deliberately do NOT share a
+// reader: merging them would couple three pages' query strings so that changing
+// one has to be argued on all three.
+
+/** The query parameter. `epic`, because the filter names an EPIC. */
+export const SWARM_EPIC_PARAM = 'epic';
+
+/** The view an epic link lands on. Named so the writer and this file agree. */
+export const SWARM_EPIC_VIEW = 'cards';
+
+/**
+ * The route an epic's task cards live at.
+ *
+ * Returns null when the id is unusable, so a caller renders no control at all
+ * rather than one that navigates to `/swarm?epic=undefined` and filters every
+ * requirement away under a pill reading "Epic: undefined". A plan's "No epic"
+ * band has no id and is exactly this case — the same omit-rather-than-render-a-
+ * dead-link rule `pipelineEpicLink.js` applies.
+ *
+ * @param {?number} epicId
+ * @returns {?string}
+ */
+export const swarmEpicLinkTo = (epicId) => {
+    const eid = toEpicId(epicId);
+    if (eid == null) return null;
+    return `/swarm?${SWARM_VIEW_PARAM}=${SWARM_EPIC_VIEW}&${SWARM_EPIC_PARAM}=${eid}`;
+};
+
+/**
+ * The epic id a `?epic=` parameter names, or null.
+ *
+ * VALIDATED, NEVER TRUSTED — the same rule `readViewParam` follows, and with
+ * more at stake: this value decides which requirements a page shows, and
+ * `Number('')` is 0 while `Number('1.5')` is 1.5, either of which would filter
+ * every row away under a pill naming an epic that does not exist. An id that
+ * names a REAL-SHAPED epic which simply has no row is not an error: the page
+ * filters to an empty set and the pill falls back to the raw id, exactly as
+ * `FeaturesPage.jsx` has behaved since req #3115.
+ *
+ * @param {{get: function(string): ?string}} searchParams
+ * @returns {?number}
+ */
+export const readEpicParam = (searchParams) =>
+    toEpicId(searchParams?.get?.(SWARM_EPIC_PARAM));
+
+/**
+ * The same params with the epic filter removed — where dismissing the pill goes.
+ *
+ * A NEW `URLSearchParams` rather than a mutation of the caller's: React Router
+ * hands back a live object, and mutating it in place changes the current
+ * location's params while re-rendering nothing.
+ *
+ * @param {URLSearchParams} searchParams
+ * @returns {URLSearchParams}
+ */
+export const withoutEpicParam = (searchParams) => {
+    const next = new URLSearchParams(searchParams || undefined);
+    next.delete(SWARM_EPIC_PARAM);
+    return next;
+};
+
+// NULLISH AND EMPTY ARE REJECTED BEFORE `Number` SEES THEM — `pipelineStepLink`'s
+// identical guard, for the identical reason: `Number(null)` and `Number('')` are
+// both 0, which is a perfectly good integer and a perfectly bad epic id.
+const toEpicId = (value) => {
+    if (value == null || String(value).trim() === '') return null;
+    const n = Number(String(value).trim());
+    return Number.isInteger(n) && n > 0 ? n : null;
+};

--- a/src/TaskPlanView/SwarmStartCard.jsx
+++ b/src/TaskPlanView/SwarmStartCard.jsx
@@ -21,6 +21,7 @@ import call_rest_api from '../RestApi/RestApi';
 import { useSnackBarStore } from '../stores/useSnackBarStore';
 import { useRequirementsByStatus, useRequirementsDone, useSessions, useCategoryColors, useAllRequirements, usePipelinedRequirementIds } from '../hooks/useDataQueries';
 import { excludePipelined } from '../utils/pipelineMembership';
+import { filterToEpic, effectiveHidePipelined } from '../utils/epicMembership';
 import { PIPELINE_FILTERED_STATUSES, tallyRequirementStatuses } from './swarmStartCardUtils';
 import { requirementKeys } from '../hooks/useQueryKeys';
 import { useCrudCallbacks } from '../hooks/useCrudCallbacks';
@@ -140,7 +141,17 @@ const computeMetWindow = () => {
     };
 };
 
-const SwarmStartCard = () => {
+// req #3428 — `epicReqIds` is the epic filter's SCOPE, handed down by the host
+// (`CategoryTabPanel`, from `SwarmView`). A Set of requirement ids, or `null`
+// when no filter is active — an AGGREGATOR NEVER INVENTS A FILTER THE HOST OWNS
+// (`memory/aggregator-card-pattern.md`), and one derivation upstairs is what
+// stops this card from disagreeing with the category cards beside it.
+//
+// AN UNFILTERED AGGREGATOR OVER A FILTERED GRID would mean something different
+// from the grid beneath it, which is the defect the pattern's own tests exist to
+// catch. Applied to the ROWS and to the CHIP BADGES from the same Set, for the
+// same reason the pipeline exclusion is.
+const SwarmStartCard = ({ epicReqIds = null }) => {
     const { idToken, profile } = useContext(AuthContext);
     const { darwinUri } = useContext(AppContext);
     const queryClient = useQueryClient();
@@ -165,16 +176,77 @@ const SwarmStartCard = () => {
 
     const showError = useSnackBarStore(s => s.showError);
 
+    // ── The inputs the chip counts are built from ───────────────────────────
+    // Hoisted ABOVE `effectiveStatus` (req #3428) so the epic override below can
+    // read the counts. Nothing here depends on which chip is selected, which is
+    // what makes the move safe: `chipOffersLaunch` is the only count-adjacent
+    // value that does, and it stays where it was.
+    const pipelinedIds = usePipelinedRequirementIds(profile?.userName);
+    const storedHidePipelined = useShowClosedStore(s => s.hidePipelinedRequirements);
+    // req #3428 — an epic filter forces the OBSERVATION chips' pipeline toggle
+    // off, through the same shared predicate the requirements page uses; the
+    // unconditional launch exclusion (`PIPELINE_FILTERED_STATUSES`) is untouched,
+    // because that one is correctness rather than a viewing preference.
+    const epicFilterActive = epicReqIds != null;
+    const hidePipelined = effectiveHidePipelined(storedHidePipelined, epicFilterActive);
+
+    // All requirements across categories — the per-status counts' source (req #2549).
+    const { data: allRequirementsForCounts } = useAllRequirements(profile?.userName, {
+        fields: 'id,requirement_status',
+    });
+
+    // THE TALLY, COMPUTED ONCE. `statusCountMap` below overlays only the `met`
+    // figure onto this; the epic chip override reads the same object. Three
+    // computations of one number is how a badge and a list start disagreeing,
+    // which is the defect this file's own comments call load-bearing.
+    const baseStatusCounts = React.useMemo(() => tallyRequirementStatuses(
+        filterToEpic(allRequirementsForCounts, epicReqIds),
+        SWARM_START_STATUSES, pipelinedIds, hidePipelined).counts,
+        [allRequirementsForCounts, epicReqIds, pipelinedIds, hidePipelined]);
+
     // Persisted-store fallback — req #2584 retired 'deferred' from this card. Users
-    // with a now-invalid persisted value get re-pointed at the default. `effectiveStatus`
+    // with a now-invalid persisted value get re-pointed at the default. `storedStatus`
     // is computed synchronously so the hook calls below never fire against the stale
     // value (otherwise we'd pay one wasted fetch for 'deferred' before the useEffect ran).
-    const effectiveStatus = SWARM_START_STATUSES.includes(selectedStatus) ? selectedStatus : 'swarm_ready';
+    const storedStatus = SWARM_START_STATUSES.includes(selectedStatus) ? selectedStatus : 'swarm_ready';
     useEffect(() => {
-        if (selectedStatus !== effectiveStatus) {
-            setSelectedStatus(effectiveStatus);
+        if (selectedStatus !== storedStatus) {
+            setSelectedStatus(storedStatus);
         }
-    }, [selectedStatus, effectiveStatus, setSelectedStatus]);
+    }, [selectedStatus, storedStatus, setSelectedStatus]);
+
+    // ── OPEN ON A CHIP THAT HAS THE EPIC'S WORK (req #3428) ─────────────────
+    // MEASURED, not reasoned: every requirement under epic 11 on 2026-08-09 was
+    // `development` AND plan-carried, while `selectedStatus` persists as
+    // `swarm_ready` — so the aggregator this requirement asks to be turned ON
+    // opened with zero rows and a `0` badge. That is structural, not incidental:
+    // an epic reached FROM THE PLAN VISUALIZER is plan-carried by construction,
+    // and the three launch chips exclude plan-carried work unconditionally. Only
+    // `development` and `met` can ever show anything under an epic filter.
+    //
+    // "The aggregator is on" is the requirement's acceptance wording, and an
+    // aggregator that is on and blank does not meet it.
+    //
+    // A DERIVED OVERRIDE, exactly like the card's forced visibility and the
+    // forced pipeline toggle — `setSelectedStatus` is never called, so dismissing
+    // the pill returns the reader to their own chip. It applies ONLY while they
+    // have not picked one during this filtered visit (`chipPickedWhileFiltered`),
+    // so a deliberate click onto an empty chip is respected rather than undone.
+    //
+    // `met` IS NOT A CANDIDATE: its badge is the trailing-24h overlay below, not
+    // the tally above, so auto-selecting it here could land on another empty chip
+    // — precisely the failure being fixed. If nothing else has rows, the reader's
+    // own chip stands.
+    const [chipPickedWhileFiltered, setChipPickedWhileFiltered] = useState(false);
+    useEffect(() => { setChipPickedWhileFiltered(false); }, [epicFilterActive]);
+    const epicChipOverride = React.useMemo(() => {
+        if (!epicFilterActive || chipPickedWhileFiltered) return null;
+        if (baseStatusCounts[storedStatus] > 0) return null;
+        return SWARM_START_STATUSES.find(
+            s => s !== 'met' && baseStatusCounts[s] > 0) ?? null;
+    }, [epicFilterActive, chipPickedWhileFiltered, baseStatusCounts, storedStatus]);
+
+    const effectiveStatus = epicChipOverride ?? storedStatus;
 
     const isMet = effectiveStatus === 'met';
 
@@ -244,8 +316,6 @@ const SwarmStartCard = () => {
     // to browse, same reasoning as the requirements table — so THOSE respect
     // the same global toggle the table and Cards view do (req #3242), on top of
     // (never instead of) the unconditional launch exclusion above.
-    const pipelinedIds = usePipelinedRequirementIds(profile?.userName);
-    const hidePipelined = useShowClosedStore(s => s.hidePipelinedRequirements);
     const chipOffersLaunch = PIPELINE_FILTERED_STATUSES.includes(effectiveStatus);
     const excludeFromThisChip = chipOffersLaunch || hidePipelined;
 
@@ -265,7 +335,14 @@ const SwarmStartCard = () => {
         [serverMetRequirements, pipelinedIds, hidePipelined]);
 
     // The array that drives the card body for the currently selected chip.
-    const currentRequirements = isMet ? eligibleMetRequirements : eligibleRequirements;
+    //
+    // req #3428 — the epic filter is the LAST pass, after both pipeline
+    // exclusions, and it is an ID-SET test: none of this card's three
+    // projections carries `feature_fk`, and none of them needs to. That is the
+    // whole reason the scope arrives as ids.
+    const currentRequirements = React.useMemo(
+        () => filterToEpic(isMet ? eligibleMetRequirements : eligibleRequirements, epicReqIds),
+        [isMet, eligibleMetRequirements, eligibleRequirements, epicReqIds]);
 
     // Fetch sessions for status badges (same as CategoryCard)
     const { data: serverSessions } = useSessions(profile?.userName);
@@ -278,11 +355,6 @@ const SwarmStartCard = () => {
         serverCategoryColors.forEach(c => { if (c.color) map[c.id] = c.color; });
         return map;
     }, [serverCategoryColors]);
-
-    // Fetch all requirements across categories — powers the per-status counts below.
-    const { data: allRequirementsForCounts } = useAllRequirements(profile?.userName, {
-        fields: 'id,requirement_status',
-    });
 
     // Count requirements per status across all categories (req #2549). Reuses the
     // same useAllRequirements query — no extra fetch.
@@ -305,14 +377,21 @@ const SwarmStartCard = () => {
     // depends on it), but the card no longer tracks it: its one consumer was the
     // explanatory sentence, and this card renders no sentences. Reading `hidden`
     // again here means a message is being reintroduced.
+    //
+    // req #3428 — the epic filter narrows the COUNT SOURCE, not the tally rule,
+    // so a badge can never disagree with the rows beneath it. The met overlay
+    // reads `eligibleMetRequirements`, which is why it gets the same pass: that
+    // array is the one the rows are NOT taken from directly (`currentRequirements`
+    // filters it), so leaving the overlay alone would print an unfiltered met
+    // count over a filtered met list.
     const statusCountMap = React.useMemo(() => {
-        const { counts } = tallyRequirementStatuses(
-            allRequirementsForCounts, SWARM_START_STATUSES, pipelinedIds, hidePipelined);
+        const counts = { ...baseStatusCounts };
         if (Array.isArray(serverMetRequirements)) {
-            counts.met = eligibleMetRequirements?.length ?? serverMetRequirements.length;
+            counts.met = filterToEpic(eligibleMetRequirements, epicReqIds)?.length
+                ?? filterToEpic(serverMetRequirements, epicReqIds).length;
         }
         return counts;
-    }, [allRequirementsForCounts, serverMetRequirements, eligibleMetRequirements, pipelinedIds, hidePipelined]);
+    }, [baseStatusCounts, serverMetRequirements, eligibleMetRequirements, epicReqIds]);
 
     // Comparators are module-level — see `aggregatorSort` above.
 
@@ -335,12 +414,18 @@ const SwarmStartCard = () => {
         // discards whatever the user has typed into the add-row but not yet saved,
         // and since req #3302 this effect re-runs on a sort-order pick as well as
         // on a refetch — so the loss went from occasional to routine.
+        //
+        // req #3428 — SUPPRESSED WHILE FILTERED, the same rule `CategoryCard`
+        // applies to its own add-row: a requirement created from here carries no
+        // feature, so it belongs to no epic and would not appear on the page that
+        // offered the control.
         setRequirementsArray(prev => {
+            if (epicFilterActive) return sorted;
             const prevTemplate = prev && prev.find(r => r.id === '');
             return [...sorted, prevTemplate
                 ?? { id: '', title: '', requirement_status: 'authoring', category_fk: null }];
         });
-    }, [currentRequirements, effectiveSortMode]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [currentRequirements, effectiveSortMode, epicFilterActive]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // Build session status map (same logic as CategoryCard)
     useEffect(() => {
@@ -381,6 +466,11 @@ const SwarmStartCard = () => {
 
     const handleChipClick = (status) => {
         if (status === effectiveStatus) return;
+        // req #3428 — the reader has now chosen, so the epic override stands down
+        // for the rest of this filtered visit. Recorded even outside a filter: it
+        // is reset whenever `epicFilterActive` changes, so it can only ever mean
+        // "picked during the current filter state".
+        setChipPickedWhileFiltered(true);
         setSelectedStatus(status);
     };
 
@@ -648,6 +738,11 @@ const SwarmStartCard = () => {
                         // because the aggregator is not a drop target.
                         sortMode: 'created',
                         setCrossCardInsertIndex,
+                        // req #3428 — no row may be dragged out of a filtered
+                        // aggregator either. Its rows land on a CategoryCard,
+                        // whose drop handler rebuilds `sort_order` from positions
+                        // in a list the reader is seeing a subset of.
+                        dragDisabled: epicFilterActive,
                         sessionStatusMap,
                         categoryColorMap,
                         strikethroughMet: false, // req #2584 — recent-Met list, not crossed-off

--- a/src/TaskPlanView/__tests__/SwarmStartCard.epicFilter.test.jsx
+++ b/src/TaskPlanView/__tests__/SwarmStartCard.epicFilter.test.jsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+//
+// Req #3428 — the aggregator under an epic filter.
+//
+// Two things are asserted here and nowhere else:
+//
+//   1. THE BADGE STILL EQUALS THE ROWS. This card's own comments call that
+//      invariant LOAD-BEARING, and it now runs through `epicReqIds` — a count
+//      and a list narrowed by the same Set, or they drift silently.
+//   2. THE CARD DOES NOT OPEN BLANK. Measured on live Darwin 2026-08-09: every
+//      requirement under epic 11 was `development` AND plan-carried, while the
+//      persisted chip is `swarm_ready`, whose launch exclusion drops plan-carried
+//      work unconditionally. The requirement asks for the aggregator ON; on its
+//      own data it was on and empty. That is what the derived chip override
+//      fixes, and this fixture reproduces exactly that shape.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DndProvider } from 'react-dnd';
+import { TouchBackend } from 'react-dnd-touch-backend';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.setConfig({ testTimeout: 30000 });
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => () => {} }));
+
+// THE LIVE SHAPE OF EPIC 11: everything `development`, everything pipelined.
+// Plus one `swarm_ready` row belonging to a DIFFERENT epic, so "the swarm_ready
+// chip is empty" is a fact about the FILTER and not about the fixture.
+const EPIC_ROWS = [
+    { id: 3428, title: 'Epic dev A', requirement_status: 'development', category_fk: 1209 },
+    { id: 3430, title: 'Epic dev B', requirement_status: 'development', category_fk: 1 },
+];
+const OTHER_ROWS = [
+    { id: 900, title: 'Someone else swarm_ready', requirement_status: 'swarm_ready', category_fk: 5 },
+];
+const ALL_ROWS = [...EPIC_ROWS, ...OTHER_ROWS];
+const PIPELINED = new Set([3428, 3430, 900]);
+
+// PRE-BUCKETED AND FROZEN AT MODULE SCOPE. A mock that builds its array inside
+// the hook mints a new reference on every render, which re-seeds the card's local
+// state, which re-renders — an infinite loop that presents as the test runner
+// being killed rather than as a failure. The real `useQuery` returns a stable
+// reference between refetches, and a double has to as well.
+const BY_STATUS = {};
+for (const r of ALL_ROWS) (BY_STATUS[r.requirement_status] ??= []).push(r);
+
+let activeStatusAsked = null;
+const EMPTY = [];
+vi.mock('../../hooks/useDataQueries', () => ({
+    useRequirementsByStatus: (_c, status) => {
+        activeStatusAsked = status;
+        return { data: BY_STATUS[status] ?? EMPTY };
+    },
+    useRequirementsDone: () => ({ data: EMPTY }),
+    useSessions: () => ({ data: EMPTY }),
+    useCategoryColors: () => ({ data: EMPTY }),
+    useAllRequirements: () => ({ data: ALL_ROWS }),
+    usePipelinedRequirementIds: () => PIPELINED,
+}));
+
+vi.mock('../../RestApi/RestApi', () => ({ default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })) }));
+
+import SwarmStartCard from '../SwarmStartCard';
+import AuthContext from '../../Context/AuthContext';
+import AppContext from '../../Context/AppContext';
+import { useSwarmStartCardStore } from '../../stores/useSwarmStartCardStore';
+import { useShowClosedStore } from '../../stores/useShowClosedStore';
+
+const EPIC_SET = new Set([3428, 3430]);
+
+let roots = [];
+function mount(epicReqIds) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const root = createRoot(container);
+    roots.push(root);
+    act(() => {
+        root.render(
+            <QueryClientProvider client={queryClient}>
+                <AppContext.Provider value={{ darwinUri: 'http://test.local' }}>
+                    <AuthContext.Provider value={{ idToken: 'tok', profile: { userName: 'tester', timezone: 'UTC' } }}>
+                        <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
+                            <SwarmStartCard epicReqIds={epicReqIds} />
+                        </DndProvider>
+                    </AuthContext.Provider>
+                </AppContext.Provider>
+            </QueryClientProvider>
+        );
+    });
+    return { container };
+}
+
+const rowIds = (container) => Array.from(
+    container.querySelectorAll('[data-testid^="requirement-"]'))
+    .map(el => el.getAttribute('data-testid').replace('requirement-', ''))
+    .filter(id => id !== 'template');
+
+const badge = (container, status) => {
+    const el = container.querySelector(`[data-testid="swarm-start-chip-badge-${status}"]`);
+    // MUI renders the count in a `.MuiBadge-badge` span; `invisible` when zero.
+    const b = el?.querySelector('.MuiBadge-badge');
+    return b ? Number(b.textContent || '0') : 0;
+};
+
+describe('SwarmStartCard under an epic filter (req #3428)', () => {
+    beforeEach(() => {
+        roots = [];
+        activeStatusAsked = null;
+        useSwarmStartCardStore.setState({ selectedStatus: 'swarm_ready', show: true });
+        useShowClosedStore.setState({ hidePipelinedRequirements: true });
+    });
+    afterEach(() => {
+        act(() => { roots.forEach((r) => r.unmount()); });
+        document.body.innerHTML = '';
+        useSwarmStartCardStore.setState({ selectedStatus: 'swarm_ready' });
+        useShowClosedStore.setState({ hidePipelinedRequirements: false });
+    });
+
+    it('DOES NOT OPEN BLANK: the persisted swarm_ready chip has none of the epic, '
+        + 'so the card opens on one that does', () => {
+        const { container } = mount(EPIC_SET);
+        expect(activeStatusAsked).toBe('development');
+        expect(rowIds(container).sort()).toEqual(['3428', '3430']);
+    });
+
+    it('never writes the reader\'s chip preference to do it', () => {
+        mount(EPIC_SET);
+        expect(useSwarmStartCardStore.getState().selectedStatus).toBe('swarm_ready');
+    });
+
+    it('the badge equals the rows on the chip it opened', () => {
+        const { container } = mount(EPIC_SET);
+        expect(badge(container, 'development')).toBe(rowIds(container).length);
+    });
+
+    it('shows the epic\'s development rows even though every one is plan-carried '
+        + 'and the pipeline toggle is ON', () => {
+        const { container } = mount(EPIC_SET);
+        expect(rowIds(container)).toHaveLength(2);
+    });
+
+    it('keeps the launch chips free of plan-carried work — that exclusion is '
+        + 'correctness, not a viewing preference', () => {
+        const { container } = mount(EPIC_SET);
+        expect(badge(container, 'swarm_ready')).toBe(0);
+    });
+
+    it('excludes another epic\'s requirements from every count', () => {
+        const { container } = mount(EPIC_SET);
+        // Requirement 900 is swarm_ready and outside the epic; without the filter
+        // it would still be pipeline-excluded, so assert on `development` where
+        // the epic's own rows live and the count is unambiguous.
+        expect(badge(container, 'development')).toBe(2);
+    });
+
+    it('suppresses the add-a-requirement row while filtered', () => {
+        const { container } = mount(EPIC_SET);
+        expect(container.querySelector('[data-testid="requirement-template"]')).toBeNull();
+    });
+
+    it('with NO filter (null) it behaves exactly as before: the stored chip is '
+        + 'honoured and the template row is back', () => {
+        const { container } = mount(null);
+        expect(activeStatusAsked).toBe('swarm_ready');
+        expect(container.querySelector('[data-testid="requirement-template"]')).not.toBeNull();
+    });
+});

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -11,6 +11,7 @@ import { fetchEntity } from './factory/createEntityQueries';
 import { fetchCoordinatesForRuns, buildRunTrackUri, COORD_TRACK_FIELDS } from '../services/mapCoordinatesBatch';
 // req #3180 — THE browser's one derivation of pipeline-step membership.
 import { pipelinedRequirementIds } from '../utils/pipelineMembership';
+import { epicRequirementIds } from '../utils/epicMembership';
 
 export function useDomains(creatorFk, { closed, fields = 'id,domain_name,sort_order', enabled = true } = {}) {
     const { darwinUri } = useContext(AppContext);
@@ -1001,6 +1002,68 @@ export const useAllPipelineStepDeps         = pipelineStepDeps.useAll;
 export function usePipelinedRequirementIds(creatorFk, { enabled = true } = {}) {
     const { data } = useAllPipelineStepRequirements(creatorFk, { enabled });
     return useMemo(() => pipelinedRequirementIds(data), [data]);
+}
+
+// Req #3428 — the requirement ids one EPIC contains, as a Set, plus the narrow
+// requirement rows the page needs to decide WHERE that work lives.
+//
+// Modelled on `usePipelinedRequirementIds` above and for the same reason: four
+// surfaces need this answer (the Cards view's rows, the aggregator's rows, the
+// aggregator's chip badges, and which project tab to open), and they must
+// consult ONE derivation or they will disagree with each other in ways nothing
+// fails on.
+//
+// AN ID SET RATHER THAN A WIDER PROJECTION. Three of those four consumers read
+// requirements through queries that do not carry `feature_fk`
+// (`useRequirementsByStatus`, `useRequirementsDone`, and the counts read), and
+// teaching all three about epics would put a column on the wire for every reader
+// of those shared cache entries, forever, to serve a filter that is off almost
+// all the time. One narrow read answers all four instead.
+//
+// `epicId == null` DISABLES BOTH READS, so a page with no filter active pays
+// nothing — not a fetch, not a parse. It returns `{ epicReqIds: null, … }`, and
+// `null` is what every consumer treats as "no filter" (an EMPTY SET means the
+// filter is on and matches nothing, which is a different page).
+//
+// `closed: ALL_ROWS` on the features read, matching the plan pages: a CLOSED
+// feature's requirements still belong to their epic, and dropping them here
+// would silently shrink the filter's population with no visible cause. It is
+// also the exact cache entry `PipelineDetail`/`StepsPage` already hold, so
+// arriving from the plan visualizer — which is how this filter is reached —
+// costs no features fetch at all.
+//
+// The narrowest projection that answers both questions: membership needs
+// `feature_fk`, and "which project tab holds this epic's work" needs
+// `category_fk`. `useAllRequirements` puts `fields` in its cache key (req #2213),
+// so this gets its own entry and cannot serve — or be served by — a wider
+// consumer's rows.
+const EPIC_MEMBERSHIP_REQUIREMENT_FIELDS = 'id,feature_fk,category_fk';
+
+//
+// A FAILED READ IS NOT AN EMPTY EPIC. Both `isError`s are read, and on either one
+// the hook returns `epicReqIds: null` — the same value that means "no filter" —
+// plus `isError: true` so the caller can say why. Discarding the error instead
+// leaves `features`/`requirements` undefined forever, which derives an EMPTY SET,
+// which renders every card gone and every badge zero: a page indistinguishable
+// from "this epic has no work", permanently, with nothing surfaced anywhere (the
+// QueryClient has no error handler). `filterToEpic`'s in-flight direction is
+// deliberate and unchanged — an empty set while a read is IN FLIGHT is a brief,
+// self-correcting state; a failed read is neither, so it must not share it.
+export function useEpicRequirementIds(creatorFk, epicId) {
+    const active = epicId !== null && epicId !== undefined;
+    const { data: features, isError: featuresError } = useAllFeatures(creatorFk, {
+        closed: ALL_ROWS, enabled: active,
+    });
+    const { data: requirements, isError: requirementsError } = useAllRequirements(creatorFk, {
+        fields: EPIC_MEMBERSHIP_REQUIREMENT_FIELDS, enabled: active,
+    });
+    const isError = active && (featuresError || requirementsError);
+
+    const epicReqIds = useMemo(
+        () => ((active && !isError) ? epicRequirementIds(features, requirements, epicId) : null),
+        [active, isError, features, requirements, epicId]);
+
+    return { epicReqIds, isError, requirements: active ? requirements : undefined };
 }
 
 // Req #3117 — the plan page's Cost column. TWO more bounded list reads, never a

--- a/src/utils/__tests__/epicMembership.test.js
+++ b/src/utils/__tests__/epicMembership.test.js
@@ -1,0 +1,151 @@
+// Req #3428 — the epic filter's pure rules.
+//
+// Every one of these is a rule a mounted test could only reach indirectly, and
+// most are the "0 is a perfectly good integer" class of bug that renders as a
+// plausible-looking page rather than as an error.
+
+import { describe, it, expect } from 'vitest';
+import {
+    featureIdsForEpic, epicRequirementIds, filterToEpic,
+    effectiveHidePipelined, firstProjectIndexWithEpicWork,
+} from '../epicMembership';
+
+const FEATURES = [
+    { id: 46, epic_fk: 11 },
+    { id: 47, epic_fk: 11 },
+    { id: 50, epic_fk: 9 },
+    { id: 51, epic_fk: null },
+];
+
+const REQUIREMENTS = [
+    { id: 3428, feature_fk: 46, category_fk: 1209 },
+    { id: 3430, feature_fk: 46, category_fk: 1 },
+    { id: 3440, feature_fk: 47, category_fk: 862 },
+    { id: 3500, feature_fk: 50, category_fk: 1209 },   // another epic
+    { id: 3600, feature_fk: null, category_fk: 1209 }, // unfiled
+];
+
+describe('featureIdsForEpic', () => {
+    it('collects only the features under the named epic', () => {
+        expect(featureIdsForEpic(FEATURES, 11)).toEqual(new Set([46, 47]));
+        expect(featureIdsForEpic(FEATURES, 9)).toEqual(new Set([50]));
+    });
+
+    it('is empty for a null epic, a missing epic, and a missing features read', () => {
+        expect(featureIdsForEpic(FEATURES, null).size).toBe(0);
+        expect(featureIdsForEpic(FEATURES, undefined).size).toBe(0);
+        expect(featureIdsForEpic(FEATURES, 999).size).toBe(0);
+        expect(featureIdsForEpic(undefined, 11).size).toBe(0);
+    });
+
+    it('never seeds the set from a feature row with no id', () => {
+        // Left unguarded this puts `NaN`/0 in the set, and the membership test
+        // below then answers true for requirements with no feature at all.
+        const ids = featureIdsForEpic([{ id: null, epic_fk: 11 }, { epic_fk: 11 }], 11);
+        expect(ids.size).toBe(0);
+    });
+});
+
+describe('epicRequirementIds', () => {
+    it('names the requirements reachable through the epic\'s features', () => {
+        expect(epicRequirementIds(FEATURES, REQUIREMENTS, 11))
+            .toEqual(new Set([3428, 3430, 3440]));
+    });
+
+    it('a requirement with no feature belongs to NO epic', () => {
+        // `Number(null)` is 0, so an unguarded `Set.has` would sweep in every
+        // unfiled requirement the moment a feature with id 0 existed.
+        const ids = epicRequirementIds([{ id: 0, epic_fk: 11 }],
+            [{ id: 3600, feature_fk: null }, { id: 3601, feature_fk: '' }], 11);
+        expect(ids.size).toBe(0);
+    });
+
+    it('is empty when either read has not resolved, or the epic is null', () => {
+        expect(epicRequirementIds(undefined, REQUIREMENTS, 11).size).toBe(0);
+        expect(epicRequirementIds(FEATURES, undefined, 11).size).toBe(0);
+        expect(epicRequirementIds(FEATURES, REQUIREMENTS, null).size).toBe(0);
+    });
+});
+
+describe('filterToEpic', () => {
+    const rows = [{ id: 3428 }, { id: 3500 }, { id: 3440 }];
+
+    it('keeps only rows in the set, matching on id alone', () => {
+        // ID-ONLY IS THE POINT: three of the four consuming projections carry no
+        // `feature_fk`, and this is what lets them be filtered anyway.
+        expect(filterToEpic(rows, new Set([3428, 3440])).map(r => r.id))
+            .toEqual([3428, 3440]);
+    });
+
+    it('returns the input UNCHANGED, by reference, when no filter is active', () => {
+        expect(filterToEpic(rows, null)).toBe(rows);
+        expect(filterToEpic(rows, undefined)).toBe(rows);
+    });
+
+    it('an EMPTY SET is a real answer and yields no rows — not "no filter"', () => {
+        // The in-flight direction, and the opposite of `excludePipelined`'s:
+        // showing everything until the features land renders the unfiltered page
+        // under a pill claiming it is filtered.
+        expect(filterToEpic(rows, new Set())).toEqual([]);
+    });
+
+    it('drops the template row, whose id is the empty string', () => {
+        expect(filterToEpic([{ id: '' }, { id: 3428 }], new Set([3428])).map(r => r.id))
+            .toEqual([3428]);
+    });
+});
+
+describe('effectiveHidePipelined', () => {
+    it('an epic filter forces the pipeline toggle off, whatever is stored', () => {
+        // The store DEFAULTS to true (req #3242), and an epic's requirements are
+        // seated in pipeline steps by construction — so without this the epic
+        // page arrives empty.
+        expect(effectiveHidePipelined(true, true)).toBe(false);
+        expect(effectiveHidePipelined(false, true)).toBe(false);
+    });
+
+    it('leaves the stored value alone with no filter active', () => {
+        expect(effectiveHidePipelined(true, false)).toBe(true);
+        expect(effectiveHidePipelined(false, false)).toBe(false);
+    });
+});
+
+describe('firstProjectIndexWithEpicWork', () => {
+    const PROJECTS = [{ id: 7 }, { id: 1 }, { id: 859 }];
+    const CATEGORIES = [
+        { id: 1, project_fk: 1 },
+        { id: 862, project_fk: 1 },
+        { id: 1209, project_fk: 1 },
+        { id: 99, project_fk: 7 },
+    ];
+    const epicIds = new Set([3428, 3430, 3440]);
+
+    it('returns the first project IN TAB ORDER that holds any of the work', () => {
+        expect(firstProjectIndexWithEpicWork(PROJECTS, CATEGORIES, REQUIREMENTS, epicIds)).toBe(1);
+    });
+
+    it('prefers the earlier tab when two projects both hold work', () => {
+        const reqs = [...REQUIREMENTS, { id: 3428, feature_fk: 46, category_fk: 99 }];
+        expect(firstProjectIndexWithEpicWork(PROJECTS, CATEGORIES, reqs, epicIds)).toBe(0);
+    });
+
+    it('is null when nothing matches — leave the reader on the tab they chose', () => {
+        expect(firstProjectIndexWithEpicWork(PROJECTS, CATEGORIES, REQUIREMENTS, new Set())).toBeNull();
+        expect(firstProjectIndexWithEpicWork(PROJECTS, CATEGORIES, REQUIREMENTS, null)).toBeNull();
+    });
+
+    it('is null while any input is still unresolved', () => {
+        expect(firstProjectIndexWithEpicWork(undefined, CATEGORIES, REQUIREMENTS, epicIds)).toBeNull();
+        expect(firstProjectIndexWithEpicWork(PROJECTS, undefined, REQUIREMENTS, epicIds)).toBeNull();
+        expect(firstProjectIndexWithEpicWork(PROJECTS, CATEGORIES, undefined, epicIds)).toBeNull();
+        expect(firstProjectIndexWithEpicWork([], CATEGORIES, REQUIREMENTS, epicIds)).toBeNull();
+    });
+
+    it('ignores work in a category this page does not render', () => {
+        // The categories read is `closed: 0`, so a closed category resolves to no
+        // project here. Selecting its project would move the reader to a tab that
+        // shows nothing — the exact outcome the seed exists to prevent.
+        const closedOnly = [{ id: 3428, feature_fk: 46, category_fk: 4242 }];
+        expect(firstProjectIndexWithEpicWork(PROJECTS, CATEGORIES, closedOnly, epicIds)).toBeNull();
+    });
+});

--- a/src/utils/epicMembership.js
+++ b/src/utils/epicMembership.js
@@ -1,0 +1,181 @@
+// Epic membership — req #3428.
+//
+// THE browser's one answer to "is this requirement part of this epic", plus the
+// three page-level questions that fall out of it. Every surface the epic filter
+// touches (the Cards view's rows, the SwarmStart aggregator's rows AND its chip
+// badges, which categories render, which project tab opens) reads them from
+// here, for the reason `pipelineMembership.js` gives about the question IT
+// answers: a second implementation is how two surfaces that must agree start
+// disagreeing, and the failure is silent — a chip badge reading 6 over 4 rows
+// looks like a rendering glitch, not a filter bug.
+//
+// WHICH QUESTION THIS ANSWERS: EPIC association, derived through
+// `requirement.feature_fk -> feature.epic_fk`. That is the "does this belong to
+// a body of work" question `pipelineMembership.js`' own header explicitly says
+// it is NOT answering (it answers STEP association — "is this scheduled"). The
+// two populations differ, both are legitimate, and they are deliberately two
+// modules so no caller reaches the wrong one by autocomplete.
+//
+// DERIVED, NEVER STORED. There is no `requirements.epic_fk` column and this must
+// not become one: the chain is two mutable links, so a stored copy is wrong the
+// moment a requirement is re-featured or a feature re-parented. Same rule the
+// plan layer states as design rule 1.
+//
+// No React, no MUI: a pure module vitest exercises with no DOM.
+
+/**
+ * The feature ids that sit under one epic.
+ *
+ * @param {?Array<{id: number, epic_fk: ?number}>} features rows from `useAllFeatures`
+ * @param {?number} epicId
+ * @returns {Set<number>} empty when `epicId` is null or nothing matches
+ */
+export const featureIdsForEpic = (features, epicId) => {
+    const ids = new Set();
+    if (epicId === null || epicId === undefined) return ids;
+    if (!Array.isArray(features)) return ids;
+    const target = Number(epicId);
+    for (const f of features) {
+        if (!f || f.epic_fk === null || f.epic_fk === undefined) continue;
+        if (Number(f.epic_fk) !== target) continue;
+        // A feature row with no id cannot name a feature. Seeding the set with
+        // null/undefined would make the `feature_fk` test below answer true for
+        // every requirement whose own `feature_fk` is unset — i.e. most of them.
+        if (f.id === null || f.id === undefined) continue;
+        ids.add(Number(f.id));
+    }
+    return ids;
+};
+
+/**
+ * The REQUIREMENT ids that belong to one epic.
+ *
+ * The shape every consumer wants, and the reason this module exists rather than
+ * a predicate each surface applies to its own rows: three of the four consumers
+ * (`useRequirementsByStatus`, `useRequirementsDone`, the counts projection) read
+ * requirements through queries that do NOT carry `feature_fk`, and widening
+ * three shared projections to teach them about epics would put a column on the
+ * wire for every reader of those caches forever. An id Set answers all four from
+ * ONE narrow read instead — `usePipelinedRequirementIds`' design, for the same
+ * reason it was chosen there.
+ *
+ * A requirement with no `feature_fk` is in NO epic. Guarded explicitly rather
+ * than left to `Set.has(Number(null))`, because `Number(null)` is 0 and a
+ * feature with id 0 would then sweep in every unfiled requirement there is.
+ *
+ * @param {?Array<{id: number, epic_fk: ?number}>} features
+ * @param {?Array<{id: number, feature_fk: ?number}>} requirements
+ * @param {?number} epicId
+ * @returns {Set<number>}
+ */
+export const epicRequirementIds = (features, requirements, epicId) => {
+    const out = new Set();
+    const featureIds = featureIdsForEpic(features, epicId);
+    if (featureIds.size === 0) return out;
+    if (!Array.isArray(requirements)) return out;
+    for (const r of requirements) {
+        if (!r || r.id === null || r.id === undefined || r.id === '') continue;
+        const fk = r.feature_fk;
+        if (fk === null || fk === undefined || fk === '') continue;
+        if (!featureIds.has(Number(fk))) continue;
+        out.add(Number(r.id));
+    }
+    return out;
+};
+
+/**
+ * Keep only the epic's requirements.
+ *
+ * `epicReqIds == null` means NO FILTER IS ACTIVE and returns the input UNCHANGED
+ * (same reference), so an ordinary page pays nothing and cannot trip a
+ * referential-equality dependency — `excludePipelined`'s contract, same reason.
+ *
+ * AN EMPTY SET IS A REAL ANSWER, NOT "no filter". While the two reads behind it
+ * are in flight the set is empty and this returns an EMPTY LIST — the opposite
+ * of `excludePipelined`'s in-flight direction, deliberately. That one DROPS rows,
+ * so "unknown" must mean "keep" or a failed fetch would hide eligible work. This
+ * one SELECTS rows, so "unknown" must mean "none yet": the alternative — show
+ * everything until the features land — renders the whole unfiltered page for a
+ * beat underneath a pill claiming it is filtered, which is the page lying about
+ * what it is showing.
+ *
+ * @param {?Array<{id: number}>} rows
+ * @param {?Set<number>} epicReqIds
+ */
+export const filterToEpic = (rows, epicReqIds) => {
+    if (!epicReqIds) return rows;
+    if (!Array.isArray(rows)) return rows;
+    return rows.filter(r => r && epicReqIds.has(Number(r.id)));
+};
+
+/**
+ * Whether the pipeline-membership filter is applying right now.
+ *
+ * ONE predicate with two consumers — the header control's visibility in
+ * `SwarmView` and the row predicate in `CategoryCard` — because those two
+ * disagreeing is a toggle that is on screen and not applying, or applying and
+ * not on screen. Both are the defect req #3242's own comment describes.
+ *
+ * An epic filter FORCES IT OFF. `hidePipelinedRequirements` defaults to `true`
+ * (req #3242, and the v8→v9 migration makes that true for existing browsers as
+ * well), while an epic's requirements are seated in pipeline steps by
+ * construction — so leaving the stored value in charge would deliver an epic
+ * page with nothing on it. The store is never WRITTEN here: an external
+ * condition does not overwrite uncommitted user intent (`normalizeView`'s
+ * doctrine), so dismissing the pill restores exactly what the reader had.
+ *
+ * @param {boolean} storedValue `useShowClosedStore.hidePipelinedRequirements`
+ * @param {boolean} epicFilterActive
+ * @returns {boolean}
+ */
+export const effectiveHidePipelined = (storedValue, epicFilterActive) =>
+    epicFilterActive ? false : !!storedValue;
+
+/**
+ * The index of the first project (in tab order) holding any of the epic's work.
+ *
+ * WHY THE PAGE NEEDS THIS AT ALL: an epic's requirements sit in categories, and
+ * categories sit in projects, so an epic link lands the reader on whichever
+ * project they last worked in — routinely one with none of that epic in it. The
+ * feature would then be invisible on arrival, which is the one outcome worth
+ * designing out.
+ *
+ * Returns null when nothing matches (leave the reader where they are — moving
+ * them to an arbitrary tab would be worse than the tab they chose) and when any
+ * input has not resolved yet.
+ *
+ * @param {?Array<{id: number}>} projects in tab order
+ * @param {?Array<{id: number, project_fk: ?number}>} categories
+ * @param {?Array<{id: number, category_fk: ?number}>} requirements
+ * @param {?Set<number>} epicReqIds
+ * @returns {?number}
+ */
+export const firstProjectIndexWithEpicWork = (projects, categories, requirements, epicReqIds) => {
+    if (!Array.isArray(projects) || projects.length === 0) return null;
+    if (!Array.isArray(categories) || !Array.isArray(requirements)) return null;
+    if (!epicReqIds || epicReqIds.size === 0) return null;
+
+    const projectByCategory = new Map();
+    for (const c of categories) {
+        if (!c || c.id === null || c.id === undefined) continue;
+        projectByCategory.set(Number(c.id), c.project_fk === null || c.project_fk === undefined
+            ? null : Number(c.project_fk));
+    }
+
+    const projectsWithWork = new Set();
+    for (const r of requirements) {
+        if (!r || !epicReqIds.has(Number(r.id))) continue;
+        if (r.category_fk === null || r.category_fk === undefined) continue;
+        const projectId = projectByCategory.get(Number(r.category_fk));
+        // A requirement in a CLOSED category resolves to no project here, because
+        // the categories read this page makes is `closed: 0`. Skipping it is
+        // correct: that category renders on no tab, so selecting its project
+        // would move the reader to a tab that shows nothing.
+        if (projectId === null || projectId === undefined) continue;
+        projectsWithWork.add(projectId);
+    }
+    if (projectsWithWork.size === 0) return null;
+
+    const index = projects.findIndex(p => p && projectsWithWork.has(Number(p.id)));
+    return index >= 0 ? index : null;
+};


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3428-epic-name-click-taskcards-1
- feat(3428): epic name click -> filtered Task Cards
- chore: init swarm session feature/3428-epic-name-click-taskcards-1

## Files changed
```
 src/SwarmView/CategoryCard.jsx                     |  58 +++++-
 src/SwarmView/CategoryTabPanel.jsx                 |  12 +-
 src/SwarmView/RequirementRow.jsx                   |  14 +-
 src/SwarmView/SwarmView.jsx                        | 167 +++++++++++++++-
 .../__tests__/CategoryCard.epicFilter.test.jsx     | 151 +++++++++++++++
 .../__tests__/SwarmView.epicFilter.test.jsx        | 209 +++++++++++++++++++++
 .../__tests__/swarmViewLink.epicParam.test.js      |  83 ++++++++
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx |  67 +++++++
 .../pipelines/__tests__/pipelinePlanLayout.test.js |  12 +-
 src/SwarmView/pipelines/pipelinePlanLayout.js      |  25 ++-
 src/SwarmView/swarmViewLink.js                     |  92 +++++++++
 src/TaskPlanView/SwarmStartCard.jsx                | 133 +++++++++++--
 .../__tests__/SwarmStartCard.epicFilter.test.jsx   | 173 +++++++++++++++++
 src/hooks/useDataQueries.js                        |  63 +++++++
 src/utils/__tests__/epicMembership.test.js         | 151 +++++++++++++++
 src/utils/epicMembership.js                        | 181 ++++++++++++++++++
 16 files changed, 1539 insertions(+), 52 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)