### PR TITLE
SessionsView/SwarmSessionDetail pipeline chip goes blank for 2.0-attributed sessions

### DIFF
--- a/src/SwarmView/detail/SwarmSessionDetail.jsx
+++ b/src/SwarmView/detail/SwarmSessionDetail.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
-import { useSession, useDevServersBySession, useAllSwarmStartSessions, useAllSwarmStarts, useAllSwarmCompleteSessions, useAllSwarmCompletes, useAllRequirements, useMachines, useAllPipelines, useAllPipelines2, useAllEpics } from '../../hooks/useDataQueries';
+import { useSession, useDevServersBySession, useAllSwarmStartSessions, useAllSwarmStarts, useAllSwarmCompleteSessions, useAllSwarmCompletes, useAllRequirements, useMachines, useAllPipelines, useAllPipelines2, useAllEpics, useAllPipeline2Epics } from '../../hooks/useDataQueries';
 import { sessionKeys } from '../../hooks/useQueryKeys';
 import { useConfirmDialog } from '../../hooks/useConfirmDialog';
 import { useSnackBarStore } from '../../stores/useSnackBarStore';
@@ -14,6 +14,7 @@ import { aiModelChipProps, aiModelLabel } from '../modelChipStyles';
 import { effortChipProps, effortLabel } from '../effortChipStyles';
 import { terminalFocusState, TERMINAL_STATE, TERMINAL_VISIBLE } from '../terminalFocus';
 import { sessionPipelineLink } from '../sessionPipelineLink';
+import { PLAN_ERA_1, PLAN_ERA_2 } from '../pipelines/planEra';
 import { PHASE_BUCKETS, GROUP_COLORS, bucketTokens, parsePhaseTokens, formatTokens } from '../sessionPhases';
 import { formatDuration } from '../../utils/formatDuration';
 import { trimMicroseconds } from '../../utils/dateFormat';
