### PR TITLE
Pipeline 2.0 - the browser consumes the composed read: one fetch, pipelineModel.js deleted, the derived block rendered

### DIFF
--- a/src/SwarmView/pipelines/PipelineDetail.jsx
+++ b/src/SwarmView/pipelines/PipelineDetail.jsx
@@ -25,6 +25,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
 import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -45,21 +46,14 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 import call_rest_api from '../../RestApi/RestApi';
 import { useSnackBarStore } from '../../stores/useSnackBarStore';
-import { pipelineKeys } from '../../hooks/useQueryKeys';
+import { pipeline2ComposeKeys } from '../../hooks/useQueryKeys';
 import AppContext from '../../Context/AppContext';
 import AuthContext from '../../Context/AuthContext';
 import '../../CalendarFC/CalendarFC.css';
 import {
-    ALL_ROWS,
-    useAllEpics,
-    useAllFeatures,
-    useAllPipelineStepDeps,
-    useAllPipelineStepRequirements,
-    useAllPipelineSteps,
-    useAllPipelines,
     useAllRequirementSessions,
-    useAllRequirements,
     useAllSessionCostRollups,
+    useComposedPipeline2,
     useMachines,
     useOrchestrationClaims,
 } from '../../hooks/useDataQueries';
@@ -72,7 +66,7 @@ import {
     findPipelineDetailMode,
 } from './pipelineDetailModes';
 import { pipelineStatusChipProps, toolbarChipProps } from './pipelineChipStyles';
-import { claimForPipeline, holderView } from './orchestrationHolder';
+import { claimForPipeline2, holderView } from './orchestrationHolder';
 import { readFocusStepParam, readLevelParam } from './pipelineStepLink';
 import { readFocusEpicParam } from './pipelineEpicLink';
 import { writePipelinePlace } from './pipelinePlace';
@@ -91,12 +85,12 @@ import {
     DEFAULT_COLOR_KEY, DEFAULT_PLAN_LEVEL_PREF, DEFAULT_STEP_WIDTH,
     isStepWidth, normalizeColorKey, normalizePlanLevelPref,
 } from './pipelinePlanLayout';
+import { buildCostIndex } from './pipelineViewModel';
 import {
-    PLAN_REQUIREMENT_FIELDS,
-    buildCostIndex,
-    buildPipelineModel,
-    orderedPlan,
-} from './pipelineViewModel';
+    adaptComposedPipeline2,
+    buildPlan2Model,
+    deriveDiagnostic,
+} from './pipeline2Adapter';
 
 // A SHARED frozen empty array for the `data = EMPTY` defaults below. A `= []`
 // literal mints a NEW array on every render while `data` is undefined — which is
