### PR TITLE
Sort requirements under Step

### DIFF
--- a/src/Steps/StepsPage.jsx
+++ b/src/Steps/StepsPage.jsx
@@ -105,6 +105,7 @@ import { useSnackBarStore } from '../stores/useSnackBarStore';
 import ChipFilter from '../Components/ChipFilter/ChipFilter';
 import { formatDateTime } from '../utils/dateFormat';
 import { PLAN_REQUIREMENT_FIELDS } from '../SwarmView/pipelines/pipelineViewModel';
+import { sortReqIdsByStatus } from '../SwarmView/pipelines/pipelinePlanLayout';
 import {
     runChipProps,
     runLabel,
@@ -166,12 +167,17 @@ const oneLine = (value) => (value ? String(value).replace(/\s+/g, ' ').trim() : 
 // Requirement ids for a hover, marking the containers. A tracking requirement is
 // linked but never gates (req #3123), and a reader looking at a step that says
 // "3 requirements — Scheduled" needs to see which of them the derivation ignored.
-const reqIdSummary = (row) => {
+//
+// Sorted met-first, deferred/wontfix-last (req #3363) via the SAME ladder the
+// plan visualizer stacks its requirement marks with — `statusOf` defaults to a
+// no-op lookup so a caller with no status map still gets the row's own order
+// rather than a crash.
+const reqIdSummary = (row, statusOf = () => null) => {
     const ids = row.reqIds || [];
     if (!ids.length) return 'No requirements linked — this step is completed by hand.';
     const tracking = new Set(row.trackingReqIds || []);
     const unresolved = new Set(row.unresolvedReqIds || []);
-    return ids.map((id) => {
+    return sortReqIdsByStatus(ids, statusOf).map((id) => {
         if (tracking.has(id)) return `${id} (tracking)`;
         if (unresolved.has(id)) return `${id} (not found)`;
         return String(id);
@@ -343,6 +349,11 @@ export default function StepsPage() {
     const { rows: allRows, unrenderedStepIds } = useMemo(() => buildStepEditorRows({
         pipelines, steps, stepRequirements, stepDeps, requirements, features, epics,
     }), [pipelines, steps, stepRequirements, stepDeps, requirements, features, epics]);
+
+    // req #3363 — id -> requirement_status, for the "Reqs" tooltip's sort.
+    const reqStatusById = useMemo(
+        () => new Map(requirements.map((r) => [r.id, r.requirement_status])),
+        [requirements]);
 
     const rows = useMemo(() => filterStepRows(allRows, {
         pipelineIds: pipelineFilter === ALL_PIPELINES ? null : [Number(pipelineFilter)],
@@ -760,7 +771,7 @@ export default function StepsPage() {
             field: 'reqCount', headerName: 'Reqs', width: 90, type: 'number',
             valueGetter: (_v, row) => (row.reqIds || []).length,
             renderCell: (params) => (
-                <Tooltip title={reqIdSummary(params.row)}>
+                <Tooltip title={reqIdSummary(params.row, (id) => reqStatusById.get(id))}>
                     <Box component="span" data-testid={`step-req-count-${params.row.id}`}>
                         {params.value}
                     </Box>

--- a/src/SwarmView/pipelines/PipelinePlanTable.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanTable.jsx
@@ -79,6 +79,7 @@ import {
     // coincidental reds.
     PAUSE_PAUSED_COLOR,
 } from './pipelineChipStyles';
+import { sortReqIdsByStatus } from './pipelinePlanLayout';
 
 const NOWRAP = { whiteSpace: 'nowrap' };
 
@@ -241,12 +242,19 @@ function StepLaunchLine({ row }) {
 // Without the distinction the derivation looks broken to a reader who is right
 // to check it. Kept to a style + tooltip on the existing link deliberately: no
 // second chip, no new column, no new view.
-function RequirementLinks({ row, pipelineId, era }) {
+//
+// Sorted met-first, deferred/wontfix-last (req #3363), the same ladder the
+// Plan visualizer stacks its requirement marks with — `statusOf` is the
+// table's own status lookup, so Table and Plan modes agree on the order for
+// the same step. `row.reqIds` ITSELF is untouched (junction order — the
+// engine's contract); only the array handed to `.map` here is reordered.
+function RequirementLinks({ row, pipelineId, era, statusOf }) {
     if (!row.reqIds.length) return <span>—</span>;
     const tracking = new Set(row.trackingReqIds || []);
+    const sortedIds = sortReqIdsByStatus(row.reqIds, statusOf);
     return (
         <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
-            {row.reqIds.map((id) => {
+            {sortedIds.map((id) => {
                 const isTracking = tracking.has(id);
                 const link = (
                     <Link
@@ -316,13 +324,19 @@ function GroupCell({ show, value, width, color, testid }) {
     );
 }
 
-export default function PipelinePlanTable({ plan, pipeline, timezone, focusStepId,
+export default function PipelinePlanTable({ plan, model, pipeline, timezone, focusStepId,
     // req #3463 — WHICH plan surface this panel is drawing. The page owns it (it
     // is the era of the route the page is mounted at) and the panel only needs
     // it to stamp the requirement links' Back state, so a plan id can be
     // returned to the route it came from.
     era = DEFAULT_PLAN_ERA,
     costError = false, showCost = false }) {
+    // req #3363 — id -> requirement_status, for `RequirementLinks`' sort. The
+    // SAME light projection the page already read (`model.requirements`); no
+    // extra fetch.
+    const reqStatusById = useMemo(
+        () => new Map((model?.requirements || []).map((r) => [r.id, r.requirement_status])),
+        [model]);
     // `showCost` is OWNED BY THE PAGE since req #3119 — the Time / Tokens control
     // renders in the header row beside the pipeline name, with the visualizer's
     // toggles, so both modes put their controls in one place.
@@ -584,7 +598,8 @@ export default function PipelinePlanTable({ plan, pipeline, timezone, focusStepI
                                                color="#b07fd8"
                                                testid={`pipeline-epic-${row.id}`} />
                                     <TableCell sx={{ width: COL.reqs }}>
-                                        <RequirementLinks row={row} pipelineId={pipeline?.id} era={era} />
+                                        <RequirementLinks row={row} pipelineId={pipeline?.id} era={era}
+                                                          statusOf={(id) => reqStatusById.get(id)} />
                                         {/* Design rule 8's own artifact, on the
                                             row that owns it — see StepLaunchLine.
                                             Directly under the ids because they

--- a/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
+++ b/src/SwarmView/pipelines/PipelinePlanVisualizer.jsx
@@ -124,7 +124,7 @@ import {
     buildReqColorViews, REQ_COLOR_KEYS, reqIdStyle, reqIdKeyEntries, normalizeColorKey,
     DEFAULT_COLOR_KEY, PLAN_KEY_MAX_H, pinnedLevelOf, DEFAULT_PLAN_LEVEL_PREF,
     EPIC_PAUSE_BUBBLE_D, pauseBubbleColor, stickyRulerY, rulerScreenBottom,
-    KEY_GROUP_TITLES,
+    KEY_GROUP_TITLES, sortReqIdsByStatus,
 } from './pipelinePlanLayout';
 import {
     epicCycleKey, epicZoomStateKey, nextLaunchStep, nextEpicZoom,
@@ -308,10 +308,6 @@ export default function PipelinePlanVisualizer({
 }) {
     const navigate = useNavigate();
 
-    const rows = plan.rows || [];
-    const rowById = useMemo(() => new Map(rows.map((r) => [r.id, r])), [rows]);
-    const eligibleStepIds = plan.eligibleStepIds || new Set();
-
     // Requirement name + status for the hover tooltip (req #3119). The canvas
     // keeps drawing bare IDS — a plan title is many times the width of the
     // column it hangs under, so putting names on the surface either shrinks them
@@ -327,6 +323,24 @@ export default function PipelinePlanVisualizer({
                 coordination: r.coordination_type, model: r.ai_model, effort: r.effort,
             }])),
         [model]);
+    // req #3363 — the requirement marks stacked under a step sort met-first,
+    // deferred/wontfix last (`sortReqIdsByStatus`'s own ladder). Only the ORDER
+    // of each row's `reqIds` changes here; the ROW ARRAY keeps the engine's own
+    // order (bead z-stacking, column/lane placement all key off it), and every
+    // other field on a row — `launchReqIds`, `trackingReqIds`,
+    // `swarmStartCommand` — is the engine's answer, computed before this runs
+    // and left untouched, so re-ordering the display never touches what
+    // `/swarm-start` launches.
+    const rows = useMemo(() => {
+        const base = plan.rows || [];
+        if (!base.length) return base;
+        const statusOf = (id) => reqInfo.get(id)?.status;
+        return base.map((r) => ((r.reqIds || []).length > 1
+            ? { ...r, reqIds: sortReqIdsByStatus(r.reqIds, statusOf) }
+            : r));
+    }, [plan.rows, reqInfo]);
+    const rowById = useMemo(() => new Map(rows.map((r) => [r.id, r])), [rows]);
+    const eligibleStepIds = plan.eligibleStepIds || new Set();
     // The requirement TITLE lookup, when that mark is showing (req #3168). Built
     // from `reqInfo`, which the hover card already needed — so the option costs
     // no extra read and no extra pass over the model. Passed as an ARGUMENT

--- a/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
+++ b/src/SwarmView/pipelines/__tests__/pipelinePlanLayout.test.js
@@ -47,6 +47,7 @@ import {
     EPIC_PALETTE,
     PAUSE_ACTIVE_COLOR, PAUSE_PAUSED_COLOR, pauseBubbleColor, EPIC_PAUSE_BUBBLE_W,
     COLOR_CHANNELS, KEY_GROUP_TITLES,
+    REQ_STEP_SORT_ORDER, sortReqIdsByStatus,
 } from '../pipelinePlanLayout';
 
 const NOW = '2026-07-27T03:00:00Z';
@@ -3367,6 +3368,84 @@ describe('requirement-status colour scale (req #3168, directive 1)', () => {
             expect(reqStatusColor(bogus), `status=${String(bogus)}`)
                 .toBe(REQ_STATUS_UNKNOWN_COLOR);
         }
+    });
+});
+
+describe('requirement mark stack order (req #3363)', () => {
+    it('covers every requirement status, met leading and wontfix trailing', () => {
+        expect(REQ_STEP_SORT_ORDER).toEqual({
+            met: 0, development: 1, swarm_ready: 2, approved: 3, authoring: 4,
+            deferred: 5, wontfix: 6,
+        });
+        expect(Object.keys(REQ_STEP_SORT_ORDER).sort())
+            .toEqual([...REQ_STATUS_ORDER].sort());
+    });
+
+    it('sorts met first, then the active ladder, deferred and wontfix last', () => {
+        const statuses = {
+            1: 'authoring', 2: 'approved', 3: 'swarm_ready', 4: 'development',
+            5: 'met', 6: 'deferred', 7: 'wontfix',
+        };
+        const ids = [1, 2, 3, 4, 5, 6, 7];
+        expect(sortReqIdsByStatus(ids, (id) => statuses[id]))
+            .toEqual([5, 4, 3, 2, 1, 6, 7]);
+    });
+
+    it('is stable within a status — ties keep the caller\'s order', () => {
+        const statuses = { 10: 'development', 11: 'met', 12: 'development', 13: 'met' };
+        expect(sortReqIdsByStatus([10, 11, 12, 13], (id) => statuses[id]))
+            .toEqual([11, 13, 10, 12]);
+    });
+
+    it('sinks an unknown or missing status below every recognised one', () => {
+        // wontfix (rank 6) is the LOWEST recognised rank, so id 1 must still
+        // lead both unknowns — an equals-input assertion here would pass
+        // against a no-op sort and prove nothing.
+        const statuses = { 1: 'wontfix', 2: 'bogus-status' };
+        expect(sortReqIdsByStatus([2, 3, 1], (id) => statuses[id]))
+            .toEqual([1, 2, 3]);
+        // No lookup at all — every id is equally unknown, so the input order
+        // survives untouched (the default `statusOf` in `reqIdSummary`).
+        expect(sortReqIdsByStatus([3, 1, 2])).toEqual([3, 1, 2]);
+    });
+
+    it('tolerates a non-array input the way every other reqIds consumer does', () => {
+        expect(sortReqIdsByStatus(null, () => 'met')).toEqual([]);
+        expect(sortReqIdsByStatus(undefined, () => 'met')).toEqual([]);
+    });
+
+    // The reordering itself happens ONE LEVEL UP, in `PipelinePlanVisualizer`'s
+    // `rows` memo, which hands `computePlanLayout` a row whose `reqIds` is
+    // ALREADY sorted (`sortReqIdsByStatus` above is the whole of that logic).
+    // What closes the loop is proving this module is a faithful PASS-THROUGH —
+    // that it stacks/lists the 'req' marks in exactly the order `reqIds`
+    // arrives in, never re-deriving an order of its own — in both req layouts.
+    it('draws the "req" marks in the exact order reqIds arrives in — vertical', () => {
+        const row = {
+            id: 1, title: 's1', run: 'auto', state: 'pending',
+            reqIds: [30, 10, 20], depIds: [], timeDeps: [],
+            epicId: null, epic: null, epicLabels: [], featureLabels: [],
+            machineLabels: [], machineLabel: '—',
+        };
+        const layout = computePlanLayout([row], { reqLayout: 'vertical' });
+        const marks = layout.labels
+            .filter((l) => l.kind === 'req' && l.stepId === 1)
+            .sort((a, b) => a.y - b.y);
+        expect(marks.map((m) => m.reqId)).toEqual([30, 10, 20]);
+    });
+
+    it('draws the "req" marks in the exact order reqIds arrives in — horizontal', () => {
+        const row = {
+            id: 1, title: 's1', run: 'auto', state: 'pending',
+            reqIds: [30, 10, 20], depIds: [], timeDeps: [],
+            epicId: null, epic: null, epicLabels: [], featureLabels: [],
+            machineLabels: [], machineLabel: '—',
+        };
+        const layout = computePlanLayout([row], { reqLayout: 'horizontal' });
+        const marks = layout.labels
+            .filter((l) => l.kind === 'req' && l.stepId === 1)
+            .sort((a, b) => a.x - b.x);
+        expect(marks.map((m) => m.reqId)).toEqual([30, 10, 20]);
     });
 });
 

--- a/src/SwarmView/pipelines/pipelinePlanLayout.js
+++ b/src/SwarmView/pipelines/pipelinePlanLayout.js
@@ -294,6 +294,46 @@ export const REQ_STATUS_UNKNOWN_COLOR = PLAN_VIZ_PALETTE.dim;
 export const reqStatusColor = (status) => (Object.hasOwn(REQ_STATUS_COLORS, status)
     ? REQ_STATUS_COLORS[status] : REQ_STATUS_UNKNOWN_COLOR);
 
+// ── Requirement marks: STACK order under a step (req #3363) ────────────────
+// A different ladder from `REQ_STATUS_ORDER` above on purpose — that one is the
+// legend's reading order (the pipeline, authoring to wontfix); this is what a
+// reader scanning DOWN a step's own requirement stack wants first. `met` leads
+// because "is this step actually finished" is the question a multi-requirement
+// step exists to answer, and the two statuses nobody returns to (`deferred`,
+// `wontfix`) sink to the bottom in the order the user named them — everything
+// still in flight runs in ladder order between the two, closest-to-done first.
+export const REQ_STEP_SORT_ORDER = {
+    met: 0, development: 1, swarm_ready: 2, approved: 3, authoring: 4,
+    deferred: 5, wontfix: 6,
+};
+
+// One past the last known rank — a status this build does not know (an
+// unresolved id, or an enum value shipped ahead of the UI) sinks below every
+// recognised one rather than guessing where it belongs.
+const REQ_STEP_SORT_UNKNOWN = Object.keys(REQ_STEP_SORT_ORDER).length;
+
+/**
+ * Sort a step's linked requirement ids by status for on-canvas display (req
+ * #3363). Stable: two requirements sharing a status keep the order the
+ * caller gave them, rather than the sort tie-breaking on id or anything else.
+ *
+ * @param {number[]} reqIds
+ * @param {(id: number) => ?string} statusOf  requirement id -> requirement_status
+ * @returns {number[]}
+ */
+export function sortReqIdsByStatus(reqIds, statusOf) {
+    const ids = Array.isArray(reqIds) ? reqIds : [];
+    const rank = (id) => {
+        const status = typeof statusOf === 'function' ? statusOf(id) : null;
+        return Object.hasOwn(REQ_STEP_SORT_ORDER, status)
+            ? REQ_STEP_SORT_ORDER[status] : REQ_STEP_SORT_UNKNOWN;
+    };
+    return ids
+        .map((id, i) => [id, i])
+        .sort(([aId, aI], [bId, bI]) => (rank(aId) - rank(bId)) || (aI - bI))
+        .map(([id]) => id);
+}
+
 // ── Requirement-id scale 2 of 3: MACHINE (the 'machine' key) ───────────────
 // The high-contrast ecosystem pairing (user directive 2026-07-27): each machine
 // reads as its PLATFORM at a glance, so the two are told apart by association


### PR DESCRIPTION
## Summary
- wip(Darwin): 2026-08-10T14:08:45Z
- chore: init swarm session feature/3363-sort-requirements-under-step-1

## Files changed
```
 src/Steps/StepsPage.jsx                            | 17 ++++-
 src/SwarmView/pipelines/PipelinePlanTable.jsx      | 23 +++++--
 src/SwarmView/pipelines/PipelinePlanVisualizer.jsx | 24 +++++--
 .../pipelines/__tests__/pipelinePlanLayout.test.js | 79 ++++++++++++++++++++++
 src/SwarmView/pipelines/pipelinePlanLayout.js      | 40 +++++++++++
 5 files changed, 171 insertions(+), 12 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)