@@ -112,14 +113,7 @@ const SwarmSessionDetail = () => {
     const { data: pipelines = [] } = useAllPipelines(profile?.userName);
     const { data: pipelines2 = [] } = useAllPipelines2(profile?.userName);
     const { data: epics = [] } = useAllEpics(profile?.userName);
-    const pipelineTitle = React.useMemo(() => {
-        if (session?.pipeline_fk == null) return null;
-        return pipelines.find(p => p.id === session.pipeline_fk)?.title ?? null;
-    }, [pipelines, session?.pipeline_fk]);
-    const epicTitle = React.useMemo(() => {
-        if (session?.epic_fk == null) return null;
-        return epics.find(e => e.id === session.epic_fk)?.title ?? null;
-    }, [epics, session?.epic_fk]);
+    const { data: epics2 = [] } = useAllPipeline2Epics(profile?.userName);
 
     // Same rule as the Sessions grid: the plan chip links only when a 2.0 id
     // exists, because the plan page is a 2.0 route now.
@@ -129,6 +123,45 @@ const SwarmSessionDetail = () => {
         // naming one plan and navigating to another.
         () => sessionPipelineLink(session, pipelines, pipelines2),
         [session, pipelines, pipelines2]);
+
+    // req #3433 — `sessionPipelineLink` already searches BOTH pipeline lists
+    // and resolves the title into `planLink.label`; before this fix the
+    // separate `pipelineTitle` memo below re-read `session.pipeline_fk`
+    // against the 1.0 `pipelines` list alone, so a 2.0-attributed session's
+    // Pipeline row showed a bare `#7` with no name even after the chip itself
+    // went era-aware (req #3463). `label` falls back to `#<id>` when no title
+    // resolved, so this only renders when there is a real name to add.
+    const pipelineTitle = planLink.state !== 'none' && planLink.label !== `#${planLink.planId}`
+        ? planLink.label : null;
+
+    // The Epic row follows the SAME era `planLink` picked, so the two rows
+    // never name two different plans for one session (a data defect on the
+    // row — both columns stamped — otherwise had the Pipeline row favour 1.0
+    // while an independent epic lookup favoured 2.0). Only when the session
+    // carries no pipeline attribution at all (a partial/cleared stamp) does
+    // this fall back to whichever epic column IS set — an epic fact worth
+    // showing even with no plan beside it, matching the row's pre-fix
+    // behaviour for that case.
+    const epicAttribution = React.useMemo(() => {
+        if (planLink.era === PLAN_ERA_2) {
+            return session?.epic2_fk != null ? { epicId: session.epic2_fk, era: PLAN_ERA_2 } : null;
+        }
+        if (planLink.era === PLAN_ERA_1) {
+            return session?.epic_fk != null ? { epicId: session.epic_fk, era: PLAN_ERA_1 } : null;
+        }
+        // No pipeline attribution at all — fall back to whichever epic column
+        // is actually set, rather than tying the Epic row's existence to a
+        // plan attribution it does not have.
+        if (session?.epic_fk != null) return { epicId: session.epic_fk, era: PLAN_ERA_1 };
+        if (session?.epic2_fk != null) return { epicId: session.epic2_fk, era: PLAN_ERA_2 };
+        return null;
+    }, [planLink.era, session?.epic_fk, session?.epic2_fk]);
+
+    const epicTitle = React.useMemo(() => {
+        if (!epicAttribution) return null;
+        const list = epicAttribution.era === PLAN_ERA_2 ? epics2 : epics;
+        return list.find(e => e.id === epicAttribution.epicId)?.title ?? null;
+    }, [epicAttribution, epics, epics2]);
 
     const hasHistory = location.key !== 'default';
     const handleBack = () => hasHistory ? navigate(-1) : navigate('/swarm/sessions');
@@ -346,14 +379,14 @@ const SwarmSessionDetail = () => {
                     </Box>
                 }
 
-                {session.epic_fk != null &&
+                {epicAttribution?.epicId != null &&
                     <Box sx={{ mb: 1 }} data-testid="session-epic">
                         <Typography variant="subtitle2" color="text.secondary" sx={labelSx}>Epic</Typography>
                         <Typography variant="body2" component="div">
                             {/* No epic detail route exists, so this is a label
                                  chip and not a link — a dead click is worse than
                                  an honest static chip. */}
-                            <Chip label={`#${session.epic_fk}`} size="small" variant="outlined"
+                            <Chip label={`#${epicAttribution.epicId}`} size="small" variant="outlined"
                                   sx={{ mr: 1 }}
                                   data-testid="session-epic-chip" />
                             {epicTitle &&

--- a/src/SwarmView/detail/__tests__/SwarmSessionDetail.attribution.test.jsx
+++ b/src/SwarmView/detail/__tests__/SwarmSessionDetail.attribution.test.jsx
@@ -33,7 +33,9 @@ const PIPELINES = [
     { id: 2, title: 'Darwin', pipeline_status: 'active' },
     { id: 3, title: 'Retired plan', pipeline_status: 'aborted' },
 ];
+const PIPELINES2 = [{ id: 7, title: '2.0 plan' }];
 const EPICS = [{ id: 34, title: 'Swarm Orchestration' }];
+const EPICS2 = [{ id: 12, title: '2.0 Epic' }];
 
 let sessionRow;
 
@@ -50,7 +52,9 @@ vi.mock('../../../hooks/useDataQueries', async (importOriginal) => {
         useAllSwarmCompletes: () => ({ data: [] }),
         useAllRequirements: () => ({ data: [] }),
         useAllPipelines: () => ({ data: PIPELINES }),
+        useAllPipelines2: () => ({ data: PIPELINES2 }),
         useAllEpics: () => ({ data: EPICS }),
+        useAllPipeline2Epics: () => ({ data: EPICS2 }),
     };
 });
 
@@ -98,6 +102,8 @@ function baseSession(overrides = {}) {
         instrumented: 1,
         pipeline_fk: null,
         epic_fk: null,
+        pipeline2_fk: null,
+        epic2_fk: null,
         machine_fk: null,
         source_ref: null,
         ...overrides,
@@ -156,5 +162,70 @@ describe('SwarmSessionDetail orchestration attribution (req #3186)', () => {
         const { container } = mount();
         expect(node(container, 'session-pipeline').textContent).toContain('#99');
         expect(node(container, 'session-epic').textContent).toContain('#98');
+    });
+
+    // req #3433 — a session seated on a Pipeline 2.0 step stamps
+    // pipeline2_fk/epic2_fk with the 1.0 pair NULL. Before this fix the Epic
+    // row gated on `epic_fk` alone and went silently blank for these sessions,
+    // and even after fixing that gate the Pipeline row's own title text was
+    // still resolved against the 1.0 `pipelines` list only — a bare `#7` with
+    // no name (caught in code review). Both rows must carry a title.
+    it('renders both rows, with titles, for a 2.0-attributed session', () => {
+        sessionRow = baseSession({ pipeline2_fk: 7, epic2_fk: 12 });
+        const { container } = mount();
+
+        const pipeline = node(container, 'session-pipeline');
+        expect(pipeline).not.toBeNull();
+        expect(pipeline.textContent).toContain('#7');
+        expect(pipeline.textContent).toContain('2.0 plan');
+
+        const epic = node(container, 'session-epic');
+        expect(epic).not.toBeNull();
+        expect(epic.textContent).toContain('#12');
+        expect(epic.textContent).toContain('2.0 Epic');
+    });
+
+    // Both columns stamped is a data defect (the two eras are supposed to be
+    // exclusive), but the two rows must still describe ONE plan rather than
+    // the Pipeline row picking 1.0 and an independently-resolved Epic row
+    // picking 2.0 for the same session.
+    it('picks one era for both rows when a row carries both eras', () => {
+        sessionRow = baseSession({ pipeline_fk: 2, epic_fk: 34, pipeline2_fk: 7, epic2_fk: 12 });
+        const { container } = mount();
+
+        expect(node(container, 'session-pipeline').textContent).toContain('Darwin');
+        const epic = node(container, 'session-epic');
+        expect(epic.textContent).toContain('#34');
+        expect(epic.textContent).toContain('Swarm Orchestration');
+        expect(epic.textContent).not.toContain('#12');
+    });
+
+    // A MIXED partial stamp — pipeline resolved to one era, epic column set
+    // only on the OTHER era — is the more likely real shape than a fully
+    // dual-stamped row (`update_swarm_session` corrects one column at a
+    // time). The Epic row must follow the Pipeline row's era rather than
+    // showing a stray epic from a different plan (caught in code review).
+    it('does not show a stray other-era epic when only the pipeline side is mixed', () => {
+        sessionRow = baseSession({ pipeline2_fk: 7, epic_fk: 34 });
+        const { container } = mount();
+        expect(node(container, 'session-pipeline').textContent).toContain('2.0 plan');
+        expect(node(container, 'session-epic')).toBeNull();
+    });
+
+    it('does not show a stray other-era epic when only the epic side is mixed', () => {
+        sessionRow = baseSession({ pipeline_fk: 2, epic2_fk: 12 });
+        const { container } = mount();
+        expect(node(container, 'session-pipeline').textContent).toContain('Darwin');
+        expect(node(container, 'session-epic')).toBeNull();
+    });
+
+    // A session can carry an epic attribution with no pipeline (a manual
+    // correction via update_swarm_session, or a partial stamp) — that used to
+    // render before this requirement's fix and must keep rendering.
+    it('still renders the Epic row when only the epic column is stamped', () => {
+        sessionRow = baseSession({ epic_fk: 34 });
+        const { container } = mount();
+        expect(node(container, 'session-pipeline')).toBeNull();
+        expect(node(container, 'session-epic').textContent).toContain('#34');
     });
 });


### PR DESCRIPTION
## Summary
- Merge branch 'master' of https://github.com/BillWilliams79/Darwin into feature/3433-sessionsviewswarmsessiondetail-1
- wip(Darwin): 2026-08-12T07:12:16Z
- chore: init swarm session feature/3433-sessionsviewswarmsessiondetail-1

## Files changed
```
 src/SwarmView/detail/SwarmSessionDetail.jsx        | 55 +++++++++++++----
 .../SwarmSessionDetail.attribution.test.jsx        | 71 ++++++++++++++++++++++
 2 files changed, 115 insertions(+), 11 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)