@@ -137,7 +131,7 @@ const EMPTY = Object.freeze([]);
 // children unmount), so `draft` and `savedRef` survive a close — which is what
 // lets the close handler save text the field never got to blur on.
 function PipelineDescriptionDialog({ pipeline, open, onClose }) {
-    const { idToken, profile } = useContext(AuthContext);
+    const { idToken } = useContext(AuthContext);
     const { darwinUri } = useContext(AppContext);
     const queryClient = useQueryClient();
     const showError = useSnackBarStore((s) => s.showError);
@@ -186,7 +180,14 @@ function PipelineDescriptionDialog({ pipeline, open, onClose }) {
         // Already saved, or already on the wire — either way, nothing to send.
         if (value === (inFlightRef.current ?? savedRef.current)) return;
         inFlightRef.current = value;
-        call_rest_api(`${darwinUri}/pipelines`, 'PUT',
+        // req #3381 — `pipeline` is now a `pipeline2_pipelines` row (the
+        // composed 2.0 read), so the edit-in-place field writes to the 2.0
+        // table and re-reads via the composed read's OWN query key — never
+        // the 1.0 `pipelines` table/`pipelineKeys` this dialog PUT to before
+        // the cutover. Item 5's "optimistic edits become re-reads": no local
+        // patch of `pipeline.description` here, the invalidation is the
+        // whole story.
+        call_rest_api(`${darwinUri}/pipeline2_pipelines`, 'PUT',
             [{ id: pipeline.id, description: value }], idToken)
             .then((result) => {
                 const code = result?.httpStatus?.httpStatus;
@@ -195,7 +196,7 @@ function PipelineDescriptionDialog({ pipeline, open, onClose }) {
                 } else {
                     savedRef.current = value;
                     queryClient.invalidateQueries({
-                        queryKey: pipelineKeys.all(profile?.userName) });
+                        queryKey: pipeline2ComposeKeys.byId(pipeline.id) });
                 }
             })
             .catch((error) => showError(error, 'Unable to update the pipeline description'))
@@ -510,22 +511,24 @@ export default function PipelineDetail() {
     const activeLevelPref = normalizePlanLevelPref(levelOverride ?? storedLevelPref);
     const activeMode = normalizeView(modeOverride || mode, PIPELINE_DETAIL_MODES);
 
-    // The list read, not a by-id read: /swarm/pipelines has already primed this
-    // exact cache entry, so arriving here costs nothing. A by-id hook would be a
-    // second cache entry and a guaranteed fetch on every navigation.
-    const { data: pipelines = [], isLoading: pipelinesLoading } = useAllPipelines(creatorFk);
-    const { data: steps = [], isLoading: stepsLoading } = useAllPipelineSteps(creatorFk);
-    const { data: stepRequirements = [], isLoading: linksLoading } =
-        useAllPipelineStepRequirements(creatorFk);
-    const { data: stepDeps = [], isLoading: depsLoading } = useAllPipelineStepDeps(creatorFk);
-    const { data: requirements = [], isLoading: reqsLoading } =
-        useAllRequirements(creatorFk, { fields: PLAN_REQUIREMENT_FIELDS });
-    // Labels are a DICTIONARY here, not a catalog: closed epics/features must
-    // still resolve or the plan blanks a column it has data for.
-    const { data: features = [], isLoading: featuresLoading, isError: featuresError } =
-        useAllFeatures(creatorFk, { closed: ALL_ROWS });
-    const { data: epics = [], isLoading: epicsLoading, isError: epicsError } =
-        useAllEpics(creatorFk);
+    // req #3381 — THE FETCH LAYER COLLAPSES. What used to be six-plus
+    // dictionary reads (pipelines, steps, step requirements, step deps,
+    // requirements, features, epics — `useAllFeatures` DIES here entirely,
+    // the one real Feature site this directory owned) joined and derived
+    // client-side (`buildPipelineModel` + `orderedPlan`) is now ONE call of
+    // the composed 2.0 read (`pipeline2_compose`, req #3367): the join AND
+    // the derivation both already ran server-side, in Lambda, and this page
+    // consumes the result rather than rebuilding it. `useMachines` survives
+    // as a second, small, whole-app dictionary read — 2.0's composed payload
+    // carries no `machines` table of its own (`pipeline2Adapter.js`'s
+    // header), and it is not scoped per-plan, so it costs nothing more than
+    // it always did.
+    //
+    // MEASURED READ COUNT: was 7 (pipelines, steps, step_requirements,
+    // step_deps, requirements, features, epics) + machines = 8 hooks feeding
+    // this page; now 2 (the composed read, machines) always-on, plus the two
+    // opt-in cost reads unchanged either way.
+    const { data: composed, isLoading: composedLoading } = useComposedPipeline2(pipelineId);
     const { data: machines = [], isLoading: machinesLoading, isError: machinesError } =
         useMachines(creatorFk);
 
@@ -545,6 +548,11 @@ export default function PipelineDetail() {
     // there), so gating the whole plan on it would trade a correct-but-costless
     // first paint for a slower one. They also do not gate because they are
     // OPT-IN at the UI: the Cost column is hidden until the user asks for it.
+    // #3345 did not move cost into the composed payload (verified against
+    // `pipeline2_compose.py` — no session/cost table appears in its reads), so
+    // this pair of reads is UNRELATED to the fetch this requirement collapses
+    // and survives unchanged, feeding `pipeline2Adapter.js` the same way it
+    // fed `orderedPlan`.
     const { data: requirementSessions = EMPTY, isError: requirementSessionsError } =
         useAllRequirementSessions(creatorFk);
     const { data: sessionCosts = EMPTY, isError: sessionCostsError } =
@@ -554,48 +562,47 @@ export default function PipelineDetail() {
     // about the data rather than about the fetch. The table says which it is.
     const costError = requirementSessionsError || sessionCostsError;
 
-    // EVERY read gates the render, the three label dictionaries included. They are
-    // not decoration: `displayOrder()` breaks ties on epic first-appearance order,
-    // so rendering before features/epics resolve produces a DIFFERENT, silently
-    // wrong row order — and one that verifyOrder() accepts, because a plan with no
-    // epics violates no invariant. The one failure mode design rule 3's self-check
-    // cannot catch is the one where the inputs, not the algorithm, are wrong.
-    const isLoading = pipelinesLoading || stepsLoading || linksLoading
-        || depsLoading || reqsLoading || featuresLoading || epicsLoading || machinesLoading;
+    const isLoading = composedLoading || machinesLoading;
 
-    // Same argument, one step further: `fetchEntity` turns a 404 into `[]` and a
-    // 5xx leaves `data` undefined, so a FAILED dictionary read is indistinguishable
-    // from an empty one and would ship that wrong order permanently, with blank
-    // Epic/Feature columns and numeric machine ids as its only symptoms. Say so.
-    const dictionaryError = featuresError || epicsError || machinesError;
+    // A failed `machines` read must not render as a column of bare ids with no
+    // explanation — the same argument `dictionaryError` made for the 1.0
+    // fetch layer, narrowed to the one dictionary this page still fetches
+    // separately from the composed read.
+    const dictionaryError = machinesError;
 
-    const pipeline = useMemo(
-        () => pipelines.find((p) => p.id === pipelineId) || null,
-        [pipelines, pipelineId]);
+    const pipeline = composed?.pipeline ?? null;
 
-    const model = useMemo(() => buildPipelineModel({
-        pipeline, steps, stepRequirements, stepDeps, requirements, features, epics, machines,
-    }), [pipeline, steps, stepRequirements, stepDeps, requirements, features, epics, machines]);
+    // req #3381 item 3 — A WITHHELD OR DEGRADED `derived` BLOCK IS A HARD
+    // STOP, NOT AN EMPTY RENDER. `null` (regime A — nothing withheld) means
+    // proceed; any other value is one of the four regimes
+    // (`derivation_failed` / `budget_derived_only` / `budget_rows_truncated`
+    // / wholly absent) and the plan panel below renders it as a diagnostic
+    // INSTEAD OF attempting a partial draw from rows with no derived state.
+    const diagnostic = useMemo(() => deriveDiagnostic(composed), [composed]);
+    const canRenderPlan = !!pipeline && !diagnostic;
+
+    const model = useMemo(
+        () => (canRenderPlan ? buildPlan2Model(composed, machines) : null),
+        [canRenderPlan, composed, machines]);
 
     const costIndex = useMemo(
         () => buildCostIndex({ requirementSessions, sessionCosts }),
         [requirementSessions, sessionCosts]);
 
-    // `now` is read ONCE per model change and handed to the engine, which never
-    // reads a clock itself. Time-gate eligibility therefore re-evaluates when the
-    // data does — on focus, on invalidation — rather than on a timer.
     const plan = useMemo(
-        () => orderedPlan(model, { now: new Date(), costIndex }),
-        [model, costIndex]);
-    // req #3225 — the whole-plan met/total, read straight off `orderedPlan`'s
-    // own derivation (no second pass over `model`).
-    const planReqCounts = plan.requirementCounts?.overall;
+        () => (canRenderPlan
+            ? adaptComposedPipeline2(composed, { machines, costIndex })
+            : null),
+        [canRenderPlan, composed, machines, costIndex]);
+    // req #3225 — the whole-plan met/total, read straight off the composed
+    // read's own `derived.requirement_counts` (no second pass over anything).
+    const planReqCounts = plan?.requirementCounts?.overall;
 
     // req #3224 — the WHOLE-PLAN reservation. An epic-scoped one is a different
     // and weaker claim ("a slice of this plan is being orchestrated") and is the
     // epics page's answer, not this header's.
     const orchestrationHolder = useMemo(
-        () => holderView(claimForPipeline(orchestrationClaims, pipeline?.id), machines),
+        () => holderView(claimForPipeline2(orchestrationClaims, pipeline?.id), machines),
         [orchestrationClaims, pipeline?.id, machines]);
 
     // `planMachines` — the distinct machine set behind the header's machine chip
@@ -676,8 +683,10 @@ export default function PipelineDetail() {
 
     // req #3242 — epics represented in THIS plan (a requirement with no epic
     // is excluded by `requirementCounts` itself, so this is never inflated by
-    // a "no epic" bucket).
-    const planEpicCount = plan.requirementCounts?.byEpic?.length ?? 0;
+    // a "no epic" bucket). `plan` is null while `diagnostic` is set (item 3 —
+    // a withheld/absent `derived` block is a hard stop, so there is no
+    // requirement-counts derivation to read).
+    const planEpicCount = plan?.requirementCounts?.byEpic?.length ?? 0;
 
     // ── ONE STRING PER ELLIPSIZING LINE ──────────────────────────────────────
     // `noWrap` with a tooltip needs the whole text as a VALUE: CSS
@@ -1080,10 +1089,33 @@ export default function PipelineDetail() {
             {dictionaryError && (
                 <Alert severity="error" variant="outlined" sx={{ mb: 2 }}
                        data-testid="pipeline-dictionary-error">
-                    The epic, feature or machine list failed to load. Epic and Feature
-                    columns will be blank, machines will read as bare ids, and the ROW
-                    ORDER is computed with those labels missing — it is not the plan&apos;s
-                    real order. Reload before acting on this page.
+                    The machine list failed to load. Machines will read as bare ids
+                    on this plan until it recovers. Reload before acting on this page.
+                </Alert>
+            )}
+
+            {/* req #3381 item 3 — A WITHHELD OR DEGRADED `derived` BLOCK IS A
+                HARD STOP, NOT AN EMPTY RENDER. `diagnostic` is set for all
+                four regimes (`derivation_failed`, `budget_derived_only`,
+                `budget_rows_truncated`, and the wholly-absent key) — the
+                panel below is never attempted from rows with no derived
+                state; this banner replaces it, in the SAME Alert treatment
+                `OrderViolationsAlert` (PipelinePlanTable.jsx) already uses
+                for an order-invariant failure, rather than inventing a
+                second diagnostic surface. */}
+            {diagnostic && (
+                <Alert severity="error" variant="outlined" sx={{ mb: 2 }}
+                       data-testid="pipeline-derived-withheld">
+                    <AlertTitle>
+                        Plan derivation unavailable ({diagnostic.regime})
+                    </AlertTitle>
+                    {diagnostic.message}
+                    {!diagnostic.rowsComplete && (
+                        <>
+                            {' '}The underlying rows are INCOMPLETE — do not sequence
+                            or launch from this plan until it recovers.
+                        </>
+                    )}
                 </Alert>
             )}
 
@@ -1091,7 +1123,10 @@ export default function PipelineDetail() {
                 canvas cancels this Box's `p: 3` on its own sides/bottom via a
                 negative margin, which relies on being the last thing in flow
                 — anything rendered after it here would overlap the canvas by
-                24px instead of leaving a gap. */}
+                24px instead of leaving a gap. A withheld/absent `derived`
+                block renders NO panel at all (item 3's hard stop) — the
+                diagnostic Alert above is then the last child instead. */}
+            {canRenderPlan && (
             <ActiveComponent plan={plan} model={model} pipeline={pipeline} timezone={timezone}
                              focusStepId={focusStepId} onStepFocus={onStepFocus}
                              focusEpicId={focusEpicId}
@@ -1116,6 +1151,7 @@ export default function PipelineDetail() {
                              onEffectiveLevel={setEffectiveLevel}
                              resetViewNonce={resetViewNonce}
                              />
+            )}
         </Box>
     );
 }

--- a/src/SwarmView/pipelines/__tests__/PipelineDetail.epicParam.test.jsx
+++ b/src/SwarmView/pipelines/__tests__/PipelineDetail.epicParam.test.jsx
@@ -43,22 +43,16 @@ vi.mock('../../../RestApi/RestApi', () => ({ default: vi.fn(() => Promise.resolv
 
 vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
     const actual = await importOriginal();
+    const { composedFixture } = await import('./pipeline2ComposedFixture');
     const empty = () => ({ data: [], isLoading: false, isError: false });
     return {
         ...actual,
-        useAllPipelines: () => ({
-            data: [{ id: 2, title: 'Darwin', pipeline_status: 'active', description: '' }],
+        // req #3381 — the composed 2.0 read replaces the six-plus dictionary
+        // reads this file used to mock.
+        useComposedPipeline2: (id) => ({
+            data: id === 2 ? composedFixture() : null,
             isLoading: false,
         }),
-        useAllPipelineSteps: () => ({
-            data: [{ id: 47, pipeline_fk: 2, title: 'Session Drain', run: 'auto', notes: null, completed_at: null }],
-            isLoading: false,
-        }),
-        useAllPipelineStepRequirements: empty,
-        useAllPipelineStepDeps: empty,
-        useAllRequirements: empty,
-        useAllFeatures: empty,
-        useAllEpics: empty,
         useMachines: empty,
         useAllRequirementSessions: empty,
         useAllSessionCostRollups: empty,

--- a/src/SwarmView/pipelines/__tests__/PipelineDetail.modeToggleAccessibleName.test.jsx
+++ b/src/SwarmView/pipelines/__tests__/PipelineDetail.modeToggleAccessibleName.test.jsx
@@ -32,22 +32,16 @@ vi.mock('../../../RestApi/RestApi', () => ({ default: vi.fn(() => Promise.resolv
 
 vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
     const actual = await importOriginal();
+    const { composedFixture } = await import('./pipeline2ComposedFixture');
     const empty = () => ({ data: [], isLoading: false, isError: false });
     return {
         ...actual,
-        useAllPipelines: () => ({
-            data: [{ id: 2, title: 'Darwin', pipeline_status: 'active', description: '' }],
+        // req #3381 — the composed 2.0 read replaces the six-plus dictionary
+        // reads this file used to mock.
+        useComposedPipeline2: (id) => ({
+            data: id === 2 ? composedFixture() : null,
             isLoading: false,
         }),
-        useAllPipelineSteps: () => ({
-            data: [{ id: 47, pipeline_fk: 2, title: 'Session Drain', run: 'auto', notes: null, completed_at: null }],
-            isLoading: false,
-        }),
-        useAllPipelineStepRequirements: empty,
-        useAllPipelineStepDeps: empty,
-        useAllRequirements: empty,
-        useAllFeatures: empty,
-        useAllEpics: empty,
         useMachines: empty,
         useAllRequirementSessions: empty,
         useAllSessionCostRollups: empty,

--- a/src/SwarmView/pipelines/__tests__/PipelineDetail.place.test.jsx
+++ b/src/SwarmView/pipelines/__tests__/PipelineDetail.place.test.jsx
@@ -53,30 +53,29 @@ vi.mock('../../../RestApi/RestApi', () => ({
     default: vi.fn(() => Promise.resolve({ httpStatus: { httpStatus: 200 }, data: [] })),
 }));
 
-const PIPELINES = [
-    { id: 2, title: 'Darwin', pipeline_status: 'active', description: '' },
-    { id: 5, title: 'Substrate', pipeline_status: 'completed', description: '' },
-];
-
 // Flipped per test to stage the sequence the real app ALWAYS goes through:
 // mount over a spinner, then the reads land.
 let loading = false;
 
 vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
     const actual = await importOriginal();
+    const { composedFixture } = await import('./pipeline2ComposedFixture');
     const empty = () => ({ data: [], isLoading: false, isError: false });
     const gated = () => ({ data: [], isLoading: loading, isError: false });
+    // req #3381 — the composed 2.0 read replaces the six-plus dictionary
+    // reads this file used to mock, keyed by the SAME `id` the old
+    // `useAllPipelines` fixture carried (2 and 5), with `loading` staging
+    // the spinner->landed sequence the same way it did before.
+    const FIXTURES = {
+        2: composedFixture({ id: 2, title: 'Darwin' }),
+        5: composedFixture({ id: 5, title: 'Substrate', pipelineStatus: 'completed' }),
+    };
     return {
         ...actual,
-        useAllPipelines: () => ({
-            data: loading ? [] : PIPELINES, isLoading: loading, isError: false,
+        useComposedPipeline2: (id) => ({
+            data: loading ? undefined : (FIXTURES[id] ?? null),
+            isLoading: loading,
         }),
-        useAllPipelineSteps: gated,
-        useAllPipelineStepRequirements: gated,
-        useAllPipelineStepDeps: gated,
-        useAllRequirements: gated,
-        useAllFeatures: gated,
-        useAllEpics: gated,
         useMachines: gated,
         useOrchestrationClaims: empty,
         useAllRequirementSessions: empty,

--- a/src/SwarmView/pipelines/__tests__/PipelineDetail.stepParam.test.jsx
+++ b/src/SwarmView/pipelines/__tests__/PipelineDetail.stepParam.test.jsx
@@ -58,22 +58,18 @@ vi.mock('../../../RestApi/RestApi', () => ({ default: vi.fn(() => Promise.resolv
 
 vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
     const actual = await importOriginal();
+    const { composedFixture } = await import('./pipeline2ComposedFixture');
     const empty = () => ({ data: [], isLoading: false, isError: false });
     return {
         ...actual,
-        useAllPipelines: () => ({
-            data: [{ id: 2, title: 'Darwin', pipeline_status: 'active', description: '' }],
+        // req #3381 — the composed 2.0 read replaces the six-plus dictionary
+        // reads this file used to mock (`useAllPipelines`/`useAllPipelineSteps`/
+        // `useAllPipelineStepRequirements`/`useAllPipelineStepDeps`/
+        // `useAllRequirements`/`useAllFeatures`/`useAllEpics`).
+        useComposedPipeline2: (id) => ({
+            data: id === 2 ? composedFixture() : null,
             isLoading: false,
         }),
-        useAllPipelineSteps: () => ({
-            data: [{ id: 47, pipeline_fk: 2, title: 'Session Drain', run: 'auto', notes: null, completed_at: null }],
-            isLoading: false,
-        }),
-        useAllPipelineStepRequirements: empty,
-        useAllPipelineStepDeps: empty,
-        useAllRequirements: empty,
-        useAllFeatures: empty,
-        useAllEpics: empty,
         useMachines: empty,
         useAllRequirementSessions: empty,
         useAllSessionCostRollups: empty,

--- a/src/SwarmView/pipelines/__tests__/PipelinesPage.restart.test.jsx
+++ b/src/SwarmView/pipelines/__tests__/PipelinesPage.restart.test.jsx
@@ -81,16 +81,30 @@ const PIPELINES = [
 
 vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
     const actual = await importOriginal();
+    const { composedFixture } = await import('./pipeline2ComposedFixture');
     const empty = () => ({ data: [], isLoading: false, isError: false });
+    // req #3381 — `useAllPipelines` SURVIVES: the LIST page (`PipelinesPage`)
+    // is still 1.0 and untouched by this requirement. Only the DETAIL page's
+    // fetch changed, to the composed 2.0 read, keyed by the SAME ids
+    // `PIPELINES` above already names.
+    const FIXTURES = {
+        2: composedFixture({ id: 2, title: 'Darwin' }),
+        5: composedFixture({ id: 5, title: 'Substrate' }),
+    };
     return {
         ...actual,
         useAllPipelines: () => ({ data: PIPELINES, isLoading: false, isError: false }),
+        // PipelinesPage.jsx itself (the LIST page, untouched — still 1.0)
+        // reads these directly for its own per-card summaries
+        // (`pipelineSummaries`/`pipelineRequirementCounts`); only the DETAIL
+        // page's fetch moved to the composed 2.0 read.
         useAllPipelineSteps: empty,
         useAllPipelineStepRequirements: empty,
         useAllPipelineStepDeps: empty,
         useAllRequirements: empty,
         useAllFeatures: empty,
         useAllEpics: empty,
+        useComposedPipeline2: (id) => ({ data: FIXTURES[id] ?? null, isLoading: false }),
         useMachines: empty,
         useOrchestrationClaims: empty,
         useAllRequirementSessions: empty,

--- a/src/SwarmView/pipelines/__tests__/orchestrationHolder.test.js
+++ b/src/SwarmView/pipelines/__tests__/orchestrationHolder.test.js
@@ -12,6 +12,7 @@ import { describe, it, expect } from 'vitest';
 import {
     STALE_AFTER_SECONDS,
     claimForPipeline,
+    claimForPipeline2,
     claimsForEpic,
     heartbeatAgeSeconds,
     heldForSeconds,
@@ -139,6 +140,44 @@ describe('scope selection', () => {
     it('renders the same scope words the engine uses', () => {
         expect(scopeLabel(claims[0])).toBe('pipeline:2');
         expect(scopeLabel(claims[1])).toBe('epic:7@2');
+    });
+});
+
+describe('scope selection — 2.0 (req #3381 code review)', () => {
+    // `pipeline2_fk`/`epic2_fk` are the SEPARATE columns a 2.0-scoped claim
+    // carries — NULL on a 1.0 row, and vice versa. `claim()`'s default
+    // fixture above never sets them, matching an un-widened
+    // `useOrchestrationClaims` read or a genuine 1.0 claim: both must read
+    // as `undefined`, not as a 2.0 scope of pipeline `undefined`.
+    const claims = [
+        claim({ id: 10, pipeline_fk: null, epic_fk: null, pipeline2_fk: 6, epic2_fk: null }),
+        claim({ id: 11, pipeline_fk: null, epic_fk: null, pipeline2_fk: 6, epic2_fk: 9 }),
+        claim({ id: 12, pipeline_fk: 2, epic_fk: null }),   // a 1.0 claim, unchanged
+    ];
+
+    it('claimForPipeline2 finds only the WHOLE-PLAN 2.0 reservation', () => {
+        expect(claimForPipeline2(claims, 6).id).toBe(10);
+        expect(claimForPipeline2(claims, 42)).toBeNull();
+        expect(claimForPipeline2(claims, null)).toBeNull();
+    });
+
+    it('claimForPipeline2 never matches a 1.0-only claim (pipeline2_fk absent)', () => {
+        // The bug this guards: `undefined === 6` is false, so a 1.0 claim
+        // must not accidentally satisfy a 2.0 lookup for the same numeric id.
+        expect(claimForPipeline2([claims[2]], 2)).toBeNull();
+    });
+
+    it('claimForPipeline never matches a 2.0-only claim (pipeline_fk absent)', () => {
+        expect(claimForPipeline([claims[0], claims[1]], 6)).toBeNull();
+    });
+
+    it('scopeLabel renders pipeline2:/epic2: for a 2.0 claim', () => {
+        expect(scopeLabel(claims[0])).toBe('pipeline2:6');
+        expect(scopeLabel(claims[1])).toBe('epic2:9@6');
+    });
+
+    it('scopeLabel still renders pipeline:/epic: for a 1.0 claim, unaffected', () => {
+        expect(scopeLabel(claims[2])).toBe('pipeline:2');
     });
 });
 

--- a/src/SwarmView/pipelines/__tests__/pipeline2Adapter.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipeline2Adapter.test.js
@@ -1,0 +1,369 @@
+// pipeline2Adapter.test.js — req #3381. This module does not derive anything
+// (the header says so); these tests hold it to that: every field a fixture
+// hands in comes back reshaped, never recomputed.
+
+import { describe, it, expect } from 'vitest';
+
+import {
+    deriveDiagnostic,
+    rowsComplete,
+    buildPlan2Rows,
+    adaptComposedPipeline2,
+    buildPlan2Model,
+    WITHHELD_DERIVATION_FAILED,
+    WITHHELD_BUDGET_DERIVED_ONLY,
+    WITHHELD_BUDGET_ROWS_TRUNCATED,
+    WITHHELD_ABSENT,
+    WITHHELD_UNSPECIFIED,
+} from '../pipeline2Adapter';
+import { buildCostIndex } from '../pipelineViewModel';
+import { composedFixture } from './pipeline2ComposedFixture';
+
+describe('deriveDiagnostic — the four regimes (req #3345 § 4.5 / #3367 deliverable 3)', () => {
+    it('is null when derived is present and not withheld (regime A)', () => {
+        expect(deriveDiagnostic(composedFixture())).toBeNull();
+    });
+
+    it('reads withheld_reason and rows_complete verbatim for a derivation failure', () => {
+        const payload = composedFixture();
+        payload.derived = {
+            withheld: true, withheld_reason: WITHHELD_DERIVATION_FAILED,
+            rows_complete: true, reason: 'boom',
+        };
+        const d = deriveDiagnostic(payload);
+        expect(d).toEqual({
+            regime: WITHHELD_DERIVATION_FAILED, rowsComplete: true, message: 'boom',
+        });
+    });
+
+    it('regime B — budget_derived_only, rows complete', () => {
+        const payload = composedFixture();
+        payload.derived = {
+            withheld: true, withheld_reason: WITHHELD_BUDGET_DERIVED_ONLY,
+            rows_complete: true, reason: 'no room for derived',
+        };
+        expect(deriveDiagnostic(payload)).toEqual({
+            regime: WITHHELD_BUDGET_DERIVED_ONLY, rowsComplete: true,
+            message: 'no room for derived',
+        });
+    });
+
+    it('regime C — budget_rows_truncated, rows INCOMPLETE', () => {
+        const payload = composedFixture();
+        payload.derived = {
+            withheld: true, withheld_reason: WITHHELD_BUDGET_ROWS_TRUNCATED,
+            rows_complete: false, reason: 'steps truncated',
+        };
+        const d = deriveDiagnostic(payload);
+        expect(d.rowsComplete).toBe(false);
+        expect(rowsComplete(payload.derived)).toBe(false);
+    });
+
+    it('regime 4 — derived wholly ABSENT, treated as incomplete by construction', () => {
+        const payload = composedFixture();
+        delete payload.derived;
+        const d = deriveDiagnostic(payload);
+        expect(d.regime).toBe(WITHHELD_ABSENT);
+        expect(d.rowsComplete).toBe(false);
+    });
+
+    it('a null/undefined payload (still loading) also reads as absent', () => {
+        expect(deriveDiagnostic(null).regime).toBe(WITHHELD_ABSENT);
+        expect(deriveDiagnostic(undefined).regime).toBe(WITHHELD_ABSENT);
+    });
+
+    it('withheld with no reason code reads as UNSPECIFIED, never as ABSENT (code review 2026-08-09)', () => {
+        // The block IS present and IS withheld — a producer bug (missing
+        // reason code), not the fourth regime (key wholly absent). Reporting
+        // WITHHELD_ABSENT here would send a reader looking for a missing key
+        // that is right there.
+        const payload = composedFixture();
+        payload.derived = { withheld: true, rows_complete: false, reason: 'no code given' };
+        const d = deriveDiagnostic(payload);
+        expect(d.regime).toBe(WITHHELD_UNSPECIFIED);
+        expect(d.regime).not.toBe(WITHHELD_ABSENT);
+    });
+
+    it('rowsComplete closes over a derived block that is not even an object', () => {
+        expect(rowsComplete(null)).toBe(false);
+        expect(rowsComplete(undefined)).toBe(false);
+        expect(rowsComplete('nonsense')).toBe(false);
+    });
+});
+
+describe('buildPlan2Rows — joining derived.rows[] back onto steps[]/epics[]/requirements[]', () => {
+    const payload = composedFixture({
+        id: 6,
+        steps: [
+            { id: 71, epic_fk: 5, title: 'Mirror Layer', run: 'auto',
+                notes: 'evidence', completed_at: null, not_before: '2026-08-01 00:00:00' },
+            { id: 72, epic_fk: 5, title: 'Clone Core', run: 'manual',
+                notes: null, completed_at: '2026-08-02 00:00:00', not_before: null },
+        ],
+        epics: [{ id: 5, title: 'Swarm Cloned Git', sort_order: 3 }],
+        requirements: [
+            { id: 3001, requirement_status: 'swarm_ready', machine_fk: 2, tracking: 0 },
+            { id: 3002, requirement_status: 'met', machine_fk: null, tracking: 1 },
+        ],
+        stepRequirements: [
+            { step_fk: 71, requirement_fk: 3001 },
+            { step_fk: 71, requirement_fk: 3002 },
+        ],
+        stepDeps: [{ id: 1, step_fk: 72, dep_step_fk: 71 }],
+    });
+    // Overwrite the fixture's own generic `derived.rows` with ones that carry
+    // realistic per-row fields, matching what `pipeline2_derive.py` actually
+    // emits (snake_case, compact — module header).
+    payload.derived.rows = [
+        {
+            id: 71, state: 'pending', run: 'auto', eligible: true, epic_id: 5,
+            dep_ids: [], out_of_scope_dep_ids: [], req_ids: [3001, 3002],
+            tracking_req_ids: [3002], unresolved_req_ids: [], launch_req_ids: [3001],
+            launch_excluded: ['3002 tracking container'], launch_block: null,
+            swarm_start_command: '/swarm-start 3001', no_launch_reason: null,
+            launch_suppressed: false, suppressed_by: [],
+        },
+        {
+            id: 72, state: 'pending', run: 'manual', eligible: false, epic_id: 5,
+            dep_ids: [71], out_of_scope_dep_ids: [], req_ids: [], tracking_req_ids: [],
+            unresolved_req_ids: [], launch_req_ids: [], launch_excluded: [],
+            launch_block: 'no-links', swarm_start_command: null,
+            no_launch_reason: 'no linked requirements — nothing to launch',
+            launch_suppressed: true, suppressed_by: ['pipeline'],
+        },
+    ];
+    const machines = [{ id: 2, title: 'Mac mini' }];
+    const rows = buildPlan2Rows(payload, machines);
+
+    it('carries every derived.rows[] field through under its camelCase name', () => {
+        const r = rows.find((x) => x.id === 71);
+        expect(r.state).toBe('pending');
+        expect(r.run).toBe('auto');
+        expect(r.eligible).toBe(true);
+        expect(r.reqIds).toEqual([3001, 3002]);
+        expect(r.trackingReqIds).toEqual([3002]);
+        expect(r.launchReqIds).toEqual([3001]);
+        expect(r.launchExcluded).toEqual(['3002 tracking container']);
+        expect(r.swarmStartCommand).toBe('/swarm-start 3001');
+        expect(r.depIds).toEqual([]);
+    });
+
+    it('joins the step dictionary for title/notes/completedAt', () => {
+        const r71 = rows.find((x) => x.id === 71);
+        expect(r71.title).toBe('Mirror Layer');
+        expect(r71.notes).toBe('evidence');
+        expect(r71.completedAt).toBeNull();
+        const r72 = rows.find((x) => x.id === 72);
+        expect(r72.title).toBe('Clone Core');
+        expect(r72.completedAt).toBe('2026-08-02 00:00:00');
+    });
+
+    it('folds a step\'s not_before into a single-entry timeDeps array', () => {
+        expect(rows.find((x) => x.id === 71).timeDeps).toEqual(['2026-08-01 00:00:00']);
+        expect(rows.find((x) => x.id === 72).timeDeps).toEqual([]);
+    });
+
+    it('joins the epic dictionary — exactly ONE epic per step, no dominant-label tally', () => {
+        const r = rows.find((x) => x.id === 71);
+        expect(r.epicId).toBe(5);
+        expect(r.epic).toBe('Swarm Cloned Git');
+        expect(r.epicSortOrder).toBe(3);
+        expect(r.epicLabels).toEqual([{ id: 5, title: 'Swarm Cloned Git' }]);
+    });
+
+    it('never synthesizes a Feature — 2.0 has none', () => {
+        for (const r of rows) {
+            expect(r.featureId).toBeNull();
+            expect(r.feature).toBeNull();
+            expect(r.featureLabels).toEqual([]);
+        }
+    });
+
+    it('never marks a row label-inherited — 2.0 containment gives every step its own epic', () => {
+        expect(rows.every((r) => r.labelInherited === false)).toBe(true);
+    });
+
+    it('derives machine labels from requirements[].machine_fk minus tracking containers', () => {
+        const r71 = rows.find((x) => x.id === 71);
+        // 3001 (Mac mini) counts; 3002 is a tracking container and is excluded —
+        // matching pipelineModel.js's machineLabels() exclusion (rule 10 sibling).
+        expect(r71.machineLabels).toEqual(['Mac mini']);
+        expect(r71.machineLabel).toBe('Mac mini');
+    });
+
+    it('degrades an unresolvable machine id to the POC #<id> form', () => {
+        const payload2 = composedFixture({
+            steps: [{ id: 1, epic_fk: null, title: 'S', run: 'auto', notes: null,
+                completed_at: null, not_before: null }],
+            requirements: [{ id: 1, requirement_status: 'swarm_ready', machine_fk: 999 }],
+            stepRequirements: [{ step_fk: 1, requirement_fk: 1 }],
+        });
+        payload2.derived.rows = [{
+            id: 1, state: 'pending', run: 'auto', eligible: false, epic_id: null,
+            dep_ids: [], out_of_scope_dep_ids: [], req_ids: [1], tracking_req_ids: [],
+            unresolved_req_ids: [], launch_req_ids: [], launch_excluded: [],
+            launch_block: 'not-ready', swarm_start_command: null, no_launch_reason: 'x',
+            launch_suppressed: false, suppressed_by: [],
+        }];
+        const r = buildPlan2Rows(payload2, [])[0];
+        expect(r.machineLabels).toEqual(['#999']);
+    });
+
+    it('a NULL machine_fk labels Any', () => {
+        const payload2 = composedFixture({
+            steps: [{ id: 1, epic_fk: null, title: 'S', run: 'auto', notes: null,
+                completed_at: null, not_before: null }],
+            requirements: [{ id: 1, requirement_status: 'swarm_ready', machine_fk: null }],
+            stepRequirements: [{ step_fk: 1, requirement_fk: 1 }],
+        });
+        payload2.derived.rows = [{
+            id: 1, state: 'pending', run: 'auto', eligible: false, epic_id: null,
+            dep_ids: [], out_of_scope_dep_ids: [], req_ids: [1], tracking_req_ids: [],
+            unresolved_req_ids: [], launch_req_ids: [], launch_excluded: [],
+            launch_block: 'not-ready', swarm_start_command: null, no_launch_reason: 'x',
+            launch_suppressed: false, suppressed_by: [],
+        }];
+        const r = buildPlan2Rows(payload2, [])[0];
+        expect(r.machineLabels).toEqual(['Any']);
+    });
+
+    it('preserves derived.rows[] array order — already display order, never re-sorted', () => {
+        const reversedPayload = composedFixture();
+        reversedPayload.derived.rows = [
+            { id: 2, state: 'pending', run: 'auto', eligible: false, epic_id: null,
+                dep_ids: [], out_of_scope_dep_ids: [], req_ids: [], tracking_req_ids: [],
+                unresolved_req_ids: [], launch_req_ids: [], launch_excluded: [],
+                launch_block: 'no-links', swarm_start_command: null, no_launch_reason: 'x',
+                launch_suppressed: false, suppressed_by: [] },
+            { id: 1, state: 'pending', run: 'auto', eligible: false, epic_id: null,
+                dep_ids: [], out_of_scope_dep_ids: [], req_ids: [], tracking_req_ids: [],
+                unresolved_req_ids: [], launch_req_ids: [], launch_excluded: [],
+                launch_block: 'no-links', swarm_start_command: null, no_launch_reason: 'x',
+                launch_suppressed: false, suppressed_by: [] },
+        ];
+        const r = buildPlan2Rows(reversedPayload, []);
+        expect(r.map((x) => x.id)).toEqual([2, 1]);
+    });
+});
+
+describe('adaptComposedPipeline2 — the plan object', () => {
+    const payload = composedFixture({
+        steps: [{ id: 1, epic_fk: 9, title: 'S', run: 'auto', notes: null,
+            completed_at: null, not_before: null }],
+        epics: [{ id: 9, title: 'E', sort_order: 1 }],
+        requirements: [{ id: 100, requirement_status: 'swarm_ready', machine_fk: null }],
+        stepRequirements: [{ step_fk: 1, requirement_fk: 100 }],
+    });
+    payload.derived = {
+        now: '2026-08-09T00:00:00Z',
+        epic_order: [9],
+        display_order: [1],
+        rows: [{
+            id: 1, state: 'pending', run: 'auto', eligible: true, epic_id: 9,
+            dep_ids: [], out_of_scope_dep_ids: [], req_ids: [100], tracking_req_ids: [],
+            unresolved_req_ids: [], launch_req_ids: [100], launch_excluded: [],
+            launch_block: null, swarm_start_command: '/swarm-start 100',
+            no_launch_reason: null, launch_suppressed: false, suppressed_by: [],
+        }],
+        pause: {
+            pipeline_status: 'active', pipeline_paused: false,
+            paused_epic_ids: [], suppressed_step_ids: [],
+        },
+        serial: {
+            execution_mode: 'serial', serial: true, epic_order: [9],
+            closed_epic_ids: [], live_epic_id: 9, waiting_epic_ids: [], held_step_ids: [],
+        },
+        eligible_step_ids: [1],
+        violations: [{ invariant: 'topology', message: 'x renders before y', step_ids: [1, 2] }],
+        cycle_detected: false,
+        cycle_step_ids: [],
+        duplicate_step_ids: [],
+        unresolved_req_ids: [],
+        out_of_scope_dep_ids: [],
+        requirement_counts: {
+            overall: { met: 0, total: 1 },
+            by_epic: [{ epic_id: 9, met: 0, total: 1 }],
+        },
+    };
+
+    it('never derives batches — 2.0 has none, drawn or otherwise', () => {
+        const plan = adaptComposedPipeline2(payload);
+        expect(plan.batches).toEqual([]);
+        expect(plan.batchLetterByStepId.size).toBe(0);
+    });
+
+    it('reshapes eligible_step_ids into a Set', () => {
+        const plan = adaptComposedPipeline2(payload);
+        expect(plan.eligibleStepIds).toBeInstanceOf(Set);
+        expect(plan.eligibleStepIds.has(1)).toBe(true);
+    });
+
+    it('reshapes violations — invariant/message kept, step_ids -> stepIds', () => {
+        const plan = adaptComposedPipeline2(payload);
+        expect(plan.violations).toEqual([
+            { invariant: 'topology', message: 'x renders before y', stepIds: [1, 2] },
+        ]);
+    });
+
+    it('reshapes requirement_counts -> requirementCounts, by_epic -> byEpic/epicId', () => {
+        const plan = adaptComposedPipeline2(payload);
+        expect(plan.requirementCounts).toEqual({
+            overall: { met: 0, total: 1 },
+            byEpic: [{ epicId: 9, met: 0, total: 1 }],
+        });
+    });
+
+    it('reshapes pause verbatim under the camelCase field names the layout reads', () => {
+        const plan = adaptComposedPipeline2(payload);
+        expect(plan.pause).toEqual({
+            pipelineStatus: 'active', pipelinePaused: false,
+            pausedEpicIds: [], suppressedStepIds: [],
+        });
+    });
+
+    it('reshapes serial verbatim', () => {
+        const plan = adaptComposedPipeline2(payload);
+        expect(plan.serial).toEqual({
+            executionMode: 'serial', serial: true, epicOrder: [9],
+            closedEpicIds: [], liveEpicId: 9, waitingEpicIds: [], heldStepIds: [],
+        });
+    });
+
+    it('attaches cost from the SAME buildCostIndex two-read mechanism as before', () => {
+        const costIndex = buildCostIndex({
+            requirementSessions: [{ requirement_fk: 100, session_fk: 1 }],
+            sessionCosts: [{ id: 1, wall_secs_total: 600, output_tokens_total: 1000 }],
+        });
+        const plan = adaptComposedPipeline2(payload, { costIndex });
+        expect(plan.rows[0].cost).toEqual({ wallSecs: 600, tokens: 1000 });
+    });
+
+    it('every row carries a cost object even with no cost data at all', () => {
+        const plan = adaptComposedPipeline2(payload);
+        expect(plan.rows[0].cost).toEqual({ wallSecs: 0, tokens: 0 });
+    });
+
+    it('still computes a client-side time axis — the payload carries no time_axis key', () => {
+        const plan = adaptComposedPipeline2(payload);
+        expect(plan.timeAxis).toBeDefined();
+        expect(plan.timeAxis.stepStarts).toBeDefined();
+    });
+});
+
+describe('buildPlan2Model — the narrow model PipelinePlanVisualizer.jsx still reads', () => {
+    it('carries pipeline/requirements/machines and nothing 2.0 does not have', () => {
+        const payload = composedFixture({
+            requirements: [{ id: 1, requirement_status: 'met' }],
+        });
+        const machines = [{ id: 1, title: 'Mac mini' }];
+        const model = buildPlan2Model(payload, machines);
+        expect(model.pipeline).toBe(payload.pipeline);
+        expect(model.requirements).toEqual(payload.requirements);
+        expect(model.machines).toBe(machines);
+        expect(model.features).toBeUndefined();
+    });
+
+    it('tolerates a null payload', () => {
+        expect(buildPlan2Model(null)).toEqual({ pipeline: null, requirements: [], machines: [] });
+    });
+});

--- a/src/SwarmView/pipelines/__tests__/pipeline2ComposedFixture.js
+++ b/src/SwarmView/pipelines/__tests__/pipeline2ComposedFixture.js
@@ -1,0 +1,109 @@
+// pipeline2ComposedFixture.js — a minimal, valid `pipeline2_compose` payload
+// for PipelineDetail's component tests (req #3381). NOT imported by
+// `pipeline2Adapter.test.js` — that file builds its own payloads inline to
+// exercise specific shapes; this one exists purely so the component tests
+// that mount `PipelineDetail` (which need SOME composed read to get past
+// `isLoading` and the not-found branch) do not each hand-roll the same
+// `{pipeline, epics, steps, ..., derived}` skeleton.
+//
+// Deliberately NOT itself mocked or imported by a `vi.mock` factory — plain
+// data a test file's OWN factory imports, matching every other fixture in
+// this directory (`substrateRebuildFixture.js`, `epicZoomFixture.js`).
+
+const asArray = (v) => (Array.isArray(v) ? v : []);
+
+/**
+ * @param {Object} [options]
+ * @param {number} [options.id]
+ * @param {string} [options.title]
+ * @param {string} [options.pipelineStatus]
+ * @param {Object[]} [options.steps]  `{id, epic_fk, title, run, notes, completed_at, not_before}`
+ * @param {Object[]} [options.epics]
+ * @param {Object[]} [options.requirements]
+ * @param {Object[]} [options.stepRequirements]  `{step_fk, requirement_fk}`
+ * @param {Object[]} [options.stepDeps]          `{id, step_fk, dep_step_fk}`
+ * @returns {Object} a composed `pipeline2_compose` payload, `derived` present
+ */
+export function composedFixture({
+    id = 2,
+    title = 'Darwin',
+    pipelineStatus = 'active',
+    steps = [{
+        id: 47, epic_fk: null, title: 'Session Drain', run: 'auto',
+        notes: null, completed_at: null, not_before: null,
+    }],
+    epics = [],
+    requirements = [],
+    stepRequirements = [],
+    stepDeps = [],
+} = {}) {
+    const linksByStep = new Map();
+    for (const link of asArray(stepRequirements)) {
+        if (!linksByStep.has(link.step_fk)) linksByStep.set(link.step_fk, []);
+        linksByStep.get(link.step_fk).push(link.requirement_fk);
+    }
+    const depsByStep = new Map();
+    for (const dep of asArray(stepDeps)) {
+        if (dep.dep_step_fk == null) continue;
+        if (!depsByStep.has(dep.step_fk)) depsByStep.set(dep.step_fk, []);
+        depsByStep.get(dep.step_fk).push(dep.dep_step_fk);
+    }
+
+    const rows = asArray(steps).map((s) => ({
+        id: s.id,
+        state: s.completed_at != null ? 'done' : 'pending',
+        run: s.run || 'auto',
+        eligible: false,
+        epic_id: s.epic_fk != null ? s.epic_fk : null,
+        dep_ids: depsByStep.get(s.id) || [],
+        out_of_scope_dep_ids: [],
+        req_ids: linksByStep.get(s.id) || [],
+        tracking_req_ids: [],
+        unresolved_req_ids: [],
+        launch_req_ids: [],
+        launch_excluded: [],
+        launch_block: 'no-links',
+        swarm_start_command: null,
+        no_launch_reason: 'no linked requirements — nothing to launch',
+        launch_suppressed: false,
+        suppressed_by: [],
+    }));
+
+    return {
+        pipeline: {
+            id, title, description: '', pipeline_status: pipelineStatus,
+            execution_mode: 'parallel', machine_fk: null,
+            started_at: null, completed_at: null, step_count: rows.length,
+        },
+        epics: asArray(epics),
+        steps: asArray(steps),
+        step_requirements: asArray(stepRequirements),
+        step_deps: asArray(stepDeps),
+        requirements: asArray(requirements),
+        derived: {
+            now: '2026-01-01T00:00:00Z',
+            epic_order: [...new Set(rows.map((r) => r.epic_id).filter((v) => v != null))],
+            display_order: rows.map((r) => r.id),
+            rows,
+            pause: {
+                pipeline_status: pipelineStatus,
+                pipeline_paused: pipelineStatus === 'paused',
+                paused_epic_ids: [],
+                suppressed_step_ids: [],
+            },
+            serial: {
+                execution_mode: 'parallel', serial: false, epic_order: [],
+                closed_epic_ids: [], live_epic_id: null,
+                waiting_epic_ids: [], held_step_ids: [],
+            },
+            eligible_step_ids: [],
+            violations: [],
+            cycle_detected: false,
+            cycle_step_ids: [],
+            duplicate_step_ids: [],
+            unresolved_req_ids: [],
+            out_of_scope_dep_ids: [],
+            requirement_counts: { overall: { met: 0, total: 0 }, by_epic: [] },
+        },
+    };
+}

--- a/src/SwarmView/pipelines/__tests__/pipelineEpicZoom.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineEpicZoom.test.js
@@ -9,7 +9,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { buildPipelineModel, orderedPlan } from '../pipelineViewModel';
+import { buildPipelineModel } from '../pipelineViewModel';
 import { computePlanLayout, placeEpicChips, STEP_DONE } from '../pipelinePlanLayout';
 import {
     epicCycleKey, epicZoomStateKey, nextBatchLetter, nextEpicZoom,
@@ -17,6 +17,9 @@ import {
     EPIC_ZOOM_BAND, EPIC_ZOOM_BATCH,
 } from '../pipelineEpicZoom';
 import { EPIC_ZOOM_READS, EPIC_ZOOM_PIPELINE, EPIC_ZOOM_NOW } from './epicZoomFixture';
+// req #3381 — `orderedPlan` was deleted from pipelineViewModel.js; see
+// testOrderedPlan.js's header for why this file still needs a `plan` fixture.
+import { buildTestOrderedPlan as orderedPlan } from './testOrderedPlan';
 
 const plan = orderedPlan(
     buildPipelineModel({ pipeline: EPIC_ZOOM_PIPELINE, ...EPIC_ZOOM_READS }),

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -12,7 +12,10 @@ import { describe, it, expect } from 'vitest';
 import { SUBSTRATE_REBUILD_MODEL, MACHINES } from './substrateRebuildFixture';
 import { timedFuzzCorpus, FUZZ_NOW } from './timedFuzzPlans';
 import { EPIC_ZOOM_READS, EPIC_ZOOM_PIPELINE, EPIC_ZOOM_NOW } from './epicZoomFixture';
-import { buildPipelineModel, orderedPlan } from '../pipelineViewModel';
+import { buildPipelineModel } from '../pipelineViewModel';
+// req #3381 — `orderedPlan` was deleted from pipelineViewModel.js; see
+// testOrderedPlan.js's header for why this file still needs a `plan` fixture.
+import { buildTestOrderedPlan as orderedPlan } from './testOrderedPlan';
 import { semanticLevel, SEMANTIC_OUT_MAX } from '../../konvaSwarmModel';
 import {
     computePlanLayout, beadStyle, stepLabelText, BEAD_RADIUS, BEAD_HIT_RADIUS,

--- a/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelineViewModel.test.js
@@ -9,7 +9,6 @@ import { describe, it, expect } from 'vitest';
 import {
     buildCostIndex,
     buildPipelineModel,
-    orderedPlan,
     planRenderRows,
     pipelineSummary,
     pipelineSummaries,
@@ -36,6 +35,12 @@ import {
     EPICS,
     MACHINES,
 } from './substrateRebuildFixture';
+// req #3381 — `orderedPlan` was deleted from pipelineViewModel.js (zero
+// production callers left once `PipelineDetail.jsx` switched to the composed
+// 2.0 read). `testOrderedPlan.js` reconstructs it as test scaffolding, purely
+// so the tests below keep exercising `planRenderRows`/`pipelineSummary`/the
+// no-'#' directive against a realistic `plan`-shaped fixture.
+import { buildTestOrderedPlan as buildTestPlan } from './testOrderedPlan';
 
 // The fixture models ONE pipeline, so its steps carry no pipeline_fk. The REST
 // rows do, and the adapter's first job is scoping by it — give them one.
@@ -137,186 +142,8 @@ describe('PLAN_REQUIREMENT_FIELDS — the one shared projection', () => {
     });
 });
 
-describe('orderedPlan — engine run + self-check', () => {
-    const plan = orderedPlan(model(), { now: '2026-07-27T03:00:00Z' });
-
-    it('renders every step of the pipeline exactly once', () => {
-        expect(plan.rows).toHaveLength(STEPS.length);
-        expect(new Set(plan.rows.map((r) => r.id)).size).toBe(STEPS.length);
-    });
-
-    it('ships a clean order for the acceptance fixture', () => {
-        // Design rule 3: an empty violation list is the ONLY green light, and the
-        // Substrate Rebuild plan is THE acceptance fixture (req #3083).
-        expect(plan.violations).toEqual([]);
-        expect(plan.cycleDetected).toBe(false);
-        expect(plan.duplicateStepIds).toEqual([]);
-    });
-
-    it('reports no unresolved requirement links when the read is complete', () => {
-        expect(plan.unresolvedReqIds).toEqual([]);
-    });
-
-    it('surfaces unresolved requirement links when the read is truncated', () => {
-        const truncated = orderedPlan(buildPipelineModel({
-            ...READS, pipeline: PIPELINE,
-            requirements: REQUIREMENTS.filter((r) => r.id !== 3050),
-        }));
-        expect(truncated.unresolvedReqIds).toContain(3050);
-    });
-
-    it('marks pending rows whose every dependency is complete as eligible', () => {
-        for (const id of plan.eligibleStepIds) {
-            const row = plan.rows.find((r) => r.id === id);
-            expect(row.state).toBe(STEP_PENDING);
-            for (const dep of row.depIds) {
-                expect(plan.rows.find((r) => r.id === dep).state).toBe(STEP_DONE);
-            }
-        }
-    });
-
-    // RECORDED PROPERTY OF THE ACCEPTANCE FIXTURE, not a placeholder: the live
-    // Substrate Rebuild plan produces ZERO launch batches. Its nearest pair is
-    // steps 41 and 43, which share the gate (step 40) and the machine but differ
-    // in run mode — an auto step and a manual step do not go out in one
-    // /swarm-start, so they are correctly not a batch. The batch machinery is
-    // therefore exercised against the synthetic model below rather than pretended
-    // into this one.
-    it('finds no launch batch in the Substrate Rebuild plan', () => {
-        expect(plan.batches).toEqual([]);
-        expect(plan.batchLetterByStepId.size).toBe(0);
-    });
-
-    it('carries requirementCounts straight from the engine (req #3225)', () => {
-        // No second derivation here — `orderedPlan` must hand back exactly
-        // what `requirementCounts(model)` computes, so the plan header and
-        // the plan visualizer print the same number from the same call.
-        expect(plan.requirementCounts).toEqual(requirementCounts(model()));
-        expect(plan.requirementCounts.overall.total).toBeGreaterThan(0);
-    });
-
-    it('carries pause state, and unpaused fixture rows are never suppressed '
-        + '(req #3226)', () => {
-        expect(plan.pause).toEqual({
-            pipelineStatus: PIPELINE.pipeline_status,
-            pipelinePaused: false,
-            pausedEpicIds: [],
-            suppressedStepIds: [],
-        });
-        expect(plan.rows.every((r) => r.launchSuppressed === false)).toBe(true);
-    });
-
-    it('a paused pipeline suppresses every row and is reflected in plan.pause '
-        + '(req #3226)', () => {
-        const paused = orderedPlan(buildPipelineModel({
-            ...READS, pipeline: { ...PIPELINE, pipeline_status: 'paused' },
-        }));
-        expect(paused.pause.pipelinePaused).toBe(true);
-        expect(paused.pause.suppressedStepIds.sort((a, b) => a - b))
-            .toEqual(paused.rows.map((r) => r.id).sort((a, b) => a - b));
-        expect(paused.rows.every((r) => r.launchSuppressed)).toBe(true);
-    });
-});
-
-// A minimal plan with a genuine batch: two pending steps sharing an identical
-// (gate, run, machine) tuple, plus a third that differs only in run mode and
-// must NOT join them.
-const BATCH_READS = {
-    steps: [
-        { id: 1, pipeline_fk: 1, title: 'gate', run: 'auto', notes: null,
-            completed_at: '2026-07-01T00:00:00' },
-        { id: 2, pipeline_fk: 1, title: 'batch mate A', run: 'auto', notes: null,
-            completed_at: null },
-        { id: 3, pipeline_fk: 1, title: 'batch mate B', run: 'auto', notes: null,
-            completed_at: null },
-        { id: 4, pipeline_fk: 1, title: 'same gate, manual', run: 'manual', notes: null,
-            completed_at: null },
-    ],
-    stepRequirements: [
-        { step_fk: 2, requirement_fk: 900 },
-        { step_fk: 3, requirement_fk: 901 },
-        { step_fk: 4, requirement_fk: 902 },
-    ],
-    stepDeps: [
-        { id: 1, step_fk: 2, dep_step_fk: 1, time_at: null },
-        { id: 2, step_fk: 3, dep_step_fk: 1, time_at: null },
-        { id: 3, step_fk: 4, dep_step_fk: 1, time_at: null },
-    ],
-    requirements: [
-        // `swarm_ready`, not `approved` — req #3360 makes it the ONLY launchable
-        // status, and this fixture's subject is BATCHING, so its requirements
-        // have to be launchable for the batch to carry a command at all.
-        { id: 900, requirement_status: 'swarm_ready', machine_fk: 2, feature_fk: 101 },
-        { id: 901, requirement_status: 'swarm_ready', machine_fk: 2, feature_fk: 101 },
-        { id: 902, requirement_status: 'swarm_ready', machine_fk: 2, feature_fk: 101 },
-    ],
-    features: [{ id: 101, title: 'Wave', epic_fk: 11 }],
-    epics: [{ id: 11, title: 'Epic' }],
-    machines: MACHINES,
-};
-
-describe('launch batches (design rule 8)', () => {
-    const plan = orderedPlan(
-        buildPipelineModel({ pipeline: PIPELINE, ...BATCH_READS }),
-        { now: '2026-07-27T03:00:00Z' });
-
-    it('groups only the steps that truly launch together', () => {
-        expect(plan.batches).toHaveLength(1);
-        expect(plan.batches[0].stepIds).toEqual([2, 3]);
-    });
-
-    it('carries the EXACT one-line /swarm-start argument list', () => {
-        expect(plan.batches[0].swarmStartArgs).toEqual([900, 901]);
-        expect(plan.batches[0].swarmStartCommand).toBe('/swarm-start 900 901');
-    });
-
-    it('names the gate and the run mode the banner prints', () => {
-        // The REMAINING gate since req #3188, and step 1 carries a completed_at
-        // stamp — so the honest banner text is "no step gate", not "steps 1".
-        // The batch is eligible NOW; naming a dep that closed on 2026-07-01
-        // read as something still holding it back.
-        expect(plan.batches[0].gateStepIds).toEqual([]);
-        expect(plan.batches[0].epicId).toBe(11);
-        expect(plan.batches[0].run).toBe('auto');
-        expect(plan.batches[0].machineLabels).toEqual(['Mac mini']);
-    });
-
-    it('gives every batch member the same letter, starting at A', () => {
-        expect(plan.batchLetterByStepId.get(2)).toBe('A');
-        expect(plan.batchLetterByStepId.get(3)).toBe('A');
-        expect(plan.batchLetterByStepId.has(4)).toBe(false);
-    });
-
-    it('renders exactly one banner, immediately above the first member', () => {
-        const rendered = planRenderRows(plan);
-        const banners = rendered.filter((e) => e.kind === 'batch');
-        expect(banners).toHaveLength(1);
-        const at = rendered.findIndex((e) => e.kind === 'batch');
-        expect(rendered[at + 1].row.id).toBe(2);
-        expect(rendered[at + 2].row.id).toBe(3);
-        expect(rendered[at + 1].batchLetter).toBe('A');
-        expect(rendered[at + 2].batchLetter).toBe('A');
-    });
-
-    it('ships a clean order — batch contiguity included', () => {
-        expect(plan.violations).toEqual([]);
-    });
-
-    it('emits a batch with no linked requirements as unlaunchable, not as a bare command', () => {
-        const reqless = orderedPlan(buildPipelineModel({
-            pipeline: PIPELINE,
-            ...BATCH_READS,
-            stepRequirements: [],
-            requirements: [],
-        }));
-        const batch = reqless.batches.find((b) => b.stepIds.includes(2));
-        expect(batch.swarmStartArgs).toEqual([]);
-        expect(batch.swarmStartCommand).toBeNull();
-    });
-});
-
 describe('planRenderRows — the flat render list', () => {
-    const plan = orderedPlan(model(), { now: '2026-07-27T03:00:00Z' });
+    const plan = buildTestPlan(model(), { now: '2026-07-27T03:00:00Z' });
     const rendered = planRenderRows(plan);
 
     it('emits every step row in display order', () => {
@@ -363,14 +190,14 @@ describe('planRenderRows — the flat render list', () => {
     });
 
     it('returns an empty list for an empty plan', () => {
-        expect(planRenderRows(orderedPlan(buildPipelineModel()))).toEqual([]);
+        expect(planRenderRows(buildTestPlan(buildPipelineModel()))).toEqual([]);
         expect(planRenderRows(null)).toEqual([]);
     });
 });
 
 describe('pipelineSummary / pipelineSummaries', () => {
     it('counts the three derived states and totals them', () => {
-        const plan = orderedPlan(model());
+        const plan = buildTestPlan(model());
         const s = pipelineSummary(plan.rows);
         expect(s.total).toBe(plan.rows.length);
         expect(s.done + s.running + s.pending).toBe(s.total);
@@ -511,7 +338,7 @@ describe('planRenderRows — grouping compares ids, not titles', () => {
     };
 
     it('prints both labels when the ids differ despite identical titles', () => {
-        const plan = orderedPlan(buildPipelineModel({ pipeline: PIPELINE, ...SAME_TITLE_READS }));
+        const plan = buildTestPlan(buildPipelineModel({ pipeline: PIPELINE, ...SAME_TITLE_READS }));
         const rows = planRenderRows(plan).filter((e) => e.kind === 'step');
         expect(rows).toHaveLength(2);
         expect(rows[0].showEpic).toBe(true);
@@ -620,7 +447,7 @@ describe('machine labels', () => {
 });
 
 describe("the no-'#' production directive", () => {
-    const plan = orderedPlan(model(), { now: '2026-07-27T03:00:00Z' });
+    const plan = buildTestPlan(model(), { now: '2026-07-27T03:00:00Z' });
 
     it('strips the hash the engine puts on an unresolvable machine id', () => {
         // machineLabels() degrades to the POC's `#<id>` form; the page must not.
@@ -769,7 +596,7 @@ describe('buildCostIndex', () => {
     });
 });
 
-describe('orderedPlan attaches cost to every row', () => {
+describe('aggregateRowCost attaches cost to every row (was orderedPlan\'s job)', () => {
     const NOW = '2026-07-27T03:00:00Z';
 
     // Step 38 links 3110, 3111 and 3112. Sessions 601/602 are private to 3110
@@ -791,13 +618,13 @@ describe('orderedPlan attaches cost to every row', () => {
     it('every row carries a cost object even with no cost data at all', () => {
         // The renderer reads row.cost unconditionally; an undefined here would be
         // a crash rather than a dash.
-        for (const r of orderedPlan(model(), { now: NOW }).rows) {
+        for (const r of buildTestPlan(model(), { now: NOW }).rows) {
             expect(r.cost).toEqual({ wallSecs: 0, tokens: 0 });
         }
     });
 
     it('a step total is the union over its requirements sessions, counted once', () => {
-        const plan = orderedPlan(model(), { now: NOW, costIndex });
+        const plan = buildTestPlan(model(), { now: NOW, costIndex });
         const row38 = plan.rows.find((r) => r.id === 38);
         // 601 + 602 + 603, with 603 counted ONCE despite serving two of the
         // step's requirements. Summing byRequirement instead would give
@@ -811,8 +638,8 @@ describe('orderedPlan attaches cost to every row', () => {
         // Cost is attached AFTER ordering and verification. If it could reach the
         // comparator, a plan would re-order itself as sessions accrued time —
         // silently, and against design rule 3's fixed banding.
-        const bare = orderedPlan(model(), { now: NOW });
-        const costed = orderedPlan(model(), { now: NOW, costIndex });
+        const bare = buildTestPlan(model(), { now: NOW });
+        const costed = buildTestPlan(model(), { now: NOW, costIndex });
         expect(costed.rows.map((r) => r.id)).toEqual(bare.rows.map((r) => r.id));
         expect(costed.violations).toEqual([]);
     });

--- a/src/SwarmView/pipelines/__tests__/testOrderedPlan.js
+++ b/src/SwarmView/pipelines/__tests__/testOrderedPlan.js
@@ -1,0 +1,65 @@
+// testOrderedPlan.js — a TEST-ONLY reconstruction of `orderedPlan`, deleted
+// from `pipelineViewModel.js` by req #3381 (zero production callers left once
+// `PipelineDetail.jsx` switched to the 2.0 composed read, which arrives
+// pre-derived — nothing in the browser composes the 1.0 engine's pieces
+// together any more).
+//
+// The 1.0 ENGINE PIECES it composed stay very much alive — `StepsPage.jsx`,
+// `PipelinesPage.jsx`, and the conformance corpus against
+// `darwin-mcp/services/pipeline_derive.py`, which the Primary AI's own 1.0
+// orchestration still reads — so several test files still need a realistic
+// `plan`-shaped fixture (order + batches + eligibility + pause + requirement
+// counts) to exercise `planRenderRows`, `pipelinePlanLayout.js` and
+// `pipelineEpicZoom.js` against. This is the composition `orderedPlan` used
+// to be, kept as test scaffolding rather than production code — not a third
+// derivation, since every step it calls is the SAME production function.
+
+import {
+    buildPlanRows, displayOrder, verifyOrder, launchBatches, eligibility,
+    pauseState, serialState, aggregateRowCost, requirementCounts,
+} from '../pipelineModel';
+import { planTimeAxis } from '../pipelinePlanTime';
+
+export function buildTestOrderedPlan(model, { now, costIndex = null } = {}) {
+    const planRows = buildPlanRows(model || {});
+    const { rows, cycleDetected, cycleStepIds, duplicateStepIds } = displayOrder(planRows);
+    const violations = verifyOrder(rows);
+    const batches = launchBatches(rows);
+
+    const batchLetterByStepId = new Map();
+    for (const b of batches) {
+        for (const id of b.stepIds) batchLetterByStepId.set(id, b.letter);
+    }
+
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    const eligibleStepIds = new Set(
+        rows.filter((r) => eligibility(r, byId, now)).map((r) => r.id));
+
+    const unresolvedReqIds = [];
+    for (const r of rows) {
+        for (const id of r.unresolvedReqIds || []) {
+            if (!unresolvedReqIds.includes(id)) unresolvedReqIds.push(id);
+        }
+    }
+
+    const pause = pauseState(model || {}, rows);
+    const serial = serialState(model || {}, rows);
+    for (const r of rows) r.cost = aggregateRowCost(r, costIndex);
+    const timeAxis = planTimeAxis(rows, (model && model.requirements) || []);
+
+    return {
+        rows,
+        violations,
+        timeAxis,
+        batches,
+        batchLetterByStepId,
+        eligibleStepIds,
+        cycleDetected,
+        cycleStepIds,
+        duplicateStepIds,
+        unresolvedReqIds,
+        requirementCounts: requirementCounts(model || {}),
+        pause,
+        serial,
+    };
+}

--- a/src/SwarmView/pipelines/orchestrationHolder.js
+++ b/src/SwarmView/pipelines/orchestrationHolder.js
@@ -102,6 +102,21 @@ export function claimForPipeline(claims, pipelineId) {
 }
 
 /**
+ * The 2.0 counterpart of `claimForPipeline` (req #3381) — `pipeline2_fk`/
+ * `epic2_fk` are the SEPARATE columns a 2.0-scoped claim carries (NULL on a
+ * 1.0 row, and vice versa — CLAUDE.md § Session orchestration attribution's
+ * pairing pattern, reused here for claims). `claimForPipeline` itself is NOT
+ * era-aware and must not become so: `PipelinesTableView.jsx`/
+ * `PipelineCardsView.jsx` (the 1.0 list page) still call it against 1.0
+ * pipeline ids and must keep matching on `pipeline_fk`.
+ */
+export function claimForPipeline2(claims, pipeline2Id) {
+    if (pipeline2Id == null) return null;
+    return asArray(claims).find(
+        (c) => c.pipeline2_fk === pipeline2Id && c.epic2_fk == null) || null;
+}
+
+/**
  * Every reservation covering an EPIC's work — its own, plus any whole-plan
  * reservation on a plan the epic is seated in.
  *
@@ -122,9 +137,17 @@ export function claimsForEpic(claims, epicId, pipelineIds = []) {
         (c) => c.epic_fk === epicId || (c.epic_fk == null && plans.has(c.pipeline_fk)));
 }
 
-/** `pipeline:2` / `epic:7@2` — the same words the engine and its edges use. */
+/** `pipeline:2` / `epic:7@2` for a 1.0 claim, `pipeline2:5` / `epic2:9@5` for
+ * a 2.0 one — the same words the engine and its edges use, on whichever pair
+ * of columns this claim actually carries (req #3381: `pipeline_fk` is NULL
+ * on a 2.0 row, so testing it first would print `pipeline:null`). */
 export function scopeLabel(claim) {
     if (!claim) return '';
+    if (claim.pipeline2_fk != null) {
+        return claim.epic2_fk == null
+            ? `pipeline2:${claim.pipeline2_fk}`
+            : `epic2:${claim.epic2_fk}@${claim.pipeline2_fk}`;
+    }
     return claim.epic_fk == null
         ? `pipeline:${claim.pipeline_fk}`
         : `epic:${claim.epic_fk}@${claim.pipeline_fk}`;

--- a/src/SwarmView/pipelines/pipeline2Adapter.js
+++ b/src/SwarmView/pipelines/pipeline2Adapter.js
@@ -1,0 +1,321 @@
+// pipeline2Adapter.js — the browser-side consumer of the Pipeline 2.0 composed
+// read (req #3381). PURE: plain payload in, plain render shapes out. No React,
+// no fetch, no clock.
+//
+// THIS MODULE DOES NOT DERIVE ANYTHING (design intent: "the visualizer
+// CONSUMES a derived block; it does not derive one" —
+// memory/pipeline-2-visualizer-design.md § 0). `pipeline2_compose` /
+// `pipeline2_derive.py` (Lambda-Rest, req #3367) already ran display order,
+// state derivation, eligibility, pause and serial-turn suppression, and
+// requirement counts — server side, ONE producer, consumed identically by the
+// MCP daemon and the browser. Everything below is RESHAPING: snake_case wire
+// keys to the camelCase `PlanRow`/`plan` shapes `pipelinePlanLayout.js`,
+// `pipelineEpicZoom.js` and `pipelineViewModel.js`'s render helpers already
+// expect, plus joining the composed payload's own `steps[]`/`epics[]`/
+// `requirements[]` dictionaries back onto the thin `derived.rows[]`.
+//
+// `derived.rows[]` already arrives in DISPLAY ORDER (`pipeline2_derive.py`
+// builds it from `display_order(...)`'s own output) — there is no ordering
+// left to do here.
+//
+// WHY A JOIN IS NEEDED AT ALL. `derived.rows[]` is deliberately compact — ids,
+// enums, short id lists (req #3078 payload budget; every per-row field there
+// is "an id, an enum string, a boolean, or a short list of one of those").
+// `title`/`notes`/`completedAt` live on `steps[]`; the epic's title and
+// `sort_order` live on `epics[]`; machine labels are derived from
+// `requirements[].machine_fk` (2.0 does not carry a `machines` dictionary of
+// its own — the caller supplies one from `useMachines`, a small whole-app
+// table, same pattern `buildCostIndex`'s two reads already use for cost).
+//
+// WHAT DOES NOT EXIST IN 2.0, deliberately not synthesized:
+//   - `feature`/`featureId`/`featureLabels` — 2.0 has no Feature; every row's
+//     epic comes directly from containment (`pipeline2_steps.epic_fk`), never
+//     a features->epic chain, so there is exactly one epic per step, not a
+//     dominant-label tally over several.
+//   - `batches`/`batchLetterByStepId` — Batch does not exist in 2.0 (req
+//     #3371 owns removing the drawing machinery; this module never builds one
+//     to remove).
+//   - `labelInherited` — 2.0's `epic_fk` is NOT NULL (containment), so a step
+//     never lacks a label to inherit from a dependency the way a req-less 1.0
+//     step could.
+
+import { planTimeAxis } from './pipelinePlanTime';
+import { sumReqCost } from './pipelineModel';
+
+const asArray = (v) => (Array.isArray(v) ? v : []);
+
+// ── The four `derived` regimes (req #3345 § 4.5 / #3367 deliverable 3) ─────
+export const WITHHELD_DERIVATION_FAILED = 'derivation_failed';
+export const WITHHELD_BUDGET_DERIVED_ONLY = 'budget_derived_only';
+export const WITHHELD_BUDGET_ROWS_TRUNCATED = 'budget_rows_truncated';
+// Synthetic — never emitted by the server (the fourth regime is defined by
+// the KEY being wholly ABSENT, so there is nothing to read a code off of).
+// Named here so this module's own diagnostic object always carries SOME
+// regime string, rather than a nullable field every consumer has to guard.
+export const WITHHELD_ABSENT = 'derived_absent';
+// Also synthetic, and DELIBERATELY a different string from WITHHELD_ABSENT
+// (code review 2026-08-09): `derived.withheld === true` with no
+// `withheld_reason` means the BLOCK IS PRESENT AND WITHHELD, just missing
+// its own reason code (a producer bug, not the fourth regime) — labelling
+// that `derived_absent` would send a reader looking for a missing KEY when
+// the key is right there.
+export const WITHHELD_UNSPECIFIED = 'withheld_unspecified';
+
+/**
+ * Whether `derived`'s ROWS are complete, closed over all FOUR states the key
+ * can be in — not merely the three the server ever emits. An ABSENT key
+ * (an old producer, or a truncated response) is the one state with nothing to
+ * read a flag off of, and the only safe reading is `false` (req #3345 § 5).
+ *
+ * @param {*} derived
+ * @returns {boolean}
+ */
+export function rowsComplete(derived) {
+    if (derived == null || typeof derived !== 'object') return false;
+    return Boolean(derived.rows_complete);
+}
+
+/**
+ * A withheld-or-absent `derived` block as a renderable diagnostic, or `null`
+ * when `derived` is present and NOT withheld (the ordinary case — nothing to
+ * report). Callers render this as a hard stop (item 3 — "a withheld or
+ * degraded derived block is a hard stop, not an empty render"): the plan
+ * table/visualizer do not attempt a partial render from rows with no
+ * derived state.
+ *
+ * @param {?Object} payload  the composed read, or null/undefined while loading
+ * @returns {?{regime: string, rowsComplete: boolean, message: string}}
+ */
+export function deriveDiagnostic(payload) {
+    const derived = payload && payload.derived;
+    if (derived == null || typeof derived !== 'object') {
+        return {
+            regime: WITHHELD_ABSENT,
+            rowsComplete: false,
+            message: 'This composed read carries no `derived` block at all — the '
+                + 'producer predates the 2.0 budget ladder (req #3345), or the key '
+                + 'was dropped before it arrived. Treat the rows as incomplete: do '
+                + 'not sequence or launch from this response.',
+        };
+    }
+    if (!derived.withheld) return null;
+    return {
+        regime: derived.withheld_reason || WITHHELD_UNSPECIFIED,
+        rowsComplete: rowsComplete(derived),
+        message: derived.reason || 'The derived block was withheld.',
+    };
+}
+
+// `epics.sort_order` as a finite number or null — never a string, never NaN.
+// Lambda-Rest hands the column back as a real int/null (it is written through
+// the MCP tools' own validation, never hand-typed JSON here), so this is a
+// narrower guard than pipelineModel.js's `epicSortOrderOf` needs for a value
+// that might arrive as an arbitrary string — but the same WHITELIST shape,
+// for the same reason: `Number([])` is 0 and `Number(true)` is 1 in
+// JavaScript, so naming the two legal input types closes that class outright.
+function epicSortOrderOf(epic) {
+    if (!epic) return null;
+    const raw = epic.sort_order;
+    if (typeof raw !== 'number' && typeof raw !== 'string') return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+}
+
+// Rule 10's machine-label derivation, narrowed to what 2.0's thin row already
+// answers: `req_ids` minus `tracking_req_ids` (rule 10 sibling — a container
+// is a launch parameter's non-answer, not a machine), each resolved through
+// `requirements[].machine_fk` against the caller-supplied machines dictionary.
+// NULL pin -> 'Any'; unknown id -> '#<id>' (matches pipelineModel.js's
+// vocabulary so a mixed 1.0/2.0 session — StepsPage.jsx and this page open in
+// two tabs — never shows two different words for the same fact).
+function machineLabelsFor(reqIds, trackingReqIds, reqsById, machinesById) {
+    const tracking = new Set(trackingReqIds || []);
+    const labels = [];
+    for (const rid of reqIds || []) {
+        if (tracking.has(rid)) continue;
+        const req = reqsById.get(rid);
+        const fk = req && req.machine_fk != null ? req.machine_fk : null;
+        const machine = fk != null ? machinesById.get(fk) : null;
+        const label = fk == null ? 'Any' : (machine ? machine.title : `#${fk}`);
+        if (!labels.includes(label)) labels.push(label);
+    }
+    return labels;
+}
+
+/**
+ * `derived.rows[]` (display order, already) joined against `steps[]`/
+ * `epics[]`/`requirements[]` into `PlanRow`-shaped objects — the same shape
+ * `pipelineModel.js::buildPlanRows` produces, so `planRenderRows`,
+ * `pipelinePlanLayout.js` and `pipelineEpicZoom.js` cannot tell which engine
+ * built the row they are drawing.
+ *
+ * @param {Object} payload    a composed `pipeline2_compose` read, derived present
+ * @param {Object[]} [machines]  from `useMachines` — 2.0 carries no dictionary
+ *                                of its own (module header)
+ * @returns {Object[]} PlanRow[]
+ */
+export function buildPlan2Rows(payload, machines = []) {
+    const derived = payload.derived || {};
+    const stepsById = new Map(asArray(payload.steps).map((s) => [s.id, s]));
+    const epicsById = new Map(asArray(payload.epics).map((e) => [e.id, e]));
+    const reqsById = new Map(asArray(payload.requirements).map((r) => [r.id, r]));
+    const machinesById = new Map(asArray(machines).map((m) => [m.id, m]));
+
+    return asArray(derived.rows).map((dr) => {
+        const step = stepsById.get(dr.id) || {};
+        const epic = dr.epic_id != null ? epicsById.get(dr.epic_id) : null;
+        const labels = machineLabelsFor(
+            dr.req_ids, dr.tracking_req_ids, reqsById, machinesById);
+        return {
+            id: dr.id,
+            title: step.title != null ? step.title : '',
+            run: dr.run || step.run || 'auto',
+            notes: step.notes != null ? step.notes : null,
+            completedAt: step.completed_at != null ? step.completed_at : null,
+            state: dr.state,
+            reqIds: dr.req_ids || [],
+            trackingReqIds: dr.tracking_req_ids || [],
+            unresolvedReqIds: dr.unresolved_req_ids || [],
+            launchReqIds: dr.launch_req_ids || [],
+            launchExcluded: dr.launch_excluded || [],
+            launchBlock: dr.launch_block != null ? dr.launch_block : null,
+            depIds: dr.dep_ids || [],
+            outOfScopeDepIds: dr.out_of_scope_dep_ids || [],
+            // 2.0 has no time-gate DEP ROWS (req #3349 folded them into the
+            // step's own `not_before` — see the importer's `step_not_before`,
+            // which does the same fold on the way in). A single value, not a
+            // list, but `formatTimeGates` already takes an array and this
+            // keeps every existing render call site unchanged.
+            timeDeps: step.not_before ? [step.not_before] : [],
+            epicId: dr.epic_id != null ? dr.epic_id : null,
+            epic: epic ? epic.title : null,
+            epicSortOrder: epicSortOrderOf(epic),
+            featureId: null,
+            feature: null,
+            epicLabels: epic ? [{ id: epic.id, title: epic.title }] : [],
+            featureLabels: [],
+            labelInherited: false,
+            machineLabels: labels,
+            machineLabel: labels.length ? labels.join(' / ') : '—',
+            eligible: Boolean(dr.eligible),
+            launchSuppressed: Boolean(dr.launch_suppressed),
+            suppressedBy: dr.suppressed_by || [],
+            swarmStartCommand: dr.swarm_start_command != null ? dr.swarm_start_command : null,
+            noLaunchReason: dr.no_launch_reason != null ? dr.no_launch_reason : null,
+        };
+    });
+}
+
+/**
+ * The full `plan` object the Table/Visualizer panels consume — the 2.0
+ * counterpart of `pipelineViewModel.js::orderedPlan`, except every field
+ * below is a RESHAPE of something `pipeline2_derive.py` already computed,
+ * never a re-derivation. `costIndex` is the one exception: #3345 did not
+ * move cost into the composed payload (verified against `pipeline2_compose.py`
+ * — no session/cost table appears in its reads), so it is attached here
+ * exactly as `orderedPlan` attached it, from the SAME `buildCostIndex` two
+ * bounded reads (req #3117) — unrelated to the fetch this requirement
+ * collapses.
+ *
+ * @param {Object} payload   composed read, `derived` present and not withheld
+ * @param {Object} [options]
+ * @param {Object[]} [options.machines]
+ * @param {?Object} [options.costIndex]
+ * @returns {Object} plan
+ */
+export function adaptComposedPipeline2(payload, { machines = [], costIndex = null } = {}) {
+    const derived = payload.derived || {};
+    const rows = buildPlan2Rows(payload, machines);
+    for (const r of rows) r.cost = sumReqCost(r.reqIds, costIndex);
+
+    const violations = asArray(derived.violations).map((v) => ({
+        invariant: v.invariant,
+        message: v.message,
+        stepIds: v.step_ids || [],
+    }));
+
+    const rc = derived.requirement_counts || {};
+    const requirementCounts = {
+        overall: rc.overall || { met: 0, total: 0 },
+        byEpic: asArray(rc.by_epic).map((b) => ({
+            epicId: b.epic_id, met: b.met, total: b.total,
+        })),
+    };
+
+    const pauseSrc = derived.pause || {};
+    const pause = {
+        pipelineStatus: pauseSrc.pipeline_status != null ? pauseSrc.pipeline_status : null,
+        pipelinePaused: Boolean(pauseSrc.pipeline_paused),
+        pausedEpicIds: pauseSrc.paused_epic_ids || [],
+        suppressedStepIds: pauseSrc.suppressed_step_ids || [],
+    };
+
+    const serialSrc = derived.serial || {};
+    const serial = {
+        executionMode: serialSrc.execution_mode || 'parallel',
+        serial: Boolean(serialSrc.serial),
+        epicOrder: serialSrc.epic_order || [],
+        closedEpicIds: serialSrc.closed_epic_ids || [],
+        liveEpicId: serialSrc.live_epic_id != null ? serialSrc.live_epic_id : null,
+        waitingEpicIds: serialSrc.waiting_epic_ids || [],
+        heldStepIds: serialSrc.held_step_ids || [],
+    };
+
+    return {
+        rows,
+        violations,
+        // req #3381 item 2's "the time axis... arrives in the payload" was
+        // WRONG when written — `derive_plan2`'s return carries no
+        // `time_axis` key — so the axis is still computed HERE, client-side,
+        // exactly as `orderedPlan` computed it. Code review 2026-08-09
+        // additionally measured that the composed read's light requirement
+        // projection dropped `started_at`/`completed_at` (which
+        // `planTimeAxis` reads per-requirement), collapsing the axis to two
+        // dead slots on the real live payload — a visible regression of req
+        // #3201, not graceful degradation. Fixed the same day by widening
+        // `_REQUIREMENT_COLUMNS` in `Lambda-Rest/pipeline2_compose.py` (two
+        // more DATETIME columns on a read already fetching every linked
+        // requirement, zero extra gateway round trips) rather than deferring
+        // it — the gap was shipping-a-known-regression, not a design choice
+        // for a later requirement to make.
+        timeAxis: planTimeAxis(rows, payload.requirements || []),
+        // Batch does not exist in 2.0 (module header) — present as empty so
+        // every consumer that destructures `plan.batches`/
+        // `batchLetterByStepId` (planRenderRows, PipelinePlanTable's banner
+        // logic) runs unchanged and draws no banners, exactly as the live
+        // plan already does today (memory/pipeline-2-visualizer-design.md § 1
+        // measured zero batches drawing on production before this
+        // requirement even ran).
+        batches: [],
+        batchLetterByStepId: new Map(),
+        eligibleStepIds: new Set(derived.eligible_step_ids || []),
+        cycleDetected: Boolean(derived.cycle_detected),
+        cycleStepIds: derived.cycle_step_ids || [],
+        duplicateStepIds: derived.duplicate_step_ids || [],
+        unresolvedReqIds: derived.unresolved_req_ids || [],
+        outOfScopeDepIds: derived.out_of_scope_dep_ids || [],
+        requirementCounts,
+        pause,
+        serial,
+    };
+}
+
+/**
+ * The `model`-shaped object `PipelinePlanVisualizer.jsx` still reads directly
+ * (`model.requirements` for the autonomy/model/effort hover card,
+ * `model.machines` for by-machine colouring) — narrower than 1.0's
+ * `PipelineModel`, because 2.0's composed payload carries nothing else `model`
+ * was ever asked for (no `features`, and `steps`/`epics`/`stepRequirements`/
+ * `stepDeps` are already folded into `plan.rows` above).
+ *
+ * @param {Object} payload
+ * @param {Object[]} [machines]
+ * @returns {{pipeline: ?Object, requirements: Object[], machines: Object[]}}
+ */
+export function buildPlan2Model(payload, machines = []) {
+    return {
+        pipeline: (payload && payload.pipeline) || null,
+        requirements: asArray(payload && payload.requirements),
+        machines: asArray(machines),
+    };
+}

--- a/src/SwarmView/pipelines/pipelineViewModel.js
+++ b/src/SwarmView/pipelines/pipelineViewModel.js
@@ -15,20 +15,12 @@
 
 import { formatDateTime } from '../../utils/dateFormat';
 import {
-    aggregateRowCost,
     buildPlanRows,
-    displayOrder,
-    verifyOrder,
-    launchBatches,
-    eligibility,
     requirementCounts,
-    pauseState,
-    serialState,
     STEP_DONE,
     STEP_RUNNING,
     STEP_PENDING,
 } from './pipelineModel';
-import { planTimeAxis } from './pipelinePlanTime';
 import { PIPELINE_STATUS_VALUES } from './pipelineChipStyles';
 
 const asArray = (v) => (Array.isArray(v) ? v : []);
@@ -239,109 +231,6 @@ export function buildCostIndex({ requirementSessions, sessionCosts } = {}) {
     }
 
     return { byRequirement, sessionIdsByRequirement, bySession };
-}
-
-/**
- * Run the engine end to end over a model: derive → order → SELF-CHECK → batch →
- * mark eligibility → attach cost → derive the time axis.
- *
- * The verifyOrder() call is on the RENDERED order, which is design rule 3's whole
- * point: the renderer checks its own output and the caller renders any violation
- * loudly. `violations` is the only green light — an empty array.
- *
- * Cost is attached HERE, onto `row.cost`, rather than computed in a cell
- * renderer: the plan table and the plan visualizer are two surfaces over one
- * plan, and a number they each derive independently is a number that can
- * disagree. It is attached AFTER ordering and verification and is never an
- * ordering input — cost must not be able to move a row.
- *
- * @param {Object} model         from buildPipelineModel
- * @param {Object} [options]
- * @param {(Date|number|string)} [options.now]  clock for time-gate eligibility
- * @param {?Object} [options.costIndex]          from buildCostIndex
- * @returns {Object} plan
- */
-export function orderedPlan(model, { now, costIndex = null } = {}) {
-    const planRows = buildPlanRows(model || {});
-    const { rows, cycleDetected, cycleStepIds, duplicateStepIds } = displayOrder(planRows);
-    const violations = verifyOrder(rows);
-    const batches = launchBatches(rows);
-
-    const batchLetterByStepId = new Map();
-    for (const b of batches) {
-        for (const id of b.stepIds) batchLetterByStepId.set(id, b.letter);
-    }
-
-    const byId = new Map(rows.map((r) => [r.id, r]));
-    const eligibleStepIds = new Set(
-        rows.filter((r) => eligibility(r, byId, now)).map((r) => r.id),
-    );
-
-    // Junction rows whose requirement is missing from the read. Design rule 5
-    // says the page renders from bounded reads; a bounded read that TRUNCATED
-    // would under-derive step state in total silence, so it is surfaced with the
-    // ordering violations rather than shrugged off.
-    const unresolvedReqIds = [];
-    for (const r of rows) {
-        for (const id of r.unresolvedReqIds || []) {
-            if (!unresolvedReqIds.includes(id)) unresolvedReqIds.push(id);
-        }
-    }
-
-    // req #3226 — pause suppression (req #3223's enforcement half, rendered
-    // here). Mutates each row with `launchSuppressed`/`suppressedBy`, the same
-    // "freshly built rows this call owns" discipline `row.cost` relies on
-    // below, so it runs first and the cost loop's own comment still describes
-    // every mutation these rows carry.
-    const pause = pauseState(model || {}, rows);
-
-    // req #3388 — serial turn-taking, IMMEDIATELY AFTER pause and before
-    // anything reads `suppressedBy`. It appends `turn` to the same list pause
-    // just wrote, so calling it later (or not at all) leaves the browser
-    // showing a step as launchable while the engine is holding it — the two
-    // surfaces disagreeing about the live plan, which is the exact failure the
-    // shared conformance corpus exists to prevent. The corpus pins
-    // `serialState` itself; THIS line is what puts it on the browser's path.
-    const serial = serialState(model || {}, rows);
-
-    // MUTATED IN PLACE deliberately: `rows` are the freshly built PlanRows this
-    // call owns (buildPlanRows returns new objects every time), never the caller's
-    // input, so there is nothing outside this function to surprise.
-    for (const r of rows) r.cost = aggregateRowCost(r, costIndex);
-
-    // The visualizer's TIME AXIS (req #3201). Derived here rather than in the
-    // canvas for the same reason cost is: the plan table and the plan
-    // visualizer are two surfaces over one plan, and a fact they each derive
-    // independently is a fact that can disagree. Like cost, and for the same
-    // reason, it is computed AFTER ordering and is never an ordering input —
-    // display order stays topological-then-state-banded (rule 3), and only the
-    // canvas's column origins and band stacking read this.
-    const timeAxis = planTimeAxis(rows, (model && model.requirements) || []);
-
-    return {
-        rows,
-        violations,
-        timeAxis,
-        batches,
-        batchLetterByStepId,
-        eligibleStepIds,
-        cycleDetected,
-        cycleStepIds,
-        duplicateStepIds,
-        unresolvedReqIds,
-        // req #3225 — pure CPU over `model.requirements`/`model.features`,
-        // both already in hand. No extra read, same as cost/timeAxis above.
-        requirementCounts: requirementCounts(model || {}),
-        // req #3226 — see the mutation above; carried here too so a consumer
-        // that only has `plan` (not the rows) can still read the plan-wide
-        // and epic-wide pause facts.
-        pause,
-        // req #3388 — the mode, the epic order, which epics are closed, whose
-        // turn it is and what that holds. Carried beside `pause` for the same
-        // reason: a consumer with only `plan` and not the rows still needs the
-        // plan-wide answer.
-        serial,
-    };
 }
 
 /**

--- a/src/hooks/factory/devopsQueries.js
+++ b/src/hooks/factory/devopsQueries.js
@@ -414,9 +414,15 @@ export const agentTelemetryRowDocs = createEntityQueries({
 // a second copy of it on the wire would invite a join against the wrong one.
 export const orchestrationClaims = createEntityQueries({
     entity: 'orchestration_claims',
+    // `pipeline2_fk`/`epic2_fk` (req #3369) added by req #3381's code review
+    // — `claimForPipeline2`/`scopeLabel`'s 2.0 branch (orchestrationHolder.js)
+    // read these and were silently dead without them: NULL on a 1.0 row and
+    // vice versa (the same era pairing req #3350 already widened `sessions`'
+    // projection for, two declarations up, which this one was missed
+    // alongside).
     defaultFields:
-        'id,pipeline_fk,epic_fk,machine_fk,terminal_pid,engine_pid,polls,' +
-        'claimed_at,creator_fk,create_ts,update_ts',
+        'id,pipeline_fk,epic_fk,pipeline2_fk,epic2_fk,machine_fk,terminal_pid,' +
+        'engine_pid,polls,claimed_at,creator_fk,create_ts,update_ts',
     fieldsInKey: true,
     defaultSort: 'claimed_at:asc',
 });

--- a/src/hooks/useDataQueries.js
+++ b/src/hooks/useDataQueries.js
@@ -2,11 +2,12 @@ import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-quer
 import { useContext, useMemo } from 'react';
 import AppContext from '../Context/AppContext';
 import AuthContext from '../Context/AuthContext';
-import { domainKeys, areaKeys, taskKeys, projectKeys, categoryKeys, requirementKeys, priorityCardOrderKeys, recurringTaskKeys, mapRunKeys, mapRouteKeys, mapCoordinateKeys, mapViewKeys, mapPartnerKeys, mapRunPartnerKeys, epicKeys, featureKeys, testCaseKeys, featureTestCaseKeys, testPlanKeys, testPlanCaseKeys, testRunKeys, testResultKeys, customerKeys, buildProjectKeys, branchKeys, buildKeys, customerReleaseKeys } from './useQueryKeys';
+import { domainKeys, areaKeys, taskKeys, projectKeys, categoryKeys, requirementKeys, priorityCardOrderKeys, recurringTaskKeys, mapRunKeys, mapRouteKeys, mapCoordinateKeys, mapViewKeys, mapPartnerKeys, mapRunPartnerKeys, epicKeys, featureKeys, testCaseKeys, featureTestCaseKeys, testPlanKeys, testPlanCaseKeys, testRunKeys, testResultKeys, customerKeys, buildProjectKeys, branchKeys, buildKeys, customerReleaseKeys, pipeline2ComposeKeys } from './useQueryKeys';
 import { devServers, sessions, swarmStarts, swarmStartSessions, swarmUndos, swarmCompletes, swarmCompleteSessions, machines, agents, instructions, architectureDocuments, agentDocuments, agentInstructions, agentTelemetryRuns, agentTelemetryRows, agentTelemetryRowDocs, orchestrationClaims, pipelines, pipelineSteps, pipelineStepRequirements, pipelineStepDeps, requirementSessions, sessionCostRollups } from './factory/devopsQueries';
 // `fetchEntity` is shared with the factory so both layers handle REST errors
 // identically (req #2593).
 import { fetchEntity } from './factory/createEntityQueries';
+import call_rest_api from '../RestApi/RestApi';
 // req #3166 — THE batched GET /map_coordinates, shared with the export paths.
 import { fetchCoordinatesForRuns, buildRunTrackUri, COORD_TRACK_FIELDS } from '../services/mapCoordinatesBatch';
 // req #3180 — THE browser's one derivation of pipeline-step membership.
@@ -998,6 +999,51 @@ export const useAllPipelineSteps            = pipelineSteps.useAll;
 export const useOrchestrationClaims         = orchestrationClaims.useAll;
 export const useAllPipelineStepRequirements = pipelineStepRequirements.useAll;
 export const useAllPipelineStepDeps         = pipelineStepDeps.useAll;
+
+// Req #3381 — the Pipeline 2.0 composed read. ONE non-generic Lambda-Rest
+// route (`pipeline2_compose`, req #3367) answers the whole plan render —
+// join AND derivation both already ran server-side — so this is a thin GET
+// over a single nested object, never a table read. `fetchEntity`'s
+// array-shaped / 404->`[]` contract does not fit a composed payload, so this
+// is hand-written rather than routed through the factory.
+//
+// The THREE READ STATES a caller distinguishes: `undefined` (still loading),
+// `null` (no such plan — a 404), or the composed object (found). A caller
+// checking `payload.derived` for the four withheld/absent regimes
+// (`pipeline2Adapter.js::deriveDiagnostic`) only does so once `data` itself
+// is a real object — `null` and `undefined` are both "nothing to derive from
+// yet" at the fetch layer, same as `!pipeline` was for the 1.0 list lookup
+// this replaces.
+export function useComposedPipeline2(pipelineId, { enabled = true } = {}) {
+    const { darwinUri } = useContext(AppContext);
+    const { idToken } = useContext(AuthContext);
+    const validId = Number.isFinite(pipelineId);
+    const uri = `${darwinUri}/pipeline2_compose?id=${pipelineId}`;
+
+    return useQuery({
+        queryKey: pipeline2ComposeKeys.byId(pipelineId),
+        queryFn: async () => {
+            // `call_rest_api` THROWS on every non-2xx status (RestApi.jsx) —
+            // it never returns control past a 404, so the 404 check has to
+            // live in the `catch`, mirroring `fetchEntity`'s own pattern
+            // (`createEntityQueries.js`). A bare `if (result.httpStatus...)`
+            // here was dead code (code review 2026-08-09): every "not found"
+            // fell through to react-query's retry (x2) before the caller
+            // ever saw anything.
+            try {
+                const result = await call_rest_api(uri, 'GET', '', idToken);
+                if (result.httpStatus.httpStatus < 200 || result.httpStatus.httpStatus >= 300) {
+                    throw result;
+                }
+                return result.data;
+            } catch (error) {
+                if (error?.httpStatus?.httpStatus === 404) return null;
+                throw error;
+            }
+        },
+        enabled: enabled && validId && !!idToken,
+    });
+}
 
 // Req #3180 — the requirement ids a pipeline STEP carries, as a Set.
 //

--- a/src/hooks/useQueryKeys.js
+++ b/src/hooks/useQueryKeys.js
@@ -108,6 +108,15 @@ export const mapCoordinateKeys = {
     byRun: (runId) => ['map_coordinates', { runId }],
 };
 
+// Req #3381 — the Pipeline 2.0 composed read (`pipeline2_compose`, req
+// #3367). Not creator-scoped in the key: the route itself scopes by the
+// authenticated token (Lambda-Rest req #3050), and this cache entry is one
+// per PLAN, the same way `mapCoordinateKeys.byRun` is one per run rather than
+// one per (creator, run).
+export const pipeline2ComposeKeys = {
+    byId: (pipelineId) => ['pipeline2_compose', { id: pipelineId }],
+};
+
 export const mapViewKeys = {
     all: (creatorFk) => ['map_views', creatorFk],
 };


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3381-pipeline-20-the-browser-consumes-1
- wip(Darwin): 2026-08-10T00:52:08Z
- chore: init swarm session feature/3381-pipeline-20-the-browser-consumes-1

## Files changed
```
 src/SwarmView/pipelines/PipelineDetail.jsx         | 180 ++++++----
 .../__tests__/PipelineDetail.epicParam.test.jsx    |  16 +-
 ...ipelineDetail.modeToggleAccessibleName.test.jsx |  16 +-
 .../__tests__/PipelineDetail.place.test.jsx        |  25 +-
 .../__tests__/PipelineDetail.stepParam.test.jsx    |  18 +-
 .../__tests__/PipelinesPage.restart.test.jsx       |  14 +
 .../__tests__/orchestrationHolder.test.js          |  39 +++
 .../pipelines/__tests__/pipeline2Adapter.test.js   | 369 +++++++++++++++++++++
 .../__tests__/pipeline2ComposedFixture.js          | 109 ++++++
 .../pipelines/__tests__/pipelineEpicZoom.test.js   |   5 +-
 .../pipelines/__tests__/pipelinePlanLayout.test.js |   5 +-
 .../pipelines/__tests__/pipelineViewModel.test.js  | 205 +-----------
 .../pipelines/__tests__/testOrderedPlan.js         |  65 ++++
 src/SwarmView/pipelines/orchestrationHolder.js     |  25 +-
 src/SwarmView/pipelines/pipeline2Adapter.js        | 321 ++++++++++++++++++
 src/SwarmView/pipelines/pipelineViewModel.js       | 111 -------
 src/hooks/factory/devopsQueries.js                 |  10 +-
 src/hooks/useDataQueries.js                        |  48 ++-
 src/hooks/useQueryKeys.js                          |   9 +
 19 files changed, 1166 insertions(+), 424 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)