### PR TITLE
Pipeline 2.0 - epic containment in the render: bands from a column, band order from the stored epic sequence, and the epic-scoped state-banding check

### DIFF
--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -5692,6 +5692,84 @@ describe('epic bands stack by `epics.sort_order` (req #3430)', () => {
     });
 });
 
+describe('a band is a plain column read — no re-tallying in this module (req #3372 item 1)', () => {
+    // Bands are keyed on `row.epicId` alone, whatever it holds — this module
+    // never re-derives it from a requirement -> feature -> epic walk (that
+    // tally is upstream, out of this module's scope by req #3372's own
+    // boundary: "you own the DRAWING ... consume its output"). Two steps
+    // carrying the SAME `epicId` band together regardless of how many
+    // requirements either has; two with DIFFERENT ids never merge.
+    const mk = (id, epicId, epic, reqIds = []) => ({
+        id, title: `s${id}`, run: 'auto', state: 'pending', reqIds,
+        depIds: [], timeDeps: [], epicId, epic,
+        epicLabels: [], featureLabels: [], machineLabels: [], machineLabel: '—',
+    });
+
+    it('groups purely by epicId, independent of the requirement count behind it', () => {
+        // The two epic-6 rows deliberately carry DIFFERENT non-empty reqIds
+        // sets — if this module were re-tallying instead of reading the
+        // column, a requirement-count-driven grouping would split them.
+        const rows = [
+            mk(1, 6, 'Mapping', [101, 102]), mk(2, 6, 'Mapping', [103]),
+            mk(3, 7, 'Backlog', [104, 105, 106]),
+        ];
+        const layout = computePlanLayout(rows);
+        expect(layout.bands.map((b) => b.epicId).sort((a, b) => a - b)).toEqual([6, 7]);
+        expect(layout.nodes.get(1).bandIndex).toBe(layout.nodes.get(2).bandIndex);
+        expect(layout.nodes.get(3).bandIndex).not.toBe(layout.nodes.get(1).bandIndex);
+    });
+
+    it('a null epicId still bands on its own — the "No epic" case is not assumed unreachable', () => {
+        // Req #3372's body instructs deleting this branch on the premise that
+        // `epic_fk` is NOT NULL upstream. MEASURED against the live code path
+        // (2026-08-10): req #3462 reverted req #3381's composed-read cutover
+        // the same day this requirement was worked, so the only live consumer
+        // of this module (`PipelineDetail.jsx`, via `pipelineModel.js`) still
+        // derives `epicId` by a requirement -> feature -> epic tally that CAN
+        // return null (a step with no linked requirement and nothing to
+        // inherit from). Deleting the null-band branch here would misrender —
+        // or throw on — that still-live case, so it is kept deliberately. See
+        // req #3372's completion report / follow-on for the structural fix.
+        const rows = [mk(1, 6, 'Mapping'), mk(2, null, 'No epic')];
+        const layout = computePlanLayout(rows);
+        expect(layout.bands).toHaveLength(2);
+        expect(layout.bands.some((b) => b.epicId == null)).toBe(true);
+        expect(layout.nodes.get(1).bandIndex).not.toBe(layout.nodes.get(2).bandIndex);
+    });
+});
+
+describe('cross-epic dependency edges stay legal — sameBand keeps routing, reports nothing '
+    + '(req #3372 item 3, gate-delta F1)', () => {
+    // Gate-delta F1 (stage-2 review pass, 2026-08-08) supersedes item 3's
+    // original "convert sameBand into a reported violation" instruction: a
+    // cross-epic arc is LEGAL and `sameBand` stays a pure boolean routing
+    // input — no assertion, no reported violation. This fixture is the
+    // POSITIVE case the delta calls for: proof the layout draws a normal
+    // 'early' arc across a band boundary rather than warning, crashing, or
+    // dropping it.
+    const mk = (id, epicId, depIds = []) => ({
+        id, title: `s${id}`, run: 'auto', state: 'pending', reqIds: [],
+        depIds, timeDeps: [], epicId, epic: `epic-${epicId}`,
+        epicLabels: [], featureLabels: [], machineLabels: [], machineLabel: '—',
+    });
+    const rows = [mk(1, 6), mk(2, 7, [1])];
+    const layout = computePlanLayout(rows);
+    const arc = layout.arcs.find((a) => a.fromId === 1 && a.toId === 2);
+
+    it('routes the cross-band arc as an ordinary "early" shape', () => {
+        expect(arc).toBeTruthy();
+        expect(arc.route).toBe('early');
+    });
+
+    it('draws it like any other arc — no violation, warning or side-channel field', () => {
+        expect(arc.path).toBeTruthy();
+        expect(layout.arcs.length).toBe(1);
+        expect(Object.keys(arc).sort()).toEqual(
+            ['fromId', 'toId', 'straight', 'route', 'x1', 'y1', 'x2', 'y2', 'path'].sort());
+        expect(layout.violations).toBeUndefined();
+    });
+});
+
 describe('time axis — horizontal position (req #3201)', () => {
     it('every arc still points forward — no step renders left of a dependency', () => {
         for (const r of timedPlan.rows) {

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -1941,6 +1941,21 @@ export function computePlanLayout(rows, opts = {}) {
     const planPaused = !!pauseInfo?.pipelinePaused;
     const bandPausedOf = (key) => planPaused || (key != null && pausedEpicIdSet.has(key));
 
+    // req #3372 (2026-08-10) — the requirement asked for the "No epic" band
+    // (the `key == null` case throughout this file) to be deleted outright,
+    // on the premise that `epic_fk` is a NOT NULL column upstream by the time
+    // a row reaches this module. MEASURED WRONG the same day: req #3462
+    // reverted req #3381's cutover of the browser onto the 2.0 composed read
+    // (a production outage — no 1.0<->2.0 pipeline id mapping exists), so
+    // `computePlanLayout`'s only live caller — `PipelinePlanVisualizer.jsx`,
+    // mounted by `PipelineDetail.jsx` via `pipelineDetailModes.js`, fed by
+    // `pipelineModel.js`'s dominant-epic tally + label inheritance — can
+    // still hand this module a row with `epicId == null`. Deleting the
+    // branch here would misrender or throw on that still-reachable case, so
+    // it is kept — see `pipelinePlanLayout.test.js` "a band is a plain
+    // column read" for the fixture proving it is exercised on purpose, not
+    // defensively. This module's own job is unaffected either way: it never
+    // re-tallies an epic itself, it only reads `row.epicId` as handed to it.
     const bandKeys = [];
     const bandByKey = new Map();
     // req #3430 — epic id -> `epics.sort_order`, or null for UNORDERED. Taken
@@ -2360,6 +2375,13 @@ export function computePlanLayout(rows, opts = {}) {
                 });
                 continue;
             }
+            // req #3372 gate-delta F1 (2026-08-08) — a cross-epic dependency
+            // edge is LEGAL, not a defect to report. `sameBand` stays a pure
+            // boolean routing input: a cross-band arc simply takes the
+            // 'early' shape below, same as any other cross-band arc always
+            // has. No assertion, no violation, no side-channel field — see
+            // "cross-epic dependency edges stay legal" in
+            // `pipelinePlanLayout.test.js` for the positive fixture.
             const sameBand = a.bandIndex === b.bandIndex;
             const late = sameBand
                 && corridorClear(a.bandIndex, a.lane, a.depth, b.depth, dId, r.id);


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3372-pipeline-20-epic-containment-in-the-1
- wip(Darwin): 2026-08-10T11:07:57Z
- chore: init swarm session feature/3372-pipeline-20-epic-containment-in-the-1

## Files changed
```
 .../pipelines/__tests__/pipelinePlanLayout.test.js | 78 ++++++++++++++++++++++
 src/SwarmView/pipelines/pipelinePlanLayout.js      | 22 ++++++
 2 files changed, 100 insertions(+)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)